### PR TITLE
chore(ci): bump public-workflows pins to v2.9.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   ci:
-    uses: praetorian-inc/public-workflows/.github/workflows/go-ci.yml@9391f462483f0ca025fbbb57bfb0f9f9561e1b6a  # v2.6.6
+    uses: praetorian-inc/public-workflows/.github/workflows/go-ci.yml@0c602372f3d0d038912dd08e159ecc83954a4995  # v2.9.3
     permissions:
       contents: read
     with:

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   claude-code-action:
-    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@2d4ebcb9a35f353647701eb4caa8ecbd46c32052  # v2.6.4
+    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@0c602372f3d0d038912dd08e159ecc83954a4995  # v2.9.3
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/claude-md-drift.yml
+++ b/.github/workflows/claude-md-drift.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   drift-check:
-    uses: praetorian-inc/public-workflows/.github/workflows/claude-md-drift.yml@5bee862b5576ede0c17b22aac4a23de5a43f31fc  # v2.6.5
+    uses: praetorian-inc/public-workflows/.github/workflows/claude-md-drift.yml@0c602372f3d0d038912dd08e159ecc83954a4995  # v2.9.3
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/codex-code.yml
+++ b/.github/workflows/codex-code.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   codex-review:
-    uses: praetorian-inc/public-workflows/.github/workflows/codex-code.yml@23254e12b026871dd9bbf2bad4ef6fee29910fb1  # v2.6.0
+    uses: praetorian-inc/public-workflows/.github/workflows/codex-code.yml@0c602372f3d0d038912dd08e159ecc83954a4995  # v2.9.3
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   notify:
-    uses: praetorian-inc/public-workflows/.github/workflows/external-contrib-notify.yml@7c1302bdef0a72e7f5743738baa45272c8e1f8d7  # v2.1.0
+    uses: praetorian-inc/public-workflows/.github/workflows/external-contrib-notify.yml@0c602372f3d0d038912dd08e159ecc83954a4995  # v2.9.3
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/gemini-code.yml
+++ b/.github/workflows/gemini-code.yml
@@ -15,7 +15,7 @@ jobs:
     if: |
       github.event.pull_request.head.repo.full_name == github.repository &&
       (github.event_name != 'pull_request_review_comment' || contains(github.event.comment.body, '@gemini'))
-    uses: praetorian-inc/public-workflows/.github/workflows/gemini-code.yml@c9c1428303d47bb07093aa47e180e0e21bc6582d  # v2.6.3
+    uses: praetorian-inc/public-workflows/.github/workflows/gemini-code.yml@0c602372f3d0d038912dd08e159ecc83954a4995  # v2.9.3
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   scan:
-    uses: praetorian-inc/public-workflows/.github/workflows/titus-scan.yml@23254e12b026871dd9bbf2bad4ef6fee29910fb1  # v2.6.0
+    uses: praetorian-inc/public-workflows/.github/workflows/titus-scan.yml@0c602372f3d0d038912dd08e159ecc83954a4995  # v2.9.3
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/verify-pins.yml
+++ b/.github/workflows/verify-pins.yml
@@ -11,6 +11,6 @@ permissions:
   contents: read
 jobs:
   verify:
-    uses: praetorian-inc/public-workflows/.github/workflows/verify-pins.yml@23254e12b026871dd9bbf2bad4ef6fee29910fb1  # v2.6.0
+    uses: praetorian-inc/public-workflows/.github/workflows/verify-pins.yml@0c602372f3d0d038912dd08e159ecc83954a4995  # v2.9.3
     permissions:
       contents: read


### PR DESCRIPTION
Bumps all praetorian-inc/public-workflows reusable-workflow pins to v2.9.3 (0c602372f3d0d038912dd08e159ecc83954a4995). Org-wide drift sweep: v2.9.3 carries the go-ci/go-sec preflight fix (changed-file detection via the commits compare API needs only contents:read, eliminating the logless startup_failure on narrow-permission callers) and the opus-4.8 'thinking' reviewer fix (>= v2.6.4). No caller max_turns change needed — drift default is now 45 in v2.9.3.