### PR TITLE
feat(ci): add Titus secrets scanning

### DIFF
--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -9,6 +9,10 @@ on:
     - cron: '0 7 * * 1'  # weekly baseline
   workflow_dispatch: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -1,0 +1,23 @@
+name: Secrets Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 7 * * 1'  # weekly baseline
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    uses: praetorian-inc/public-workflows/.github/workflows/titus-scan.yml@debcee1fd3a78e908b1f89d8f2bef0644c454cbc  # v2.2.0
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    secrets: inherit
+


### PR DESCRIPTION
Adds `secrets-scan.yml` calling the centralized `titus-scan.yml` reusable from public-workflows. Scans for leaked secrets, credentials, and API keys using Titus (487 rules).

- Runs on push to main, PRs, weekly schedule, and manual dispatch
- Findings upload to GitHub Security tab via SARIF
- Non-blocking (observe mode) — won't fail builds
- Preflight skips docs/images-only PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)