### PR TITLE
Add UPX-compressed binaries to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install UPX
+        run: |
+          UPX_VERSION=4.2.4
+          curl -sL "https://github.com/upx/upx/releases/download/v${UPX_VERSION}/upx-${UPX_VERSION}-amd64_linux.tar.xz" | tar xJ
+          sudo mv "upx-${UPX_VERSION}-amd64_linux/upx" /usr/local/bin/
+          upx --version
+
       - name: Fetch tags for changelog
         run: git fetch --force --tags
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -43,13 +43,58 @@ builds:
       - goos: freebsd
         goarch: arm
 
+  - id: brutus-packed
+    main: ./cmd/brutus
+    binary: brutus
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+      - -X main.Version={{.Version}}
+      - -X main.BuildTime={{.Date}}
+      - -X main.CommitSHA={{.ShortCommit}}
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+
+upx:
+  - enabled: true
+    ids:
+      - brutus-packed
+    compress: best
+    lzma: true
+
 archives:
   - id: default
+    ids:
+      - brutus
     formats:
       - tar.gz
     name_template: >-
       {{ .ProjectName }}-{{ .Os }}-{{ .Arch }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    files:
+      - LICENSE
+      - README.md
+
+  - id: packed
+    ids:
+      - brutus-packed
+    formats:
+      - tar.gz
+    name_template: >-
+      {{ .ProjectName }}-{{ .Os }}-{{ .Arch }}-upx
     format_overrides:
       - goos: windows
         formats:
@@ -142,6 +187,16 @@ release:
     | Windows | 386 | `brutus-windows-386.zip` |
     | FreeBSD | amd64 | `brutus-freebsd-amd64.tar.gz` |
     | FreeBSD | arm64 | `brutus-freebsd-arm64.tar.gz` |
+
+    ### UPX-Compressed Binaries (smaller, same functionality)
+
+    | OS | Architecture | Binary |
+    |----|--------------|--------|
+    | Linux | amd64 | `brutus-linux-amd64-upx.tar.gz` |
+    | Linux | arm64 | `brutus-linux-arm64-upx.tar.gz` |
+    | macOS | amd64 (Intel) | `brutus-darwin-amd64-upx.tar.gz` |
+    | macOS | arm64 (Apple Silicon) | `brutus-darwin-arm64-upx.tar.gz` |
+    | Windows | amd64 | `brutus-windows-amd64-upx.zip` |
 
     ---
     **Full Changelog**: https://github.com/praetorian-inc/brutus/compare/{{ .PreviousTag }}...{{ .Tag }}

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile for Brutus
 # Modern credential brute-forcing library in pure Go
 
-.PHONY: all build build-wasm clean test test-integration lint install help \
+.PHONY: all build build-packed build-wasm clean test test-integration lint install help \
 	services-up services-down
 
 # Build configuration
@@ -27,6 +27,14 @@ build:
 	@echo "Building $(BINARY_NAME) $(VERSION)..."
 	GOWORK=off CGO_ENABLED=0 go build -trimpath -ldflags="$(LDFLAGS)" -o $(BINARY_NAME) ./cmd/brutus
 	@echo "Built: $(BINARY_NAME)"
+
+# Build UPX-compressed binary (requires: upx)
+build-packed: build
+	@command -v upx >/dev/null 2>&1 || { echo "ERROR: upx not found. Install with: brew install upx"; exit 1; }
+	@echo "Compressing $(BINARY_NAME) with UPX..."
+	cp $(BINARY_NAME) $(BINARY_NAME)-upx
+	upx --best --lzma $(BINARY_NAME)-upx
+	@echo "Packed: $(BINARY_NAME)-upx"
 
 # Build IronRDP WASM module (requires Rust toolchain with wasm32-wasip1 target)
 build-wasm:
@@ -110,7 +118,7 @@ install:
 
 # Clean build artifacts
 clean:
-	rm -f $(BINARY_NAME)
+	rm -f $(BINARY_NAME) $(BINARY_NAME)-upx
 	rm -rf $(BUILD_DIR)
 	rm -f coverage.out
 
@@ -250,6 +258,7 @@ help:
 	@echo ""
 	@echo "Build targets:"
 	@echo "  build        Build single static binary (default)"
+	@echo "  build-packed Build UPX-compressed binary (requires upx)"
 	@echo "  build-wasm   Build IronRDP WASM module (requires Rust)"
 	@echo "  build-all    Build for all platforms"
 	@echo "  install      Install to GOPATH/bin"


### PR DESCRIPTION
## Summary

- Adds a separate set of UPX-packed binaries alongside existing release artifacts for users who need smaller binaries (~60-70% size reduction)
- Configures GoReleaser with a second build ID (`brutus-packed`) and UPX post-processing with best compression + LZMA
- Installs UPX 4.2.4 in the release workflow before GoReleaser runs
- Adds `make build-packed` target for local use

## Details

The packed binaries are published as separate archives with a `-upx` suffix (e.g., `brutus-linux-amd64-upx.tar.gz`) and do not replace the existing standard binaries. UPX targets are linux/darwin/windows on amd64/arm64 (skipping windows/arm64 and FreeBSD which UPX doesn't support).

Release notes footer is updated to list the UPX variants.

## Test plan

- [x] `goreleaser check` passes with no errors
- [ ] `goreleaser release --snapshot --clean` produces both standard and `-upx` archives
- [ ] `make build-packed` produces a working compressed binary locally
- [ ] Tag push triggers release with both archive sets

🤖 Generated with [Claude Code](https://claude.com/claude-code)