### PR TITLE
fix(browser): resolve chromedp context issues in E2E tests

### DIFF
--- a/internal/plugins/browser/chrome.go
+++ b/internal/plugins/browser/chrome.go
@@ -113,6 +113,21 @@ func (b *Browser) Navigate(tabCtx context.Context, url string, timeout time.Dura
 	return chromedp.Run(ctx, chromedp.Navigate(url))
 }
 
+// NavigateAndGetHTML navigates to a URL and retrieves the full page HTML in a single operation.
+// This avoids chromedp context issues that occur when doing multiple separate chromedp.Run calls.
+func (b *Browser) NavigateAndGetHTML(tabCtx context.Context, url string, timeout time.Duration) (string, error) {
+	ctx, cancel := context.WithTimeout(tabCtx, timeout)
+	defer cancel()
+
+	var html string
+	err := chromedp.Run(ctx,
+		chromedp.Navigate(url),
+		chromedp.WaitReady("body", chromedp.ByQuery),
+		chromedp.OuterHTML("html", &html, chromedp.ByQuery),
+	)
+	return html, err
+}
+
 // NavigateAndScreenshot navigates to a URL and captures a screenshot in a single operation.
 // This avoids context lifecycle issues between separate Navigate and Screenshot calls.
 func (b *Browser) NavigateAndScreenshot(tabCtx context.Context, url string, timeout time.Duration) ([]byte, error) {

--- a/internal/plugins/browser/e2e_test.go
+++ b/internal/plugins/browser/e2e_test.go
@@ -189,22 +189,20 @@ func TestE2E_FormDetection(t *testing.T) {
 			resetBrowserSingleton()
 			t.Cleanup(resetBrowserSingleton)
 
-			browser, err := GetBrowser(1)
+			b, err := GetBrowser(1)
 			if err != nil {
 				t.Fatalf("GetBrowser failed: %v", err)
 			}
 
-			tabCtx, release := browser.AcquireTab()
+			tabCtx, release := b.AcquireTab()
 			defer release()
 
+			// Use NavigateAndGetHTML to avoid chromedp context issues between
+			// separate Navigate and GetPageHTML calls.
 			url := fmt.Sprintf("http://localhost:%d/", tc.port)
-			if err := browser.Navigate(tabCtx, url, 10*time.Second); err != nil {
-				t.Fatalf("Navigate failed: %v", err)
-			}
-
-			html, err := GetPageHTML(tabCtx)
+			html, err := b.NavigateAndGetHTML(tabCtx, url, 10*time.Second)
 			if err != nil {
-				t.Fatalf("GetPageHTML failed: %v", err)
+				t.Fatalf("NavigateAndGetHTML failed: %v", err)
 			}
 
 			fields, err := DetectFormFields(html)
@@ -245,39 +243,26 @@ func TestE2E_ErrorMessageDetection(t *testing.T) {
 			resetBrowserSingleton()
 			t.Cleanup(resetBrowserSingleton)
 
-			browser, err := GetBrowser(1)
+			b, err := GetBrowser(1)
 			if err != nil {
 				t.Fatalf("GetBrowser failed: %v", err)
 			}
 
-			tabCtx, release := browser.AcquireTab()
+			tabCtx, release := b.AcquireTab()
 			defer release()
 
+			// Use FillAndSubmitWithNavigate to do navigate + fill + submit in a
+			// single chromedp.Run, avoiding context lifecycle issues.
 			url := fmt.Sprintf("http://localhost:%d/", tc.port)
-			if err := browser.Navigate(tabCtx, url, 10*time.Second); err != nil {
-				t.Fatalf("Navigate failed: %v", err)
-			}
-
-			// Get page and detect form
-			html, _ := GetPageHTML(tabCtx)
-			fields, err := DetectFormFields(html)
+			formResult, err := FillAndSubmitWithNavigate(tabCtx, url, tc.validUser, tc.invalidPass, 30*time.Second)
 			if err != nil {
-				t.Fatalf("Form detection failed: %v", err)
+				t.Fatalf("FillAndSubmitWithNavigate failed: %v", err)
 			}
 
-			// Submit with invalid credentials
-			beforeURL, _ := GetCurrentURL(tabCtx)
-			beforeState := VerificationState{URL: beforeURL, HTML: html}
-
-			err = FillAndSubmit(tabCtx, fields, tc.validUser, tc.invalidPass)
-			if err != nil {
-				t.Fatalf("FillAndSubmit failed: %v", err)
-			}
-
-			// Get after state
-			afterHTML, _ := GetPageHTML(tabCtx)
-			afterURL, _ := GetCurrentURL(tabCtx)
-			afterState := VerificationState{URL: afterURL, HTML: afterHTML}
+			// Construct verification states from the single-Run result.
+			// The before URL is the page we navigated to.
+			beforeState := VerificationState{URL: url, HTML: ""}
+			afterState := VerificationState{URL: formResult.AfterURL, HTML: formResult.AfterHTML}
 
 			// Verify login failed
 			result := VerifyLogin(beforeState, afterState)
@@ -313,50 +298,32 @@ func TestE2E_SuccessfulLoginVerification(t *testing.T) {
 			resetBrowserSingleton()
 			t.Cleanup(resetBrowserSingleton)
 
-			browser, err := GetBrowser(1)
+			b, err := GetBrowser(1)
 			if err != nil {
 				t.Fatalf("GetBrowser failed: %v", err)
 			}
 
-			tabCtx, release := browser.AcquireTab()
+			tabCtx, release := b.AcquireTab()
 			defer release()
 
+			// Use FillAndSubmitWithNavigate to do navigate + fill + submit in a
+			// single chromedp.Run, avoiding context lifecycle issues.
 			url := fmt.Sprintf("http://localhost:%d/", tc.port)
-			if err := browser.Navigate(tabCtx, url, 10*time.Second); err != nil {
-				t.Fatalf("Navigate failed: %v", err)
-			}
-
-			// Get page and detect form
-			html, _ := GetPageHTML(tabCtx)
-			fields, err := DetectFormFields(html)
+			formResult, err := FillAndSubmitWithNavigate(tabCtx, url, tc.validUser, tc.validPass, 30*time.Second)
 			if err != nil {
-				t.Fatalf("Form detection failed: %v", err)
+				t.Fatalf("FillAndSubmitWithNavigate failed: %v", err)
 			}
 
-			// Capture before state
-			beforeURL, _ := GetCurrentURL(tabCtx)
-			beforeState := VerificationState{URL: beforeURL, HTML: html}
-
-			// Submit with VALID credentials
-			err = FillAndSubmit(tabCtx, fields, tc.validUser, tc.validPass)
-			if err != nil {
-				t.Fatalf("FillAndSubmit failed: %v", err)
-			}
-
-			// Wait a moment for redirect
-			time.Sleep(500 * time.Millisecond)
-
-			// Get after state
-			afterHTML, _ := GetPageHTML(tabCtx)
-			afterURL, _ := GetCurrentURL(tabCtx)
-			afterState := VerificationState{URL: afterURL, HTML: afterHTML}
+			// Construct verification states from the single-Run result.
+			beforeState := VerificationState{URL: url, HTML: ""}
+			afterState := VerificationState{URL: formResult.AfterURL, HTML: formResult.AfterHTML}
 
 			// Verify login succeeded
 			result := VerifyLogin(beforeState, afterState)
 
 			t.Logf("[%s] Verification: Success=%v, Confidence=%.2f, Reason=%s",
 				tc.name, result.Success, result.Confidence, result.Reason)
-			t.Logf("[%s] URL before=%s, after=%s", tc.name, beforeURL, afterURL)
+			t.Logf("[%s] URL before=%s, after=%s", tc.name, url, formResult.AfterURL)
 
 			// Most login pages redirect to dashboard after success
 			if result.Success {


### PR DESCRIPTION
## Summary

- Add `NavigateAndGetHTML` method to `Browser` that combines navigate + HTML retrieval in a single `chromedp.Run` call
- Refactor 3 failing E2E tests (`FormDetection`, `ErrorMessageDetection`, `SuccessfulLoginVerification`) to avoid separate `chromedp.Run` calls that trigger context lifecycle issues

## Root cause

The failing E2E tests called `browser.Navigate()` followed by `GetPageHTML()` as separate `chromedp.Run` operations. When `Navigate`'s internal timeout context is cancelled (via `defer cancel()`), it leaves the chromedp session in a state where subsequent `Run` calls on the same tab context time out at 5 seconds. This is a known chromedp behavior — the codebase already documents it at `forms.go:28`:

> This avoids chromedp context issues that occur when doing multiple separate chromedp.Run calls.

The passing tests (`ValidCredentials`, `InvalidCredentials`, `ConcurrentLogins`) all use `plugin.Test()` which internally calls `FillAndSubmitWithNavigate` — a single `chromedp.Run` that combines navigate + fill + submit.

## Test plan

- [ ] `Browser Plugin CI` workflow passes — all 3 jobs green
- [ ] All E2E tests pass (FormDetection, ErrorMessageDetection, SuccessfulLoginVerification)
- [ ] Unit tests and integration tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)