### PR TITLE
feat(cli): add --badkeys-only flag and fix HTTP default credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,11 @@ naabu -host 10.0.0.0/8 -p 22 -rate 1000 -silent | \
   nerva --json | \
   brutus --json -o ssh-key-findings.json
 
+# Test ONLY bad keys (skip password wordlists and non-SSH protocols)
+naabu -host 10.0.0.0/8 -p 22 -rate 1000 -silent | \
+  nerva --json | \
+  brutus --badkeys-only --json -o ssh-key-findings.json
+
 # Find systems using SSH keys (key field is true)
 cat ssh-key-findings.json | jq 'select(.key == true)'
 ```
@@ -362,11 +367,17 @@ Single binary deployment with no external key files needed. Each key is paired w
 Brutus carries the **[rapid7/ssh-badkeys](https://github.com/rapid7/ssh-badkeys)** and **[Vagrant](https://github.com/hashicorp/vagrant)** key collections embedded in the binary:
 
 ```bash
-# Test all embedded bad keys against a target (enabled by default for SSH)
+# Bad keys are tested by default for SSH targets (alongside password wordlists)
 brutus --target 192.168.1.100:22 --protocol ssh
 
-# Combine with pipeline for network-wide key testing
-naabu -host 10.0.0.0/24 -p 22 -silent | nerva --json | brutus
+# Test ONLY bad keys (no password wordlists, skip non-SSH protocols)
+brutus --target 192.168.1.100:22 --protocol ssh --badkeys-only
+
+# Disable bad key testing entirely
+brutus --target 192.168.1.100:22 --protocol ssh --no-badkeys -p "password"
+
+# Combine with pipeline for network-wide key-only testing
+naabu -host 10.0.0.0/24 -p 22 -silent | nerva --json | brutus --badkeys-only
 ```
 
 ### Embedded Key Collection

--- a/cmd/brutus/config.go
+++ b/cmd/brutus/config.go
@@ -38,6 +38,7 @@ type baseConfigOptions struct {
 	quiet            bool
 	verbose          bool
 	useBadkeys       bool
+	badkeysOnly      bool
 	protocolOverride string        // Override nerva-detected protocol
 	aiMode           bool          // Enable AI-powered credential detection for HTTP
 	aiVerify         bool          // Use Claude Vision to verify login success

--- a/cmd/brutus/main.go
+++ b/cmd/brutus/main.go
@@ -102,8 +102,8 @@ func main() {
 	noColor := flag.Bool("no-color", false, "Disable colored output")
 	quiet := flag.Bool("q", false, "Quiet mode - only show successful credentials")
 	verbose := flag.Bool("v", false, "Verbose mode - show detailed progress to stderr")
-	badkeys := flag.Bool("badkeys", true, "Test embedded bad SSH keys (rapid7/ssh-badkeys, vagrant)")
 	noBadkeys := flag.Bool("no-badkeys", false, "Disable embedded bad key testing")
+	badkeysOnly := flag.Bool("badkeys-only", false, "Only test embedded bad SSH keys (skip password wordlists and non-SSH protocols)")
 	verifyTLS := flag.Bool("verify-tls", false, "Require strict TLS certificate verification (default: disabled)")
 
 	// Custom usage
@@ -164,8 +164,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Determine if badkeys should be used (--no-badkeys overrides --badkeys)
-	useBadkeys := resolveBadkeys(*badkeys, *noBadkeys)
+	// Determine if badkeys should be used (enabled by default, --no-badkeys disables)
+	useBadkeys := !*noBadkeys
 
 	// Validate: -k requires explicit -u or -U (not default usernames)
 	if err := validateKeyFileFlags(*keyFile, usernameFlagSet, *usernameFile); err != nil {
@@ -220,6 +220,7 @@ func main() {
 		quiet:            *quiet,
 		verbose:          *verbose,
 		useBadkeys:       useBadkeys,
+		badkeysOnly:      *badkeysOnly,
 		protocolOverride: *protocol,
 		aiMode:           *aiMode,
 		aiVerify:         *aiVerify,
@@ -315,11 +316,6 @@ func runSingleTargetMode(target, protocol string, baseConfig *baseConfigOptions,
 	}
 
 	return results, success
-}
-
-// resolveBadkeys determines if bad SSH keys should be tested (--no-badkeys overrides --badkeys).
-func resolveBadkeys(badkeys, noBadkeys bool) bool {
-	return badkeys && !noBadkeys
 }
 
 // validateKeyFileFlags checks that -k is used with explicit -u or -U.

--- a/cmd/brutus/runner.go
+++ b/cmd/brutus/runner.go
@@ -61,6 +61,11 @@ func runFromStdin(base *baseConfigOptions, jsonOut bool) ([]brutus.Result, bool)
 			}
 		}
 
+		// --badkeys-only: skip non-SSH targets entirely
+		if base.badkeysOnly && protocol != "ssh" {
+			continue
+		}
+
 		// Determine TLS mode for this specific target
 		targetTLSMode := detectTLS(base.tlsMode, nrv.TLS, base.verbose)
 
@@ -121,6 +126,7 @@ func runSingleTarget(target, protocol, tlsMode string, base *baseConfigOptions, 
 		Keys:          base.keys,
 		UseDefaults:   true,
 		NoBadkeys:     !base.useBadkeys,
+		BadkeysOnly:   base.badkeysOnly,
 		Threads:       base.threads,
 		Timeout:       base.timeout,
 		StopOnSuccess: base.stopOnSuccess,

--- a/cmd/brutus/usage.go
+++ b/cmd/brutus/usage.go
@@ -41,8 +41,8 @@ Credential Options:
   -k <keyfile>           SSH private key file
 
 SSH Options:
-  --badkeys              Test embedded bad SSH keys (rapid7/ssh-badkeys, vagrant) [default: true]
-  --no-badkeys           Disable embedded bad key testing
+  --badkeys-only         Only test bad SSH keys (skip password wordlists and non-SSH protocols)
+  --no-badkeys           Disable embedded bad key testing (badkeys are tested by default for SSH)
 
 RDP Options:
   --sticky-keys          Enable sticky keys backdoor detection for RDP targets
@@ -145,8 +145,11 @@ Examples:
   # Quiet mode (only show valid credentials)
   brutus --target 192.168.1.10:22 --protocol ssh -p "pass123" -q
 
-  # SSH with embedded bad keys (enabled by default for SSH)
+  # SSH with embedded bad keys (tested by default for SSH)
   brutus --target 192.168.1.10:22 --protocol ssh
+
+  # Test ONLY bad keys (skip password wordlists and non-SSH protocols)
+  naabu -host 10.0.0.0/24 -p 22 -silent | nerva --json | brutus --badkeys-only
 
   # Disable bad key testing
   brutus --target 192.168.1.10:22 --protocol ssh --no-badkeys -p "password"

--- a/pkg/brutus/brutus.go
+++ b/pkg/brutus/brutus.go
@@ -135,6 +135,7 @@ type Config struct {
 	Credentials   []Credential  // pre-paired credentials (no Cartesian product)
 	UseDefaults   bool          // load protocol-specific default credentials from embedded wordlists
 	NoBadkeys     bool          // skip embedded bad SSH keys when UseDefaults is true
+	BadkeysOnly   bool          // only test embedded bad SSH keys (skip password wordlists)
 	Timeout       time.Duration // per-credential timeout (default: 10s)
 	Threads       int           // concurrent workers (default: 10)
 	StopOnSuccess bool          // stop after first valid cred (default: true)
@@ -255,6 +256,16 @@ func (c *Config) applyDefaults() {
 	hasCreds := len(c.Credentials) > 0
 	hasPasswords := len(c.Passwords) > 0
 	hasKeys := len(c.Keys) > 0
+
+	// BadkeysOnly mode: only load bad SSH keys, skip wordlists entirely
+	if c.BadkeysOnly {
+		if c.Protocol == "ssh" && !hasCreds && !hasKeys {
+			for _, k := range badkeys.GetSSHCredentials() {
+				c.Credentials = append(c.Credentials, Credential{Username: k.Username, Key: k.Key})
+			}
+		}
+		return
+	}
 
 	// Load SSH badkeys as paired credentials when no keys/creds were provided
 	if c.Protocol == "ssh" && !c.NoBadkeys && !hasCreds && !hasKeys {

--- a/pkg/brutus/defaults_test.go
+++ b/pkg/brutus/defaults_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestDefaultCredentials_LoadsWordlists(t *testing.T) {
-	protocols := []string{"ssh", "mysql", "ftp", "redis", "postgresql", "vnc", "rdp", "smb", "mongodb", "snmp"}
+	protocols := []string{"ssh", "mysql", "ftp", "redis", "postgresql", "vnc", "rdp", "smb", "mongodb", "snmp", "http", "https", "elasticsearch"}
 	for _, proto := range protocols {
 		creds := DefaultCredentials(proto)
 		if len(creds) == 0 {
@@ -88,6 +88,33 @@ func TestApplyDefaults_SSH_ExplicitCredsSkipsDefaults(t *testing.T) {
 	}
 }
 
+func TestApplyDefaults_SSH_BadkeysOnly(t *testing.T) {
+	cfg := &Config{Target: "x:22", Protocol: "ssh", UseDefaults: true, BadkeysOnly: true}
+	cfg.applyDefaults()
+
+	if len(cfg.Credentials) == 0 {
+		t.Fatal("expected badkeys credentials, got none")
+	}
+
+	// Should have ONLY key-based credentials (no password wordlist)
+	for _, c := range cfg.Credentials {
+		if len(c.Key) == 0 {
+			t.Errorf("BadkeysOnly should only load key-based credentials, got password credential: %s:%s", c.Username, c.Password)
+		}
+	}
+}
+
+func TestApplyDefaults_NonSSH_BadkeysOnly(t *testing.T) {
+	for _, proto := range []string{"mysql", "ftp", "redis", "postgresql"} {
+		cfg := &Config{Target: "x:1234", Protocol: proto, UseDefaults: true, BadkeysOnly: true}
+		cfg.applyDefaults()
+
+		if len(cfg.Credentials) > 0 {
+			t.Errorf("BadkeysOnly with protocol %q should load no credentials, got %d", proto, len(cfg.Credentials))
+		}
+	}
+}
+
 func TestApplyDefaults_MySQL(t *testing.T) {
 	cfg := &Config{Target: "x:3306", Protocol: "mysql", UseDefaults: true}
 	cfg.applyDefaults()
@@ -147,7 +174,7 @@ func TestApplyDefaults_Disabled(t *testing.T) {
 }
 
 func TestValidate_UseDefaults_PassesWithoutExplicitCreds(t *testing.T) {
-	protocols := []string{"ssh", "mysql", "ftp", "redis", "postgresql"}
+	protocols := []string{"ssh", "mysql", "ftp", "redis", "postgresql", "http", "https", "elasticsearch"}
 	for _, proto := range protocols {
 		cfg := &Config{Target: "x:1234", Protocol: proto, UseDefaults: true}
 		if err := cfg.validate(); err != nil {

--- a/pkg/brutus/wordlists/http_defaults.txt
+++ b/pkg/brutus/wordlists/http_defaults.txt
@@ -1,0 +1,14 @@
+# HTTP Basic Auth Default Credentials
+# Format: username:password
+# Covers common web admin panels (Grafana, Jenkins, Elasticsearch, etc.)
+admin:admin
+admin:password
+admin:changeme
+admin:
+root:root
+root:password
+root:changeme
+elastic:elastic
+elastic:changeme
+user:user
+guest:guest

--- a/pkg/brutus/wordlists/https_defaults.txt
+++ b/pkg/brutus/wordlists/https_defaults.txt
@@ -1,0 +1,14 @@
+# HTTPS Basic Auth Default Credentials
+# Format: username:password
+# Same as HTTP defaults — covers TLS-enabled admin panels
+admin:admin
+admin:password
+admin:changeme
+admin:
+root:root
+root:password
+root:changeme
+elastic:elastic
+elastic:changeme
+user:user
+guest:guest


### PR DESCRIPTION
## Summary
- Add `--badkeys-only` flag that restricts testing to only embedded bad SSH keys, skipping password wordlists and non-SSH protocols entirely (in nerva/stdin mode, non-SSH targets are filtered out)
- Remove redundant `--badkeys` flag — badkeys are tested by default for SSH; use `--no-badkeys` to disable
- Fix bug where HTTP-based services (e.g., Elasticsearch on port 9200) reported by nerva as `"http"` would fail with `credentials required` because no `http_defaults.txt` wordlist existed

## Test plan
- [x] `TestApplyDefaults_SSH_BadkeysOnly` — verifies only key-based creds loaded (no passwords)
- [x] `TestApplyDefaults_NonSSH_BadkeysOnly` — verifies no creds loaded for non-SSH protocols
- [x] `TestDefaultCredentials_LoadsWordlists` — now includes http, https, elasticsearch
- [x] `TestValidate_UseDefaults_PassesWithoutExplicitCreds` — now includes http, https, elasticsearch
- [x] Full test suite passes (`make test`)
- [x] Build passes (`make build`)
- [ ] Manual: `naabu ... | nerva --json | brutus --badkeys-only` should only show SSH bad key hits
- [ ] Manual: `naabu ... | nerva --json | brutus` should no longer error on port 9200 (Elasticsearch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)