### PR TITLE
ci: add centralized go-security.yml workflow (gosec + govulncheck)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   security:
-    uses: praetorian-inc/public-workflows/.github/workflows/go-security.yml@4900fbd3aaf1992181e2ebfb108c71fee8250c67  # v2.0.1
+    uses: praetorian-inc/public-workflows/.github/workflows/go-security.yml@a2b8d84dbc6aa0136dabf4ce5dda0fe28b6bf407  # v1.1.2
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   security:
-    uses: praetorian-inc/public-workflows/.github/workflows/go-security.yml@240855e97e4efd9157b2a1ae1f7a2815ab60b878  # v1.1.1
+    uses: praetorian-inc/public-workflows/.github/workflows/go-security.yml@a2b8d84dbc6aa0136dabf4ce5dda0fe28b6bf407  # v1.1.2
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   security:
-    uses: praetorian-inc/public-workflows/.github/workflows/go-security.yml@a2b8d84dbc6aa0136dabf4ce5dda0fe28b6bf407  # v1.1.2
+    uses: praetorian-inc/public-workflows/.github/workflows/go-security.yml@4900fbd3aaf1992181e2ebfb108c71fee8250c67  # v2.0.1
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   security:
-    uses: praetorian-inc/public-workflows/.github/workflows/go-security.yml@a2b8d84dbc6aa0136dabf4ce5dda0fe28b6bf407  # v1.1.2
+    uses: praetorian-inc/public-workflows/.github/workflows/go-security.yml@faa2e42989736cf9b3f47e5377dd5f2e0327517f  # v2.0.2
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,21 @@
+name: Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'  # Mondays 06:00 UTC — weekly baseline
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  security:
+    uses: praetorian-inc/public-workflows/.github/workflows/go-security.yml@d805693c16ea002e098e5520592959a8e98e12ac  # v1.1.0
+    permissions:
+      contents: read
+      security-events: write
+    secrets: inherit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   security:
-    uses: praetorian-inc/public-workflows/.github/workflows/go-security.yml@d805693c16ea002e098e5520592959a8e98e12ac  # v1.1.0
+    uses: praetorian-inc/public-workflows/.github/workflows/go-security.yml@240855e97e4efd9157b2a1ae1f7a2815ab60b878  # v1.1.1
     permissions:
       contents: read
       security-events: write


### PR DESCRIPTION
Adds `.github/workflows/security.yml` calling centralized `praetorian-inc/public-workflows/go-security.yml@v1.1.0` (SHA `d805693c16ea002e098e5520592959a8e98e12ac`). Runs gosec (SAST) and govulncheck (Go vulndb) on push, PR, and weekly Monday schedule. SARIF findings published to GitHub Security tab.

**Note:** This PR is intentionally additive (new file only) and does NOT touch the existing `ci.yml`. The old `ci.yml` still has a `security:` job that installs `gosec@latest` — that job is broken (gosec v2.25.0 requires Go 1.25+; brutus pins Go 1.24.13) and is what caused [PR #57](https://github.com/praetorian-inc/brutus/pull/57)'s Security Scan failure. The fix for that broken job is [PR #56 (migrate-ci-to-reusable-workflow)](https://github.com/praetorian-inc/brutus/pull/56), which rewrites `ci.yml` entirely and removes the inline security job.

Once #56 merges, brutus will have:
- `ci.yml` (lint/test/build via `go-ci.yml@<SHA>`)
- `security.yml` (gosec/govulncheck via `go-security.yml@v1.1.0`)

Part of ENG-3079 supply-chain hardening rollout.

See https://github.com/praetorian-inc/public-workflows/pull/9 for the reusable workflow definition and rationale.

## Merge order

Recommended: merge #56 first (fixes #57's Security Scan failure), then this PR.

## Test plan
- [ ] New go-security.yml jobs complete (gosec + govulncheck) — expected pass on the SARIF-upload path
- [ ] (After #56 merges) Old broken `security:` job no longer exists