### PR TITLE
Add external contribution notification workflow

### DIFF
--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: praetorian-inc/external-contrib-action@v1
         with:
           linear-team-id: "43502f93-0130-4cad-b35c-601bc4cc19a0"
-          linear-assignee-id: "b9498122-ca97-46ff-b01b-a182fbac07f7"
+          linear-assignee-id: ${{ secrets.LINEAR_ASSIGNEE_ID }}
           slack-channel-id: "C0ADYMH1VE3"
         env:
           ORG_MEMBER_CHECK_PAT: ${{ secrets.ORG_MEMBER_CHECK_PAT }}

--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -12,9 +12,9 @@ jobs:
     steps:
       - uses: praetorian-inc/external-contrib-action@v1
         with:
-          linear-team-id: "43502f93-0130-4cad-b35c-601bc4cc19a0"
+          linear-team-id: ${{ secrets.LINEAR_TEAM_ID }}
           linear-assignee-id: ${{ secrets.LINEAR_ASSIGNEE_ID }}
-          slack-channel-id: "C0ADYMH1VE3"
+          slack-channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
         env:
           ORG_MEMBER_CHECK_PAT: ${{ secrets.ORG_MEMBER_CHECK_PAT }}
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}

--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: praetorian-inc/external-contrib-action@v1
         with:
           linear-team-id: "43502f93-0130-4cad-b35c-601bc4cc19a0"
+          linear-assignee-id: "b9498122-ca97-46ff-b01b-a182fbac07f7"
           slack-channel-id: "C0ADYMH1VE3"
         env:
           ORG_MEMBER_CHECK_PAT: ${{ secrets.ORG_MEMBER_CHECK_PAT }}

--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -1,0 +1,20 @@
+name: External Contribution Notify
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: praetorian-inc/external-contrib-action@v1
+        with:
+          linear-team-id: "43502f93-0130-4cad-b35c-601bc4cc19a0"
+          slack-channel-id: "C0ADYMH1VE3"
+        env:
+          ORG_MEMBER_CHECK_PAT: ${{ secrets.ORG_MEMBER_CHECK_PAT }}
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that triggers when a non-org member opens a PR or Issue
- Automatically creates a Linear issue in the Labs team (Triage state) with `external-contribution` label
- Posts a Slack Block Kit notification to #brutus with buttons linking to GitHub and Linear
- Uses `praetorian-inc/external-contrib-action@v1` (org-level secrets already configured)

## How it works

- `pull_request_target` + `issues` events trigger on `opened`
- Checks org membership via GitHub API (SAML-authorized PAT)
- Skips org members and bot accounts silently
- External contributors → Linear issue + Slack notification

## Test plan

- [x] Unit tests passing (28 tests, 4 suites) in external-contrib-action CI
- [x] Integration tested with external-contrib-test repo
- [ ] Verify first real external contribution triggers correctly after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)