### PR TITLE
ci(codex): bump public-workflows codex pin to v2.6.0

### DIFF
--- a/.github/workflows/codex-code.yml
+++ b/.github/workflows/codex-code.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   codex-review:
-    uses: praetorian-inc/public-workflows/.github/workflows/codex-code.yml@f7fb4810ccab4ab589499b632fb61983124ece79  # v2.4.0
+    uses: praetorian-inc/public-workflows/.github/workflows/codex-code.yml@23254e12b026871dd9bbf2bad4ef6fee29910fb1  # v2.6.0
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## What
Bump the `public-workflows/codex-code.yml` reusable pin to **v2.6.0** (commit `23254e12`).
For most repos this is `v2.4.0 -> v2.6.0`; for `guard` it moves an **untagged** pin onto a clean tag.

## Why it's safe (zero behavior change)
`codex-code.yml` is **byte-identical** across v2.4.0, v2.5.0, and v2.6.0 (sha256 `57a901ac…`).
The codex reviewer logic — including the Harden-Runner sudo/container fix (#80) — is unchanged.
The v2.5.0 → v2.6.0 deltas in public-workflows were **go-release/cosign** only, which this file
does not consume. This PR only updates the pin string + version comment.

Hygiene/convergence: keeps every caller on a tagged, current pin.