### PR TITLE
feat: migrate from fingerprintx to Nerva

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,13 +92,13 @@ DEMO_COMPOSE := $(DEMO_DIR)/docker-compose.yml
 
 .PHONY: demo-up demo-down demo demo-ssh-key demo-wait demo-deps demo-simple
 
-# Install demo dependencies (naabu + fingerprintx from ProjectDiscovery)
+# Install demo dependencies (naabu + nerva)
 demo-deps:
 	@echo "Installing demo dependencies..."
 	@echo "Installing naabu (port scanner)..."
 	go install github.com/projectdiscovery/naabu/v2/cmd/naabu@latest
-	@echo "Installing fingerprintx (service fingerprinter)..."
-	go install github.com/projectdiscovery/fingerprintx/cmd/fingerprintx@latest
+	@echo "Installing nerva (service fingerprinter)..."
+	go install github.com/praetorian-inc/nerva/cmd/nerva@latest
 	@echo ""
 	@echo "Done! Make sure $(shell go env GOPATH)/bin is in your PATH."
 
@@ -146,26 +146,26 @@ demo-down:
 	docker compose -f $(DEMO_COMPOSE) down -v
 	@echo "Demo environment stopped."
 
-# Run full pipeline demo: naabu -> fingerprintx -> brutus
+# Run full pipeline demo: naabu -> nerva -> brutus
 demo: build demo-up
 	@echo ""
 	@echo "═══════════════════════════════════════════════════════════════════"
-	@echo "  Brutus Demo: naabu -> fingerprintx -> brutus pipeline"
+	@echo "  Brutus Demo: naabu -> nerva -> brutus pipeline"
 	@echo "═══════════════════════════════════════════════════════════════════"
 	@echo ""
 	@command -v naabu >/dev/null 2>&1 || { echo "ERROR: naabu not found. Run: make demo-deps"; exit 1; }
-	@command -v fingerprintx >/dev/null 2>&1 || { echo "ERROR: fingerprintx not found. Run: make demo-deps"; exit 1; }
-	@echo "Running: naabu | fingerprintx --json | brutus (uses built-in default credentials)"
+	@command -v nerva >/dev/null 2>&1 || { echo "ERROR: nerva not found. Run: make demo-deps"; exit 1; }
+	@echo "Running: naabu | nerva --json | brutus (uses built-in default credentials)"
 	@echo ""
 	naabu -host 127.0.0.1 -p 21,2222,3306,6379 -silent | \
-		fingerprintx --json | \
+		nerva --json | \
 		./brutus
 	@echo ""
 	@echo "═══════════════════════════════════════════════════════════════════"
 	@echo "  Demo complete! Run 'make demo-down' to stop the environment."
 	@echo "═══════════════════════════════════════════════════════════════════"
 
-# Simple demo without naabu/fingerprintx (direct brutus testing)
+# Simple demo without naabu/nerva (direct brutus testing)
 demo-simple: build demo-up
 	@echo ""
 	@echo "═══════════════════════════════════════════════════════════════════"
@@ -220,11 +220,11 @@ help:
 	@echo "  version          Show version info"
 	@echo ""
 	@echo "Demo targets:"
-	@echo "  demo-deps    Install naabu + fingerprintx (required for full demo)"
+	@echo "  demo-deps    Install naabu + nerva (required for full demo)"
 	@echo "  demo-up      Start demo environment (vulnerable containers)"
 	@echo "  demo-down    Stop demo environment"
-	@echo "  demo         Run full pipeline: naabu -> fingerprintx -> brutus"
-	@echo "  demo-simple  Run demo without naabu/fingerprintx (direct testing)"
+	@echo "  demo         Run full pipeline: naabu -> nerva -> brutus"
+	@echo "  demo-simple  Run demo without naabu/nerva (direct testing)"
 	@echo "  demo-ssh-key Quick SSH private key demo only"
 	@echo ""
 	@echo "Cleanup targets:"

--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@
 
 Brutus is a multi-protocol authentication testing tool designed to address a critical gap in offensive security tooling: efficient credential validation across diverse network services. While HTTP-focused tools are abundant, penetration testers and red team operators frequently encounter databases, SSH, SMB, and other network services that require purpose-built authentication testing capabilities.
 
