### PR TITLE
ci: enable external-contrib-action v2 (disable dry-run)

### DIFF
--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -20,7 +20,7 @@ jobs:
           linear-assignee-id: ${{ secrets.LINEAR_ASSIGNEE_ID }}
           linear-parent-issue-id: ${{ secrets.LINEAR_PARENT_ISSUE_ID }}
           slack-channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-          dry-run: "true"
+          dry-run: "false"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORG_MEMBER_CHECK_PAT: ${{ secrets.ORG_MEMBER_CHECK_PAT }}


### PR DESCRIPTION
## Summary
- Disables dry-run mode on the external-contrib-action v2 workflow
- Enables live Slack notifications, Linear issue creation, and auto-reply comments for external contributions
- Validated on augustus before rollout

## Test plan
- [ ] Merge PR
- [ ] Verify next external contribution triggers Slack + Linear + auto-reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)