### PR TITLE
feat(cli): add --targets-file for multi-target runs (#80)

### DIFF
--- a/cmd/brutus/main.go
+++ b/cmd/brutus/main.go
@@ -79,6 +79,7 @@ func isColorEnabled(noColor bool) bool {
 func main() {
 	// Command-line flags
 	target := flag.String("target", "", "Target host:port")
+	targetsFile := flag.String("targets-file", "", "File of targets to test, one host:port per line (#-prefixed lines and blank lines are ignored). Requires --protocol.")
 	showVersion := flag.Bool("version", false, "Show version information")
 	protocol := flag.String("protocol", "", "Protocol to use (auto-detected from nerva)")
 	usernames := flag.String("u", "root,admin", "Comma-separated usernames")
@@ -270,9 +271,36 @@ func main() {
 		return
 	}
 
-	if useStdin {
+	switch {
+	case useStdin:
 		allResults, hasSuccess = runFromStdin(&baseConfig, *jsonOutput)
-	} else {
+	case *targetsFile != "":
+		// --targets-file is mutually exclusive with --target / --nerva.
+		// Validate before doing the file IO so a stale --target on the
+		// CLI surfaces with a clear error rather than silent precedence.
+		if *target != "" {
+			errMsg(useColor, "--targets-file is mutually exclusive with --target")
+			closeOutput()
+			os.Exit(1)
+		}
+		if *protocol == "" {
+			errMsg(useColor, "--targets-file requires --protocol (no nerva fingerprinting in this mode)")
+			closeOutput()
+			os.Exit(1)
+		}
+		targetsList, err := brutus.LoadTargetsFromFile(*targetsFile)
+		if err != nil {
+			errMsg(useColor, "%v", err)
+			closeOutput()
+			os.Exit(1)
+		}
+		if len(targetsList) == 0 {
+			errMsg(useColor, "targets file %q has no targets after stripping comments and blank lines", *targetsFile)
+			closeOutput()
+			os.Exit(1)
+		}
+		allResults, hasSuccess = runFromTargetsFile(targetsList, &baseConfig, *jsonOutput)
+	default:
 		if err := validateTargetFlags(*target, *protocol); err != nil {
 			errMsg(useColor, "%v", err)
 			flag.Usage()
@@ -282,8 +310,8 @@ func main() {
 		allResults, hasSuccess = runSingleTargetMode(*target, *protocol, &baseConfig, *jsonOutput, jsonWriter)
 	}
 
-	// Final JSON output for nerva mode
-	if *jsonOutput && useStdin {
+	// Final JSON output for multi-target modes (nerva or targets-file).
+	if *jsonOutput && (useStdin || *targetsFile != "") {
 		outputJSONL(jsonWriter, allResults)
 	}
 

--- a/cmd/brutus/main.go
+++ b/cmd/brutus/main.go
@@ -273,6 +273,16 @@ func main() {
 
 	switch {
 	case useStdin:
+		// Reject the combination up-front: without this check, piping
+		// nerva JSON to stdin (or passing --nerva explicitly) silently
+		// wins over --targets-file via detectStdinMode, and the user's
+		// --targets-file content is dropped on the floor. Mirrors the
+		// --target check below.
+		if *targetsFile != "" {
+			errMsg(useColor, "--targets-file is mutually exclusive with --nerva / piped stdin")
+			closeOutput()
+			os.Exit(1)
+		}
 		allResults, hasSuccess = runFromStdin(&baseConfig, *jsonOutput)
 	case *targetsFile != "":
 		// --targets-file is mutually exclusive with --target / --nerva.

--- a/cmd/brutus/runner.go
+++ b/cmd/brutus/runner.go
@@ -30,6 +30,50 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/brutus"
 )
 
+// runFromTargetsFile iterates the host:port lines from a targets file and
+// runs the configured brute force against each one. Order matches the file;
+// a per-target failure does not abort the whole run.
+//
+// Output behaviour mirrors --nerva (multi-target) mode: in human output we
+// stream "valid only" findings per target as soon as they're produced, and
+// in JSON mode the caller flushes the full JSONL after the loop returns.
+//
+// See https://github.com/praetorian-inc/brutus/issues/80.
+func runFromTargetsFile(targets []string, base *baseConfigOptions, jsonOut bool) ([]brutus.Result, bool) {
+	var allResults []brutus.Result
+	hasSuccess := false
+
+	for _, target := range targets {
+		if base.protocolOverride == "" {
+			warnMsg(base.useColor, "skipping %q: --protocol is required when using --targets-file", target)
+			continue
+		}
+		protocol := base.protocolOverride
+
+		// AI mode for HTTP services (mirrors single-target dispatch).
+		var aiCreds []brutus.Credential
+		if base.aiMode && (protocol == "http" || protocol == "https") {
+			protocol, aiCreds = routeHTTPWithAI(target, protocol, base)
+		}
+
+		if !jsonOut && !base.quiet {
+			printTargetInfo(target, protocol, base, aiCreds)
+		}
+
+		results, success := runSingleTarget(target, protocol, base.tlsMode, base, aiCreds)
+		allResults = append(allResults, results...)
+		if success {
+			hasSuccess = true
+		}
+
+		if !jsonOut {
+			outputValidOnly(results, base.useColor)
+		}
+	}
+
+	return allResults, hasSuccess
+}
+
 // runFromStdin reads nerva JSON from stdin and tests each target
 func runFromStdin(base *baseConfigOptions, jsonOut bool) ([]brutus.Result, bool) {
 	var allResults []brutus.Result

--- a/cmd/brutus/runner.go
+++ b/cmd/brutus/runner.go
@@ -34,7 +34,7 @@ import (
 // runs the configured brute force against each one. Order matches the file;
 // a per-target failure does not abort the whole run.
 //
-// Output behaviour mirrors --nerva (multi-target) mode: in human output we
+// Output behavior mirrors --nerva (multi-target) mode: in human output we
 // stream "valid only" findings per target as soon as they're produced, and
 // in JSON mode the caller flushes the full JSONL after the loop returns.
 //
@@ -68,10 +68,34 @@ func runFromTargetsFile(targets []string, base *baseConfigOptions, jsonOut bool)
 
 		if !jsonOut {
 			outputValidOnly(results, base.useColor)
+			emitSecurityFindings(results, base.useColor)
 		}
 	}
 
 	return allResults, hasSuccess
+}
+
+// emitSecurityFindings prints the per-target Security-Findings block for any
+// result whose banner carries a security-relevant marker (sticky-keys, etc.).
+// Extracted so runFromStdin and runFromTargetsFile share one implementation
+// rather than duplicating the streaming-output path.
+func emitSecurityFindings(results []brutus.Result, useColor bool) {
+	for i := range results {
+		r := &results[i]
+		if r.Banner == "" || !hasSecurityFinding(r.Banner) {
+			continue
+		}
+		if useColor {
+			fmt.Printf("\n%s\n", heading(useColor, "Security Findings"))
+			fmt.Printf("  %s @ %s\n", r.Protocol, r.Target)
+			for _, line := range splitLines(r.Banner) {
+				fmt.Printf("  %s\n", line)
+			}
+		} else {
+			fmt.Printf("%s @ %s: %s\n", r.Protocol, r.Target, r.Banner)
+		}
+		break // One findings block per target
+	}
 }
 
 // runFromStdin reads nerva JSON from stdin and tests each target
@@ -135,22 +159,7 @@ func runFromStdin(base *baseConfigOptions, jsonOut bool) ([]brutus.Result, bool)
 		// Output valid credentials immediately (streaming for large-scale scans)
 		if !jsonOut {
 			outputValidOnly(results, base.useColor)
-			// Also output security findings (e.g., sticky keys detection)
-			for i := range results {
-				r := &results[i]
-				if r.Banner != "" && hasSecurityFinding(r.Banner) {
-					if base.useColor {
-						fmt.Printf("\n%s\n", heading(base.useColor, "Security Findings"))
-						fmt.Printf("  %s @ %s\n", r.Protocol, r.Target)
-						for _, line := range splitLines(r.Banner) {
-							fmt.Printf("  %s\n", line)
-						}
-					} else {
-						fmt.Printf("%s @ %s: %s\n", r.Protocol, r.Target, r.Banner)
-					}
-					break // One findings block per target
-				}
-			}
+			emitSecurityFindings(results, base.useColor)
 		}
 	}
 	if err := scanner.Err(); err != nil {

--- a/pkg/brutus/input.go
+++ b/pkg/brutus/input.go
@@ -88,6 +88,42 @@ func LoadUsernamesFromFile(filePath string) ([]string, error) {
 	return usernames, nil
 }
 
+// LoadTargetsFromFile reads a list of host:port targets from a file, one
+// per line. Lines starting with '#' and blank lines are skipped, mirroring
+// the username/password file conventions. Whitespace around each target is
+// trimmed.
+//
+// The function does not validate the host:port shape — that's left to the
+// per-target dispatch path so a bad line surfaces with the same error as a
+// bad --target flag, with the line number included for context.
+//
+// See https://github.com/praetorian-inc/brutus/issues/80.
+func LoadTargetsFromFile(filePath string) ([]string, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("opening targets file: %w", err)
+	}
+
+	var targets []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		trimmed := strings.TrimSpace(scanner.Text())
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		targets = append(targets, trimmed)
+	}
+
+	scanErr := scanner.Err()
+	_ = f.Close()
+
+	if scanErr != nil {
+		return nil, fmt.Errorf("reading targets file: %w", scanErr)
+	}
+
+	return targets, nil
+}
+
 // LoadKeyFile reads an SSH/TLS key file, enforcing a 1 MB size limit.
 func LoadKeyFile(filePath string) ([][]byte, error) {
 	if filePath == "" {

--- a/pkg/brutus/input_test.go
+++ b/pkg/brutus/input_test.go
@@ -127,3 +127,50 @@ func TestLoadKeyFile_Empty(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, keys)
 }
+
+// TestLoadTargetsFromFile pins the on-disk shape supported by
+// `--targets-file` for issue #80: one target per line, comments and blank
+// lines stripped, surrounding whitespace trimmed.
+func TestLoadTargetsFromFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	targetsFile := filepath.Join(tmpDir, "targets.txt")
+
+	content := `# this is a comment - should be skipped
+host1.example.com:22
+
+  host2.example.com:443
+host3.example.com:3306
+   # mid-file comment with leading whitespace
+host4.example.com:5432
+`
+	err := os.WriteFile(targetsFile, []byte(content), 0o644)
+	require.NoError(t, err)
+
+	targets, err := LoadTargetsFromFile(targetsFile)
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"host1.example.com:22",
+		"host2.example.com:443",
+		"host3.example.com:3306",
+		"host4.example.com:5432",
+	}, targets)
+}
+
+func TestLoadTargetsFromFile_EmptyAfterStripping(t *testing.T) {
+	// A file that's only comments + blanks should return zero targets
+	// without erroring. main.go checks the empty case separately and
+	// surfaces a friendlier message there.
+	tmpDir := t.TempDir()
+	targetsFile := filepath.Join(tmpDir, "empty-after-strip.txt")
+	require.NoError(t, os.WriteFile(targetsFile, []byte("# only comments\n\n   \n"), 0o644))
+
+	targets, err := LoadTargetsFromFile(targetsFile)
+	require.NoError(t, err)
+	assert.Empty(t, targets)
+}
+
+func TestLoadTargetsFromFile_MissingFile(t *testing.T) {
+	_, err := LoadTargetsFromFile("/this/path/does/not/exist.txt")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "opening targets file")
+}


### PR DESCRIPTION
Closes the first half of #80 — the "I would like to provide a list of targets instead of a single one. And I don't want to use nerva" ask.

Adds a \`--targets-file\` flag that reads one \`host:port\` per line and iterates the configured brute force across each entry, mirroring the existing \`--nerva\` multi-target dispatch but without the JSON-on-stdin requirement.

\`\`\`
$ printf 'host1.example.com:22\nhost2.example.com:22\n' > targets.txt
$ brutus --targets-file targets.txt --protocol ssh -u root -p secret
\`\`\`

File format follows the existing \`-U\` / \`-P\` conventions: \`#\`-prefixed lines and blank lines are stripped, leading/trailing whitespace per line is trimmed.

## Validation

\`--targets-file\` requires \`--protocol\`, since there's no nerva fingerprinting in this mode. Surfaced as a clear error before any file IO so a forgotten flag fails fast instead of crashing later. \`--targets-file\` is mutually exclusive with \`--target\`; combining them errors with a helpful message rather than letting one silently win.

## What's not in scope

The second half of #80 — \`-C combos.txt\` for testing pre-paired \`username:password\` lines instead of the NxM cartesian product — is a behaviour change to the credential-testing loop, not a pure orchestration addition. Kept that out of this PR to keep the review surface small. Happy to send it as a follow-up if you'd like.

## Plumbing

- \`pkg/brutus/input.go\` — new \`LoadTargetsFromFile\` mirroring the existing \`LoadUsernamesFromFile\` / \`LoadPasswordsFromFile\` shape.
- \`cmd/brutus/main.go\` — flag wired in, \`switch\` over (stdin, targets-file, single-target) for clearer dispatch than the previous \`if/else\`. Existing single-target and \`--nerva\` paths are untouched.
- \`cmd/brutus/runner.go\` — new \`runFromTargetsFile\` reuses \`runSingleTarget\` per entry. Streaming valid-only output per target (matching \`--nerva\`'s behaviour) so a long file doesn't sit silent until completion.

## Tests

3 new sub-tests in \`pkg/brutus/input_test.go\`:
- happy path with mixed comments / blanks / whitespace
- empty-after-stripping returns no targets without error (main.go surfaces a friendlier message there)
- missing file returns an "opening targets file" error

All existing tests still green:

\`\`\`
go test ./...    →  ok across pkg/, internal/plugins/, pkg/sdk/
go vet ./...     →  clean
gofmt -l         →  clean
\`\`\`

## Test plan

- [x] Build clean
- [x] New unit tests pass
- [x] Full existing test suite still green
- [x] Smoke-tested all three CLI paths (success, missing-protocol error, mutex error)