### PR TITLE
ci(codex): bump reviewer model to gpt-5.5

### DIFF
--- a/.github/workflows/codex-code.yml
+++ b/.github/workflows/codex-code.yml
@@ -23,6 +23,6 @@ jobs:
       contents: read
       pull-requests: write
     with:
-      model: "gpt-5.4"
+      model: "gpt-5.5"
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
Bumps the Codex PR-reviewer model `gpt-5.4` → `gpt-5.5` (validated accessible with the org OPENAI_API_KEY). Model-only change; the codex-version reliability pin rides the Dependabot re-pin to public-workflows v2.3.2 (separate line, no conflict).