### PR TITLE
fix(docs): correct pre-built binary download URLs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,22 +107,23 @@ Download from [GitHub Releases](https://github.com/praetorian-inc/brutus/release
 
 ```bash
 # Linux (amd64)
-curl -L https://github.com/praetorian-inc/brutus/releases/latest/download/brutus-linux-amd64 -o brutus
-chmod +x brutus
+curl -L https://github.com/praetorian-inc/brutus/releases/latest/download/brutus-linux-amd64.tar.gz | tar xz
 sudo mv brutus /usr/local/bin/
 
 # macOS (Apple Silicon)
-curl -L https://github.com/praetorian-inc/brutus/releases/latest/download/brutus-darwin-arm64 -o brutus
-chmod +x brutus
+curl -L https://github.com/praetorian-inc/brutus/releases/latest/download/brutus-darwin-arm64.tar.gz | tar xz
 sudo mv brutus /usr/local/bin/
 
 # macOS (Intel)
-curl -L https://github.com/praetorian-inc/brutus/releases/latest/download/brutus-darwin-amd64 -o brutus
-chmod +x brutus
+curl -L https://github.com/praetorian-inc/brutus/releases/latest/download/brutus-darwin-amd64.tar.gz | tar xz
 sudo mv brutus /usr/local/bin/
+```
 
+```powershell
 # Windows (PowerShell)
-Invoke-WebRequest -Uri https://github.com/praetorian-inc/brutus/releases/latest/download/brutus-windows-amd64.exe -OutFile brutus.exe
+Invoke-WebRequest -Uri https://github.com/praetorian-inc/brutus/releases/latest/download/brutus-windows-amd64.zip -OutFile brutus.zip
+Expand-Archive -Path brutus.zip -DestinationPath .
+Remove-Item brutus.zip
 ```
 
 ### Go Install


### PR DESCRIPTION
## Summary
- Release assets are `.tar.gz` archives (Linux/macOS) and `.zip` archives (Windows), not raw binaries — the old URLs returned 404
- Updated Linux/macOS install commands to pipe `curl` into `tar xz` for the `.tar.gz` archives
- Updated Windows install command to download the `.zip`, extract with `Expand-Archive`, and clean up
- Split Windows into its own `powershell` fenced code block for proper syntax highlighting

## Test plan
- [ ] Verify each download URL resolves: `curl -sI <url> | grep 200`
- [ ] Run Linux install snippet in a fresh shell and confirm `brutus --help` works
- [ ] Run macOS install snippet and confirm `brutus --help` works
- [ ] Run Windows install snippet in PowerShell and confirm `brutus.exe --help` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)