-Built in Go as a single binary with zero external dependencies, Brutus integrates seamlessly with [fingerprintx](https://github.com/praetorian-inc/fingerprintx) for automated service discovery, enabling operators to rapidly identify and test authentication vectors across entire network ranges.
+Built in Go as a single binary with zero external dependencies, Brutus integrates seamlessly with [Nerva](https://github.com/praetorian-inc/nerva) for automated service discovery, enabling operators to rapidly identify and test authentication vectors across entire network ranges.
 
 **Key features:**
 - **Zero dependencies:** Single binary, cross-platform (Linux, Windows, macOS)
 - **24 protocols:** SSH, RDP, MySQL, PostgreSQL, MSSQL, Redis, SMB, LDAP, WinRM, SNMP, HTTP Basic Auth, and more
-- **Pipeline integration:** Native support for fingerprintx and naabu workflows
+- **Pipeline integration:** Native support for Nerva and naabu workflows
 - **Embedded bad keys:** Built-in collection of known SSH keys (Vagrant, F5, ExaGrid, etc.)
 - **Go library:** Import directly into your security automation tools
 - **Production ready:** Rate limiting, connection pooling, and comprehensive error handling
@@ -43,7 +43,7 @@ Traditional tools like **THC Hydra** have served the security community well, bu
 
 - **True zero-dependency deployment:** Download a single binary and run. No `libssh-dev`, no `libmysqlclient-dev`, no compilation errors. Works identically on Linux, macOS, and Windows.
 
-- **Native pipeline integration:** Brutus speaks JSON and integrates directly with [fingerprintx](https://github.com/praetorian-inc/fingerprintx) and [naabu](https://github.com/projectdiscovery/naabu). Pipe discovered services straight into credential testing without format conversion or scripting.
+- **Native pipeline integration:** Brutus speaks JSON and integrates directly with [Nerva](https://github.com/praetorian-inc/nerva) and [naabu](https://github.com/projectdiscovery/naabu). Pipe discovered services straight into credential testing without format conversion or scripting.
 
 - **Embedded intelligence:** Known SSH bad keys (Vagrant, F5 BIG-IP, ExaGrid, etc.) are compiled into the binary and tested automatically for SSH targets.
 
@@ -51,7 +51,7 @@ Traditional tools like **THC Hydra** have served the security community well, bu
 
 ```bash
 # Full network credential audit in one pipeline
-naabu -host 10.0.0.0/24 -p 22,3306,5432,6379 -silent | fingerprintx --json | brutus --json
+naabu -host 10.0.0.0/24 -p 22,3306,5432,6379 -silent | nerva --json | brutus --json
 ```
 
 ---
@@ -75,11 +75,11 @@ Found a private key on a compromised system? Spray it across the network to find
 ```bash
 # Discover SSH services and spray a found private key
 naabu -host 10.0.0.0/24 -p 22 -silent | \
-  fingerprintx --json | \
+  nerva --json | \
   brutus -u root,admin,ubuntu,deploy -k /path/to/found_key --json
 ```
 
-This pipeline discovers all SSH services, identifies them with fingerprintx, and tests the compromised key against common usernames—revealing lateral movement opportunities in seconds.
+This pipeline discovers all SSH services, identifies them with Nerva, and tests the compromised key against common usernames—revealing lateral movement opportunities in seconds.
 
 ### Web Admin Panel Testing
 
@@ -88,7 +88,7 @@ Discover HTTP services with Basic Auth and test default credentials:
 ```bash
 # Discover and test admin panels across a network
 naabu -host 10.0.0.0/24 -p 80,443,3000,8080,9090 -silent | \
-  fingerprintx --json | \
+  nerva --json | \
   brutus --json
 ```
 
@@ -189,7 +189,7 @@ $ brutus --target 192.168.1.100:22 --protocol ssh -u root -p toor --json
 
 ## Pipeline Integration
 
-Brutus integrates seamlessly with **[fingerprintx](https://github.com/praetorian-inc/fingerprintx)** and **[naabu](https://github.com/projectdiscovery/naabu)** for complete network reconnaissance.
+Brutus integrates seamlessly with **[Nerva](https://github.com/praetorian-inc/nerva)** and **[naabu](https://github.com/projectdiscovery/naabu)** for complete network reconnaissance.
 
 ### Real-World Scenarios
 
@@ -198,7 +198,7 @@ Brutus integrates seamlessly with **[fingerprintx](https://github.com/praetorian
 ```bash
 # Discover all open ports, identify services, test default credentials
 naabu -host 10.10.10.0/24 -p 22,23,21,3306,5432,6379,27017,445 -silent | \
-  fingerprintx --json | \
+  nerva --json | \
   brutus --json -o results.json
 
 # Review findings (all output is successful credentials)
@@ -210,11 +210,11 @@ cat results.json | jq '.'
 ```bash
 # Full pipeline against a single target
 naabu -host target.example.com -top-ports 1000 -silent | \
-  fingerprintx --json | \
+  nerva --json | \
   brutus
 
 # Or scan a list of subdomains
-cat subdomains.txt | naabu -silent | fingerprintx --json | brutus
+cat subdomains.txt | naabu -silent | nerva --json | brutus
 ```
 
 #### Scenario 3: Database Hunting in an Internal Assessment
@@ -222,7 +222,7 @@ cat subdomains.txt | naabu -silent | fingerprintx --json | brutus
 ```bash
 # Find and test all databases in a range
 naabu -host 192.168.0.0/16 -p 3306,5432,1433,27017,6379,9042 -silent | \
-  fingerprintx --json | \
+  nerva --json | \
   brutus -t 5 --json | \
   tee database-findings.json
 
@@ -236,7 +236,7 @@ jq -r '"\(.target) \(.username):\(.password)"' database-findings.json
 # Test embedded bad keys (Vagrant, F5 BIG-IP, ExaGrid, etc.) across a range
 # Badkeys are tested by default for SSH services
 naabu -host 10.0.0.0/8 -p 22 -rate 1000 -silent | \
-  fingerprintx --json | \
+  nerva --json | \
   brutus --json -o ssh-key-findings.json
 
 # Find systems using SSH keys (key field is true)
@@ -248,24 +248,24 @@ cat ssh-key-findings.json | jq 'select(.key == true)'
 ```bash
 # Test only Redis instances found in the network
 naabu -host 172.16.0.0/12 -p 6379 -silent | \
-  fingerprintx --json | \
+  nerva --json | \
   brutus
 
 # Test only MongoDB with custom credentials
 naabu -host 10.0.0.0/24 -p 27017 -silent | \
-  fingerprintx --json | \
+  nerva --json | \
   brutus -u admin,root,mongodb -p admin,password,mongodb
 ```
 
 ### Pipeline Input Format
 
-Brutus accepts input from fingerprintx in JSON format:
+Brutus accepts input from Nerva in JSON format:
 
 ```bash
-# fingerprintx JSON output
-{"ip":"192.168.1.100","port":22,"service":"ssh","version":"OpenSSH_8.9p1"}
-{"ip":"192.168.1.101","port":3306,"service":"mysql","version":"8.0.32"}
-{"ip":"192.168.1.102","port":6379,"service":"redis","version":"7.0.5"}
+# nerva JSON output
+{"ip":"192.168.1.100","port":22,"protocol":"ssh","tls":false,"transport":"tcp","version":"OpenSSH_8.9p1"}
+{"ip":"192.168.1.101","port":3306,"protocol":"mysql","tls":false,"transport":"tcp","version":"8.0.32"}
+{"ip":"192.168.1.102","port":6379,"protocol":"redis","tls":false,"transport":"tcp","version":"7.0.5"}
 ```
 
 Brutus automatically:
@@ -295,7 +295,7 @@ Brutus outputs only successful credentials in JSONL format (one JSON object per 
 |---------|:-----:|:------:|:------:|:----------:|
 | Single Binary | ❌ | ❌ | ❌ | ✅ |
 | Zero Dependencies | ❌ | ❌ | ❌ | ✅ |
-| fingerprintx Pipeline | ❌ | ❌ | ❌ | ✅ |
+| Nerva Pipeline | ❌ | ❌ | ❌ | ✅ |
 | JSON Streaming | ⚠️ | ❌ | ❌ | ✅ |
 | Cross-Platform | ⚠️ | ⚠️ | ⚠️ | ✅ |
 | Consistent Errors | ⚠️ | ⚠️ | ⚠️ | ✅ |
@@ -366,7 +366,7 @@ Brutus carries the **[rapid7/ssh-badkeys](https://github.com/rapid7/ssh-badkeys)
 brutus --target 192.168.1.100:22 --protocol ssh
 
 # Combine with pipeline for network-wide key testing
-naabu -host 10.0.0.0/24 -p 22 -silent | fingerprintx --json | brutus
+naabu -host 10.0.0.0/24 -p 22 -silent | nerva --json | brutus
 ```
 
 ### Embedded Key Collection
@@ -444,7 +444,7 @@ export PERPLEXITY_API_KEY="your-perplexity-key"  # Optional: additional web sear
 
 # AI-powered credential testing against HTTP services
 naabu -host 192.168.1.0/24 -p 80,443,8080 -silent | \
-  fingerprintx --json | \
+  nerva --json | \
   brutus --experimental-ai
 ```
 
@@ -568,7 +568,7 @@ brutus --target 10.0.0.50:3389 --nla-check
 
 # Pipeline: scan a /24 for non-NLA RDP targets
 naabu -host 10.0.0.0/24 -p 3389 -silent | \
-  fingerprintx --json | \
+  nerva --json | \
   brutus --nla-check --json
 ```
 
@@ -584,7 +584,7 @@ brutus --target 10.0.0.50:3389 --sticky-keys-scan
 
 # Pipeline: scan only non-NLA targets
 naabu -host 10.0.0.0/24 -p 3389 -silent | \
-  fingerprintx --json | \
+  nerva --json | \
   brutus --sticky-keys-scan --json
 ```
 
@@ -593,7 +593,7 @@ naabu -host 10.0.0.0/24 -p 3389 -silent | \
 ```bash
 # Phase 1: Find non-NLA targets
 naabu -host 10.0.0.0/16 -p 3389 -rate 1000 -silent | \
-  fingerprintx --json | \
+  nerva --json | \
   brutus --nla-check --json -o nla-results.json
 
 # Filter non-NLA targets
@@ -616,7 +616,7 @@ jq 'select(.finding == "[CRITICAL]")' sticky-keys-findings.json
 {"protocol":"rdp","target":"10.0.0.50:3389","scan_type":"sticky_keys_scan","finding":"[CRITICAL]","banner":"[CRITICAL] Sticky keys backdoor CONFIRMED (confidence: 85%)","success":true}
 ```
 
-Both flags can be combined (`--nla-check --sticky-keys-scan`) to run both checks in a single pass. Both accept stdin from fingerprintx (filtering to RDP targets automatically) or a single `--target`.
+Both flags can be combined (`--nla-check --sticky-keys-scan`) to run both checks in a single pass. Both accept stdin from nerva (filtering to RDP targets automatically) or a single `--target`.
 
 **Technical implementation:** RDP protocol support uses [IronRDP](https://github.com/Devolutions/IronRDP) (Rust) compiled to WebAssembly and executed via [wazero](https://github.com/tetragonalworks/wazero), maintaining Brutus's zero-CGO, single-binary design.
 

--- a/cmd/brutus/config.go
+++ b/cmd/brutus/config.go
@@ -38,7 +38,7 @@ type baseConfigOptions struct {
 	quiet            bool
 	verbose          bool
 	useBadkeys       bool
-	protocolOverride string        // Override fingerprintx-detected protocol
+	protocolOverride string        // Override nerva-detected protocol
 	aiMode           bool          // Enable AI-powered credential detection for HTTP
 	aiVerify         bool          // Use Claude Vision to verify login success
 	tlsMode          string        // TLS verification mode: "disable", "verify", "skip-verify"

--- a/cmd/brutus/integration_test.go
+++ b/cmd/brutus/integration_test.go
@@ -31,16 +31,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestFingerprintxIntegration tests the full pipeline: fingerprintx -> brutus
-// This test requires fingerprintx to be installed.
-func TestFingerprintxIntegration(t *testing.T) {
+// TestNervaIntegration tests the full pipeline: nerva -> brutus
+// This test requires nerva to be installed.
+func TestNervaIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
 
-	// Check if fingerprintx is installed
-	if _, err := exec.LookPath("fingerprintx"); err != nil {
-		t.Skip("Skipping: fingerprintx not installed (run: go install github.com/praetorian-inc/fingerprintx/cmd/fingerprintx@latest)")
+	// Check if nerva is installed
+	if _, err := exec.LookPath("nerva"); err != nil {
+		t.Skip("Skipping: nerva not installed (run: go install github.com/praetorian-inc/nerva/cmd/nerva@latest)")
 	}
 
 	// Start a test HTTP server with Basic Auth
@@ -61,22 +61,22 @@ func TestFingerprintxIntegration(t *testing.T) {
 	// Extract host:port from server URL
 	serverAddr := strings.TrimPrefix(server.URL, "http://")
 
-	// Run fingerprintx against the test server
-	fpxCmd := exec.Command("fingerprintx", "-t", serverAddr, "--json")
-	fpxOutput, err := fpxCmd.Output()
+	// Run nerva against the test server
+	nrvCmd := exec.Command("nerva", "-t", serverAddr, "--json")
+	nrvOutput, err := nrvCmd.Output()
 	if err != nil {
-		t.Fatalf("fingerprintx failed: %v", err)
+		t.Fatalf("nerva failed: %v", err)
 	}
 
-	t.Logf("fingerprintx output: %s", string(fpxOutput))
+	t.Logf("nerva output: %s", string(nrvOutput))
 
-	// Verify fingerprintx detected the HTTP service
-	var fpxResult FingerprintxResult
-	if err := json.Unmarshal(bytes.TrimSpace(fpxOutput), &fpxResult); err != nil {
-		t.Fatalf("Failed to parse fingerprintx JSON: %v (output: %s)", err, string(fpxOutput))
+	// Verify nerva detected the HTTP service
+	var nrvResult NervaResult
+	if err := json.Unmarshal(bytes.TrimSpace(nrvOutput), &nrvResult); err != nil {
+		t.Fatalf("Failed to parse nerva JSON: %v (output: %s)", err, string(nrvOutput))
 	}
 
-	assert.Equal(t, "http", fpxResult.Protocol, "fingerprintx should detect HTTP protocol")
+	assert.Equal(t, "http", nrvResult.Protocol, "nerva should detect HTTP protocol")
 
 	// Build brutus binary
 	buildCmd := exec.Command("go", "build", "-o", "brutus_test", ".")
@@ -87,9 +87,9 @@ func TestFingerprintxIntegration(t *testing.T) {
 	}
 	defer os.Remove("brutus_test")
 
-	// Run brutus with fingerprintx output via stdin
-	brutusCmd := exec.Command("./brutus_test", "--fingerprintx", "-p", "admin", "--json")
-	brutusCmd.Stdin = bytes.NewReader(fpxOutput)
+	// Run brutus with nerva output via stdin
+	brutusCmd := exec.Command("./brutus_test", "--nerva", "-p", "admin", "--json")
+	brutusCmd.Stdin = bytes.NewReader(nrvOutput)
 	brutusOutput, err := brutusCmd.CombinedOutput()
 
 	t.Logf("brutus output: %s", string(brutusOutput))
@@ -110,8 +110,8 @@ func TestFingerprintxIntegration(t *testing.T) {
 	assert.Contains(t, result["target"], serverAddr, "target should match")
 }
 
-// TestFingerprintxJSONParsing tests parsing of fingerprintx JSON format
-func TestFingerprintxJSONParsing(t *testing.T) {
+// TestNervaJSONParsing tests parsing of nerva JSON format
+func TestNervaJSONParsing(t *testing.T) {
 	tests := []struct {
 		name         string
 		json         string
@@ -121,35 +121,35 @@ func TestFingerprintxJSONParsing(t *testing.T) {
 	}{
 		{
 			name:         "HTTP protocol",
-			json:         `{"ip":"192.168.1.1","port":80,"protocol":"http","transport":"tcp"}`,
+			json:         `{"ip":"192.168.1.1","port":80,"protocol":"http","tls":false,"transport":"tcp"}`,
 			wantProtocol: "http",
 			wantIP:       "192.168.1.1",
 			wantPort:     80,
 		},
 		{
 			name:         "SSH protocol",
-			json:         `{"ip":"10.0.0.1","port":22,"protocol":"ssh","transport":"tcp","metadata":{"version":"OpenSSH_8.9"}}`,
+			json:         `{"ip":"10.0.0.1","port":22,"protocol":"ssh","tls":false,"transport":"tcp","version":"OpenSSH_8.9","metadata":{"banner":"SSH-2.0-OpenSSH_8.9"}}`,
 			wantProtocol: "ssh",
 			wantIP:       "10.0.0.1",
 			wantPort:     22,
 		},
 		{
 			name:         "MySQL protocol",
-			json:         `{"ip":"db.example.com","port":3306,"protocol":"mysql","transport":"tcp"}`,
+			json:         `{"ip":"db.example.com","port":3306,"protocol":"mysql","tls":false,"transport":"tcp"}`,
 			wantProtocol: "mysql",
 			wantIP:       "db.example.com",
 			wantPort:     3306,
 		},
 		{
 			name:         "HTTPS protocol",
-			json:         `{"ip":"secure.example.com","port":443,"protocol":"https","transport":"tcp"}`,
+			json:         `{"ip":"secure.example.com","port":443,"protocol":"https","tls":true,"transport":"tcp"}`,
 			wantProtocol: "https",
 			wantIP:       "secure.example.com",
 			wantPort:     443,
 		},
 		{
 			name:         "SNMP protocol",
-			json:         `{"ip":"192.168.1.1","port":161,"protocol":"snmp","transport":"udp"}`,
+			json:         `{"ip":"192.168.1.1","port":161,"protocol":"snmp","tls":false,"transport":"udp"}`,
 			wantProtocol: "snmp",
 			wantIP:       "192.168.1.1",
 			wantPort:     161,
@@ -158,22 +158,22 @@ func TestFingerprintxJSONParsing(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var fpx FingerprintxResult
-			err := json.Unmarshal([]byte(tt.json), &fpx)
+			var nrv NervaResult
+			err := json.Unmarshal([]byte(tt.json), &nrv)
 			require.NoError(t, err)
 
-			assert.Equal(t, tt.wantProtocol, fpx.Protocol)
-			assert.Equal(t, tt.wantIP, fpx.IP)
-			assert.Equal(t, tt.wantPort, fpx.Port)
+			assert.Equal(t, tt.wantProtocol, nrv.Protocol)
+			assert.Equal(t, tt.wantIP, nrv.IP)
+			assert.Equal(t, tt.wantPort, nrv.Port)
 
 			// Verify protocol mapping works
-			protocol := mapServiceToProtocol(fpx.Protocol)
+			protocol := mapServiceToProtocol(nrv.Protocol)
 			assert.NotEmpty(t, protocol, "protocol should map to a brutus protocol")
 		})
 	}
 }
 
-// TestServiceToProtocolMapping tests the fingerprintx service to brutus protocol mapping
+// TestServiceToProtocolMapping tests the nerva service to brutus protocol mapping
 func TestServiceToProtocolMapping(t *testing.T) {
 	tests := []struct {
 		service  string
@@ -220,7 +220,7 @@ func TestServiceToProtocolMapping(t *testing.T) {
 	}
 }
 
-// TestStdinMode tests the --fingerprintx flag with simulated fingerprintx output
+// TestStdinMode tests the --nerva flag with simulated nerva output
 func TestStdinMode(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -244,8 +244,8 @@ func TestStdinMode(t *testing.T) {
 	host := parts[0]
 	port := parts[1]
 
-	// Create fingerprintx-style JSON input
-	fpxJSON := fmt.Sprintf(`{"ip":"%s","port":%s,"protocol":"http","transport":"tcp"}`, host, port)
+	// Create nerva-style JSON input
+	nrvJSON := fmt.Sprintf(`{"ip":"%s","port":%s,"protocol":"http","tls":false,"transport":"tcp"}`, host, port)
 
 	// Build brutus
 	buildCmd := exec.Command("go", "build", "-o", "brutus_test", ".")
@@ -256,8 +256,8 @@ func TestStdinMode(t *testing.T) {
 	defer os.Remove("brutus_test")
 
 	// Run brutus with stdin and valid credentials
-	brutusCmd := exec.Command("./brutus_test", "--fingerprintx", "-u", "testuser", "-p", "testpass", "--json")
-	brutusCmd.Stdin = strings.NewReader(fpxJSON)
+	brutusCmd := exec.Command("./brutus_test", "--nerva", "-u", "testuser", "-p", "testpass", "--json")
+	brutusCmd.Stdin = strings.NewReader(nrvJSON)
 	output, err := brutusCmd.CombinedOutput()
 
 	t.Logf("Output: %s", string(output))

--- a/cmd/brutus/main.go
+++ b/cmd/brutus/main.go
@@ -80,7 +80,7 @@ func main() {
 	// Command-line flags
 	target := flag.String("target", "", "Target host:port")
 	showVersion := flag.Bool("version", false, "Show version information")
-	protocol := flag.String("protocol", "", "Protocol to use (auto-detected from fingerprintx)")
+	protocol := flag.String("protocol", "", "Protocol to use (auto-detected from nerva)")
 	usernames := flag.String("u", "root,admin", "Comma-separated usernames")
 	usernameFile := flag.String("U", "", "Username file (one per line)")
 	passwords := flag.String("p", "", "Comma-separated passwords")
@@ -94,7 +94,7 @@ func main() {
 	snmpTier := flag.String("snmp-tier", "default", "SNMP community string tier: default (20), extended (50), full (120)")
 	rateLimit := flag.Float64("rate-limit", 0, "Max requests per second (0 = unlimited)")
 	jitter := flag.Duration("jitter", 0, "Random delay variance for rate limiting (e.g., 100ms)")
-	stdinMode := flag.Bool("fingerprintx", false, "Read targets from fingerprintx JSON on stdin")
+	stdinMode := flag.Bool("nerva", false, "Read targets from nerva JSON on stdin")
 	maxAttempts := flag.Int("max-attempts", 0, "Max password attempts per user (0 = unlimited)")
 	sprayMode := flag.Bool("spray", false, "Password spraying: try each password across all users")
 	retries := flag.Int("retries", 2, "Max retries per credential on connection error (0 = no retry)")
@@ -146,10 +146,10 @@ func main() {
 		os.Exit(0)
 	}
 
-	// Auto-detect fingerprintx mode: if stdin has data and no target specified, use fingerprintx mode
+	// Auto-detect nerva mode: if stdin has data and no target specified, use nerva mode
 	useStdin := detectStdinMode(*stdinMode, *target)
 
-	// Show banner (unless in JSON mode, fingerprintx mode, or quiet mode)
+	// Show banner (unless in JSON mode, nerva mode, or quiet mode)
 	if shouldShowBanner(*showBanner, *jsonOutput, useStdin, *quiet, useColor) {
 		printBanner(useColor)
 	}
@@ -250,7 +250,7 @@ func main() {
 			scanResults, hasSuccess = runScanFromStdin(&baseConfig)
 		} else {
 			if *target == "" {
-				errMsg(useColor, "--target is required for scan modes (or pipe fingerprintx JSON to stdin)")
+				errMsg(useColor, "--target is required for scan modes (or pipe nerva JSON to stdin)")
 				closeOutput()
 				os.Exit(1)
 			}
@@ -280,7 +280,7 @@ func main() {
 		allResults, hasSuccess = runSingleTargetMode(*target, *protocol, &baseConfig, *jsonOutput, jsonWriter)
 	}
 
-	// Final JSON output for fingerprintx mode
+	// Final JSON output for nerva mode
 	if *jsonOutput && useStdin {
 		outputJSONL(jsonWriter, allResults)
 	}
@@ -333,7 +333,7 @@ func validateKeyFileFlags(keyFile string, usernameFlagSet bool, usernameFile str
 // validateTargetFlags checks that required flags are provided for single-target mode.
 func validateTargetFlags(target, protocol string) error {
 	if target == "" {
-		return fmt.Errorf("--target is required (or pipe fingerprintx JSON to stdin)")
+		return fmt.Errorf("--target is required (or pipe nerva JSON to stdin)")
 	}
 	if protocol == "" {
 		return fmt.Errorf("--protocol is required when using --target\nExample: brutus --target %s --protocol ssh", target)

--- a/cmd/brutus/mapping.go
+++ b/cmd/brutus/mapping.go
@@ -16,16 +16,19 @@ package main
 
 import "strings"
 
-// FingerprintxResult represents the JSON output from fingerprintx
-type FingerprintxResult struct {
+// NervaResult represents the JSON output from nerva
+type NervaResult struct {
+	Host      string                 `json:"host,omitempty"`
 	IP        string                 `json:"ip"`
 	Port      int                    `json:"port"`
 	Protocol  string                 `json:"protocol"`
+	TLS       bool                   `json:"tls"`
 	Transport string                 `json:"transport"`
+	Version   string                 `json:"version,omitempty"`
 	Metadata  map[string]interface{} `json:"metadata"`
 }
 
-// mapServiceToProtocol maps fingerprintx service names to brutus protocol names
+// mapServiceToProtocol maps nerva service names to brutus protocol names
 func mapServiceToProtocol(service string) string {
 	// Normalize to lowercase
 	service = strings.ToLower(service)

--- a/cmd/brutus/output.go
+++ b/cmd/brutus/output.go
@@ -119,7 +119,7 @@ func outputValidOnly(results []brutus.Result, useColor bool) {
 }
 
 // outputJSONL streams successful results as JSONL (one JSON object per line)
-// This matches the output format of naabu and fingerprintx for easy piping
+// This matches the output format of naabu and nerva for easy piping
 func outputJSONL(w io.Writer, results []brutus.Result) {
 	type JSONResult struct {
 		Protocol     string `json:"protocol"`

--- a/cmd/brutus/runner.go
+++ b/cmd/brutus/runner.go
@@ -30,7 +30,7 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/brutus"
 )
 
-// runFromStdin reads fingerprintx JSON from stdin and tests each target
+// runFromStdin reads nerva JSON from stdin and tests each target
 func runFromStdin(base *baseConfigOptions, jsonOut bool) ([]brutus.Result, bool) {
 	var allResults []brutus.Result
 	hasSuccess := false
@@ -42,19 +42,19 @@ func runFromStdin(base *baseConfigOptions, jsonOut bool) ([]brutus.Result, bool)
 			continue
 		}
 
-		// Parse fingerprintx JSON
-		var fpx FingerprintxResult
-		if err := json.Unmarshal([]byte(line), &fpx); err != nil {
+		// Parse nerva JSON
+		var nrv NervaResult
+		if err := json.Unmarshal([]byte(line), &nrv); err != nil {
 			warnMsg(base.useColor, "failed to parse JSON: %v", err)
 			continue
 		}
 
-		// Determine protocol: use override if specified, otherwise map from fingerprintx
+		// Determine protocol: use override if specified, otherwise map from nerva
 		var protocol string
 		if base.protocolOverride != "" {
 			protocol = base.protocolOverride
 		} else {
-			protocol = mapServiceToProtocol(fpx.Protocol)
+			protocol = mapServiceToProtocol(nrv.Protocol)
 			if protocol == "" {
 				// Unsupported service, skip
 				continue
@@ -62,10 +62,13 @@ func runFromStdin(base *baseConfigOptions, jsonOut bool) ([]brutus.Result, bool)
 		}
 
 		// Determine TLS mode for this specific target
-		targetTLSMode := detectTLSFromMetadata(base.tlsMode, fpx.Metadata, base.verbose)
+		targetTLSMode := detectTLS(base.tlsMode, nrv.TLS, base.verbose)
 
 		// Build target string
-		target := fmt.Sprintf("%s:%d", fpx.IP, fpx.Port)
+		target := fmt.Sprintf("%s:%d", nrv.IP, nrv.Port)
+		if nrv.Host != "" {
+			target = fmt.Sprintf("%s:%d", nrv.Host, nrv.Port)
+		}
 
 		// AI mode: For HTTP services, detect auth type and route appropriately
 		var aiCreds []brutus.Credential
@@ -235,16 +238,14 @@ func configureAICredentials(config *brutus.Config, aiCreds []brutus.Credential, 
 	config.LLMConfig = nil
 }
 
-// detectTLSFromMetadata checks if TLS is detected in fingerprintx metadata and upgrades the TLS mode.
-func detectTLSFromMetadata(baseTLSMode string, metadata map[string]interface{}, verbose bool) string {
+// detectTLS checks if TLS was detected by nerva and upgrades the TLS mode.
+func detectTLS(baseTLSMode string, tlsDetected bool, verbose bool) string {
 	if baseTLSMode != "disable" {
 		return baseTLSMode
 	}
-	if tlsMeta, ok := metadata["tls"]; ok {
-		if tlsEnabled, ok := tlsMeta.(bool); ok && tlsEnabled {
-			logVerbose(verbose, "TLS detected in fingerprintx metadata, auto-upgrading to skip-verify mode")
-			return "skip-verify"
-		}
+	if tlsDetected {
+		logVerbose(verbose, "TLS detected by nerva, auto-upgrading to skip-verify mode")
+		return "skip-verify"
 	}
 	return baseTLSMode
 }
@@ -372,7 +373,7 @@ func runStickyKeysDetectionOnly(target string, base *baseConfigOptions) ([]brutu
 	return []brutus.Result{result}, result.Success
 }
 
-// runScanFromStdin reads fingerprintx JSON from stdin and runs scan checks on RDP targets.
+// runScanFromStdin reads nerva JSON from stdin and runs scan checks on RDP targets.
 func runScanFromStdin(base *baseConfigOptions) ([]brutus.Result, bool) {
 	var allResults []brutus.Result
 	hasSuccess := false
@@ -384,19 +385,22 @@ func runScanFromStdin(base *baseConfigOptions) ([]brutus.Result, bool) {
 			continue
 		}
 
-		var fpx FingerprintxResult
-		if err := json.Unmarshal([]byte(line), &fpx); err != nil {
+		var nrv NervaResult
+		if err := json.Unmarshal([]byte(line), &nrv); err != nil {
 			warnMsg(base.useColor, "failed to parse JSON: %v", err)
 			continue
 		}
 
 		// Filter to RDP targets only
-		protocol := mapServiceToProtocol(fpx.Protocol)
+		protocol := mapServiceToProtocol(nrv.Protocol)
 		if protocol != "rdp" && base.protocolOverride != "rdp" {
 			continue
 		}
 
-		target := fmt.Sprintf("%s:%d", fpx.IP, fpx.Port)
+		target := fmt.Sprintf("%s:%d", nrv.IP, nrv.Port)
+		if nrv.Host != "" {
+			target = fmt.Sprintf("%s:%d", nrv.Host, nrv.Port)
+		}
 		results, success := runScanSingleTarget(target, base)
 		allResults = append(allResults, results...)
 		if success {

--- a/cmd/brutus/usage.go
+++ b/cmd/brutus/usage.go
@@ -25,12 +25,12 @@ func customUsage() {
 
 Usage:
   brutus --target <host:port> --protocol <proto> [options]                # Single target mode
-  naabu ... | fingerprintx --json | brutus [options]                      # Pipeline mode (stdin auto-detected)
-  naabu ... | fingerprintx --json | brutus --experimental-ai [options]                 # AI-powered credential detection
+  naabu ... | nerva --json | brutus [options]                      # Pipeline mode (stdin auto-detected)
+  naabu ... | nerva --json | brutus --experimental-ai [options]                 # AI-powered credential detection
 
 Target Options:
   --target <host:port>   Target host and port (requires --protocol)
-  --fingerprintx         Read targets from fingerprintx JSON on stdin
+  --nerva         Read targets from nerva JSON on stdin
   --protocol <proto>     Protocol to use (auto-detected in pipeline mode)
 
 Credential Options:
@@ -73,7 +73,7 @@ SNMP Options:
 TLS Options:
   --verify-tls           Require strict TLS certificate verification (default: disabled)
                          Note: Default is no TLS/SSL validation since we're testing
-                         default credentials. fingerprintx TLS detection auto-upgrades
+                         default credentials. nerva TLS detection auto-upgrades
                          to skip-verify mode when TLS is detected.
   --snmp-tier <tier>     SNMP community string tier: default (20), extended (50), full (120)
 
@@ -99,18 +99,18 @@ Other Options:
   --version              Show version information
   -h, --help             Show this help message
 
-Fingerprintx Integration:
-  Brutus integrates seamlessly with fingerprintx for automated service discovery
-  and credential testing. Use naabu for port discovery, fingerprintx for service
+Nerva Integration:
+  Brutus integrates seamlessly with nerva for automated service discovery
+  and credential testing. Use naabu for port discovery, nerva for service
   fingerprinting (with --json output), then pipe to Brutus:
 
-    naabu -host <targets> -silent | fingerprintx --json | brutus --fingerprintx [options]
+    naabu -host <targets> -silent | nerva --json | brutus --nerva [options]
 
-  For known open ports, pipe directly to fingerprintx:
+  For known open ports, pipe directly to nerva:
 
-    echo "host:port" | fingerprintx --json | brutus --fingerprintx [options]
+    echo "host:port" | nerva --json | brutus --nerva [options]
 
-  Brutus automatically detects protocols from fingerprintx JSON output,
+  Brutus automatically detects protocols from nerva JSON output,
   eliminating the need to specify -protocol manually.
 
 Supported Protocols:
@@ -125,13 +125,13 @@ Supported Protocols:
 
 Examples:
   # Scan network range with naabu, fingerprint services, and test credentials
-  naabu -host 192.168.1.0/24 -silent | fingerprintx --json | brutus --fingerprintx -P passwords.txt
+  naabu -host 192.168.1.0/24 -silent | nerva --json | brutus --nerva -P passwords.txt
 
   # Targeted port scan with service fingerprinting and credential testing
-  naabu -host 10.0.0.1 -p 22,3306 -silent | fingerprintx --json | brutus --fingerprintx -u root -p "toor,admin"
+  naabu -host 10.0.0.1 -p 22,3306 -silent | nerva --json | brutus --nerva -u root -p "toor,admin"
 
   # Fingerprint known open ports and test with private keys
-  echo "192.168.1.10:22" | fingerprintx --json | brutus --fingerprintx -u root,ubuntu -k ~/.ssh/id_rsa
+  echo "192.168.1.10:22" | nerva --json | brutus --nerva -u root,ubuntu -k ~/.ssh/id_rsa
 
   # Single target mode
   brutus --target 192.168.1.10:22 --protocol ssh -p "password,Password1"
@@ -152,13 +152,13 @@ Examples:
   brutus --target 192.168.1.10:22 --protocol ssh --no-badkeys -p "password"
 
   # Pipeline mode with output to file
-  naabu -host 10.0.0.0/8 -p 22,3306 -rate 1000 -silent | fingerprintx --json | brutus -t 20 -o findings.json
+  naabu -host 10.0.0.0/8 -p 22,3306 -rate 1000 -silent | nerva --json | brutus -t 20 -o findings.json
 
   # AI-powered credential detection for HTTP services (auto-detects Basic Auth vs form)
   brutus --target 192.168.1.1:80 --protocol http --experimental-ai -u admin -p "admin,password"
 
   # AI mode in pipeline - auto-login to any HTTP service with default device credentials
-  naabu -host 192.168.1.0/24 -p 80,443,8080 -silent | fingerprintx --json | brutus --experimental-ai
+  naabu -host 192.168.1.0/24 -p 80,443,8080 -silent | nerva --json | brutus --experimental-ai
 
   # RDP credential testing with sticky keys backdoor detection (heuristic only)
   brutus --target 10.0.0.50:3389 --protocol rdp --sticky-keys -u administrator -p "Password1"

--- a/testdata/demo/README.md
+++ b/testdata/demo/README.md
@@ -1,7 +1,7 @@
 # Brutus Demo Environment
 
 This directory contains a demo environment for showcasing the full Brutus pipeline:
-**naabu** (port scan) -> **fingerprintx** (service fingerprint) -> **brutus** (credential test)
+**naabu** (port scan) -> **nerva** (service fingerprint) -> **brutus** (credential test)
 
 ## Quick Start
 
@@ -46,7 +46,7 @@ brutus -target 127.0.0.1:2222 -u vagrant -k testdata/demo/vulnerable_key
 ```bash
 # Port scan -> Service fingerprint -> Credential test (badkeys enabled by default)
 naabu -host 127.0.0.1 -p 21,2222,3306,6379 -silent | \
-  fingerprintx --json | \
+  nerva --json | \
   brutus -u root,vagrant,ftpuser -p "rootpass,vagrant,ftppass,redispass"
 ```
 


### PR DESCRIPTION
## Summary
- Replace all fingerprintx references with [Nerva](https://github.com/praetorian-inc/nerva), our maintained fork with 120+ protocol plugins, CPE extraction, and richer metadata
- Rename `FingerprintxResult` → `NervaResult` struct with new `Host`, `TLS`, `Version` fields matching Nerva's JSON schema
- Replace `--fingerprintx` CLI flag with `--nerva` (clean break, no backward compat)
- Update TLS detection to use Nerva's top-level `tls` boolean instead of metadata lookup
- Prefer hostname over IP for target construction (enables proper TLS SNI)
- Update all docs (README, usage, Makefile demo targets, demo README) and integration tests

## Test plan
- [x] `go build ./cmd/brutus/` compiles successfully
- [x] `go test -short ./...` — all 30 test packages pass
- [x] Zero remaining `fingerprintx` references in codebase (grep verified)
- [ ] Integration test with nerva binary installed (`TestNervaIntegration`)
- [ ] Manual pipeline test: `naabu ... | nerva --json | brutus --nerva`

🤖 Generated with [Claude Code](https://claude.com/claude-code)