### PR TITLE
ci: migrate to centralized go-ci.yml reusable workflow (ENG-3081)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   ci:
-    uses: praetorian-inc/public-workflows/.github/workflows/go-ci.yml@f89bda45e8073b1b6ac20198164de2b71ebf0c69  # v1.0.2
+    uses: praetorian-inc/public-workflows/.github/workflows/go-ci.yml@135c50049eeef6e664bd7ea4aacaa33118083e30  # v2.0.10
     permissions:
       contents: read
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,103 +10,12 @@ on:
 permissions:
   contents: read
 
-env:
-  GO_VERSION: '1.24.13'
-
 jobs:
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup Go
-        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Run golangci-lint
-        run: |
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-          golangci-lint run --timeout=5m
-
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup Go
-        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Download dependencies
-        run: go mod download
-
-      - name: Run tests
-        run: go test -short -coverprofile=coverage.out -covermode=atomic ./...
-
-      - name: Upload coverage to Codecov
-        if: always()
-        run: |
-          curl -Os https://cli.codecov.io/latest/linux/codecov
-          chmod +x codecov
-          ./codecov upload-process -t ${{ secrets.CODECOV_TOKEN }} -f coverage.out || true
-
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        goos: [linux, darwin, windows]
-        goarch: [amd64, arm64]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup Go
-        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Build
-        env:
-          GOOS: ${{ matrix.goos }}
-          GOARCH: ${{ matrix.goarch }}
-          CGO_ENABLED: '0'
-        run: |
-          go build -trimpath -ldflags="-s -w" -o brutus-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/brutus
-
-  # Security scanning
-  security:
-    name: Security Scan
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup Go
-        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Run Gosec Security Scanner
-        run: |
-          go install github.com/securego/gosec/v2/cmd/gosec@latest
-          gosec -no-fail -fmt sarif -out results.sarif ./...
-
-      - name: Check SARIF results
-        if: always()
-        continue-on-error: true
-        run: |
-          if [ -f results.sarif ]; then
-            echo "Gosec found $(jq '.runs[0].results | length' results.sarif) issues"
-          fi
-
-      - name: Run govulncheck
-        run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
-          govulncheck ./...
+  ci:
+    uses: praetorian-inc/public-workflows/.github/workflows/go-ci.yml@f89bda45e8073b1b6ac20198164de2b71ebf0c69  # v1.0.2
+    permissions:
+      contents: read
+    with:
+      build-cmd-path: ./cmd/brutus
+      build-binary-name: brutus
+    secrets: inherit

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,45 +1,58 @@
+version: "2"
+
 run:
-  timeout: 5m
   tests: true
 
 linters:
   enable:
     - errcheck
-    - gosimple
     - govet
     - ineffassign
     - staticcheck
     - unused
-    - gofmt
-    - goimports
     - misspell
     - unconvert
     - unparam
     - gocritic
+  settings:
+    errcheck:
+      check-type-assertions: true
+    govet:
+      enable:
+        - shadow
+    misspell:
+      locale: US
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - style
+        - performance
+  exclusions:
+    generated: lax
+    rules:
+      - path: _test\.go
+        linters:
+          - unparam
+      - path: _test\.go
+        linters:
+          - revive
+        text: "dot-imports"
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 
-linters-settings:
-  errcheck:
-    check-type-assertions: true
-  govet:
-    check-shadowing: true
-  goimports:
-    local-prefixes: github.com/praetorian-inc/brutus
-  misspell:
-    locale: US
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - style
-      - performance
-
-issues:
-  exclude-rules:
-    # Allow unused parameters in test files
-    - path: _test\.go
-      linters:
-        - unparam
-    # Allow dot imports in test files
-    - path: _test\.go
-      linters:
-        - revive
-      text: "dot-imports"
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/praetorian-inc/brutus
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/cmd/brutus/config.go
+++ b/cmd/brutus/config.go
@@ -42,18 +42,18 @@ type baseConfigOptions struct {
 	protocolOverride string        // Override nerva-detected protocol
 	aiMode           bool          // Enable AI-powered credential detection for HTTP
 	tlsMode          string        // TLS verification mode: "disable", "verify", "skip-verify"
-	rateLimit         float64             // Max requests per second (0 = unlimited)
-	jitter            time.Duration       // Random delay variance for rate limiting
-	maxAttempts       int
-	maxRetries        int
-	sprayMode         bool
-	anthropicKey      string              // ANTHROPIC_API_KEY (read once in main)
-	perplexityKey     string              // PERPLEXITY_API_KEY (read once in main)
-	stickyKeys        bool                // Sticky keys backdoor detection mode (no brute force)
-	stickyKeysExec    string              // Command to execute via sticky keys backdoor
-	stickyKeysWeb     bool                // Start web terminal for sticky keys interaction
-	stickyKeysOpen    bool                // Auto-open browser when sticky keys web terminal starts
-	aiVerify          bool                // AI-powered login verification (Claude Vision before/after screenshots)
+	rateLimit        float64       // Max requests per second (0 = unlimited)
+	jitter           time.Duration // Random delay variance for rate limiting
+	maxAttempts      int
+	maxRetries       int
+	sprayMode        bool
+	anthropicKey     string // ANTHROPIC_API_KEY (read once in main)
+	perplexityKey    string // PERPLEXITY_API_KEY (read once in main)
+	stickyKeys       bool   // Sticky keys backdoor detection mode (no brute force)
+	stickyKeysExec   string // Command to execute via sticky keys backdoor
+	stickyKeysWeb    bool   // Start web terminal for sticky keys interaction
+	stickyKeysOpen   bool   // Auto-open browser when sticky keys web terminal starts
+	aiVerify         bool   // AI-powered login verification (Claude Vision before/after screenshots)
 }
 
 // determineTLSMode returns the appropriate TLS mode based on the verify-tls flag

--- a/cmd/brutus/integration_test.go
+++ b/cmd/brutus/integration_test.go
@@ -27,9 +27,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/praetorian-inc/brutus/pkg/brutus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/brutus/pkg/brutus"
 )
 
 // TestNervaIntegration tests the full pipeline: nerva -> brutus

