### PR TITLE
chore(ci): remove CODECOV_TOKEN env block (tokenless via GitHub App)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,6 @@ jobs:
         with:
           files: coverage.out
           fail_ci_if_error: false
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   build:
     name: Build


### PR DESCRIPTION
## Summary

Remove the `CODECOV_TOKEN` secret reference from the test job. Codecov GitHub App is now installed on the org with access to brutus, enabling tokenless uploads for public repos.

## Test plan
- [ ] CI passes
- [ ] Coverage still uploads to Codecov after merge (tokenless)