### PR TITLE
feat: add --nmap-file and --masscan-file flags for scan tool integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Built in Go as a single binary with zero external dependencies, Brutus integrate
 **Key features:**
 - **Zero dependencies:** Single binary, cross-platform (Linux, Windows, macOS)
 - **24 protocols:** SSH, RDP, MySQL, PostgreSQL, MSSQL, Redis, SMB, LDAP, WinRM, SNMP, HTTP Basic Auth, and more
-- **Pipeline integration:** Native support for Nerva and naabu workflows
+- **Pipeline integration:** Native support for Nerva, naabu, nmap, and masscan workflows
 - **Embedded bad keys:** Built-in collection of known SSH keys (Vagrant, F5, ExaGrid, etc.)
 - **Go library:** Import directly into your security automation tools
 - **Production ready:** Rate limiting, connection pooling, and comprehensive error handling
@@ -43,7 +43,7 @@ Traditional tools like **THC Hydra** have served the security community well, bu
 
 - **True zero-dependency deployment:** Download a single binary and run. No `libssh-dev`, no `libmysqlclient-dev`, no compilation errors. Works identically on Linux, macOS, and Windows.
 
-- **Native pipeline integration:** Brutus speaks JSON and integrates directly with [Nerva](https://github.com/praetorian-inc/nerva) and [naabu](https://github.com/projectdiscovery/naabu). Pipe discovered services straight into credential testing without format conversion or scripting.
+- **Native pipeline integration:** Brutus speaks JSON and integrates directly with [Nerva](https://github.com/praetorian-inc/nerva), [naabu](https://github.com/projectdiscovery/naabu), [nmap](https://nmap.org), and [masscan](https://github.com/robertdavidgraham/masscan). Pipe discovered services straight into credential testing without format conversion or scripting.
 
 - **Embedded intelligence:** Known SSH bad keys (Vagrant, F5 BIG-IP, ExaGrid, etc.) are compiled into the binary and tested automatically for SSH targets.
 
@@ -325,6 +325,63 @@ naabu -host 10.0.0.0/24 -p 27017 -silent | \
   brutus -u admin,root,mongodb -p admin,password,mongodb
 ```
 
+### Scan Tool Import (Nmap & Masscan)
+
+Brutus can import targets directly from **nmap** and **masscan** scan output files, eliminating the need for format conversion or intermediate tools.
+
+#### Nmap XML Import (`--nmap-file`)
+
+Import targets from nmap's XML output (`-oX`). Nmap provides service fingerprinting, so Brutus automatically maps detected services to the correct protocol:
+
+```bash
+# Run an nmap service scan
+nmap -sV -oX scan.xml 10.0.0.0/24 -p 22,3306,5432,6379,445,3389
+
+# Feed nmap results directly to Brutus
+brutus creds --nmap-file scan.xml -P passwords.txt
+
+# Test web services from nmap scan
+brutus web --nmap-file scan.xml -c "admin:admin,root:password"
+
+# Test SNMP from nmap scan
+brutus snmp --nmap-file scan.xml --mode extended
+
+# JSON output for scripting
+brutus creds --nmap-file scan.xml --json -o results.json
+```
+
+Nmap service names are automatically mapped to Brutus protocols (e.g., `ms-wbt-server` → `rdp`, `microsoft-ds` → `smb`). TLS is detected from nmap's `tunnel="ssl"` attribute. Only open ports on up hosts are imported.
+
+#### Masscan JSON Import (`--masscan-file`)
+
+Import targets from masscan's JSON output (`-oJ`). Since masscan is a port scanner only (no service fingerprinting), you must either specify `--protocol` or let Brutus auto-fingerprint with Nerva:
+
+```bash
+# Run a masscan port scan
+masscan 10.0.0.0/24 -p 22,3306,5432,6379 -oJ scan.json --rate 10000
+
+# Test all discovered ports as SSH (when you know what's running)
+brutus creds --masscan-file scan.json --protocol ssh -u root -P passwords.txt
+
+# Auto-fingerprint with Nerva (when services are unknown)
+brutus creds --masscan-file scan.json -P passwords.txt
+```
+
+#### Combining with Other Workflows
+
+The `--nmap-file` and `--masscan-file` flags work with all subcommands and are mutually exclusive with `--target`, `--targets-file`, and stdin:
+
+```bash
+# Scan for RDP backdoors from nmap results
+brutus logon --nmap-file scan.xml
+
+# Test SSH bad keys from nmap results
+brutus badkeys --nmap-file scan.xml
+
+# Override protocol for all masscan targets
+brutus creds --masscan-file scan.json --protocol redis -p "redis,password"
+```
+
 ### Pipeline Input Format
 
 Brutus accepts multiple input formats from stdin:
@@ -379,6 +436,7 @@ Brutus outputs only successful credentials in JSONL format (one JSON object per 
 | Single Binary | ❌ | ❌ | ❌ | ✅ |
 | Zero Dependencies | ❌ | ❌ | ❌ | ✅ |
 | Nerva Pipeline | ❌ | ❌ | ❌ | ✅ |
+| Nmap/Masscan Import | ❌ | ❌ | ❌ | ✅ |
 | JSON Streaming | ⚠️ | ❌ | ❌ | ✅ |
 | Cross-Platform | ⚠️ | ⚠️ | ⚠️ | ✅ |
 | Consistent Errors | ⚠️ | ⚠️ | ⚠️ | ✅ |

--- a/cmd/brutus/cmd_badkeys.go
+++ b/cmd/brutus/cmd_badkeys.go
@@ -43,7 +43,10 @@ collection of known bad keys.`,
   echo "192.168.1.10:22" | brutus badkeys
 
   # URI format
-  echo "ssh://192.168.1.10:22" | brutus badkeys`,
+  echo "ssh://192.168.1.10:22" | brutus badkeys
+
+  # Import targets from nmap XML scan (only SSH services tested)
+  brutus badkeys --nmap-file scan.xml`,
 	RunE: runBadkeys,
 }
 

--- a/cmd/brutus/cmd_creds.go
+++ b/cmd/brutus/cmd_creds.go
@@ -50,7 +50,13 @@ In pipeline/fingerprint mode, HTTP and SNMP services are automatically skipped.`
   naabu -host 10.0.0.0/24 -silent | nerva --json | brutus creds -P passwords.txt
 
   # Pipe URI targets (protocol from scheme, no fingerprinting needed)
-  echo "ssh://192.168.1.10:22" | brutus creds -p "password,Password1"`,
+  echo "ssh://192.168.1.10:22" | brutus creds -p "password,Password1"
+
+  # Import targets from nmap XML scan
+  brutus creds --nmap-file scan.xml -P passwords.txt
+
+  # Import targets from masscan (requires --protocol or auto-fingerprints with Nerva)
+  brutus creds --masscan-file scan.json --protocol ssh -P passwords.txt`,
 	RunE: runCreds,
 }
 

--- a/cmd/brutus/cmd_logon.go
+++ b/cmd/brutus/cmd_logon.go
@@ -58,7 +58,10 @@ confirmation via screenshot analysis.`,
   echo "10.0.0.50:3389" | brutus logon
 
   # Pipe URI targets
-  echo "rdp://10.0.0.50:3389" | brutus logon`,
+  echo "rdp://10.0.0.50:3389" | brutus logon
+
+  # Import targets from nmap XML scan (only RDP services tested)
+  brutus logon --nmap-file scan.xml`,
 	RunE: runLogon,
 }
 