--- a/cmd/brutus/main.go
+++ b/cmd/brutus/main.go
@@ -58,7 +58,7 @@ func setupOutputWriter(outputFile string) (w io.Writer, forceJSON bool, cleanup 
 	if err != nil {
 		return nil, false, func() {}, fmt.Errorf("creating output file: %w", err)
 	}
-	return f, true, func() { f.Close() }, nil
+	return f, true, func() { _ = f.Close() }, nil
 }
 
 // shouldShowBanner determines whether to display the ASCII art banner.
@@ -170,8 +170,8 @@ func main() {
 	useBadkeys := !*noBadkeys
 
 	// Validate: -k requires explicit -u or -U (not default usernames)
-	if err := validateKeyFileFlags(*keyFile, usernameFlagSet, *usernameFile); err != nil {
-		errMsg(useColor, "%v", err)
+	if validateErr := validateKeyFileFlags(*keyFile, usernameFlagSet, *usernameFile); validateErr != nil {
+		errMsg(useColor, "%v", validateErr)
 		os.Exit(1)
 	}
 
@@ -242,7 +242,6 @@ func main() {
 
 	var allResults []brutus.Result
 	var hasSuccess bool
-
 
 	// Scan/detection mode: --sticky-keys (without --sticky-keys-exec or --sticky-keys-web)
 	// bypasses normal brute force entirely and runs sticky keys backdoor detection

--- a/cmd/brutus/research.go
+++ b/cmd/brutus/research.go
@@ -43,7 +43,6 @@ func routeHTTPWithAI(target, protocol string, base *baseConfigOptions) (string, 
 	return "browser", nil
 }
 
-
 // configureVisionAnalyzer sets up Claude Vision for screenshot analysis on the browser plugin.
 func configureVisionAnalyzer(plugin *browser.Plugin, apiKey string, verbose bool) {
 	if apiKey != "" {

--- a/cmd/brutus/runner.go
+++ b/cmd/brutus/runner.go
@@ -240,7 +240,7 @@ func configureAICredentials(config *brutus.Config, aiCreds []brutus.Credential, 
 }
 
 // detectTLS checks if TLS was detected by nerva and upgrades the TLS mode.
-func detectTLS(baseTLSMode string, tlsDetected bool, verbose bool) string {
+func detectTLS(baseTLSMode string, tlsDetected, verbose bool) string {
 	if baseTLSMode != "disable" {
 		return baseTLSMode
 	}

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -49,7 +49,8 @@ func main() {
 	validCount := 0
 	errorCount := 0
 
-	for _, r := range results {
+	for i := range results {
+		r := &results[i]
 		if r.Success {
 			fmt.Printf("[+] Valid: %s:%s (%.2fs)\n",
 				r.Username, r.Password, r.Duration.Seconds())

--- a/examples/browser/main.go
+++ b/examples/browser/main.go
@@ -67,7 +67,8 @@ func main() {
 	fmt.Println("Results:")
 	fmt.Println("--------")
 
-	for _, r := range results {
+	for i := range results {
+		r := &results[i]
 		status := "FAIL"
 		if r.Success {
 			status = "SUCCESS"
@@ -89,8 +90,8 @@ func main() {
 
 	// Summary
 	var successCount int
-	for _, r := range results {
-		if r.Success {
+	for i := range results {
+		if results[i].Success {
 			successCount++
 		}
 	}

--- a/examples/llm/main.go
+++ b/examples/llm/main.go
@@ -61,7 +61,8 @@ func main() {
 	llmSuccessCount := 0
 	errorCount := 0
 
-	for _, r := range results {
+	for i := range results {
+		r := &results[i]
 		if r.Success {
 			source := "default"
 			if r.LLMSuggested {

--- a/internal/analyzers/claude/claude.go
+++ b/internal/analyzers/claude/claude.go
@@ -56,7 +56,7 @@ func init() {
 type Client struct {
 	APIKey   string
 	Model    string
-	Endpoint string        // Optional: override endpoint for testing
+	Endpoint string // Optional: override endpoint for testing
 	Timeout  time.Duration
 }
 
@@ -156,7 +156,7 @@ func (c *Client) Analyze(ctx context.Context, banner brutus.BannerInfo) ([]strin
 	if err != nil {
 		return nil, fmt.Errorf("claude api request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -344,7 +344,7 @@ func (c *Client) doVisionRequestRaw(ctx context.Context, reqBody visionRequest) 
 	if err != nil {
 		return "", fmt.Errorf("claude api request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)

--- a/internal/analyzers/claude/types.go
+++ b/internal/analyzers/claude/types.go
@@ -30,6 +30,7 @@ type ApplicationInfo struct {
 }
 
 // FormHints provides CSS selectors for form fields (when detected by AI)
+//
 // Deprecated: Use FormLabels instead
 type FormHints struct {
 	UsernameSelector string `json:"username_selector,omitempty"`

--- a/internal/analyzers/perplexity/perplexity.go
+++ b/internal/analyzers/perplexity/perplexity.go
@@ -162,7 +162,7 @@ func (c *Client) ResearchCredentials(ctx context.Context, appType, vendor, model
 	if err != nil {
 		return nil, fmt.Errorf("perplexity api request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	// Check status
 	if resp.StatusCode != http.StatusOK {
@@ -219,7 +219,7 @@ func (c *Client) researchFromTextWithPairs(ctx context.Context, text string) ([]
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("api error: status %d", resp.StatusCode)

--- a/internal/plugins/browser/browser.go
+++ b/internal/plugins/browser/browser.go
@@ -68,7 +68,6 @@ type Plugin struct {
 
 	// Verbose enables detailed logging
 	Verbose bool
-
 }
 
 // Name returns the protocol name
@@ -106,12 +105,12 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	url := buildURL(target, p.UseHTTPS)
 
 	if p.Verbose {
-		fmt.Fprintf(logOutput, "[verbose] Testing %s:%s...\n", username, password)
+		_, _ = fmt.Fprintf(logOutput, "[verbose] Testing %s:%s...\n", username, password)
 	}
 
 	// AI verify mode: capture screenshots and use heuristic + Claude Vision
 	if p.AIVerify && p.VisionAnalyzer != nil {
-		return p.testWithAIVerify(ctx, tabCtx, url, username, password, result, start)
+		return p.testWithAIVerify(ctx, tabCtx, url, username, password, result)
 	}
 
 	// Navigate, fill form, and submit in ONE chromedp.Run call
@@ -124,8 +123,8 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 
 	// Verify login success using the captured post-login state
 	if p.Verbose {
-		fmt.Fprintf(logOutput, "[verbose] After login URL: %s\n", submitResult.AfterURL)
-		fmt.Fprintf(logOutput, "[verbose] Page has password field: %v\n", submitResult.HasPassword)
+		_, _ = fmt.Fprintf(logOutput, "[verbose] After login URL: %s\n", submitResult.AfterURL)
+		_, _ = fmt.Fprintf(logOutput, "[verbose] Page has password field: %v\n", submitResult.HasPassword)
 	}
 
 	// Determine success: no password field and no error indicators
@@ -134,23 +133,23 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		// Still on login page - login failed
 		result.Success = false
 		if p.Verbose {
-			fmt.Fprintf(logOutput, "[verbose] Login failed (still on login page)\n")
+			_, _ = fmt.Fprintf(logOutput, "[verbose] Login failed (still on login page)\n")
 		}
 	case looksLikeLoginFailure(submitResult.AfterHTML):
 		// Error indicators found
 		result.Success = false
 		if p.Verbose {
-			fmt.Fprintf(logOutput, "[verbose] Login failed (error indicators found)\n")
+			_, _ = fmt.Fprintf(logOutput, "[verbose] Login failed (error indicators found)\n")
 		}
 	default:
 		// No password field, no errors - success
 		result.Success = true
 		if p.Verbose {
-			fmt.Fprintf(logOutput, "[verbose] Login appears successful\n")
+			_, _ = fmt.Fprintf(logOutput, "[verbose] Login appears successful\n")
 		}
 		// In visible/demo mode, pause to show the successful login page
 		if p.Visible {
-			fmt.Fprintf(logOutput, "[demo] Pausing 3s to show successful login...\n")
+			_, _ = fmt.Fprintf(logOutput, "[demo] Pausing 3s to show successful login...\n")
 			time.Sleep(3 * time.Second)
 		}
 	}
@@ -162,7 +161,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 // It captures before/after screenshots and sends them to Claude Vision when the heuristic
 // confidence is too low to make a reliable determination.
 func (p *Plugin) testWithAIVerify(ctx, tabCtx context.Context, url, username, password string,
-	result *brutus.Result, start time.Time) *brutus.Result {
+	result *brutus.Result) *brutus.Result {
 
 	submitResult, submitErr := FillSubmitAndScreenshot(tabCtx, url, username, password, p.PageLoadTimeout+15*time.Second)
 	if submitErr != nil {
@@ -171,8 +170,8 @@ func (p *Plugin) testWithAIVerify(ctx, tabCtx context.Context, url, username, pa
 	}
 
 	if p.Verbose {
-		fmt.Fprintf(logOutput, "[verbose] After login URL: %s\n", submitResult.AfterURL)
-		fmt.Fprintf(logOutput, "[verbose] Page has password field: %v\n", submitResult.HasPassword)
+		_, _ = fmt.Fprintf(logOutput, "[verbose] After login URL: %s\n", submitResult.AfterURL)
+		_, _ = fmt.Fprintf(logOutput, "[verbose] Page has password field: %v\n", submitResult.HasPassword)
 	}
 
 	// Run heuristic verification first (fast, no API call)
@@ -181,7 +180,7 @@ func (p *Plugin) testWithAIVerify(ctx, tabCtx context.Context, url, username, pa
 	heuristic := VerifyLogin(before, after)
 
 	if p.Verbose {
-		fmt.Fprintf(logOutput, "[verbose] Heuristic: success=%v confidence=%.2f reason=%s\n",
+		_, _ = fmt.Fprintf(logOutput, "[verbose] Heuristic: success=%v confidence=%.2f reason=%s\n",
 			heuristic.Success, heuristic.Confidence, heuristic.Reason)
 	}
 
@@ -189,23 +188,23 @@ func (p *Plugin) testWithAIVerify(ctx, tabCtx context.Context, url, username, pa
 	if heuristic.Confidence >= 0.70 {
 		result.Success = heuristic.Success
 		if p.Verbose {
-			fmt.Fprintf(logOutput, "[verbose] Using heuristic result (confidence %.2f)\n", heuristic.Confidence)
+			_, _ = fmt.Fprintf(logOutput, "[verbose] Using heuristic result (confidence %.2f)\n", heuristic.Confidence)
 		}
 	} else {
 		// Ambiguous: use Claude Vision for verification
 		if p.Verbose {
-			fmt.Fprintf(logOutput, "[verbose] Heuristic ambiguous (%.2f), using Claude Vision...\n", heuristic.Confidence)
+			_, _ = fmt.Fprintf(logOutput, "[verbose] Heuristic ambiguous (%.2f), using Claude Vision...\n", heuristic.Confidence)
 		}
 
 		verification, verifyErr := p.VisionAnalyzer.VerifyLogin(ctx, submitResult.BeforeScreenshot, submitResult.AfterScreenshot)
 		if verifyErr != nil {
 			if p.Verbose {
-				fmt.Fprintf(logOutput, "[verbose] Vision error: %v, falling back to heuristic\n", verifyErr)
+				_, _ = fmt.Fprintf(logOutput, "[verbose] Vision error: %v, falling back to heuristic\n", verifyErr)
 			}
 			result.Success = heuristic.Success
 		} else {
 			if p.Verbose {
-				fmt.Fprintf(logOutput, "[verbose] Vision: success=%v confidence=%.2f reason=%s\n",
+				_, _ = fmt.Fprintf(logOutput, "[verbose] Vision: success=%v confidence=%.2f reason=%s\n",
 					verification.Success, verification.Confidence, verification.Reason)
 			}
 			result.Success = verification.Success
@@ -213,7 +212,7 @@ func (p *Plugin) testWithAIVerify(ctx, tabCtx context.Context, url, username, pa
 	}
 
 	if result.Success && p.Visible {
-		fmt.Fprintf(logOutput, "[demo] Pausing 3s to show successful login...\n")
+		_, _ = fmt.Fprintf(logOutput, "[demo] Pausing 3s to show successful login...\n")
 		time.Sleep(3 * time.Second)
 	}
 
@@ -229,7 +228,7 @@ func (p *Plugin) AnalyzePage(ctx context.Context, target string) (*claude.PageAn
 		browserMode = "visible"
 	}
 	if p.Verbose {
-		fmt.Fprintf(logOutput, "[verbose] Initializing %s browser...\n", browserMode)
+		_, _ = fmt.Fprintf(logOutput, "[verbose] Initializing %s browser...\n", browserMode)
 	}
 
 	// Set visible mode before getting browser (must be before first GetBrowser call)
@@ -242,7 +241,7 @@ func (p *Plugin) AnalyzePage(ctx context.Context, target string) (*claude.PageAn
 	}
 
 	if p.Verbose {
-		fmt.Fprintf(logOutput, "[verbose] Browser started, acquiring tab...\n")
+		_, _ = fmt.Fprintf(logOutput, "[verbose] Browser started, acquiring tab...\n")
 	}
 
 	// Acquire a tab
@@ -253,7 +252,7 @@ func (p *Plugin) AnalyzePage(ctx context.Context, target string) (*claude.PageAn
 	url := buildURL(target, p.UseHTTPS)
 
 	if p.Verbose {
-		fmt.Fprintf(logOutput, "[verbose] Navigating to %s...\n", url)
+		_, _ = fmt.Fprintf(logOutput, "[verbose] Navigating to %s...\n", url)
 	}
 
 	// Navigate and capture screenshot in a single operation
@@ -264,11 +263,11 @@ func (p *Plugin) AnalyzePage(ctx context.Context, target string) (*claude.PageAn
 	}
 
 	if p.Verbose {
-		fmt.Fprintf(logOutput, "[verbose] Page loaded and screenshot captured\n")
+		_, _ = fmt.Fprintf(logOutput, "[verbose] Page loaded and screenshot captured\n")
 	}
 
 	if p.Verbose {
-		fmt.Fprintf(logOutput, "[verbose] Screenshot captured (%d bytes)\n", len(screenshot))
+		_, _ = fmt.Fprintf(logOutput, "[verbose] Screenshot captured (%d bytes)\n", len(screenshot))
 	}
 
 	// Analyze with Claude Vision
@@ -277,7 +276,7 @@ func (p *Plugin) AnalyzePage(ctx context.Context, target string) (*claude.PageAn
 	}
 
 	if p.Verbose {
-		fmt.Fprintf(logOutput, "[verbose] Uploading screenshot to Claude Vision API...\n")
+		_, _ = fmt.Fprintf(logOutput, "[verbose] Uploading screenshot to Claude Vision API...\n")
 	}
 
 	pageAnalysis, err := p.VisionAnalyzer.AnalyzeScreenshot(ctx, screenshot)
@@ -286,7 +285,7 @@ func (p *Plugin) AnalyzePage(ctx context.Context, target string) (*claude.PageAn
 	}
 
 	if p.Verbose {
-		fmt.Fprintf(logOutput, "[verbose] Vision detected: %s %s %s (confidence: %.2f)\n",
+		_, _ = fmt.Fprintf(logOutput, "[verbose] Vision detected: %s %s %s (confidence: %.2f)\n",
 			pageAnalysis.Application.Vendor,
 			pageAnalysis.Application.Model,
 			pageAnalysis.Application.Type,
@@ -297,7 +296,7 @@ func (p *Plugin) AnalyzePage(ctx context.Context, target string) (*claude.PageAn
 	var credentials []brutus.Credential
 	if len(pageAnalysis.SuggestedCredentials) > 0 {
 		if p.Verbose {
-			fmt.Fprintf(logOutput, "[verbose] Claude Vision suggested %d credential pairs\n", len(pageAnalysis.SuggestedCredentials))
+			_, _ = fmt.Fprintf(logOutput, "[verbose] Claude Vision suggested %d credential pairs\n", len(pageAnalysis.SuggestedCredentials))
 		}
 		for _, c := range pageAnalysis.SuggestedCredentials {
 			credentials = append(credentials, brutus.Credential{
@@ -310,7 +309,7 @@ func (p *Plugin) AnalyzePage(ctx context.Context, target string) (*claude.PageAn
 	// Research additional credentials with Perplexity (if configured)
 	if p.CredentialResearcher != nil && pageAnalysis.IsLoginPage {
 		if p.Verbose {
-			fmt.Fprintf(logOutput, "[verbose] Researching additional credentials with Perplexity for %s %s...\n",
+			_, _ = fmt.Fprintf(logOutput, "[verbose] Researching additional credentials with Perplexity for %s %s...\n",
 				pageAnalysis.Application.Vendor,
 				pageAnalysis.Application.Model)
 		}
@@ -326,7 +325,7 @@ func (p *Plugin) AnalyzePage(ctx context.Context, target string) (*claude.PageAn
 		perplexityCreds, err := p.CredentialResearcher.AnalyzeCredentials(ctx, bannerInfo)
 		if err != nil {
 			if p.Verbose {
-				fmt.Fprintf(logOutput, "[verbose] Perplexity research error: %v\n", err)
+				_, _ = fmt.Fprintf(logOutput, "[verbose] Perplexity research error: %v\n", err)
 			}
 			// Non-fatal - continue with Claude's suggestions
 		} else if len(perplexityCreds) > 0 {
@@ -345,7 +344,7 @@ func (p *Plugin) AnalyzePage(ctx context.Context, target string) (*claude.PageAn
 				}
 			}
 			if p.Verbose {
-				fmt.Fprintf(logOutput, "[verbose] Perplexity returned %d credentials (%d new after dedup)\n", len(perplexityCreds), added)
+				_, _ = fmt.Fprintf(logOutput, "[verbose] Perplexity returned %d credentials (%d new after dedup)\n", len(perplexityCreds), added)
 			}
 		}
 	}

--- a/internal/plugins/browser/forms.go
+++ b/internal/plugins/browser/forms.go
@@ -272,6 +272,7 @@ func FillSubmitAndScreenshot(tabCtx context.Context, url, username, password str
 }
 
 // FillAndSubmit fills form fields and clicks submit using JavaScript for reliability
+//
 // Deprecated: Use FillAndSubmitWithNavigate instead to avoid context issues
 func FillAndSubmit(tabCtx context.Context, fields *FormFields, username, password string) error {
 	ctx, cancel := context.WithTimeout(tabCtx, 15*time.Second)

--- a/internal/plugins/couchdb/couchdb.go
+++ b/internal/plugins/couchdb/couchdb.go
@@ -77,7 +77,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		result.Error = brutus.WrapConnError(err)
 		return result
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	// Classify response
 	if resp.StatusCode == http.StatusOK {

--- a/internal/plugins/elasticsearch/elasticsearch.go
+++ b/internal/plugins/elasticsearch/elasticsearch.go
@@ -77,7 +77,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		result.Error = brutus.WrapConnError(err)
 		return result
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	// Check status code
 	if resp.StatusCode == http.StatusUnauthorized {

--- a/internal/plugins/ftp/ftp.go
+++ b/internal/plugins/ftp/ftp.go
@@ -63,7 +63,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		result.Error = brutus.WrapConnError(err)
 		return result
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Set overall deadline for FTP operations
 	_ = conn.SetDeadline(time.Now().Add(timeout))

--- a/internal/plugins/ftp/ftp_test.go
+++ b/internal/plugins/ftp/ftp_test.go
@@ -18,8 +18,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/praetorian-inc/brutus/pkg/brutus"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/praetorian-inc/brutus/pkg/brutus"
 )
 
 func TestPlugin_Name(t *testing.T) {

--- a/internal/plugins/http/http.go
+++ b/internal/plugins/http/http.go
@@ -138,7 +138,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		result.Error = brutus.WrapConnError(err)
 		return result
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	// Read limited response body for banner
 	bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, MaxBodyRead))
@@ -182,7 +182,7 @@ func (p *Plugin) isOpenAccess(ctx context.Context, url string, newClient func() 
 	if err != nil {
 		return false
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	return resp.StatusCode >= 200 && resp.StatusCode < 300
 }

--- a/internal/plugins/imap/imap.go
+++ b/internal/plugins/imap/imap.go
@@ -77,7 +77,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		result.Error = classifyError(err)
 		return result
 	}
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	// Check if context was canceled during dial
 	if dialCtx.Err() != nil {

--- a/internal/plugins/influxdb/influxdb.go
+++ b/internal/plugins/influxdb/influxdb.go
@@ -79,7 +79,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		result.Error = brutus.WrapConnError(err)
 		return result
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	// Classify response
 	if resp.StatusCode == http.StatusUnauthorized {

--- a/internal/plugins/ldap/ldap.go
+++ b/internal/plugins/ldap/ldap.go
@@ -98,7 +98,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		result.Error = classifyError(err)
 		return result
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Set operation timeout
 	conn.SetTimeout(timeout)

--- a/internal/plugins/mssql/mssql.go
+++ b/internal/plugins/mssql/mssql.go
@@ -69,7 +69,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		result.Error = brutus.WrapConnError(err)
 		return result
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	// Set connection timeout
 	db.SetConnMaxLifetime(timeout)

--- a/internal/plugins/mysql/mysql.go
+++ b/internal/plugins/mysql/mysql.go
@@ -75,7 +75,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		result.Error = brutus.WrapConnError(err)
 		return result
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	// Set connection timeout
 	db.SetConnMaxLifetime(timeout)

--- a/internal/plugins/neo4j/neo4j.go
+++ b/internal/plugins/neo4j/neo4j.go
@@ -75,7 +75,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		result.Error = classifyError(err)
 		return result
 	}
-	defer driver.Close(ctx)
+	defer func() { _ = driver.Close(ctx) }()
 
 	// Create context with timeout for verification
 	verifyCtx, cancel := context.WithTimeout(ctx, timeout)

--- a/internal/plugins/pop3/pop3.go
+++ b/internal/plugins/pop3/pop3.go
@@ -59,7 +59,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		result.Error = brutus.WrapConnError(err)
 		return result
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Set overall deadline for POP3 operations
 	_ = conn.SetDeadline(time.Now().Add(timeout))

--- a/internal/plugins/pop3/pop3_test.go
+++ b/internal/plugins/pop3/pop3_test.go
@@ -18,8 +18,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/praetorian-inc/brutus/pkg/brutus"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/praetorian-inc/brutus/pkg/brutus"
 )
 
 func TestPlugin_Name(t *testing.T) {

--- a/internal/plugins/postgresql/postgresql.go
+++ b/internal/plugins/postgresql/postgresql.go
@@ -77,7 +77,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		result.Error = classifyError(err)
 		return result
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	// Create context with timeout
 	pingCtx, cancel := context.WithTimeout(ctx, timeout)

--- a/internal/plugins/rdp/exec.go
+++ b/internal/plugins/rdp/exec.go
@@ -183,7 +183,7 @@ func saveRGBAScreenshot(rgba []byte, width, height uint32, path string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	return png.Encode(f, img)
 }

--- a/internal/plugins/rdp/interactive.go
+++ b/internal/plugins/rdp/interactive.go
@@ -63,7 +63,7 @@ func NewInteractiveSession(ctx context.Context, target string, timeout time.Dura
 
 	inst, err := newInstance(ctx, eng, conn)
 	if err != nil {
-		conn.Close()
+		_ = conn.Close()
 		return nil, fmt.Errorf("wasm instance: %w", err)
 	}
 
@@ -78,15 +78,15 @@ func NewInteractiveSession(ctx context.Context, target string, timeout time.Dura
 	}
 	configBytes, err := json.Marshal(cfg)
 	if err != nil {
-		inst.close(ctx)
-		conn.Close()
+		_ = inst.close(ctx)
+		_ = conn.Close()
 		return nil, fmt.Errorf("marshal config: %w", err)
 	}
 
 	connHandle, _, err := p.runConnectorForSession(ctx, inst, configBytes)
 	if err != nil {
-		inst.close(ctx)
-		conn.Close()
+		_ = inst.close(ctx)
+		_ = conn.Close()
 		return nil, fmt.Errorf("connector: %w", err)
 	}
 
@@ -94,20 +94,20 @@ func NewInteractiveSession(ctx context.Context, target string, timeout time.Dura
 	callCtx := inst.callCtx(ctx)
 	sessionNewFn := inst.mod.ExportedFunction("session_new")
 	if sessionNewFn == nil {
-		inst.close(ctx)
-		conn.Close()
+		_ = inst.close(ctx)
+		_ = conn.Close()
 		return nil, fmt.Errorf("session_new not exported")
 	}
 	results, err := sessionNewFn.Call(callCtx, uint64(connHandle), uint64(width), uint64(height))
 	if err != nil {
-		inst.close(ctx)
-		conn.Close()
+		_ = inst.close(ctx)
+		_ = conn.Close()
 		return nil, fmt.Errorf("session_new: %w", err)
 	}
 	sessHandle := uint32(results[0])
 	if sessHandle == 0 {
-		inst.close(ctx)
-		conn.Close()
+		_ = inst.close(ctx)
+		_ = conn.Close()
 		return nil, fmt.Errorf("session_new returned null handle")
 	}
 
@@ -404,8 +404,8 @@ func (s *InteractiveSession) Close() {
 	if freeFn := s.inst.mod.ExportedFunction("connector_free"); freeFn != nil {
 		_, _ = freeFn.Call(callCtx, uint64(s.connHandle))
 	}
-	s.inst.close(context.Background())
-	s.conn.Close()
+	_ = s.inst.close(context.Background())
+	_ = s.conn.Close()
 }
 
 // parseTarget splits host:port with default port 3389.

--- a/internal/plugins/rdp/rdp.go
+++ b/internal/plugins/rdp/rdp.go
@@ -109,7 +109,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		result.Error = brutus.WrapConnError(err)
 		return result
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Create a fresh WASM instance for this Test() call (D1: per-call isolation)
 	inst, err := newInstance(ctx, eng, conn)
@@ -117,7 +117,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		result.Error = fmt.Errorf("connection error: wasm instance: %w", err)
 		return result
 	}
-	defer inst.close(ctx)
+	defer func() { _ = inst.close(ctx) }()
 
 	// Prepare connector config
 	cfg := rdpConfig{
@@ -389,13 +389,13 @@ func (p *Plugin) RunStickyKeysCheck(ctx context.Context, target string, timeout 
 	if err != nil {
 		return &StickyKeysResult{Performed: false, SkipReason: fmt.Sprintf("connection failed: %v", err)}
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	inst, err := newInstance(ctx, eng, conn)
 	if err != nil {
 		return &StickyKeysResult{Performed: false, SkipReason: fmt.Sprintf("wasm instance: %v", err)}
 	}
-	defer inst.close(ctx)
+	defer func() { _ = inst.close(ctx) }()
 
 	stickyResult, err := p.runStickyKeysDetection(ctx, inst, addr)
 	if err != nil {

--- a/internal/plugins/rdp/session.go
+++ b/internal/plugins/rdp/session.go
@@ -47,7 +47,6 @@ type StickyKeysResult struct {
 // leftShiftScancode is the scancode for Left Shift key (used for sticky keys detection).
 const leftShiftScancode = 0x2A
 
-
 // runConnectorForSession drives the connector state machine and returns the connector handle
 // (for session handoff) instead of consuming it. Similar to runConnector but doesn't free the handle.
 func (p *Plugin) runConnectorForSession(ctx context.Context, inst *wasmInstance, config []byte) (handle uint32, banner string, err error) { //nolint:unparam // banner reserved for future use

--- a/internal/plugins/rdp/sticky_vision.go
+++ b/internal/plugins/rdp/sticky_vision.go
@@ -98,7 +98,7 @@ func analyzeStickyKeysVision(ctx context.Context, pngData []byte, apiKey string)
 	if err != nil {
 		return "", fmt.Sprintf("api error: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxVisionResponseSize))
 	if err != nil {

--- a/internal/plugins/rdp/wasm.go
+++ b/internal/plugins/rdp/wasm.go
@@ -110,7 +110,7 @@ func initEngine() (*wasmEngine, error) {
 			Instantiate(ctx)
 		if err != nil {
 			engineErr = fmt.Errorf("host module: %w", err)
-			r.Close(ctx)
+			_ = r.Close(ctx)
 			return
 		}
 
@@ -118,7 +118,7 @@ func initEngine() (*wasmEngine, error) {
 		compiled, err := r.CompileModule(ctx, ironrdpWasm)
 		if err != nil {
 			engineErr = fmt.Errorf("compile wasm: %w", err)
-			r.Close(ctx)
+			_ = r.Close(ctx)
 			return
 		}
 

--- a/internal/plugins/rdp/wasm_test.go
+++ b/internal/plugins/rdp/wasm_test.go
@@ -38,7 +38,7 @@ func TestWasmAllocDealloc(t *testing.T) {
 	// Create instance without a real connection (nil conn for unit test)
 	inst, err := newInstance(ctx, eng, nil)
 	require.NoError(t, err)
-	defer inst.close(ctx)
+	defer func() { _ = inst.close(ctx) }()
 
 	// Test alloc
 	allocFn := inst.mod.ExportedFunction("wasm_alloc")
@@ -64,7 +64,7 @@ func TestWasmMemoryRoundTrip(t *testing.T) {
 
 	inst, err := newInstance(ctx, eng, nil)
 	require.NoError(t, err)
-	defer inst.close(ctx)
+	defer func() { _ = inst.close(ctx) }()
 
 	// Write data to WASM memory
 	testData := []byte("hello from Go!")
@@ -89,7 +89,7 @@ func TestWasmConnectorNew(t *testing.T) {
 
 	inst, err := newInstance(ctx, eng, nil)
 	require.NoError(t, err)
-	defer inst.close(ctx)
+	defer func() { _ = inst.close(ctx) }()
 
 	connectorNewFn := inst.mod.ExportedFunction("connector_new")
 	require.NotNil(t, connectorNewFn, "connector_new must be exported")
@@ -121,7 +121,7 @@ func TestWasmConnectorNewEmptyConfig(t *testing.T) {
 
 	inst, err := newInstance(ctx, eng, nil)
 	require.NoError(t, err)
-	defer inst.close(ctx)
+	defer func() { _ = inst.close(ctx) }()
 
 	connectorNewFn := inst.mod.ExportedFunction("connector_new")
 	require.NotNil(t, connectorNewFn)
@@ -140,7 +140,7 @@ func TestWasmVersion(t *testing.T) {
 
 	inst, err := newInstance(ctx, eng, nil)
 	require.NoError(t, err)
-	defer inst.close(ctx)
+	defer func() { _ = inst.close(ctx) }()
 
 	versionFn := inst.mod.ExportedFunction("version")
 	require.NotNil(t, versionFn, "version must be exported")
@@ -169,7 +169,7 @@ func TestWasmExportsExist(t *testing.T) {
 
 	inst, err := newInstance(ctx, eng, nil)
 	require.NoError(t, err)
-	defer inst.close(ctx)
+	defer func() { _ = inst.close(ctx) }()
 
 	requiredExports := []string{
 		"wasm_alloc",
@@ -196,11 +196,11 @@ func TestWasmInstanceIsolation(t *testing.T) {
 	// Create two separate instances
 	inst1, err := newInstance(ctx, eng, nil)
 	require.NoError(t, err)
-	defer inst1.close(ctx)
+	defer func() { _ = inst1.close(ctx) }()
 
 	inst2, err := newInstance(ctx, eng, nil)
 	require.NoError(t, err)
-	defer inst2.close(ctx)
+	defer func() { _ = inst2.close(ctx) }()
 
 	// Write different data to each instance
 	data1 := []byte("instance-one-data")
@@ -245,7 +245,7 @@ func TestWasmInstanceClose(t *testing.T) {
 	// Engine should still be usable for new instances
 	inst2, err := newInstance(ctx, eng, nil)
 	require.NoError(t, err, "engine must remain usable after closing an instance")
-	defer inst2.close(ctx)
+	defer func() { _ = inst2.close(ctx) }()
 
 	// New instance should work normally
 	testData := []byte("still works")
@@ -265,7 +265,7 @@ func TestWasmContextKey(t *testing.T) {
 
 	inst, err := newInstance(ctx, eng, nil)
 	require.NoError(t, err)
-	defer inst.close(ctx)
+	defer func() { _ = inst.close(ctx) }()
 
 	// Without instance in context, getInstance returns nil
 	assert.Nil(t, getInstance(ctx), "getInstance should return nil for bare context")

--- a/internal/plugins/rdp/webterm.go
+++ b/internal/plugins/rdp/webterm.go
@@ -190,7 +190,7 @@ func RunWebTerminal(ctx context.Context, target string, timeout time.Duration, o
 	}
 	tcpAddr, ok := listener.Addr().(*net.TCPAddr)
 	if !ok {
-		listener.Close()
+		_ = listener.Close()
 		return fmt.Errorf("unexpected listener address type")
 	}
 	port := tcpAddr.Port
@@ -249,7 +249,7 @@ func RunWebTerminal(ctx context.Context, target string, timeout time.Duration, o
 	// Shut down server when context is canceled
 	go func() {
 		<-ctx.Done()
-		server.Close()
+		_ = server.Close()
 	}()
 
 	url := fmt.Sprintf("http://127.0.0.1:%d", port)
@@ -277,7 +277,7 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request, mgr *sessionManager
 	if wsErr != nil {
 		return
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
@@ -352,10 +352,9 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request, mgr *sessionManager
 func streamFrames(ctx context.Context, cancel context.CancelFunc, conn net.Conn, mu *sync.Mutex, mgr *sessionManager) {
 	// Recover from panics caused by accessing a closed/freed session during reconnect.
 	defer func() {
-		if r := recover(); r != nil {
-			// Session was closed during reconnect — not a fatal error.
-			// The browser will reconnect with a new WebSocket after /reconnect succeeds.
-		}
+		// Session may be closed during reconnect — not a fatal error.
+		// The browser will reconnect with a new WebSocket after /reconnect succeeds.
+		_ = recover()
 	}()
 
 	ticker := time.NewTicker(100 * time.Millisecond) // ~10 FPS
@@ -466,11 +465,11 @@ func upgradeWebSocket(w http.ResponseWriter, r *http.Request) (net.Conn, error) 
 		"Connection: Upgrade\r\n" +
 		"Sec-WebSocket-Accept: " + accept + "\r\n\r\n"
 	if _, err := bufrw.WriteString(resp); err != nil {
-		conn.Close()
+		_ = conn.Close()
 		return nil, err
 	}
 	if err := bufrw.Flush(); err != nil {
-		conn.Close()
+		_ = conn.Close()
 		return nil, err
 	}
 
@@ -499,13 +498,14 @@ func readWSMessage(conn net.Conn) ([]byte, error) {
 	masked := header[1]&0x80 != 0
 	payloadLen := uint64(header[1] & 0x7F)
 
-	if payloadLen == 126 {
+	switch payloadLen {
+	case 126:
 		ext := make([]byte, 2)
 		if err := readFull(conn, ext); err != nil {
 			return nil, err
 		}
 		payloadLen = uint64(ext[0])<<8 | uint64(ext[1])
-	} else if payloadLen == 127 {
+	case 127:
 		ext := make([]byte, 8)
 		if err := readFull(conn, ext); err != nil {
 			return nil, err

--- a/internal/plugins/redis/redis.go
+++ b/internal/plugins/redis/redis.go
@@ -73,7 +73,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		ReadTimeout:  timeout,
 		WriteTimeout: timeout,
 	})
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	// Create context with timeout
 	pingCtx, cancel := context.WithTimeout(ctx, timeout)

--- a/internal/plugins/smb/smb.go
+++ b/internal/plugins/smb/smb.go
@@ -71,7 +71,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		result.Error = brutus.WrapConnError(err)
 		return result
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Parse domain and username
 	domain, user := parseDomainUsername(username)

--- a/internal/plugins/smtp/smtp.go
+++ b/internal/plugins/smtp/smtp.go
@@ -67,7 +67,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		result.Error = brutus.WrapConnError(err)
 		return result
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Set deadline for the entire operation
 	deadline := time.Now().Add(timeout)
@@ -88,7 +88,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		result.Error = classifyError(err)
 		return result
 	}
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	// Try STARTTLS if available
 	// Read TLS mode from context

--- a/internal/plugins/snmp/snmp.go
+++ b/internal/plugins/snmp/snmp.go
@@ -84,7 +84,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		result.Error = brutus.WrapConnError(connectErr)
 		return result
 	}
-	defer snmp.Conn.Close()
+	defer func() { _ = snmp.Conn.Close() }()
 
 	// Try to get sysDescr - this validates the community string
 	oids := []string{SysDescrOID}

--- a/internal/plugins/ssh/ssh.go
+++ b/internal/plugins/ssh/ssh.go
@@ -78,7 +78,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		result.Error = brutus.WrapConnError(err)
 		return result
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Perform SSH handshake
 	sshConn, chans, reqs, err := ssh.NewClientConn(conn, target, config)
@@ -86,7 +86,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		result.Error = classifyAuthError(err)
 		return result
 	}
-	defer sshConn.Close()
+	defer func() { _ = sshConn.Close() }()
 
 	// Capture SSH server version banner
 	result.Banner = string(sshConn.ServerVersion())
@@ -151,7 +151,7 @@ func (p *Plugin) TestKey(ctx context.Context, target, username string, key []byt
 		result.Error = brutus.WrapConnError(err)
 		return result
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Perform SSH handshake
 	sshConn, chans, reqs, err := ssh.NewClientConn(conn, target, config)
@@ -159,7 +159,7 @@ func (p *Plugin) TestKey(ctx context.Context, target, username string, key []byt
 		result.Error = classifyAuthError(err)
 		return result
 	}
-	defer sshConn.Close()
+	defer func() { _ = sshConn.Close() }()
 
 	// Capture SSH server version banner
 	result.Banner = string(sshConn.ServerVersion())

--- a/internal/plugins/ssh/ssh_test.go
+++ b/internal/plugins/ssh/ssh_test.go
@@ -18,8 +18,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/praetorian-inc/brutus/pkg/brutus"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/praetorian-inc/brutus/pkg/brutus"
 )
 
 func TestPlugin_Name(t *testing.T) {

--- a/internal/plugins/telnet/telnet.go
+++ b/internal/plugins/telnet/telnet.go
@@ -68,7 +68,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		result.Error = classifyError(err)
 		return result
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Set overall timeout
 	_ = conn.SetDeadline(time.Now().Add(timeout))

--- a/internal/plugins/vnc/vnc.go
+++ b/internal/plugins/vnc/vnc.go
@@ -71,7 +71,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		result.Error = brutus.WrapConnError(err)
 		return result
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Create VNC client configuration
 	cfg := &vnc.ClientConfig{

--- a/pkg/brutus/http.go
+++ b/pkg/brutus/http.go
@@ -68,15 +68,15 @@ func DetectHTTPAuthType(target string, useHTTPS bool, timeout time.Duration, tls
 	if err != nil {
 		return "", ""
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	// Build banner from response headers and body
 	var bannerBuilder strings.Builder
-	bannerBuilder.WriteString(fmt.Sprintf("HTTP/%d.%d %s\n", resp.ProtoMajor, resp.ProtoMinor, resp.Status))
+	fmt.Fprintf(&bannerBuilder, "HTTP/%d.%d %s\n", resp.ProtoMajor, resp.ProtoMinor, resp.Status)
 
 	for _, header := range []string{"Server", "WWW-Authenticate", "X-Powered-By", "X-Server", "X-AspNet-Version"} {
 		if val := resp.Header.Get(header); val != "" {
-			bannerBuilder.WriteString(fmt.Sprintf("%s: %s\n", header, val))
+			fmt.Fprintf(&bannerBuilder, "%s: %s\n", header, val)
 		}
 	}
 

--- a/pkg/brutus/http_test.go
+++ b/pkg/brutus/http_test.go
@@ -28,7 +28,7 @@ import (
 func TestDetectHTTPAuthType_ClosesIdleConnections(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintln(w, "Test page")
+		_, _ = fmt.Fprintln(w, "Test page")
 	}))
 	defer server.Close()
 

--- a/pkg/brutus/input.go
+++ b/pkg/brutus/input.go
@@ -49,7 +49,7 @@ func LoadPasswordsFromFile(filePath string) ([]string, error) {
 	}
 
 	scanErr := scanner.Err()
-	f.Close()
+	_ = f.Close()
 
 	if scanErr != nil {
 		return nil, fmt.Errorf("reading password file: %w", scanErr)
@@ -79,7 +79,7 @@ func LoadUsernamesFromFile(filePath string) ([]string, error) {
 	}
 
 	scanErr := scanner.Err()
-	f.Close()
+	_ = f.Close()
 
 	if scanErr != nil {
 		return nil, fmt.Errorf("reading username file: %w", scanErr)

--- a/pkg/brutus/ratelimit_test.go
+++ b/pkg/brutus/ratelimit_test.go
@@ -190,18 +190,18 @@ func (p *testRateLimitPlugin) Test(ctx context.Context, target, username, passwo
 // TestSubSecondRateLimit tests that fractional rates (sub-1 RPS) work correctly
 func TestSubSecondRateLimit(t *testing.T) {
 	tests := []struct {
-		name            string
-		rateLimit       float64
-		numRequests     int
-		minDurationMS   int64
-		description     string
+		name          string
+		rateLimit     float64
+		numRequests   int
+		minDurationMS int64
+		description   string
 	}{
 		{
-			name:            "0.5 RPS (1 request every 2 seconds)",
-			rateLimit:       0.5,
-			numRequests:     2,
-			minDurationMS:   2000, // First request immediate, second after 2s
-			description:     "0.5 RPS means 1 request every 2 seconds",
+			name:          "0.5 RPS (1 request every 2 seconds)",
+			rateLimit:     0.5,
+			numRequests:   2,
+			minDurationMS: 2000, // First request immediate, second after 2s
+			description:   "0.5 RPS means 1 request every 2 seconds",
 		},
 	}
 


### PR DESCRIPTION
## Summary

Migrates brutus's main CI workflow to the centralized `go-ci.yml@v1.0.2` ([ENG-3092](https://linear.app/praetorianlabs/issue/ENG-3092)).

Inline 4-job ci.yml → 18-line caller. Same lint+test+build behavior, now SHA-pinned and with Harden-Runner.

browser-plugin-ci.yml, browser-plugin-integration.yml, ci-integration.yml, release.yml unchanged.

Note: previous ci.yml was failing CI — migration replaces the failing workflow with the proven reusable pattern.

Refs: ENG-3079, ENG-3081