### PR TITLE
ci(codex): bump public-workflows pin to v2.4.0

### DIFF
--- a/.github/workflows/codex-code.yml
+++ b/.github/workflows/codex-code.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   codex-review:
-    uses: praetorian-inc/public-workflows/.github/workflows/codex-code.yml@25c08fbd15a931e275f207ecee1758c931f89ea5  # v2.1.0  # v2.1.2 (private repo pre-fetch fix)
+    uses: praetorian-inc/public-workflows/.github/workflows/codex-code.yml@f7fb4810ccab4ab589499b632fb61983124ece79  # v2.4.0
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Bumps the Codex PR reviewer pin to `v2.4.0` (`f7fb4810`).

**Why:** this repo was pinned to a pre-fix `public-workflows` version (v2.1.0 / v2.3.1) where Harden-Runner's `disable-sudo-and-containers` pre-disables sudo on the codex job. `openai/codex-action` needs sudo to lock its proxy file before it irreversibly drops sudo, so the action exits 1 before any review runs — the Codex review silently fails on every real code PR. (Green checks on docs/release-only PRs are preflight-skips, which masked this.)

Fixed upstream in praetorian-inc/public-workflows#80, released in **v2.4.0** (also carries the gpt-5.5 default + CVE-2025-32955 container-lockdown hardening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)