### PR TITLE
Fix release: extract UPX to /tmp to avoid dirty git

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,8 +73,9 @@ jobs:
       - name: Install UPX
         run: |
           UPX_VERSION=4.2.4
-          curl -sL "https://github.com/upx/upx/releases/download/v${UPX_VERSION}/upx-${UPX_VERSION}-amd64_linux.tar.xz" | tar xJ
-          sudo mv "upx-${UPX_VERSION}-amd64_linux/upx" /usr/local/bin/
+          curl -sL "https://github.com/upx/upx/releases/download/v${UPX_VERSION}/upx-${UPX_VERSION}-amd64_linux.tar.xz" \
+            | tar xJ -C /tmp
+          sudo mv "/tmp/upx-${UPX_VERSION}-amd64_linux/upx" /usr/local/bin/
           upx --version
 
       - name: Fetch tags for changelog


### PR DESCRIPTION
## Summary

- Fixes the v1.5.0 release failure caused by GoReleaser detecting a dirty git state
- The UPX installation step was extracting the tarball into the working directory, leaving `upx-4.2.4-amd64_linux/` as an untracked directory
- Changed `tar xJ` to `tar xJ -C /tmp` so the extraction happens outside the repo

## Context

The v1.5.0 release workflow [failed](https://github.com/praetorian-inc/brutus/actions/runs/26037093973) at the GoReleaser step with:
```
git is in a dirty state
?? upx-4.2.4-amd64_linux/
```

## Test plan

- [ ] Merge this PR, delete the v1.5.0 tag, re-tag, and re-run the release workflow
- [ ] Verify both standard and `-upx` archives appear in the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)