### PR TITLE
security(ci): wire environment protection for secret-bearing jobs

### DIFF
--- a/.github/workflows/browser-plugin-ci.yml
+++ b/.github/workflows/browser-plugin-ci.yml
@@ -125,6 +125,7 @@ jobs:
   vision-api-tests:
     name: Vision API Tests
     runs-on: ubuntu-latest
+    environment: internal
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -161,6 +162,7 @@ jobs:
   full-pipeline-test:
     name: Full Pipeline Test
     runs-on: ubuntu-latest
+    environment: internal
     needs: [unit-tests, integration-tests]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
   integration:
     name: Integration Tests
     runs-on: ubuntu-latest
+    environment: internal
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     services:
       # SSH server for password testing


### PR DESCRIPTION
## Summary

- Adds `environment: internal` to all CI jobs that access `ANTHROPIC_API_KEY` or `PERPLEXITY_API_KEY` secrets, completing the environment protection work from INF2-56
- **`.github/workflows/ci.yml`**: Added `environment: internal` to the `integration` job, which uses `ANTHROPIC_API_KEY`
- **`.github/workflows/browser-plugin-ci.yml`**: Added `environment: internal` to the `vision-api-tests` job (uses `ANTHROPIC_API_KEY`) and the `full-pipeline-test` job (uses both `ANTHROPIC_API_KEY` and `PERPLEXITY_API_KEY`)

## Context

GitHub environment protection rules ensure that secret-bearing jobs require approval before running, preventing unauthorized access to API keys from forked PRs or untrusted workflows. The `internal` environment must be configured in the repository settings with the desired protection rules (e.g., required reviewers, deployment branches).

## Test plan

- [ ] Verify the `internal` environment is configured in the GitHub repository settings with appropriate protection rules
- [ ] Trigger a PR build and confirm that `integration`, `vision-api-tests`, and `full-pipeline-test` jobs wait for environment approval
- [ ] Confirm that jobs without secrets (`lint`, `test`, `build`, `unit-tests`, `integration-tests`, `build` in browser-plugin-ci) run without requiring approval