### PR TITLE
fix(tests): resolve Windows test reliability and error handling issues

### DIFF
--- a/internal/plugins/http/http_test.go
+++ b/internal/plugins/http/http_test.go
@@ -68,7 +68,7 @@ func TestPlugin_Test_ValidCredentials(t *testing.T) {
 	assert.Equal(t, "secret", result.Password)
 	assert.True(t, result.Success)
 	assert.Nil(t, result.Error)
-	assert.Greater(t, result.Duration, time.Duration(0))
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_InvalidCredentials(t *testing.T) {
@@ -99,7 +99,7 @@ func TestPlugin_Test_InvalidCredentials(t *testing.T) {
 	assert.Equal(t, "wrongpassword", result.Password)
 	assert.False(t, result.Success)
 	assert.Nil(t, result.Error) // Auth failure returns nil error
-	assert.Greater(t, result.Duration, time.Duration(0))
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_BannerCapture_Grafana(t *testing.T) {

--- a/internal/plugins/mongodb/mongodb_test.go
+++ b/internal/plugins/mongodb/mongodb_test.go
@@ -86,7 +86,7 @@ func TestPlugin_Test_InvalidTarget(t *testing.T) {
 	assert.Contains(t, result.Error.Error(), "connection error")
 	assert.Equal(t, "mongodb", result.Protocol)
 	assert.Equal(t, "invalid:target:format", result.Target)
-	assert.Greater(t, result.Duration, time.Duration(0))
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_ResultStructure(t *testing.T) {
@@ -102,7 +102,7 @@ func TestPlugin_Test_ResultStructure(t *testing.T) {
 	assert.Equal(t, "user", result.Username)
 	assert.Equal(t, "pass", result.Password)
 	assert.False(t, result.Success)
-	assert.Greater(t, result.Duration, time.Duration(0))
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_ContextCancellation(t *testing.T) {

--- a/internal/plugins/neo4j/neo4j_test.go
+++ b/internal/plugins/neo4j/neo4j_test.go
@@ -44,7 +44,7 @@ func TestPlugin_Test_ValidCredentials(t *testing.T) {
 	assert.Equal(t, "password", result.Password)
 	assert.True(t, result.Success)
 	assert.Nil(t, result.Error)
-	assert.Greater(t, result.Duration, time.Duration(0))
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_InvalidCredentials(t *testing.T) {
@@ -63,7 +63,7 @@ func TestPlugin_Test_InvalidCredentials(t *testing.T) {
 	assert.Equal(t, "wrongpassword", result.Password)
 	assert.False(t, result.Success)
 	assert.Nil(t, result.Error) // Auth failure returns nil error
-	assert.Greater(t, result.Duration, time.Duration(0))
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_ConnectionError(t *testing.T) {

--- a/internal/plugins/postgresql/postgresql_test.go
+++ b/internal/plugins/postgresql/postgresql_test.go
@@ -116,7 +116,7 @@ func TestPlugin_Test_ValidCredentials(t *testing.T) {
 	assert.Equal(t, pass, result.Password)
 	assert.True(t, result.Success, "Expected successful authentication")
 	assert.Nil(t, result.Error, "Expected no error on successful auth")
-	assert.Greater(t, result.Duration, time.Duration(0))
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_InvalidCredentials(t *testing.T) {
@@ -137,7 +137,7 @@ func TestPlugin_Test_InvalidCredentials(t *testing.T) {
 	assert.Equal(t, "wrongpassword", result.Password)
 	assert.False(t, result.Success, "Expected failed authentication")
 	assert.Nil(t, result.Error, "Authentication failure should have nil error")
-	assert.Greater(t, result.Duration, time.Duration(0))
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_ConnectionRefused(t *testing.T) {
@@ -154,7 +154,7 @@ func TestPlugin_Test_ConnectionRefused(t *testing.T) {
 	assert.False(t, result.Success, "Expected connection failure")
 	assert.NotNil(t, result.Error, "Connection error should have non-nil error")
 	assert.Contains(t, result.Error.Error(), "connection error")
-	assert.Greater(t, result.Duration, time.Duration(0))
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_InvalidTarget(t *testing.T) {
@@ -171,7 +171,7 @@ func TestPlugin_Test_InvalidTarget(t *testing.T) {
 	assert.False(t, result.Success, "Expected connection failure")
 	assert.NotNil(t, result.Error, "DNS error should have non-nil error")
 	assert.Contains(t, result.Error.Error(), "connection error")
-	assert.Greater(t, result.Duration, time.Duration(0))
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_Timeout(t *testing.T) {
@@ -221,7 +221,7 @@ func TestPlugin_Test_MissingPort(t *testing.T) {
 	assert.Equal(t, "localhost", result.Target)
 	// Connection may fail or succeed depending on implementation
 	// Just verify we get a valid result structure
-	assert.Greater(t, result.Duration, time.Duration(0))
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestInit(t *testing.T) {

--- a/internal/plugins/rdp/rdp_test.go
+++ b/internal/plugins/rdp/rdp_test.go
@@ -245,7 +245,7 @@ func TestPlugin_Integration_ValidCredentials(t *testing.T) {
 	assert.Equal(t, pass, result.Password)
 	assert.True(t, result.Success, "valid credentials should succeed")
 	assert.Nil(t, result.Error)
-	assert.Greater(t, result.Duration, time.Duration(0))
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Integration_InvalidCredentials(t *testing.T) {
@@ -261,7 +261,7 @@ func TestPlugin_Integration_InvalidCredentials(t *testing.T) {
 	assert.Equal(t, host, result.Target)
 	assert.False(t, result.Success, "wrong password should fail")
 	assert.Nil(t, result.Error, "auth failure should return nil error (not connection error)")
-	assert.Greater(t, result.Duration, time.Duration(0))
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Integration_DomainUsername(t *testing.T) {
@@ -281,5 +281,5 @@ func TestPlugin_Integration_DomainUsername(t *testing.T) {
 	assert.Equal(t, "rdp", result.Protocol)
 	assert.Equal(t, host, result.Target)
 	assert.Equal(t, domainUser, result.Username)
-	assert.Greater(t, result.Duration, time.Duration(0))
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }

--- a/internal/plugins/rdp/webterm.go
+++ b/internal/plugins/rdp/webterm.go
@@ -215,12 +215,14 @@ func RunWebTerminal(ctx context.Context, target string, timeout time.Duration, o
 			height = curSess.Height()
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		if err := json.NewEncoder(w).Encode(map[string]interface{}{
 			"width":  width,
 			"height": height,
 			"target": target,
 			"token":  token,
-		})
+		}); err != nil {
+			fmt.Fprintf(os.Stderr, "[!] Failed to encode /info response: %v\n", err)
+		}
 	})
 	mux.HandleFunc("/reconnect", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -236,13 +238,17 @@ func RunWebTerminal(ctx context.Context, target string, timeout time.Duration, o
 		if reconnErr := mgr.Reconnect(ctx); reconnErr != nil {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusInternalServerError)
-			_ = json.NewEncoder(w).Encode(map[string]string{"error": reconnErr.Error()})
+			if err := json.NewEncoder(w).Encode(map[string]string{"error": reconnErr.Error()}); err != nil {
+				fmt.Fprintf(os.Stderr, "[!] Failed to encode error response: %v\n", err)
+			}
 			fmt.Fprintf(os.Stderr, "[!] Reconnect failed: %v\n", reconnErr)
 			return
 		}
 		fmt.Fprintf(os.Stderr, "[+] Reconnected successfully.\n")
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+		if err := json.NewEncoder(w).Encode(map[string]string{"status": "ok"}); err != nil {
+			fmt.Fprintf(os.Stderr, "[!] Failed to encode success response: %v\n", err)
+		}
 	})
 	server := &http.Server{Handler: mux}
 

--- a/internal/plugins/redis/redis_test.go
+++ b/internal/plugins/redis/redis_test.go
@@ -127,7 +127,7 @@ func TestPlugin_Test_ValidCredentials(t *testing.T) {
 	assert.Equal(t, pass, result.Password)
 	assert.True(t, result.Success, "Expected successful authentication")
 	assert.Nil(t, result.Error, "Expected no error on successful auth")
-	assert.Greater(t, result.Duration, time.Duration(0))
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_InvalidCredentials(t *testing.T) {
@@ -148,7 +148,7 @@ func TestPlugin_Test_InvalidCredentials(t *testing.T) {
 	assert.Equal(t, "wrongpassword", result.Password)
 	assert.False(t, result.Success, "Expected failed authentication")
 	assert.Nil(t, result.Error, "Authentication failure should have nil error")
-	assert.Greater(t, result.Duration, time.Duration(0))
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_NoAuthRequired(t *testing.T) {
@@ -168,7 +168,7 @@ func TestPlugin_Test_NoAuthRequired(t *testing.T) {
 	assert.Equal(t, "", result.Password)
 	// If Redis has no auth, this should succeed
 	// If Redis requires auth, this should fail with nil error (auth failure)
-	assert.Greater(t, result.Duration, time.Duration(0))
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_ConnectionRefused(t *testing.T) {
@@ -185,7 +185,7 @@ func TestPlugin_Test_ConnectionRefused(t *testing.T) {
 	assert.False(t, result.Success, "Expected connection failure")
 	assert.NotNil(t, result.Error, "Connection error should have non-nil error")
 	assert.Contains(t, result.Error.Error(), "connection error")
-	assert.Greater(t, result.Duration, time.Duration(0))
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_InvalidTarget(t *testing.T) {
@@ -202,7 +202,7 @@ func TestPlugin_Test_InvalidTarget(t *testing.T) {
 	assert.False(t, result.Success, "Expected connection failure")
 	assert.NotNil(t, result.Error, "DNS error should have non-nil error")
 	assert.Contains(t, result.Error.Error(), "connection error")
-	assert.Greater(t, result.Duration, time.Duration(0))
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_Timeout(t *testing.T) {
@@ -252,7 +252,7 @@ func TestPlugin_Test_MissingPort(t *testing.T) {
 	assert.Equal(t, "localhost", result.Target)
 	// Connection may fail or succeed depending on implementation
 	// Just verify we get a valid result structure
-	assert.Greater(t, result.Duration, time.Duration(0))
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestInit(t *testing.T) {

--- a/internal/plugins/smb/smb_test.go
+++ b/internal/plugins/smb/smb_test.go
@@ -47,7 +47,7 @@ func TestPlugin_Test_ValidCredentials(t *testing.T) {
 	assert.Equal(t, "password", result.Password)
 	assert.True(t, result.Success)
 	assert.Nil(t, result.Error)
-	assert.Greater(t, result.Duration, time.Duration(0))
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_InvalidCredentials(t *testing.T) {
@@ -66,7 +66,7 @@ func TestPlugin_Test_InvalidCredentials(t *testing.T) {
 	assert.Equal(t, "wrongpassword", result.Password)
 	assert.False(t, result.Success)
 	assert.Nil(t, result.Error) // Auth failure returns nil error
-	assert.Greater(t, result.Duration, time.Duration(0))
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_ConnectionError(t *testing.T) {

--- a/internal/plugins/smtp/smtp_test.go
+++ b/internal/plugins/smtp/smtp_test.go
@@ -44,7 +44,7 @@ func TestPlugin_Test_ValidCredentials(t *testing.T) {
 	assert.Equal(t, "password", result.Password)
 	assert.True(t, result.Success)
 	assert.Nil(t, result.Error)
-	assert.Greater(t, result.Duration, time.Duration(0))
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_InvalidCredentials(t *testing.T) {
@@ -63,7 +63,7 @@ func TestPlugin_Test_InvalidCredentials(t *testing.T) {
 	assert.Equal(t, "wrongpassword", result.Password)
 	assert.False(t, result.Success)
 	assert.Nil(t, result.Error) // Auth failure returns nil error
-	assert.Greater(t, result.Duration, time.Duration(0))
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_ConnectionError(t *testing.T) {

--- a/internal/plugins/vnc/vnc_test.go
+++ b/internal/plugins/vnc/vnc_test.go
@@ -45,7 +45,7 @@ func TestPlugin_Test_ValidCredentials(t *testing.T) {
 	assert.Equal(t, "password", result.Password)
 	assert.True(t, result.Success)
 	assert.Nil(t, result.Error)
-	assert.Greater(t, result.Duration, time.Duration(0))
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_InvalidCredentials(t *testing.T) {
@@ -64,7 +64,7 @@ func TestPlugin_Test_InvalidCredentials(t *testing.T) {
 	assert.Equal(t, "wrongpassword", result.Password)
 	assert.False(t, result.Success)
 	assert.Nil(t, result.Error) // Auth failure returns nil error
-	assert.Greater(t, result.Duration, time.Duration(0))
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_ConnectionError(t *testing.T) {

--- a/internal/plugins/winrm/winrm_test.go
+++ b/internal/plugins/winrm/winrm_test.go
@@ -192,7 +192,7 @@ func TestPlugin_Test_ConnectionRefused(t *testing.T) {
 	assert.False(t, result.Success)
 	assert.NotNil(t, result.Error)
 	assert.Contains(t, result.Error.Error(), "connection error")
-	assert.Greater(t, result.Duration, time.Duration(0))
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_InvalidTarget(t *testing.T) {
@@ -207,7 +207,7 @@ func TestPlugin_Test_InvalidTarget(t *testing.T) {
 	assert.False(t, result.Success)
 	assert.NotNil(t, result.Error)
 	assert.Contains(t, result.Error.Error(), "connection error")
-	assert.Greater(t, result.Duration, time.Duration(0))
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_Timeout(t *testing.T) {
@@ -249,7 +249,7 @@ func TestPlugin_Test_MissingPort(t *testing.T) {
 	assert.NotNil(t, result)
 	assert.Equal(t, "winrm", result.Protocol)
 	assert.Equal(t, "localhost", result.Target)
-	assert.Greater(t, result.Duration, time.Duration(0))
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_HTTPS(t *testing.T) {
@@ -283,7 +283,7 @@ func TestPlugin_Test_ValidCredentials(t *testing.T) {
 	assert.Equal(t, "winrm", result.Protocol)
 	assert.True(t, result.Success)
 	assert.Nil(t, result.Error)
-	assert.Greater(t, result.Duration, time.Duration(0))
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_InvalidCredentials(t *testing.T) {
@@ -303,7 +303,7 @@ func TestPlugin_Test_InvalidCredentials(t *testing.T) {
 	assert.Equal(t, "winrm", result.Protocol)
 	assert.False(t, result.Success)
 	assert.Nil(t, result.Error) // Auth failure returns nil error
-	assert.Greater(t, result.Duration, time.Duration(0))
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestInit(t *testing.T) {

--- a/pkg/brutus/errors.go
+++ b/pkg/brutus/errors.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package brutus
 
 import (

--- a/pkg/brutus/input.go
+++ b/pkg/brutus/input.go
@@ -48,11 +48,13 @@ func LoadPasswordsFromFile(filePath string) ([]string, error) {
 		passwords = append(passwords, trimmed)
 	}
 
-	scanErr := scanner.Err()
-	_ = f.Close()
+	if err := scanner.Err(); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("reading password file: %w", err)
+	}
 
-	if scanErr != nil {
-		return nil, fmt.Errorf("reading password file: %w", scanErr)
+	if err := f.Close(); err != nil {
+		return nil, fmt.Errorf("closing password file: %w", err)
 	}
 
 	return passwords, nil
@@ -78,11 +80,13 @@ func LoadUsernamesFromFile(filePath string) ([]string, error) {
 		usernames = append(usernames, trimmed)
 	}
 
-	scanErr := scanner.Err()
-	_ = f.Close()
+	if err := scanner.Err(); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("reading username file: %w", err)
+	}
 
-	if scanErr != nil {
-		return nil, fmt.Errorf("reading username file: %w", scanErr)
+	if err := f.Close(); err != nil {
+		return nil, fmt.Errorf("closing username file: %w", err)
 	}
 
 	return usernames, nil


### PR DESCRIPTION
This commit addresses multiple small issues found across the codebase:

Test Reliability (Windows):
- Change assert.Greater to assert.GreaterOrEqual for Duration checks
- Fixes flaky tests on Windows where time.Since() can return 0 for fast ops
- Affects: mongodb, winrm, vnc, smtp, smb, redis, rdp, postgresql, neo4j, http tests

Documentation:
- Add missing Apache license header to pkg/brutus/errors.go

Error Handling:
- Fix ignored file close errors in LoadPasswordsFromFile and LoadUsernamesFromFile
- Properly check and return close errors instead of silently ignoring
- Fix ignored JSON encoding errors in webterm.go HTTP handlers
- Add error logging for failed JSON encodes in /info and /reconnect endpoints