### PR TITLE
fix(postgresql): default to dbname=postgres instead of dbname=<username>

### DIFF
--- a/internal/plugins/postgresql/postgresql.go
+++ b/internal/plugins/postgresql/postgresql.go
@@ -62,8 +62,13 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	// Parse target to extract host and port
 	host, port := brutus.ParseTarget(target, "5432")
 
-	// Build PostgreSQL connection string
-	connStr := fmt.Sprintf("user=%s password=%s host=%s port=%s sslmode=disable connect_timeout=%d",
+	// Build PostgreSQL connection string.
+	// Default to dbname=postgres (the system database that always exists),
+	// consistent with how the MSSQL plugin defaults to database=master.
+	// Without this, lib/pq defaults to dbname=<username> which fails when
+	// no database matching the username has been created — PostgreSQL
+	// rejects the connection before authentication even occurs.
+	connStr := fmt.Sprintf("dbname=postgres user=%s password=%s host=%s port=%s sslmode=disable connect_timeout=%d",
 		username, password, host, port, int(timeout.Seconds()))
 
 	// Open database connection


### PR DESCRIPTION
## Problem

When no `dbname` is specified in the PostgreSQL connection string, `lib/pq` defaults to using the **username** as the database name. PostgreSQL rejects the connection with `FATAL: database "<username>" does not exist` **before authentication even occurs**, causing valid credentials to appear invalid.

This is a real-world issue: when credential spraying against a PostgreSQL server with user `admin`, the plugin tries to connect to database `admin` — which typically doesn't exist — and the valid credential is never tested.

## Evidence

Test environment: PostgreSQL 16 Docker container with `POSTGRES_USER=admin`, `POSTGRES_PASSWORD=SuperSecretTestOnly123`, `POSTGRES_DB=chariot`. No database named `admin` exists — only `chariot`, `postgres`, `template0`, `template1`.

**Before** (`main` — dbname defaults to username):
```
$ ./brutus-before --target 107.22.66.244:5432 --protocol postgresql -u admin -p SuperSecretTestOnly123 -v

[verbose] Completed: 1 results, 0 successful
Results: 0 valid, 1 invalid, 0 errors (total: 1)
```

**After** (`fix/postgresql-default-dbname` — dbname=postgres):
```
$ ./brutus-after --target 107.22.66.244:5432 --protocol postgresql -u admin -p SuperSecretTestOnly123 -v

[verbose] Completed: 1 results, 1 successful
[+] VALID: postgresql admin:SuperSecretTestOnly123 @ 107.22.66.244:5432 (973ms)
Results: 1 valid, 0 invalid, 0 errors (total: 1)
```

## Fix

Default to `dbname=postgres` which is the system database that always exists on every PostgreSQL installation. This is consistent with how the MSSQL plugin already defaults to `database=master`.

## Test plan
- [x] All existing unit tests pass (`go test ./...` — 25 plugin suites, 0 failures)
- [x] Before/after binary comparison against live PostgreSQL 16
- [x] Verified MSSQL plugin uses same pattern (`database=master`)