### PR TITLE
Upgrade external-contrib-action to v2 with auto-reply

### DIFF
--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -2,21 +2,27 @@ name: External Contribution Notify
 
 on:
   issues:
-    types: [opened]
+    types: [opened, assigned, closed]
   pull_request_target:
-    types: [opened]
+    types: [opened, assigned, closed]
+
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - uses: praetorian-inc/external-contrib-action@v1
+      - uses: praetorian-inc/external-contrib-action@v2
         with:
           linear-team-id: ${{ secrets.LINEAR_TEAM_ID }}
           linear-assignee-id: ${{ secrets.LINEAR_ASSIGNEE_ID }}
           linear-parent-issue-id: ${{ secrets.LINEAR_PARENT_ISSUE_ID }}
           slack-channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          dry-run: "true"
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORG_MEMBER_CHECK_PAT: ${{ secrets.ORG_MEMBER_CHECK_PAT }}
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## Summary
- Upgrades `external-contrib-action` from `@v1` to `@v2` with auto-reply comments on external Issues/PRs
- Adds `assigned` and `closed` event triggers (in addition to existing `opened`)
- Adds `issues: write` and `pull-requests: write` permissions for comment posting
- Passes `GITHUB_TOKEN` to the action
- **Starts with `dry-run: "true"`** — no comments will be posted until dry-run is removed

## What v2 does
When an external contributor opens, is assigned, or closes an Issue/PR, the action auto-posts a human-sounding comment:
- **Opened:** Welcome message acknowledging the contribution
- **Assigned:** "We're looking into this" with the assignee's display name
- **Closed:** Resolution message (different wording if the contributor closed it themselves)

## Test plan
- [ ] Verify CI passes on this PR
- [ ] After merge, open a test issue from a non-org account
- [ ] Check Actions logs for `[DRY RUN] Would post comment...`
- [ ] Assign yourself → verify investigating message in logs
- [ ] Close the issue → verify resolution message in logs
- [ ] Once validated, follow-up PR removes `dry-run: "true"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)