### PR TITLE
fix: skip SMB IPv6 tests when Docker SMB service is running

### DIFF
--- a/internal/plugins/smb/smb_test.go
+++ b/internal/plugins/smb/smb_test.go
@@ -16,6 +16,7 @@ package smb
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -131,6 +132,10 @@ func TestPlugin_Test_DomainUsername(t *testing.T) {
 }
 
 func TestPlugin_Test_IPv6Target(t *testing.T) {
+	if os.Getenv("SMB_TEST_HOST") != "" {
+		t.Skip("SMB service is running; IPv6 loopback on port 445 reaches the Docker container")
+	}
+
 	p := &Plugin{}
 	ctx := context.Background()
 
@@ -146,6 +151,10 @@ func TestPlugin_Test_IPv6Target(t *testing.T) {
 }
 
 func TestPlugin_Test_IPv6TargetNoPort(t *testing.T) {
+	if os.Getenv("SMB_TEST_HOST") != "" {
+		t.Skip("SMB service is running; IPv6 loopback on default port 445 reaches the Docker container")
+	}
+
 	p := &Plugin{}
 	ctx := context.Background()
 


### PR DESCRIPTION
## Summary

- Skip `TestPlugin_Test_IPv6Target` and `TestPlugin_Test_IPv6TargetNoPort` when `SMB_TEST_HOST` is set

## Root Cause

The integration test CI runs a Docker SMB container (`dperson/samba`) on port 445. Docker binds to all interfaces including IPv6, so when these tests connect to `[::1]:445`, they reach the real SMB server instead of getting a connection refused error. The SMB container allows guest access, so the connection succeeds and both `result.Success = true` and `result.Error = nil`, causing both tests to fail.

## Fix

Skip the IPv6 connection tests when `SMB_TEST_HOST` is set, which indicates the integration test environment has a real SMB service on port 445. IPv6 parsing is still fully covered by `TestParseTarget`.

## Test plan

- [x] Tests pass locally without `SMB_TEST_HOST` (connection refused on IPv6 loopback)
- [x] Tests skip when `SMB_TEST_HOST=localhost:445` is set
- [x] Full test suite passes (`go test ./...`)
- [ ] Integration CI passes with Docker SMB service

🤖 Generated with [Claude Code](https://claude.com/claude-code)