### PR TITLE
feat: add capability-sdk integration for Chariot platform

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/masterzen/winrm v0.0.0-20250927112105-5f8e6c707321
 	github.com/mitchellh/go-vnc v0.0.0-20150629162542-723ed9867aed
 	github.com/neo4j/neo4j-go-driver/v5 v5.28.4
+	github.com/praetorian-inc/capability-sdk v0.0.0-20260407200040-0c1ef1feb1e6
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/stretchr/testify v1.11.1
 	github.com/tetratelabs/wazero v1.11.0
@@ -62,7 +63,6 @@ require (
 	github.com/masterzen/simplexml v0.0.0-20190410153822-31eea3082786 // indirect
 	github.com/montanaflynn/stats v0.7.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/praetorian-inc/capability-sdk v0.0.0-20260407200040-0c1ef1feb1e6 // indirect
 	github.com/tidwall/transform v0.0.0-20201103190739-32f242e2dbde // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/scram v1.1.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/praetorian-inc/brutus
 
-go 1.24.0
+go 1.24.6
 
 require (
 	github.com/chromedp/chromedp v0.14.2
@@ -62,6 +62,7 @@ require (
 	github.com/masterzen/simplexml v0.0.0-20190410153822-31eea3082786 // indirect
 	github.com/montanaflynn/stats v0.7.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/praetorian-inc/capability-sdk v0.0.0-20260407200040-0c1ef1feb1e6 // indirect
 	github.com/tidwall/transform v0.0.0-20201103190739-32f242e2dbde // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/scram v1.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -132,6 +132,8 @@ github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzb
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/praetorian-inc/capability-sdk v0.0.0-20260407200040-0c1ef1feb1e6 h1:Hihpd+SwV+24JJBBHX4Eur8B3bZm6NiggzvkJxVRq4c=
+github.com/praetorian-inc/capability-sdk v0.0.0-20260407200040-0c1ef1feb1e6/go.mod h1:/qQhuKn0EqiccC5zOv2ExYa5amYrlDJP1PV5t1LsjM8=
 github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
 github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/pkg/sdk/capability.go
+++ b/pkg/sdk/capability.go
@@ -63,14 +63,14 @@ func (c *Capability) Parameters() []capability.Parameter {
 	}
 }
 
-func (c *Capability) Match(ctx capability.ExecutionContext, _ capmodel.Port) error {
+func (c *Capability) Match(ctx capability.ExecutionContext, _ capmodel.Port) error { //nolint:gocritic // hugeParam: signature required by capability.Capability interface
 	if !ctx.Manual {
 		return fmt.Errorf("brutus may only be run manually")
 	}
 	return nil
 }
 
-func (c *Capability) Invoke(ctx capability.ExecutionContext, input capmodel.Port, output capability.Emitter) error {
+func (c *Capability) Invoke(ctx capability.ExecutionContext, input capmodel.Port, output capability.Emitter) error { //nolint:gocritic // hugeParam: signature required by capability.Capability interface
 	if !ctx.Manual {
 		return fmt.Errorf("brutus may only be run manually")
 	}

--- a/pkg/sdk/capability.go
+++ b/pkg/sdk/capability.go
@@ -1,0 +1,158 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package sdk provides a capability-sdk compatible wrapper around the Brutus
+// credential testing library. It implements capability.Capability[capmodel.Port]
+// so that Brutus can be registered as a Chariot capability.
+package sdk
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/praetorian-inc/brutus/pkg/brutus"
+	_ "github.com/praetorian-inc/brutus/pkg/builtins"
+	"github.com/praetorian-inc/capability-sdk/pkg/capability"
+	"github.com/praetorian-inc/capability-sdk/pkg/capmodel"
+)
+
+const (
+	UsernameParam  = "usernames"
+	PasswordParam  = "passwords"
+	RateLimitParam = "ratelimit"
+	ProtocolParam  = "protocol"
+)
+
+// Capability implements capability.Capability[capmodel.Port] using the Brutus
+// credential testing library.
+type Capability struct{}
+
+// Compile-time interface check.
+var _ capability.Capability[capmodel.Port] = (*Capability)(nil)
+
+// NewCapability returns a new Brutus SDK capability instance.
+func NewCapability() *Capability {
+	return &Capability{}
+}
+
+func (c *Capability) Name() string        { return "brutus" }
+func (c *Capability) Description() string { return "credential testing against network services" }
+func (c *Capability) Input() any          { return capmodel.Port{} }
+
+func (c *Capability) Parameters() []capability.Parameter {
+	return []capability.Parameter{
+		capability.String(UsernameParam, "Comma-separated list of usernames to test (defaults to brutus-provided list)"),
+		capability.String(PasswordParam, "Comma-separated list of passwords to test (defaults to brutus-provided list)"),
+		capability.Float(RateLimitParam, "Requests per second, supports fractional values like 0.5 (defaults to unlimited)"),
+		capability.String(ProtocolParam, "The protocol to use (defaults to the protocol detected on this port)"),
+	}
+}
+
+func (c *Capability) Match(ctx capability.ExecutionContext, _ capmodel.Port) error {
+	if !ctx.Manual {
+		return fmt.Errorf("brutus may only be run manually")
+	}
+	return nil
+}
+
+func (c *Capability) Invoke(ctx capability.ExecutionContext, input capmodel.Port, output capability.Emitter) error {
+	protocol := input.Service
+	if p, ok := ctx.Parameters.GetString(ProtocolParam); ok && p != "" {
+		protocol = p
+	}
+	if protocol == "" {
+		return fmt.Errorf("no protocol specified and port has no service detected")
+	}
+
+	// Validate port number
+	if input.Port < 1 || input.Port > 65535 {
+		return fmt.Errorf("invalid port number: %d", input.Port)
+	}
+
+	// Validate hostname
+	if input.Parent.DNS == "" {
+		return fmt.Errorf("no hostname specified in port parent asset")
+	}
+
+	target := fmt.Sprintf("%s:%d", input.Parent.DNS, input.Port)
+
+	cfg := &brutus.Config{
+		Target:      target,
+		Protocol:    protocol,
+		UseDefaults: true,
+	}
+
+	if usernames, ok := ctx.Parameters.GetString(UsernameParam); ok && usernames != "" {
+		cfg.Usernames = splitAndTrim(usernames)
+	}
+
+	if passwords, ok := ctx.Parameters.GetString(PasswordParam); ok && passwords != "" {
+		cfg.Passwords = splitAndTrim(passwords)
+	}
+
+	if rateLimit, ok := ctx.Parameters.GetFloat(RateLimitParam); ok && rateLimit > 0 {
+		cfg.RateLimit = rateLimit
+	}
+
+	results, err := brutus.BruteWithContext(context.Background(), cfg)
+	if err != nil {
+		return fmt.Errorf("brute force execution failed: %w", err)
+	}
+
+	for _, r := range results {
+		if !r.Success {
+			continue
+		}
+
+		proof, err := json.Marshal(map[string]string{
+			"username": r.Username,
+			"password": r.Password,
+			"protocol": r.Protocol,
+			"target":   r.Target,
+			"banner":   r.Banner,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to marshal proof: %w", err)
+		}
+
+		risk := capmodel.Risk{
+			TargetName: target,
+			Name:       "Weak Credentials",
+			Source:     "brutus",
+			Status:     "OH",
+			Proof:      proof,
+			Target:     input,
+		}
+
+		if err := output.Emit(risk); err != nil {
+			return fmt.Errorf("failed to emit risk: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func splitAndTrim(s string) []string {
+	parts := strings.Split(s, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		trimmed := strings.TrimSpace(p)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}

--- a/pkg/sdk/capability.go
+++ b/pkg/sdk/capability.go
@@ -50,6 +50,10 @@ func NewCapability() *Capability {
 	return &Capability{}
 }
 
+// bruteFunc is the function used to run brute force sweeps. It is a package-level
+// variable so that tests can inject a stub without a broad DI refactor.
+var bruteFunc = brutus.BruteWithContext
+
 func (c *Capability) Name() string        { return "brutus" }
 func (c *Capability) Description() string { return "credential testing against network services" }
 func (c *Capability) Input() any          { return capmodel.Port{} }
@@ -109,16 +113,22 @@ func (c *Capability) Invoke(ctx capability.ExecutionContext, input capmodel.Port
 		cfg.Passwords = splitAndTrim(passwords)
 	}
 
-	if rateLimit, ok := ctx.Parameters.GetFloat(RateLimitParam); ok && rateLimit > 0 {
-		cfg.RateLimit = rateLimit
+	if rateLimit, ok := ctx.Parameters.GetFloat(RateLimitParam); ok {
+		if rateLimit < 0 {
+			return fmt.Errorf("invalid ratelimit %g: must be non-negative", rateLimit)
+		}
+		// rateLimit == 0 is treated as "unlimited" per parameter description.
+		if rateLimit > 0 {
+			cfg.RateLimit = rateLimit
+		}
 	}
 
-	results, err := brutus.BruteWithContext(context.Background(), cfg)
-	if err != nil {
-		return fmt.Errorf("brute force execution failed: %w", err)
+	results, runErr := bruteFunc(context.Background(), cfg)
+	var errs []error
+	if runErr != nil {
+		errs = append(errs, fmt.Errorf("brute force execution failed: %w", runErr))
 	}
 
-	var emitErrs []error
 	for i := range results {
 		r := &results[i]
 		if !r.Success {
@@ -146,11 +156,11 @@ func (c *Capability) Invoke(ctx capability.ExecutionContext, input capmodel.Port
 		}
 
 		if err := output.Emit(risk); err != nil {
-			emitErrs = append(emitErrs, err)
+			errs = append(errs, fmt.Errorf("failed to emit risk for %s: %w", r.Username, err))
 		}
 	}
 
-	return errors.Join(emitErrs...)
+	return errors.Join(errs...)
 }
 
 func splitAndTrim(s string) []string {

--- a/pkg/sdk/capability.go
+++ b/pkg/sdk/capability.go
@@ -71,6 +71,10 @@ func (c *Capability) Match(ctx capability.ExecutionContext, _ capmodel.Port) err
 }
 
 func (c *Capability) Invoke(ctx capability.ExecutionContext, input capmodel.Port, output capability.Emitter) error {
+	if !ctx.Manual {
+		return fmt.Errorf("brutus may only be run manually")
+	}
+
 	protocol := input.Service
 	if p, ok := ctx.Parameters.GetString(ProtocolParam); ok && p != "" {
 		protocol = p
@@ -115,7 +119,8 @@ func (c *Capability) Invoke(ctx capability.ExecutionContext, input capmodel.Port
 	}
 
 	var emitErrs []error
-	for _, r := range results {
+	for i := range results {
+		r := &results[i]
 		if !r.Success {
 			continue
 		}

--- a/pkg/sdk/capability.go
+++ b/pkg/sdk/capability.go
@@ -20,13 +20,15 @@ package sdk
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/praetorian-inc/brutus/pkg/brutus"
-	_ "github.com/praetorian-inc/brutus/pkg/builtins"
 	"github.com/praetorian-inc/capability-sdk/pkg/capability"
 	"github.com/praetorian-inc/capability-sdk/pkg/capmodel"
+
+	"github.com/praetorian-inc/brutus/pkg/brutus"
+	_ "github.com/praetorian-inc/brutus/pkg/builtins"
 )
 
 const (
@@ -112,6 +114,7 @@ func (c *Capability) Invoke(ctx capability.ExecutionContext, input capmodel.Port
 		return fmt.Errorf("brute force execution failed: %w", err)
 	}
 
+	var emitErrs []error
 	for _, r := range results {
 		if !r.Success {
 			continue
@@ -138,11 +141,11 @@ func (c *Capability) Invoke(ctx capability.ExecutionContext, input capmodel.Port
 		}
 
 		if err := output.Emit(risk); err != nil {
-			return fmt.Errorf("failed to emit risk: %w", err)
+			emitErrs = append(emitErrs, err)
 		}
 	}
 
-	return nil
+	return errors.Join(emitErrs...)
 }
 
 func splitAndTrim(s string) []string {

--- a/pkg/sdk/capability_test.go
+++ b/pkg/sdk/capability_test.go
@@ -1,0 +1,332 @@
+package sdk
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/praetorian-inc/brutus/pkg/brutus"
+	"github.com/praetorian-inc/capability-sdk/pkg/capability"
+	"github.com/praetorian-inc/capability-sdk/pkg/capmodel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCapability_Interface(t *testing.T) {
+	var _ capability.Capability[capmodel.Port] = (*Capability)(nil)
+}
+
+func TestCapability_Name(t *testing.T) {
+	c := NewCapability()
+	assert.Equal(t, "brutus", c.Name())
+}
+
+func TestCapability_Description(t *testing.T) {
+	c := NewCapability()
+	assert.Equal(t, "credential testing against network services", c.Description())
+}
+
+func TestCapability_Input(t *testing.T) {
+	c := NewCapability()
+	assert.Equal(t, capmodel.Port{}, c.Input())
+}
+
+func TestCapability_Parameters(t *testing.T) {
+	c := NewCapability()
+	params := c.Parameters()
+
+	require.Len(t, params, 4)
+
+	assert.Equal(t, "usernames", params[0].Name)
+	assert.Equal(t, "string", params[0].Type)
+
+	assert.Equal(t, "passwords", params[1].Name)
+	assert.Equal(t, "string", params[1].Type)
+
+	assert.Equal(t, "ratelimit", params[2].Name)
+	assert.Equal(t, "float", params[2].Type)
+
+	assert.Equal(t, "protocol", params[3].Name)
+	assert.Equal(t, "string", params[3].Type)
+}
+
+func TestCapability_Match_ManualOnly(t *testing.T) {
+	c := NewCapability()
+	ctx := capability.ExecutionContext{Manual: true}
+	err := c.Match(ctx, capmodel.Port{})
+	assert.NoError(t, err)
+}
+
+func TestCapability_Match_RejectsAutomated(t *testing.T) {
+	c := NewCapability()
+	ctx := capability.ExecutionContext{Manual: false}
+	err := c.Match(ctx, capmodel.Port{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "manually")
+}
+
+func TestSplitAndTrim(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "simple",
+			input:    "admin,root,user",
+			expected: []string{"admin", "root", "user"},
+		},
+		{
+			name:     "with spaces",
+			input:    " admin , root , user ",
+			expected: []string{"admin", "root", "user"},
+		},
+		{
+			name:     "single value",
+			input:    "admin",
+			expected: []string{"admin"},
+		},
+		{
+			name:     "empty strings filtered",
+			input:    "admin,,root,",
+			expected: []string{"admin", "root"},
+		},
+		{
+			name:     "all empty",
+			input:    ",,",
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := splitAndTrim(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCapability_Invoke_InvalidPort(t *testing.T) {
+	c := NewCapability()
+	ctx := capability.ExecutionContext{Manual: true}
+	input := capmodel.Port{
+		Service: "ssh",
+		Port:    0,
+		Parent:  capmodel.Asset{DNS: "example.com"},
+	}
+	err := c.Invoke(ctx, input, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid port")
+}
+
+func TestCapability_Invoke_EmptyHostname(t *testing.T) {
+	c := NewCapability()
+	ctx := capability.ExecutionContext{Manual: true}
+	input := capmodel.Port{
+		Service: "ssh",
+		Port:    22,
+		Parent:  capmodel.Asset{DNS: ""},
+	}
+	err := c.Invoke(ctx, input, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no hostname")
+}
+
+func TestCapability_Invoke_NoProtocol(t *testing.T) {
+	c := NewCapability()
+	ctx := capability.ExecutionContext{Manual: true}
+	input := capmodel.Port{
+		Port:   22,
+		Parent: capmodel.Asset{DNS: "example.com"},
+	}
+	err := c.Invoke(ctx, input, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no protocol")
+}
+
+// mockPlugin is a test plugin that always succeeds.
+type mockPlugin struct{}
+
+func (p *mockPlugin) Name() string { return "mock-test" }
+func (p *mockPlugin) Test(ctx context.Context, target, username, password string, timeout time.Duration) *brutus.Result {
+	return &brutus.Result{
+		Protocol: "mock-test",
+		Target:   target,
+		Username: username,
+		Password: password,
+		Success:  true,
+		Banner:   "mock banner",
+	}
+}
+
+func TestCapability_Invoke_Success(t *testing.T) {
+	brutus.ResetPlugins()
+	brutus.Register("mock-test", func() brutus.Plugin { return &mockPlugin{} })
+	defer brutus.ResetPlugins()
+
+	c := NewCapability()
+
+	var emitted []any
+	emitter := capability.EmitterFunc(func(models ...any) error {
+		emitted = append(emitted, models...)
+		return nil
+	})
+
+	ctx := capability.ExecutionContext{
+		Manual: true,
+		Parameters: capability.Parameters{
+			{Name: "usernames", Value: "admin", Type: "string"},
+			{Name: "passwords", Value: "password123", Type: "string"},
+			{Name: "protocol", Value: "mock-test", Type: "string"},
+		},
+	}
+
+	input := capmodel.Port{
+		Port:    22,
+		Service: "mock-test",
+		Parent:  capmodel.Asset{DNS: "127.0.0.1"},
+	}
+
+	err := c.Invoke(ctx, input, emitter)
+	require.NoError(t, err)
+	require.Len(t, emitted, 1)
+
+	risk, ok := emitted[0].(capmodel.Risk)
+	require.True(t, ok)
+	assert.Equal(t, "127.0.0.1:22", risk.TargetName)
+	assert.Equal(t, "Weak Credentials", risk.Name)
+	assert.Equal(t, "brutus", risk.Source)
+	assert.Equal(t, "OH", risk.Status)
+
+	var proof map[string]string
+	err = json.Unmarshal(risk.Proof, &proof)
+	require.NoError(t, err)
+	assert.Equal(t, "admin", proof["username"])
+	assert.Equal(t, "password123", proof["password"])
+	assert.Equal(t, "mock-test", proof["protocol"])
+}
+
+type mockFailPlugin struct{}
+
+func (p *mockFailPlugin) Name() string { return "mock-fail" }
+func (p *mockFailPlugin) Test(ctx context.Context, target, username, password string, timeout time.Duration) *brutus.Result {
+	return &brutus.Result{
+		Protocol: "mock-fail",
+		Target:   target,
+		Username: username,
+		Password: password,
+		Success:  false,
+	}
+}
+
+func TestCapability_Invoke_NoSuccessfulResults(t *testing.T) {
+	brutus.ResetPlugins()
+	brutus.Register("mock-fail", func() brutus.Plugin { return &mockFailPlugin{} })
+	defer brutus.ResetPlugins()
+
+	c := NewCapability()
+
+	var emitted []any
+	emitter := capability.EmitterFunc(func(models ...any) error {
+		emitted = append(emitted, models...)
+		return nil
+	})
+
+	ctx := capability.ExecutionContext{
+		Manual: true,
+		Parameters: capability.Parameters{
+			{Name: "usernames", Value: "admin", Type: "string"},
+			{Name: "passwords", Value: "wrong", Type: "string"},
+			{Name: "protocol", Value: "mock-fail", Type: "string"},
+		},
+	}
+
+	input := capmodel.Port{
+		Port:    22,
+		Service: "mock-fail",
+		Parent:  capmodel.Asset{DNS: "127.0.0.1"},
+	}
+
+	err := c.Invoke(ctx, input, emitter)
+	assert.NoError(t, err)
+	assert.Empty(t, emitted, "no risks should be emitted for failed auth")
+}
+
+func TestCapability_Invoke_ProtocolFromService(t *testing.T) {
+	brutus.ResetPlugins()
+	brutus.Register("mock-test", func() brutus.Plugin { return &mockPlugin{} })
+	defer brutus.ResetPlugins()
+
+	c := NewCapability()
+
+	var emitted []any
+	emitter := capability.EmitterFunc(func(models ...any) error {
+		emitted = append(emitted, models...)
+		return nil
+	})
+
+	ctx := capability.ExecutionContext{
+		Manual: true,
+		Parameters: capability.Parameters{
+			{Name: "usernames", Value: "admin", Type: "string"},
+			{Name: "passwords", Value: "pass", Type: "string"},
+		},
+	}
+
+	input := capmodel.Port{
+		Port:    22,
+		Service: "mock-test",
+		Parent:  capmodel.Asset{DNS: "127.0.0.1"},
+	}
+
+	err := c.Invoke(ctx, input, emitter)
+	require.NoError(t, err)
+	assert.Len(t, emitted, 1, "should emit one risk from mock plugin")
+}
+
+func TestCapability_Invoke_PortOutOfRange(t *testing.T) {
+	c := NewCapability()
+	ctx := capability.ExecutionContext{Manual: true}
+
+	input := capmodel.Port{
+		Service: "ssh",
+		Port:    70000,
+		Parent:  capmodel.Asset{DNS: "example.com"},
+	}
+	err := c.Invoke(ctx, input, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid port")
+}
+
+func TestCapability_Invoke_EmitterError(t *testing.T) {
+	brutus.ResetPlugins()
+	brutus.Register("mock-test", func() brutus.Plugin { return &mockPlugin{} })
+	defer brutus.ResetPlugins()
+
+	c := NewCapability()
+
+	emitter := capability.EmitterFunc(func(models ...any) error {
+		return fmt.Errorf("emit failed")
+	})
+
+	ctx := capability.ExecutionContext{
+		Manual: true,
+		Parameters: capability.Parameters{
+			{Name: "usernames", Value: "admin", Type: "string"},
+			{Name: "passwords", Value: "pass", Type: "string"},
+			{Name: "protocol", Value: "mock-test", Type: "string"},
+		},
+	}
+
+	input := capmodel.Port{
+		Port:    22,
+		Service: "mock-test",
+		Parent:  capmodel.Asset{DNS: "127.0.0.1"},
+	}
+
+	err := c.Invoke(ctx, input, emitter)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to emit risk")
+}

--- a/pkg/sdk/capability_test.go
+++ b/pkg/sdk/capability_test.go
@@ -7,11 +7,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/praetorian-inc/brutus/pkg/brutus"
 	"github.com/praetorian-inc/capability-sdk/pkg/capability"
 	"github.com/praetorian-inc/capability-sdk/pkg/capmodel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	
+	"github.com/praetorian-inc/brutus/pkg/brutus"
 )
 
 func TestCapability_Interface(t *testing.T) {
@@ -328,5 +329,5 @@ func TestCapability_Invoke_EmitterError(t *testing.T) {
 
 	err := c.Invoke(ctx, input, emitter)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to emit risk")
+	assert.Contains(t, err.Error(), "emit failed")
 }

--- a/pkg/sdk/capability_test.go
+++ b/pkg/sdk/capability_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/praetorian-inc/capability-sdk/pkg/capmodel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	
+
 	"github.com/praetorian-inc/brutus/pkg/brutus"
 )
 

--- a/pkg/sdk/capability_test.go
+++ b/pkg/sdk/capability_test.go
@@ -331,3 +331,151 @@ func TestCapability_Invoke_EmitterError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "emit failed")
 }
+
+func TestInvoke_RejectsNegativeRateLimit(t *testing.T) {
+	orig := bruteFunc
+	defer func() { bruteFunc = orig }()
+
+	called := false
+	bruteFunc = func(_ context.Context, _ *brutus.Config) ([]brutus.Result, error) {
+		called = true
+		return nil, nil
+	}
+
+	c := NewCapability()
+	ctx := capability.ExecutionContext{
+		Manual: true,
+		Parameters: capability.Parameters{
+			{Name: "usernames", Value: "admin", Type: "string"},
+			{Name: "passwords", Value: "pass", Type: "string"},
+			{Name: "protocol", Value: "ssh", Type: "string"},
+			{Name: "ratelimit", Value: "-1", Type: "float"},
+		},
+	}
+	input := capmodel.Port{
+		Port:    22,
+		Service: "ssh",
+		Parent:  capmodel.Asset{DNS: "127.0.0.1"},
+	}
+
+	err := c.Invoke(ctx, input, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "must be non-negative")
+	assert.False(t, called, "bruteFunc should not be called when ratelimit is negative")
+}
+
+func TestInvoke_ZeroRateLimitMeansUnlimited(t *testing.T) {
+	orig := bruteFunc
+	defer func() { bruteFunc = orig }()
+
+	var capturedCfg *brutus.Config
+	bruteFunc = func(_ context.Context, cfg *brutus.Config) ([]brutus.Result, error) {
+		capturedCfg = cfg
+		return nil, nil
+	}
+
+	c := NewCapability()
+	ctx := capability.ExecutionContext{
+		Manual: true,
+		Parameters: capability.Parameters{
+			{Name: "usernames", Value: "admin", Type: "string"},
+			{Name: "passwords", Value: "pass", Type: "string"},
+			{Name: "protocol", Value: "ssh", Type: "string"},
+			{Name: "ratelimit", Value: "0", Type: "float"},
+		},
+	}
+	input := capmodel.Port{
+		Port:    22,
+		Service: "ssh",
+		Parent:  capmodel.Asset{DNS: "127.0.0.1"},
+	}
+	emitter := capability.EmitterFunc(func(_ ...any) error { return nil })
+
+	err := c.Invoke(ctx, input, emitter)
+	require.NoError(t, err)
+	require.NotNil(t, capturedCfg)
+	assert.Equal(t, 0.0, capturedCfg.RateLimit)
+}
+
+func TestInvoke_PositiveRateLimitPropagates(t *testing.T) {
+	orig := bruteFunc
+	defer func() { bruteFunc = orig }()
+
+	var capturedCfg *brutus.Config
+	bruteFunc = func(_ context.Context, cfg *brutus.Config) ([]brutus.Result, error) {
+		capturedCfg = cfg
+		return nil, nil
+	}
+
+	c := NewCapability()
+	ctx := capability.ExecutionContext{
+		Manual: true,
+		Parameters: capability.Parameters{
+			{Name: "usernames", Value: "admin", Type: "string"},
+			{Name: "passwords", Value: "pass", Type: "string"},
+			{Name: "protocol", Value: "ssh", Type: "string"},
+			{Name: "ratelimit", Value: "2.5", Type: "float"},
+		},
+	}
+	input := capmodel.Port{
+		Port:    22,
+		Service: "ssh",
+		Parent:  capmodel.Asset{DNS: "127.0.0.1"},
+	}
+	emitter := capability.EmitterFunc(func(_ ...any) error { return nil })
+
+	err := c.Invoke(ctx, input, emitter)
+	require.NoError(t, err)
+	require.NotNil(t, capturedCfg)
+	assert.Equal(t, 2.5, capturedCfg.RateLimit)
+}
+
+func TestInvoke_PartialResultsOnBruteError(t *testing.T) {
+	orig := bruteFunc
+	defer func() { bruteFunc = orig }()
+
+	bruteFunc = func(_ context.Context, _ *brutus.Config) ([]brutus.Result, error) {
+		return []brutus.Result{
+			{
+				Protocol: "ssh",
+				Target:   "127.0.0.1:22",
+				Username: "admin",
+				Password: "pass",
+				Success:  true,
+				Banner:   "SSH-2.0-OpenSSH",
+			},
+		}, fmt.Errorf("context deadline exceeded")
+	}
+
+	c := NewCapability()
+	ctx := capability.ExecutionContext{
+		Manual: true,
+		Parameters: capability.Parameters{
+			{Name: "usernames", Value: "admin", Type: "string"},
+			{Name: "passwords", Value: "pass", Type: "string"},
+			{Name: "protocol", Value: "ssh", Type: "string"},
+		},
+	}
+	input := capmodel.Port{
+		Port:    22,
+		Service: "ssh",
+		Parent:  capmodel.Asset{DNS: "127.0.0.1"},
+	}
+
+	var emitted []any
+	emitter := capability.EmitterFunc(func(models ...any) error {
+		emitted = append(emitted, models...)
+		return nil
+	})
+
+	err := c.Invoke(ctx, input, emitter)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "brute force execution failed")
+	assert.Contains(t, err.Error(), "context deadline exceeded")
+	require.Len(t, emitted, 1)
+
+	risk, ok := emitted[0].(capmodel.Risk)
+	require.True(t, ok)
+	assert.Equal(t, "Weak Credentials", risk.Name)
+	assert.Equal(t, "brutus", risk.Source)
+}


### PR DESCRIPTION
## Summary

- Add `pkg/sdk` package implementing `capability.Capability[capmodel.Port]` for Chariot platform integration (LAB-1879)
- Add `github.com/praetorian-inc/capability-sdk` dependency
- 17 unit tests with 93.3% coverage on new code
- Zero changes to existing code — all 31 existing test packages continue to pass

## Details

This PR adds a new `pkg/sdk` package that wraps the existing Brutus credential testing library as a Chariot SDK capability. The chariot wrapper at `guard/backend/pkg/tasks/capabilities/brutus/` can now delegate to `brutussdk.NewCapability()` instead of maintaining its own implementation.

**New files:**
- `pkg/sdk/capability.go` — Implements `Name`, `Description`, `Input`, `Parameters`, `Match`, `Invoke`
- `pkg/sdk/capability_test.go` — 17 tests covering interface compliance, metadata, match logic, invoke happy/error paths, input validation, emitter error propagation

**Invoke flow:**
1. Extract protocol from port service or parameter override
2. Validate port number (1-65535) and hostname
3. Build `brutus.Config` with target, protocol, and parsed parameters
4. Call `brutus.BruteWithContext()` 
5. Emit `capmodel.Risk` for each successful credential found

**Follow-up:** Chariot wrapper update to delegate to this SDK capability (separate PR in guard repo)

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes  
- [x] `go test -short ./...` — all 31 packages pass
- [x] `go test -cover ./pkg/sdk/` — 93.3% coverage
- [ ] Chariot wrapper integration (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)