@@ -126,9 +129,18 @@ func runLogon(cmd *cobra.Command, args []string) error {
 		var scanResults []brutus.Result
 		var hasSuccess bool
 
+		// Validate mutual exclusivity of target sources.
+		if err := validateTargetSources(useStdin); err != nil {
+			return err
+		}
+
 		switch {
 		case useStdin:
 			scanResults, hasSuccess = runScanFromStdin(rc)
+		case flagNmapFile != "":
+			scanResults, hasSuccess = runScanFromNmapFile(rc)
+		case flagMasscanFile != "":
+			scanResults, hasSuccess = runScanFromMasscanFile(rc)
 		case flagTargetsFile != "":
 			targetsList, loadErr := brutusinput.LoadTargetsFromFile(flagTargetsFile)
 			if loadErr != nil {

--- a/cmd/brutus/cmd_snmp.go
+++ b/cmd/brutus/cmd_snmp.go
@@ -49,7 +49,10 @@ Custom community strings can also be provided via -c or -C.`,
   naabu -host 10.0.0.0/24 -p 161 -silent | nerva --json | brutus snmp
 
   # Targets file
-  brutus snmp --targets-file snmp-hosts.txt --mode extended`,
+  brutus snmp --targets-file snmp-hosts.txt --mode extended
+
+  # Import targets from nmap XML scan (only SNMP services tested)
+  brutus snmp --nmap-file scan.xml --mode extended`,
 	RunE: runSNMP,
 }
 

--- a/cmd/brutus/cmd_web.go
+++ b/cmd/brutus/cmd_web.go
@@ -50,7 +50,10 @@ In pipeline/fingerprint mode, only HTTP-like services are tested.`,
   brutus web --target 192.168.1.1:443 --https --experimental-ai
 
   # Browser with visible window (demo mode)
-  brutus web --target 192.168.1.1:8080 --experimental-ai --browser-visible`,
+  brutus web --target 192.168.1.1:8080 --experimental-ai --browser-visible
+
+  # Import targets from nmap XML scan
+  brutus web --nmap-file scan.xml --experimental-ai`,
 	RunE: runWeb,
 }
 

--- a/cmd/brutus/flags.go
+++ b/cmd/brutus/flags.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -34,6 +35,8 @@ var (
 	flagTarget      string
 	flagTargetsFile string
 	flagProtocol    string
+	flagNmapFile    string
+	flagMasscanFile string
 )
 
 // Credential flags
@@ -108,6 +111,8 @@ func registerSharedFlags(cmd *cobra.Command) {
 	// Target
 	pf.StringVar(&flagTarget, "target", "", "Target host:port")
 	pf.StringVar(&flagTargetsFile, "targets-file", "", "File of targets to test, one host:port per line (fingerprints with Nerva unless --protocol is set)")
+	pf.StringVar(&flagNmapFile, "nmap-file", "", "Nmap XML file (-oX output) to import targets from")
+	pf.StringVar(&flagMasscanFile, "masscan-file", "", "Masscan JSON file (-oJ output) to import targets from")
 
 	// Performance
 	pf.IntVarP(&flagThreads, "threads", "t", 10, "Number of concurrent threads")
@@ -279,13 +284,39 @@ func shouldShowBanner(jsonOutput, stdinMode, quiet, useColor bool) bool {
 }
 
 // detectStdinMode returns true if stdin mode should be used.
-// Stdin is auto-detected when no --target or --targets-file is provided
+// Stdin is auto-detected when no explicit target source is provided
 // and data is being piped in.
 func detectStdinMode(target, targetsFile string) bool {
-	if targetsFile != "" || target != "" {
+	if targetsFile != "" || target != "" || flagNmapFile != "" || flagMasscanFile != "" {
 		return false
 	}
 	return hasStdinData()
+}
+
+// validateTargetSources checks that at most one target source is specified.
+// The target sources are: --target, --targets-file, --nmap-file, --masscan-file, and stdin.
+func validateTargetSources(stdinDetected bool) error {
+	var names []string
+	if flagTarget != "" {
+		names = append(names, "--target")
+	}
+	if flagTargetsFile != "" {
+		names = append(names, "--targets-file")
+	}
+	if flagNmapFile != "" {
+		names = append(names, "--nmap-file")
+	}
+	if flagMasscanFile != "" {
+		names = append(names, "--masscan-file")
+	}
+	if stdinDetected {
+		names = append(names, "stdin")
+	}
+	if len(names) > 1 {
+		return fmt.Errorf("conflicting target sources: %s are mutually exclusive",
+			strings.Join(names, ", "))
+	}
+	return nil
 }
 
 // isColorEnabled returns true if colored output should be used.

--- a/cmd/brutus/root.go
+++ b/cmd/brutus/root.go
@@ -44,7 +44,11 @@ Subcommands:
 All subcommands accept targets via stdin (one per line, formats can be mixed):
   Nerva JSON:  {"ip":"10.0.0.1","port":22,"protocol":"ssh"}
   URI scheme:  ssh://192.168.1.1:22, rdp://10.0.0.50:3389
-  Bare target: 192.168.1.1:22 (auto-fingerprinted with Nerva)`,
+  Bare target: 192.168.1.1:22 (auto-fingerprinted with Nerva)
+
+Targets can also be imported from scan tool output:
+  Nmap XML:     brutus creds --nmap-file scan.xml
+  Masscan JSON: brutus creds --masscan-file scan.json`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE:          runRoot,
@@ -79,6 +83,11 @@ func runRoot(cmd *cobra.Command, args []string) error {
 func runSubcommand(cmd *cobra.Command, baseConfig *runConfig) error {
 	useStdin := detectStdinMode(flagTarget, flagTargetsFile)
 
+	// Validate mutual exclusivity of target sources.
+	if err := validateTargetSources(useStdin); err != nil {
+		return err
+	}
+
 	// Set up output writer before banner check so --output can imply --json.
 	jsonWriter, forceJSON, closeOutput, err := setupOutputWriter(flagOutputFile)
 	if err != nil {
@@ -101,15 +110,15 @@ func runSubcommand(cmd *cobra.Command, baseConfig *runConfig) error {
 
 	switch {
 	case useStdin:
-		if flagTargetsFile != "" {
-			return fmt.Errorf("--targets-file is mutually exclusive with piped stdin")
-		}
 		allResults, hasSuccess = runFromStdin(baseConfig, flagJSON)
 
+	case flagNmapFile != "":
+		allResults, hasSuccess = runFromNmapFile(baseConfig, flagJSON)
+
+	case flagMasscanFile != "":
+		allResults, hasSuccess = runFromMasscanFile(baseConfig, flagJSON)
+
 	case flagTargetsFile != "":
-		if flagTarget != "" {
-			return fmt.Errorf("--targets-file is mutually exclusive with --target")
-		}
 		targetsList, err := brutusinput.LoadTargetsFromFile(flagTargetsFile)
 		if err != nil {
 			return err
@@ -156,7 +165,7 @@ func runSubcommand(cmd *cobra.Command, baseConfig *runConfig) error {
 	}
 
 	// Final JSON output for multi-target modes
-	if flagJSON && (useStdin || flagTargetsFile != "") {
+	if flagJSON && (useStdin || flagTargetsFile != "" || flagNmapFile != "" || flagMasscanFile != "") {
 		outputJSONL(jsonWriter, allResults)
 	}
 

--- a/cmd/brutus/runner.go
+++ b/cmd/brutus/runner.go
@@ -482,3 +482,118 @@ func runScanSingleTarget(target string, base *runConfig) ([]brutus.Result, bool)
 
 	return logon.DetectBackdoors(ctx, target, base.timeout, base.aiMode)
 }
+
+// runFromNmapFile loads targets from an nmap XML file and processes each
+// discovered service. Nmap provides service identification, so results are
+// fed through processNervaResult (same path as Nerva JSON stdin input).
+func runFromNmapFile(base *runConfig, jsonOut bool) ([]brutus.Result, bool) {
+	nmapResults, err := brutusinput.LoadNmapFile(flagNmapFile)
+	if err != nil {
+		errMsg(base.useColor, "%v", err)
+		return nil, false
+	}
+	if len(nmapResults) == 0 {
+		warnMsg(base.useColor, "nmap file %q contains no open ports", flagNmapFile)
+		return nil, false
+	}
+
+	logVerbose(base.verbose, "Loaded %d open port(s) from nmap file %s", len(nmapResults), flagNmapFile)
+
+	var allResults []brutus.Result
+	hasSuccess := false
+
+	for i := range nmapResults {
+		nrv := &nmapResults[i]
+
+		// If no --protocol override, check that the nmap service maps to a known Brutus protocol.
+		if base.protocolOverride == "" {
+			protocol := brutusinput.MapServiceToProtocol(nrv.Protocol)
+			if protocol == "" {
+				logVerbose(base.verbose, "skipping %s:%d — unknown nmap service %q",
+					nrv.IP, nrv.Port, nrv.Protocol)
+				continue
+			}
+			nrv.Protocol = protocol
+		}
+
+		res, success := processNervaResult(nrv, base, jsonOut)
+		allResults = append(allResults, res...)
+		if success {
+			hasSuccess = true
+		}
+	}
+
+	return allResults, hasSuccess
+}
+
+// runFromMasscanFile loads targets from a masscan JSON file and processes
+// each discovered open port. Because masscan does not fingerprint services,
+// targets are handled like bare host:port entries:
+//   - If --protocol is set, targets are tested directly with that protocol.
+//   - If --protocol is not set, targets are batch-fingerprinted with Nerva.
+func runFromMasscanFile(base *runConfig, jsonOut bool) ([]brutus.Result, bool) {
+	masscanResults, err := brutusinput.LoadMasscanFile(flagMasscanFile)
+	if err != nil {
+		errMsg(base.useColor, "%v", err)
+		return nil, false
+	}
+	if len(masscanResults) == 0 {
+		warnMsg(base.useColor, "masscan file %q contains no open ports", flagMasscanFile)
+		return nil, false
+	}
+
+	logVerbose(base.verbose, "Loaded %d open port(s) from masscan file %s", len(masscanResults), flagMasscanFile)
+
+	// Convert NervaResults to host:port strings for the existing pipelines.
+	targets := make([]string, 0, len(masscanResults))
+	for _, nrv := range masscanResults {
+		targets = append(targets, nrv.TargetAddr())
+	}
+
+	if base.protocolOverride != "" {
+		return runFromTargetsFile(targets, base, jsonOut)
+	}
+	return runFromFingerprint(targets, base, jsonOut)
+}
+
+// runScanFromNmapFile loads nmap results and runs logon-screen detection
+// on any RDP services found.
+func runScanFromNmapFile(base *runConfig) ([]brutus.Result, bool) {
+	nmapResults, err := brutusinput.LoadNmapFile(flagNmapFile)
+	if err != nil {
+		errMsg(base.useColor, "%v", err)
+		return nil, false
+	}
+
+	var allResults []brutus.Result
+	hasSuccess := false
+	for _, nrv := range nmapResults {
+		protocol := brutusinput.MapServiceToProtocol(nrv.Protocol)
+		if base.protocolFilter != nil && !base.protocolFilter(protocol) {
+			continue
+		}
+		res, success := runScanSingleTarget(nrv.TargetAddr(), base)
+		allResults = append(allResults, res...)
+		if success {
+			hasSuccess = true
+		}
+	}
+	return allResults, hasSuccess
+}
+
+// runScanFromMasscanFile loads masscan results and fingerprints them with
+// Nerva, then runs logon-screen detection on any discovered RDP services.
+func runScanFromMasscanFile(base *runConfig) ([]brutus.Result, bool) {
+	masscanResults, err := brutusinput.LoadMasscanFile(flagMasscanFile)
+	if err != nil {
+		errMsg(base.useColor, "%v", err)
+		return nil, false
+	}
+
+	targets := make([]string, 0, len(masscanResults))
+	for _, nrv := range masscanResults {
+		targets = append(targets, nrv.TargetAddr())
+	}
+
+	return runLogonFingerprint(targets, base)
+}

--- a/cmd/brutus/runner.go
+++ b/cmd/brutus/runner.go
@@ -505,15 +505,21 @@ func runFromNmapFile(base *runConfig, jsonOut bool) ([]brutus.Result, bool) {
 	for i := range nmapResults {
 		nrv := &nmapResults[i]
 
-		// If no --protocol override, check that the nmap service maps to a known Brutus protocol.
-		if base.protocolOverride == "" {
-			protocol := brutusinput.MapServiceToProtocol(nrv.Protocol)
-			if protocol == "" {
-				logVerbose(base.verbose, "skipping %s:%d — unknown nmap service %q",
-					nrv.IP, nrv.Port, nrv.Protocol)
-				continue
-			}
-			nrv.Protocol = protocol
+		// Skip ports where nmap couldn't identify the service.
+		if nrv.Protocol == "" {
+			logVerbose(base.verbose, "skipping %s:%d — nmap could not identify service",
+				nrv.IP, nrv.Port)
+			continue
+		}
+
+		// When a protocol override is set (from --protocol flag or subcommand
+		// like snmp/badkeys/logon), only test ports whose nmap-detected service
+		// matches. Without this, "brutus snmp --nmap-file scan.xml" would run
+		// SNMP checks against every open port (SSH, HTTP, etc.).
+		if base.protocolOverride != "" && nrv.Protocol != base.protocolOverride {
+			logVerbose(base.verbose, "skipping %s:%d — nmap service %q doesn't match protocol %q",
+				nrv.IP, nrv.Port, nrv.Protocol, base.protocolOverride)
+			continue
 		}
 
 		res, success := processNervaResult(nrv, base, jsonOut)
@@ -568,8 +574,10 @@ func runScanFromNmapFile(base *runConfig) ([]brutus.Result, bool) {
 	var allResults []brutus.Result
 	hasSuccess := false
 	for _, nrv := range nmapResults {
-		protocol := brutusinput.MapServiceToProtocol(nrv.Protocol)
-		if base.protocolFilter != nil && !base.protocolFilter(protocol) {
+		if nrv.Protocol == "" {
+			continue
+		}
+		if base.protocolFilter != nil && !base.protocolFilter(nrv.Protocol) {
 			continue
 		}
 		res, success := runScanSingleTarget(nrv.TargetAddr(), base)

--- a/pkg/brutus/input/masscan.go
+++ b/pkg/brutus/input/masscan.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package input
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+)
+
+// masscanEntry represents a single host entry in masscan JSON output (-oJ).
+type masscanEntry struct {
+	IP    string        `json:"ip"`
+	Ports []masscanPort `json:"ports"`
+}
+
+// masscanPort represents a single port within a masscan entry.
+type masscanPort struct {
+	Port   int    `json:"port"`
+	Proto  string `json:"proto"`
+	Status string `json:"status"`
+}
+
+// trailingCommaRe matches trailing commas before ] or } in JSON.
+// Masscan produces JSON with trailing commas between entries.
+var trailingCommaRe = regexp.MustCompile(`,\s*([}\]])`)
+
+// LoadMasscanFile parses a masscan JSON file (-oJ output) and returns a
+// slice of NervaResult for each open port. Because masscan does not perform
+// service fingerprinting, the Protocol field is left empty — callers must
+// either require --protocol or run Nerva fingerprinting on the returned
+// targets.
+func LoadMasscanFile(filePath string) ([]NervaResult, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("opening masscan file: %w", err)
+	}
+
+	// Normalize masscan's quirky JSON: remove trailing commas before ] or }.
+	cleaned := trailingCommaRe.ReplaceAll(data, []byte("$1"))
+
+	var entries []masscanEntry
+	if err := json.Unmarshal(cleaned, &entries); err != nil {
+		return nil, fmt.Errorf("parsing masscan JSON: %w", err)
+	}
+
+	var results []NervaResult
+	for _, entry := range entries {
+		for _, port := range entry.Ports {
+			if port.Status != "open" {
+				continue
+			}
+
+			results = append(results, NervaResult{
+				IP:        entry.IP,
+				Port:      port.Port,
+				Protocol:  "", // masscan does not fingerprint services
+				Transport: port.Proto,
+			})
+		}
+	}
+
+	return results, nil
+}

--- a/pkg/brutus/input/masscan.go
+++ b/pkg/brutus/input/masscan.go
@@ -15,10 +15,10 @@
 package input
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
-	"regexp"
 )
 
 // masscanEntry represents a single host entry in masscan JSON output (-oJ).
@@ -34,10 +34,6 @@ type masscanPort struct {
 	Status string `json:"status"`
 }
 
-// trailingCommaRe matches trailing commas before ] or } in JSON.
-// Masscan produces JSON with trailing commas between entries.
-var trailingCommaRe = regexp.MustCompile(`,\s*([}\]])`)
-
 // LoadMasscanFile parses a masscan JSON file (-oJ output) and returns a
 // slice of NervaResult for each open port. Because masscan does not perform
 // service fingerprinting, the Protocol field is left empty — callers must
@@ -49,8 +45,12 @@ func LoadMasscanFile(filePath string) ([]NervaResult, error) {
 		return nil, fmt.Errorf("opening masscan file: %w", err)
 	}
 
-	// Normalize masscan's quirky JSON: remove trailing commas before ] or }.
-	cleaned := trailingCommaRe.ReplaceAll(data, []byte("$1"))
+	// Normalize masscan's quirky JSON: strip the trailing comma before the
+	// closing ']'. Masscan emits a comma after every entry including the last
+	// one, producing e.g. `[{...}, {...}, ]`. We only fix this structural
+	// artifact at the end of the array rather than applying a global regex
+	// that could corrupt string literals containing ", ]" or ", }".
+	cleaned := stripTrailingComma(data)
 
 	var entries []masscanEntry
 	if err := json.Unmarshal(cleaned, &entries); err != nil {
@@ -74,4 +74,30 @@ func LoadMasscanFile(filePath string) ([]NervaResult, error) {
 	}
 
 	return results, nil
+}
+
+// stripTrailingComma removes the last comma before the closing ']' of a
+// JSON array. This is the only structural fix masscan output needs — the
+// last entry is followed by a comma before ']'. Operating only on the
+// trailing position avoids corrupting commas inside string values.
+func stripTrailingComma(data []byte) []byte {
+	// Find the last ']' (top-level array close).
+	idx := bytes.LastIndexByte(data, ']')
+	if idx < 0 {
+		return data
+	}
+
+	// Walk backwards from ']' skipping whitespace to find a comma.
+	i := idx - 1
+	for i >= 0 && (data[i] == ' ' || data[i] == '\t' || data[i] == '\n' || data[i] == '\r') {
+		i--
+	}
+	if i >= 0 && data[i] == ',' {
+		// Remove the comma by splicing it out.
+		out := make([]byte, 0, len(data)-1)
+		out = append(out, data[:i]...)
+		out = append(out, data[i+1:]...)
+		return out
+	}
+	return data
 }

--- a/pkg/brutus/input/masscan_test.go
+++ b/pkg/brutus/input/masscan_test.go
@@ -1,0 +1,127 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package input
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadMasscanFile_BasicParse(t *testing.T) {
+	// Masscan's actual output format with trailing commas
+	json := `[
+{   "ip": "192.168.1.1",   "timestamp": "1234567890", "ports": [ {"port": 22, "proto": "tcp", "status": "open", "reason": "syn-ack", "ttl": 64} ] }
+,
+{   "ip": "192.168.1.2",   "timestamp": "1234567891", "ports": [ {"port": 80, "proto": "tcp", "status": "open", "reason": "syn-ack", "ttl": 128} ] }
+]`
+
+	file := writeTempFile(t, "masscan.json", json)
+	results, err := LoadMasscanFile(file)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	assert.Equal(t, "192.168.1.1", results[0].IP)
+	assert.Equal(t, 22, results[0].Port)
+	assert.Equal(t, "tcp", results[0].Transport)
+	assert.Equal(t, "", results[0].Protocol) // masscan doesn't fingerprint
+
+	assert.Equal(t, "192.168.1.2", results[1].IP)
+	assert.Equal(t, 80, results[1].Port)
+}
+
+func TestLoadMasscanFile_TrailingComma(t *testing.T) {
+	// Masscan sometimes produces a trailing comma before the closing bracket
+	json := `[
+{   "ip": "10.0.0.1",   "ports": [ {"port": 443, "proto": "tcp", "status": "open"} ] },
+]`
+
+	file := writeTempFile(t, "masscan-trailing.json", json)
+	results, err := LoadMasscanFile(file)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "10.0.0.1", results[0].IP)
+	assert.Equal(t, 443, results[0].Port)
+}
+
+func TestLoadMasscanFile_SkipsClosedPorts(t *testing.T) {
+	json := `[
+{"ip": "10.0.0.1", "ports": [
+    {"port": 22, "proto": "tcp", "status": "open"},
+    {"port": 23, "proto": "tcp", "status": "closed"}
+]}
+]`
+
+	file := writeTempFile(t, "masscan-closed.json", json)
+	results, err := LoadMasscanFile(file)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, 22, results[0].Port)
+}
+
+func TestLoadMasscanFile_MultiplePorts(t *testing.T) {
+	json := `[
+{"ip": "10.0.0.1", "ports": [
+    {"port": 22, "proto": "tcp", "status": "open"},
+    {"port": 80, "proto": "tcp", "status": "open"},
+    {"port": 443, "proto": "tcp", "status": "open"}
+]}
+]`
+
+	file := writeTempFile(t, "masscan-multi.json", json)
+	results, err := LoadMasscanFile(file)
+	require.NoError(t, err)
+	require.Len(t, results, 3)
+}
+
+func TestLoadMasscanFile_FileNotFound(t *testing.T) {
+	_, err := LoadMasscanFile("/nonexistent/masscan.json")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "opening masscan file")
+}
+
+func TestLoadMasscanFile_InvalidJSON(t *testing.T) {
+	file := writeTempFile(t, "bad.json", "not json {{{")
+	_, err := LoadMasscanFile(file)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parsing masscan JSON")
+}
+
+func TestLoadMasscanFile_EmptyArray(t *testing.T) {
+	file := writeTempFile(t, "empty.json", "[]")
+	results, err := LoadMasscanFile(file)
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestLoadMasscanFile_TargetAddr(t *testing.T) {
+	json := `[{"ip": "192.168.1.1", "ports": [{"port": 22, "proto": "tcp", "status": "open"}]}]`
+	file := writeTempFile(t, "masscan-addr.json", json)
+	results, err := LoadMasscanFile(file)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "192.168.1.1:22", results[0].TargetAddr())
+}
+
+func TestLoadMasscanFile_UDPPorts(t *testing.T) {
+	json := `[{"ip": "10.0.0.1", "ports": [{"port": 161, "proto": "udp", "status": "open"}]}]`
+	file := writeTempFile(t, "masscan-udp.json", json)
+	results, err := LoadMasscanFile(file)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "udp", results[0].Transport)
+	assert.Equal(t, 161, results[0].Port)
+}

--- a/pkg/brutus/input/nmap.go
+++ b/pkg/brutus/input/nmap.go
@@ -1,0 +1,191 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package input
+
+import (
+	"encoding/xml"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// nmapRun is the root element of nmap XML output (-oX).
+type nmapRun struct {
+	XMLName xml.Name   `xml:"nmaprun"`
+	Hosts   []nmapHost `xml:"host"`
+}
+
+type nmapHost struct {
+	Status    nmapStatus    `xml:"status"`
+	Addresses []nmapAddress `xml:"address"`
+	Hostnames nmapHostnames `xml:"hostnames"`
+	Ports     nmapPorts     `xml:"ports"`
+}
+
+type nmapStatus struct {
+	State string `xml:"state,attr"`
+}
+
+type nmapAddress struct {
+	Addr     string `xml:"addr,attr"`
+	AddrType string `xml:"addrtype,attr"`
+}
+
+type nmapHostnames struct {
+	Hostnames []nmapHostname `xml:"hostname"`
+}
+
+type nmapHostname struct {
+	Name string `xml:"name,attr"`
+	Type string `xml:"type,attr"`
+}
+
+type nmapPorts struct {
+	Ports []nmapPort `xml:"port"`
+}
+
+type nmapPort struct {
+	Protocol string      `xml:"protocol,attr"`
+	PortID   string      `xml:"portid,attr"`
+	State    nmapState   `xml:"state"`
+	Service  nmapService `xml:"service"`
+}
+
+type nmapState struct {
+	State string `xml:"state,attr"`
+}
+
+type nmapService struct {
+	Name    string `xml:"name,attr"`
+	Product string `xml:"product,attr"`
+	Version string `xml:"version,attr"`
+	Tunnel  string `xml:"tunnel,attr"`
+}
+
+// LoadNmapFile parses an nmap XML file (-oX output) and returns a slice of
+// NervaResult for each open port. Hosts that are not "up" and ports that are
+// not "open" are skipped. The nmap service name is normalized and mapped
+// through MapServiceToProtocol; unknown services are preserved as-is so the
+// caller can decide to skip or fingerprint them.
+func LoadNmapFile(filePath string) ([]NervaResult, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("opening nmap file: %w", err)
+	}
+
+	var run nmapRun
+	if err := xml.Unmarshal(data, &run); err != nil {
+		return nil, fmt.Errorf("parsing nmap XML: %w", err)
+	}
+
+	var results []NervaResult
+	for _, host := range run.Hosts {
+		if host.Status.State != "up" {
+			continue
+		}
+
+		ip := extractNmapIP(host.Addresses)
+		hostname := extractNmapHostname(host.Hostnames)
+
+		for _, port := range host.Ports.Ports {
+			if port.State.State != "open" {
+				continue
+			}
+
+			portNum, err := strconv.Atoi(port.PortID)
+			if err != nil {
+				continue
+			}
+
+			tls := strings.EqualFold(port.Service.Tunnel, "ssl")
+			version := buildNmapVersion(port.Service.Product, port.Service.Version)
+
+			serviceName := normalizeNmapService(port.Service.Name)
+			protocol := MapServiceToProtocol(serviceName)
+			if protocol == "" {
+				protocol = serviceName
+			}
+
+			// Upgrade http to https when TLS tunnel is detected.
+			if tls && protocol == "http" {
+				protocol = "https"
+			}
+
+			results = append(results, NervaResult{
+				Host:      hostname,
+				IP:        ip,
+				Port:      portNum,
+				Protocol:  protocol,
+				TLS:       tls,
+				Transport: port.Protocol,
+				Version:   version,
+			})
+		}
+	}
+
+	return results, nil
+}
+
+// extractNmapIP returns the first IPv4 or IPv6 address from the address list.
+func extractNmapIP(addrs []nmapAddress) string {
+	for _, a := range addrs {
+		if a.AddrType == "ipv4" || a.AddrType == "ipv6" {
+			return a.Addr
+		}
+	}
+	return ""
+}
+
+// extractNmapHostname returns the first hostname entry.
+func extractNmapHostname(hostnames nmapHostnames) string {
+	for _, h := range hostnames.Hostnames {
+		if h.Name != "" {
+			return h.Name
+		}
+	}
+	return ""
+}
+
+// buildNmapVersion concatenates product and version strings.
+func buildNmapVersion(product, version string) string {
+	var parts []string
+	if product != "" {
+		parts = append(parts, product)
+	}
+	if version != "" {
+		parts = append(parts, version)
+	}
+	return strings.Join(parts, " ")
+}
+
+// normalizeNmapService handles nmap-specific service name variations that
+// differ from the names in MapServiceToProtocol.
+func normalizeNmapService(name string) string {
+	name = strings.ToLower(name)
+	switch {
+	case name == "ms-sql-s" || name == "ms-sql":
+		return "mssql"
+	case name == "microsoft-ds" || name == "netbios-ssn":
+		return "smb"
+	case name == "http-proxy" || name == "http-alt":
+		return "http"
+	case name == "ssl/http" || name == "https-alt":
+		return "https"
+	case name == "ms-wbt-server":
+		return "rdp"
+	}
+	return name
+}

--- a/pkg/brutus/input/nmap.go
+++ b/pkg/brutus/input/nmap.go
@@ -175,16 +175,16 @@ func buildNmapVersion(product, version string) string {
 // differ from the names in MapServiceToProtocol.
 func normalizeNmapService(name string) string {
 	name = strings.ToLower(name)
-	switch {
-	case name == "ms-sql-s" || name == "ms-sql":
+	switch name {
+	case "ms-sql-s", "ms-sql":
 		return "mssql"
-	case name == "microsoft-ds" || name == "netbios-ssn":
+	case "microsoft-ds", "netbios-ssn":
 		return "smb"
-	case name == "http-proxy" || name == "http-alt":
+	case "http-proxy", "http-alt":
 		return "http"
-	case name == "ssl/http" || name == "https-alt":
+	case "ssl/http", "https-alt":
 		return "https"
-	case name == "ms-wbt-server":
+	case "ms-wbt-server":
 		return "rdp"
 	}
 	return name

--- a/pkg/brutus/input/nmap.go
+++ b/pkg/brutus/input/nmap.go
@@ -78,8 +78,8 @@ type nmapService struct {
 // LoadNmapFile parses an nmap XML file (-oX output) and returns a slice of
 // NervaResult for each open port. Hosts that are not "up" and ports that are
 // not "open" are skipped. The nmap service name is normalized and mapped
-// through MapServiceToProtocol; unknown services are preserved as-is so the
-// caller can decide to skip or fingerprint them.
+// through MapServiceToProtocol; unknown services have Protocol set to "" so
+// callers can skip or fingerprint them.
 func LoadNmapFile(filePath string) ([]NervaResult, error) {
 	data, err := os.ReadFile(filePath)
 	if err != nil {
@@ -115,9 +115,6 @@ func LoadNmapFile(filePath string) ([]NervaResult, error) {
 
 			serviceName := normalizeNmapService(port.Service.Name)
 			protocol := MapServiceToProtocol(serviceName)
-			if protocol == "" {
-				protocol = serviceName
-			}
 
 			// Upgrade http to https when TLS tunnel is detected.
 			if tls && protocol == "http" {

--- a/pkg/brutus/input/nmap_test.go
+++ b/pkg/brutus/input/nmap_test.go
@@ -1,0 +1,231 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package input
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeTempFile creates a temporary file with the given content and returns its path.
+func writeTempFile(t *testing.T, name, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	return path
+}
+
+func TestLoadNmapFile_BasicParse(t *testing.T) {
+	xml := `<?xml version="1.0"?>
+<nmaprun scanner="nmap">
+  <host starttime="1" endtime="2">
+    <status state="up"/>
+    <address addr="192.168.1.1" addrtype="ipv4"/>
+    <hostnames>
+      <hostname name="host.example.com" type="PTR"/>
+    </hostnames>
+    <ports>
+      <port protocol="tcp" portid="22">
+        <state state="open"/>
+        <service name="ssh" product="OpenSSH" version="8.9p1"/>
+      </port>
+      <port protocol="tcp" portid="80">
+        <state state="open"/>
+        <service name="http" product="nginx"/>
+      </port>
+      <port protocol="tcp" portid="443">
+        <state state="open"/>
+        <service name="http" tunnel="ssl" product="nginx"/>
+      </port>
+      <port protocol="tcp" portid="3306">
+        <state state="closed"/>
+        <service name="mysql"/>
+      </port>
+    </ports>
+  </host>
+</nmaprun>`
+
+	file := writeTempFile(t, "nmap.xml", xml)
+	results, err := LoadNmapFile(file)
+	require.NoError(t, err)
+	require.Len(t, results, 3) // SSH, HTTP, HTTPS (closed port excluded)
+
+	// SSH
+	assert.Equal(t, "192.168.1.1", results[0].IP)
+	assert.Equal(t, "host.example.com", results[0].Host)
+	assert.Equal(t, 22, results[0].Port)
+	assert.Equal(t, "ssh", results[0].Protocol)
+	assert.False(t, results[0].TLS)
+	assert.Equal(t, "OpenSSH 8.9p1", results[0].Version)
+	assert.Equal(t, "tcp", results[0].Transport)
+
+	// HTTP (port 80)
+	assert.Equal(t, 80, results[1].Port)
+	assert.Equal(t, "http", results[1].Protocol)
+	assert.False(t, results[1].TLS)
+
+	// HTTPS (port 443 with tunnel="ssl") — upgraded from http to https
+	assert.Equal(t, 443, results[2].Port)
+	assert.Equal(t, "https", results[2].Protocol)
+	assert.True(t, results[2].TLS)
+}
+
+func TestLoadNmapFile_SkipsDownHosts(t *testing.T) {
+	xml := `<?xml version="1.0"?>
+<nmaprun>
+  <host><status state="down"/><address addr="10.0.0.1" addrtype="ipv4"/>
+    <ports><port protocol="tcp" portid="22"><state state="open"/>
+    <service name="ssh"/></port></ports>
+  </host>
+</nmaprun>`
+
+	file := writeTempFile(t, "nmap-down.xml", xml)
+	results, err := LoadNmapFile(file)
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestLoadNmapFile_MultipleHosts(t *testing.T) {
+	xml := `<?xml version="1.0"?>
+<nmaprun>
+  <host><status state="up"/><address addr="10.0.0.1" addrtype="ipv4"/>
+    <ports>
+      <port protocol="tcp" portid="22"><state state="open"/><service name="ssh"/></port>
+    </ports>
+  </host>
+  <host><status state="up"/><address addr="10.0.0.2" addrtype="ipv4"/>
+    <ports>
+      <port protocol="tcp" portid="3389"><state state="open"/><service name="ms-wbt-server"/></port>
+    </ports>
+  </host>
+</nmaprun>`
+
+	file := writeTempFile(t, "nmap-multi.xml", xml)
+	results, err := LoadNmapFile(file)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	assert.Equal(t, "10.0.0.1", results[0].IP)
+	assert.Equal(t, "ssh", results[0].Protocol)
+	assert.Equal(t, "10.0.0.2", results[1].IP)
+	assert.Equal(t, "rdp", results[1].Protocol) // ms-wbt-server normalized
+}
+
+func TestLoadNmapFile_NmapServiceNormalization(t *testing.T) {
+	tests := []struct {
+		nmapName string
+		expected string
+	}{
+		{"ms-sql-s", "mssql"},
+		{"ms-sql", "mssql"},
+		{"microsoft-ds", "smb"},
+		{"netbios-ssn", "smb"},
+		{"ms-wbt-server", "rdp"},
+		{"http-proxy", "http"},
+		{"http-alt", "http"},
+		{"ssl/http", "https"},
+		{"https-alt", "https"},
+		{"ssh", "ssh"},
+		{"mysql", "mysql"},
+		{"postgresql", "postgresql"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.nmapName, func(t *testing.T) {
+			result := normalizeNmapService(tt.nmapName)
+			mapped := MapServiceToProtocol(result)
+			if mapped == "" {
+				mapped = result
+			}
+			assert.Equal(t, tt.expected, mapped)
+		})
+	}
+}
+
+func TestLoadNmapFile_FileNotFound(t *testing.T) {
+	_, err := LoadNmapFile("/nonexistent/nmap.xml")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "opening nmap file")
+}
+
+func TestLoadNmapFile_InvalidXML(t *testing.T) {
+	file := writeTempFile(t, "bad.xml", "not xml at all <><>")
+	_, err := LoadNmapFile(file)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parsing nmap XML")
+}
+
+func TestLoadNmapFile_EmptyFile(t *testing.T) {
+	xml := `<?xml version="1.0"?><nmaprun></nmaprun>`
+	file := writeTempFile(t, "empty.xml", xml)
+	results, err := LoadNmapFile(file)
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestLoadNmapFile_TargetAddr(t *testing.T) {
+	xml := `<?xml version="1.0"?>
+<nmaprun>
+  <host><status state="up"/><address addr="10.0.0.5" addrtype="ipv4"/>
+    <ports><port protocol="tcp" portid="22"><state state="open"/><service name="ssh"/></port></ports>
+  </host>
+</nmaprun>`
+
+	file := writeTempFile(t, "nmap-addr.xml", xml)
+	results, err := LoadNmapFile(file)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "10.0.0.5:22", results[0].TargetAddr())
+}
+
+func TestLoadNmapFile_UDPPorts(t *testing.T) {
+	xml := `<?xml version="1.0"?>
+<nmaprun>
+  <host><status state="up"/><address addr="10.0.0.1" addrtype="ipv4"/>
+    <ports>
+      <port protocol="udp" portid="161"><state state="open"/><service name="snmp"/></port>
+    </ports>
+  </host>
+</nmaprun>`
+
+	file := writeTempFile(t, "nmap-udp.xml", xml)
+	results, err := LoadNmapFile(file)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "snmp", results[0].Protocol)
+	assert.Equal(t, "udp", results[0].Transport)
+}
+
+func TestLoadNmapFile_HostnamePreferred(t *testing.T) {
+	xml := `<?xml version="1.0"?>
+<nmaprun>
+  <host><status state="up"/>
+    <address addr="10.0.0.1" addrtype="ipv4"/>
+    <hostnames><hostname name="db.internal" type="PTR"/></hostnames>
+    <ports><port protocol="tcp" portid="5432"><state state="open"/><service name="postgresql"/></port></ports>
+  </host>
+</nmaprun>`
+
+	file := writeTempFile(t, "nmap-hostname.xml", xml)
+	results, err := LoadNmapFile(file)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "db.internal", results[0].Host)
+	assert.Equal(t, "10.0.0.1", results[0].IP)
+	// TargetAddr prefers hostname
+	assert.Equal(t, "db.internal:5432", results[0].TargetAddr())
+}

--- a/pkg/brutus/input/nmap_test.go
+++ b/pkg/brutus/input/nmap_test.go
@@ -148,9 +148,6 @@ func TestLoadNmapFile_NmapServiceNormalization(t *testing.T) {
 		t.Run(tt.nmapName, func(t *testing.T) {
 			result := normalizeNmapService(tt.nmapName)
 			mapped := MapServiceToProtocol(result)
-			if mapped == "" {
-				mapped = result
-			}
 			assert.Equal(t, tt.expected, mapped)
 		})
 	}
@@ -208,6 +205,28 @@ func TestLoadNmapFile_UDPPorts(t *testing.T) {
 	require.Len(t, results, 1)
 	assert.Equal(t, "snmp", results[0].Protocol)
 	assert.Equal(t, "udp", results[0].Transport)
+}
+
+func TestLoadNmapFile_UnknownServiceEmpty(t *testing.T) {
+	xml := `<?xml version="1.0"?>
+<nmaprun>
+  <host><status state="up"/><address addr="10.0.0.1" addrtype="ipv4"/>
+    <ports>
+      <port protocol="tcp" portid="3306"><state state="open"/><service name="tcpwrapped"/></port>
+      <port protocol="tcp" portid="22"><state state="open"/><service name="ssh"/></port>
+    </ports>
+  </host>
+</nmaprun>`
+
+	file := writeTempFile(t, "nmap-unknown.xml", xml)
+	results, err := LoadNmapFile(file)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	// tcpwrapped is unknown — Protocol should be empty
+	assert.Equal(t, "", results[0].Protocol)
+	assert.Equal(t, 3306, results[0].Port)
+	// ssh is known
+	assert.Equal(t, "ssh", results[1].Protocol)
 }
 
 func TestLoadNmapFile_HostnamePreferred(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `--nmap-file` flag to import targets from nmap XML (`-oX`) output, automatically mapping nmap service fingerprints to brutus protocols
- Add `--masscan-file` flag to import targets from masscan JSON (`-oJ`) output, with `--protocol` for direct testing or Nerva fingerprinting fallback
- Enforce mutual exclusivity between all target sources (`--target`, `--targets-file`, `--nmap-file`, `--masscan-file`, stdin)
- Update README with documentation and usage examples for both flags

## Details

**Nmap XML parser** (`pkg/brutus/input/nmap.go`):
- Parses full nmap XML including host status, addresses, hostnames, ports, and service info
- Handles nmap-specific service name variations (e.g., `ms-wbt-server` → `rdp`, `microsoft-ds` → `smb`)
- Detects TLS from nmap's `tunnel="ssl"` attribute
- Extracts version strings from product/version fields

**Masscan JSON parser** (`pkg/brutus/input/masscan.go`):
- Handles masscan's non-standard JSON (trailing commas between entries)
- Since masscan doesn't fingerprint services, works in two modes:
  - With `--protocol`: tests all ports against the specified protocol
  - Without `--protocol`: uses Nerva for service fingerprinting

**CLI integration** (`cmd/brutus/`):
- New flags registered on all subcommands (creds, web, snmp, logon, badkeys)
- Centralized `validateTargetSources()` for mutual exclusivity checks
- Nmap results feed through existing `processNervaResult()` pipeline
- Masscan results feed through `runFromTargetsFile()` or `runFromFingerprint()` paths

## Test plan

- [x] Unit tests for nmap parser (10 cases) and masscan parser (9 cases)
- [x] `go build ./...` passes
- [x] `go test ./pkg/... ./cmd/... -count=1 -short` passes
- [x] E2E tested against demo Docker environment (SSH, MySQL, Redis, FTP, HTTP) — nmap scan → `--nmap-file` found credentials for FTP, SSH, Redis, HTTP Basic Auth
- [x] E2E tested `--masscan-file --protocol ssh` and `--masscan-file --protocol redis` — found credentials
- [x] Mutual exclusivity errors verified for all invalid flag combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)