### PR TITLE
fix(ci): update Go version from 1.24.13 to 1.25.0 in all workflows

### DIFF
--- a/.github/workflows/browser-plugin-ci.yml
+++ b/.github/workflows/browser-plugin-ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: '1.24.13'
+          go-version: '1.25.0'
           cache: true
 
       - name: Run unit tests
@@ -54,23 +54,23 @@ jobs:
     services:
       # Mock device containers
       mock-router:
-        image: golang:1.24-alpine
+        image: golang:1.25-alpine
         ports:
           - 8081:8080
       mock-camera:
-        image: golang:1.24-alpine
+        image: golang:1.25-alpine
         ports:
           - 8082:8080
       mock-printer:
-        image: golang:1.24-alpine
+        image: golang:1.25-alpine
         ports:
           - 8083:8080
       mock-nas:
-        image: golang:1.24-alpine
+        image: golang:1.25-alpine
         ports:
           - 8084:8080
       mock-generic:
-        image: golang:1.24-alpine
+        image: golang:1.25-alpine
         ports:
           - 8085:8080
 
@@ -80,7 +80,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: '1.24.13'
+          go-version: '1.25.0'
           cache: true
 
       - name: Verify Chrome installation
@@ -129,7 +129,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: '1.24.13'
+          go-version: '1.25.0'
           cache: true
 
       - name: Build

--- a/.github/workflows/browser-plugin-integration.yml
+++ b/.github/workflows/browser-plugin-integration.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: '1.24.13'
+          go-version: '1.25.0'
           cache: true
 
       - name: Verify Chrome installation
@@ -62,7 +62,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: '1.24.13'
+          go-version: '1.25.0'
           cache: true
 
       - name: Verify Chrome installation

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: '1.24.13'
+  GO_VERSION: '1.25.0'
 
 jobs:
   integration:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: '1.24.13'
+  GO_VERSION: '1.25.0'
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

- `go.mod` requires Go 1.25.0 but all CI workflows were still pinned to Go 1.24.13
- This causes every workflow to fail immediately with: `go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)`
- No tests, builds, or releases could succeed — the version mismatch aborts before any Go command runs

## Affected workflows

| Workflow | What was wrong |
|---|---|
| `ci-integration.yml` | `GO_VERSION: '1.24.13'` env var |
| `release.yml` | `GO_VERSION: '1.24.13'` env var |
| `browser-plugin-ci.yml` | `go-version: '1.24.13'` (3 jobs) + `golang:1.24-alpine` service images (5 containers) |
| `browser-plugin-integration.yml` | `go-version: '1.24.13'` (2 jobs) |

All updated to `1.25.0` / `golang:1.25-alpine`.

## Test plan

- [ ] `ci-integration.yml` — integration tests run without Go version error
- [ ] `release.yml` — release workflow can build and test
- [ ] `browser-plugin-ci.yml` — browser plugin CI passes
- [ ] `browser-plugin-integration.yml` — browser plugin integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)