### PR TITLE
Fix Secrets Scan workflow startup_failure

### DIFF
--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -23,5 +23,6 @@ jobs:
       contents: read
       security-events: write
       actions: read
+      pull-requests: read
     secrets: inherit
 


### PR DESCRIPTION
## Summary
- Add missing `pull-requests: read` permission to the Secrets Scan workflow caller

## Root cause
The reusable `titus-scan.yml` workflow (from `public-workflows`) has a `preflight` job that requires `pull-requests: read` to check which files changed in a PR. The caller in `secrets-scan.yml` only granted `contents: read`, `security-events: write`, and `actions: read`. When a reusable workflow's job requests permissions the caller hasn't granted, GitHub rejects the workflow at startup — resulting in `startup_failure` on every run (10+ consecutive failures, zero jobs created).

## Test plan
- [x] Verify `titus-scan.yml` preflight job requires `pull-requests: read`
- [ ] Merge and confirm the Secrets Scan workflow runs successfully on the next push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)