### PR TITLE
feat: add aggressiveness mode system and tiered wordlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Built in Go as a single binary with zero external dependencies, Brutus integrate
 **Key features:**
 - **Zero dependencies:** Single binary, cross-platform (Linux, Windows, macOS)
 - **24 protocols:** SSH, RDP, MySQL, PostgreSQL, MSSQL, Redis, SMB, LDAP, WinRM, SNMP, HTTP Basic Auth, and more
+- **Aggressiveness modes:** `--mode cautious|default|exhaustive` for tuning coverage vs. safety
 - **Pipeline integration:** Native support for Nerva, naabu, nmap, and masscan workflows
 - **Embedded bad keys:** Built-in collection of known SSH keys (Vagrant, F5, ExaGrid, etc.)
 - **Go library:** Import directly into your security automation tools
@@ -528,6 +529,33 @@ naabu -host 10.0.0.0/24 -p 22 -silent | nerva --json | brutus --badkeys-only
 | Array Networks | - | sync | vAPV/vxAG appliances |
 | Quantum DXi | - | root | Deduplication appliances |
 | Loadbalancer.org | - | root | Enterprise load balancers |
+
+---
+
+## Aggressiveness Modes
+
+The global `--mode` flag (`-m`) controls aggressiveness across all subcommands. It sets performance tuning presets that balance coverage against safety:
+
+| Mode | Threads | Timeout | Rate Limit | Jitter | Retries | Use Case |
+|------|---------|---------|------------|--------|---------|----------|
+| `cautious` | 5 | 15s | 2 req/s | 500ms | 1 | Production environments, avoid lockouts |
+| `default` | 10 | 10s | Unlimited | None | 2 | Standard testing |
+| `exhaustive` | 20 | 10s | Unlimited | None | 3 | Lab/CTF environments, maximum coverage |
+
+Mode presets are applied first, then any explicit CLI flags override them:
+
+```bash
+# Safe mode for production Active Directory (low concurrency, rate-limited)
+brutus creds --target dc.corp.local:445 --protocol smb -m cautious -U users.txt -P passwords.txt
+
+# Maximum coverage for a CTF
+brutus creds --target 10.10.10.100:22 --protocol ssh -m exhaustive -U users.txt -P rockyou.txt
+
+# Cautious mode but override threads
+brutus creds --target 192.168.1.100:22 --protocol ssh -m cautious --threads 20
+```
+
+For SNMP, the mode also controls the built-in wordlist depth (see [SNMP Community String Testing](#snmp-community-string-testing)).
 
 ---
 

--- a/cmd/brutus/cmd_snmp.go
+++ b/cmd/brutus/cmd_snmp.go
@@ -28,19 +28,19 @@ var snmpCmd = &cobra.Command{
 switches, and other SNMP-enabled infrastructure.
 
 Community strings are selected by mode:
-  default   ~20 common strings (public, private, community, etc.)
-  extended  ~50 strings (adds vendor-specific: Cisco, HP, Juniper, etc.)
-  full      ~120 strings (comprehensive: SCADA, IP cameras, storage, etc.)
+  cautious    ~25 common strings (public, private, community, etc.)
+  default     ~75 strings (adds vendor-specific: Cisco, HP, Juniper, etc.)
+  exhaustive  ~200+ strings (comprehensive: SCADA, IP cameras, storage, etc.)
 
 Custom community strings can also be provided via -c or -C.`,
 	Example: `  # Test with default community strings
   brutus snmp --target 192.168.1.1:161
 
-  # Use extended mode for more coverage
-  brutus snmp --target 192.168.1.1:161 --mode extended
+  # Use default mode for more coverage
+  brutus snmp --target 192.168.1.1:161 --mode default
 
-  # Full mode for comprehensive testing
-  brutus snmp --target 10.0.0.1:161 --mode full
+  # Exhaustive mode for comprehensive testing
+  brutus snmp --target 10.0.0.1:161 --mode exhaustive
 
   # Custom community strings
   brutus snmp --target 192.168.1.1:161 -c "mycommunity,secretstring"

--- a/cmd/brutus/cmd_snmp.go
+++ b/cmd/brutus/cmd_snmp.go
@@ -70,9 +70,11 @@ func runSNMP(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// If no custom community strings, load from mode
+	// If no custom community strings, load from mode.
+	// Use flagMode directly since SNMP has its own legacy tier names
+	// (extended, full) that NormalizeMode would map to "default".
 	if len(passwords) == 0 {
-		passwords, err = snmpPkg.ConfigureSNMP(base.mode)
+		passwords, err = snmpPkg.ConfigureSNMP(flagMode)
 		if err != nil {
 			return err
 		}

--- a/cmd/brutus/config.go
+++ b/cmd/brutus/config.go
@@ -40,7 +40,7 @@ type baseConfigOptions struct {
 	jitter           time.Duration // Random delay variance for rate limiting
 	maxAttempts      int
 	maxRetries       int
-	mode             string // Credential/community tier: default, extended, full
+	mode             string // Aggressiveness tier: cautious, default, exhaustive
 	anthropicKey     string // ANTHROPIC_API_KEY (read once in main)
 	perplexityKey    string // PERPLEXITY_API_KEY (read once in main)
 

--- a/cmd/brutus/fingerprint.go
+++ b/cmd/brutus/fingerprint.go
@@ -181,26 +181,6 @@ func runFromFingerprint(targets []string, base *runConfig, jsonOut bool) ([]brut
 
 		target := nrv.TargetAddr()
 
-		// If Nerva detected anonymous access, report the finding and skip
-		// credential testing — every password "works" on a service that
-		// doesn't enforce auth, so brute force results would be misleading.
-		if nrv.HasNoAuth() {
-			logVerbose(base.verbose, "Nerva detected unauthenticated access on %s (%s) — skipping credential testing", target, protocol)
-			finding := brutus.Result{
-				Protocol: protocol,
-				Target:   target,
-				Username: "(unauthenticated)",
-				Success:  true,
-				Banner:   fmt.Sprintf("[CRITICAL] %s accessible without authentication (detected by Nerva fingerprinting)", protocol),
-			}
-			allResults = append(allResults, finding)
-			hasSuccess = true
-			if !jsonOut {
-				emitSecurityFindings([]brutus.Result{finding}, base.useColor)
-			}
-			continue
-		}
-
 		// Detect HTTP auth type for web subcommand (form-based → browser protocol).
 		var aiCreds []brutus.Credential
 		if base.web != nil && (protocol == "http" || protocol == "https") {

--- a/cmd/brutus/fingerprint.go
+++ b/cmd/brutus/fingerprint.go
@@ -181,6 +181,26 @@ func runFromFingerprint(targets []string, base *runConfig, jsonOut bool) ([]brut
 
 		target := nrv.TargetAddr()
 
+		// If Nerva detected anonymous access, report the finding and skip
+		// credential testing — every password "works" on a service that
+		// doesn't enforce auth, so brute force results would be misleading.
+		if nrv.HasNoAuth() {
+			logVerbose(base.verbose, "Nerva detected unauthenticated access on %s (%s) — skipping credential testing", target, protocol)
+			finding := brutus.Result{
+				Protocol: protocol,
+				Target:   target,
+				Username: "(unauthenticated)",
+				Success:  true,
+				Banner:   fmt.Sprintf("[CRITICAL] %s accessible without authentication (detected by Nerva fingerprinting)", protocol),
+			}
+			allResults = append(allResults, finding)
+			hasSuccess = true
+			if !jsonOut {
+				emitSecurityFindings([]brutus.Result{finding}, base.useColor)
+			}
+			continue
+		}
+
 		// Detect HTTP auth type for web subcommand (form-based → browser protocol).
 		var aiCreds []brutus.Credential
 		if base.web != nil && (protocol == "http" || protocol == "https") {

--- a/cmd/brutus/flags.go
+++ b/cmd/brutus/flags.go
@@ -122,7 +122,7 @@ func registerSharedFlags(cmd *cobra.Command) {
 	pf.IntVar(&flagRetries, "retries", 2, "Max retries on connection error (0 = disabled)")
 
 	// Mode
-	pf.StringVarP(&flagMode, "mode", "m", "default", "Credential/community tier: default, extended, full")
+	pf.StringVarP(&flagMode, "mode", "m", "default", "Aggressiveness tier: cautious, default, exhaustive")
 
 	// Output
 	pf.BoolVar(&flagJSON, "json", false, "JSON output format")
@@ -194,20 +194,51 @@ func registerRootFlags(cmd *cobra.Command) {
 // buildBaseConfig constructs a baseConfigOptions with only the shared fields.
 // Subcommand-specific loading (credentials, keys, AI config) is handled by
 // each subcommand's runXxx function.
-func buildBaseConfig(_ *cobra.Command) *baseConfigOptions {
+//
+// Mode presets supply defaults for threads, timeout, rate-limit, jitter,
+// max-attempts, and retries. Explicit CLI flags override presets.
+func buildBaseConfig(cmd *cobra.Command) *baseConfigOptions {
+	mode := brutus.NormalizeMode(flagMode)
+	presets := mode.Presets()
+
+	threads := presets.Threads
+	if isFlagChanged(cmd, "threads") {
+		threads = flagThreads
+	}
+	timeout := presets.Timeout
+	if isFlagChanged(cmd, "timeout") {
+		timeout = flagTimeout
+	}
+	rateLimit := presets.RateLimit
+	if isFlagChanged(cmd, "rate-limit") {
+		rateLimit = flagRateLimit
+	}
+	jitter := presets.Jitter
+	if isFlagChanged(cmd, "jitter") {
+		jitter = flagJitter
+	}
+	maxAttempts := presets.MaxAttempts
+	if isFlagChanged(cmd, "max-attempts") {
+		maxAttempts = flagMaxAttempts
+	}
+	maxRetries := presets.MaxRetries
+	if isFlagChanged(cmd, "retries") {
+		maxRetries = flagRetries
+	}
+
 	return &baseConfigOptions{
-		threads:          flagThreads,
-		timeout:          flagTimeout,
+		threads:          threads,
+		timeout:          timeout,
 		useColor:         isColorEnabled(flagNoColor),
 		quiet:            flagQuiet,
 		verbose:          flagVerbose,
 		protocolOverride: flagProtocol,
 		aiMode:           flagAIMode,
 		tlsMode:          determineTLSMode(flagVerifyTLS),
-		rateLimit:        flagRateLimit,
-		jitter:           flagJitter,
-		maxAttempts:      flagMaxAttempts,
-		maxRetries:       flagRetries,
+		rateLimit:        rateLimit,
+		jitter:           jitter,
+		maxAttempts:      maxAttempts,
+		maxRetries:       maxRetries,
 		mode:             flagMode,
 		anthropicKey:     os.Getenv("ANTHROPIC_API_KEY"),
 		perplexityKey:    os.Getenv("PERPLEXITY_API_KEY"),

--- a/cmd/brutus/main.go
+++ b/cmd/brutus/main.go
@@ -21,7 +21,6 @@ import (
 
 	// Import plugins and analyzers to register them
 	_ "github.com/praetorian-inc/brutus/internal/analyzers"
-	_ "github.com/praetorian-inc/brutus/internal/enumplugins"
 	_ "github.com/praetorian-inc/brutus/internal/plugins"
 )
 

--- a/cmd/brutus/main.go
+++ b/cmd/brutus/main.go
@@ -21,6 +21,7 @@ import (
 
 	// Import plugins and analyzers to register them
 	_ "github.com/praetorian-inc/brutus/internal/analyzers"
+	_ "github.com/praetorian-inc/brutus/internal/enumplugins"
 	_ "github.com/praetorian-inc/brutus/internal/plugins"
 )
 

--- a/cmd/brutus/root.go
+++ b/cmd/brutus/root.go
@@ -26,7 +26,7 @@ import (
 )
 
 // errNoSubcommand is returned when the root command is invoked without a subcommand.
-var errNoSubcommand = fmt.Errorf("a subcommand is required (creds, web, snmp, badkeys, logon)")
+var errNoSubcommand = fmt.Errorf("a subcommand is required (creds, web, snmp, badkeys, logon, enum)")
 
 var rootCmd = &cobra.Command{
 	Use:   "brutus",
@@ -40,6 +40,7 @@ Subcommands:
   snmp     Test SNMP community strings against targets
   badkeys  Test known weak/compromised SSH keys against targets
   logon    Detect Windows logon-screen backdoors (sticky keys, utilman)
+  enum     Enumerate email accounts against SaaS services (M365, Google, etc.)
 
 All subcommands accept targets via stdin (one per line, formats can be mixed):
   Nerva JSON:  {"ip":"10.0.0.1","port":22,"protocol":"ssh"}
@@ -58,11 +59,20 @@ func init() {
 	registerSharedFlags(rootCmd)
 	registerRootFlags(rootCmd)
 
+	// Validate shared flags before any subcommand runs.
+	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		if !brutus.ValidMode(flagMode) {
+			return fmt.Errorf("invalid --mode %q (valid: cautious, default, exhaustive)", flagMode)
+		}
+		return nil
+	}
+
 	rootCmd.AddCommand(credsCmd)
 	rootCmd.AddCommand(webCmd)
 	rootCmd.AddCommand(snmpCmd)
 	rootCmd.AddCommand(badkeysCmd)
 	rootCmd.AddCommand(logonCmd)
+	rootCmd.AddCommand(enumCmd)
 }
 
 // runRoot handles the root command (no subcommand). It only supports --version;

--- a/cmd/brutus/root.go
+++ b/cmd/brutus/root.go
@@ -26,7 +26,7 @@ import (
 )
 
 // errNoSubcommand is returned when the root command is invoked without a subcommand.
-var errNoSubcommand = fmt.Errorf("a subcommand is required (creds, web, snmp, badkeys, logon, enum)")
+var errNoSubcommand = fmt.Errorf("a subcommand is required (creds, web, snmp, badkeys, logon)")
 
 var rootCmd = &cobra.Command{
 	Use:   "brutus",
@@ -61,7 +61,10 @@ func init() {
 
 	// Validate shared flags before any subcommand runs.
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
-		if !brutus.ValidMode(flagMode) {
+		// SNMP has its own tier names (extended, full) that predate the global
+		// mode system. Skip strict validation for SNMP so legacy modes pass
+		// through to ConfigureSNMP which handles the mapping.
+		if cmd.Name() != "snmp" && !brutus.ValidMode(flagMode) {
 			return fmt.Errorf("invalid --mode %q (valid: cautious, default, exhaustive)", flagMode)
 		}
 		return nil
@@ -72,7 +75,6 @@ func init() {
 	rootCmd.AddCommand(snmpCmd)
 	rootCmd.AddCommand(badkeysCmd)
 	rootCmd.AddCommand(logonCmd)
-	rootCmd.AddCommand(enumCmd)
 }
 
 // runRoot handles the root command (no subcommand). It only supports --version;

--- a/cmd/brutus/root.go
+++ b/cmd/brutus/root.go
@@ -40,7 +40,6 @@ Subcommands:
   snmp     Test SNMP community strings against targets
   badkeys  Test known weak/compromised SSH keys against targets
   logon    Detect Windows logon-screen backdoors (sticky keys, utilman)
-  enum     Enumerate email accounts against SaaS services (M365, Google, etc.)
 
 All subcommands accept targets via stdin (one per line, formats can be mixed):
   Nerva JSON:  {"ip":"10.0.0.1","port":22,"protocol":"ssh"}

--- a/cmd/brutus/runner.go
+++ b/cmd/brutus/runner.go
@@ -286,6 +286,7 @@ func runSingleTarget(target, protocol, tlsMode string, base *runConfig, aiCreds 
 		MaxRetries:      base.maxRetries,
 		Verbose:         base.verbose,
 		SkipUnauthCheck: skipUnauthCheck,
+		Mode:            brutus.NormalizeMode(base.mode),
 	}
 
 	// Handle HTTP with AI-researched credentials

--- a/pkg/brutus/brutus.go
+++ b/pkg/brutus/brutus.go
@@ -113,6 +113,7 @@ type Config struct {
 	StickyKeys      bool          // enable sticky keys backdoor detection (RDP)
 	AIMode          bool          // enable Vision API for screenshot analysis (RDP)
 	SkipUnauthCheck bool          // skip CheckUnauth probe (when Nerva already detected it)
+	Mode            Mode          // aggressiveness tier for wordlist depth (default: ModeDefault)
 }
 
 // Result contains the outcome of testing a single credential.
@@ -275,7 +276,11 @@ func (c *Config) applyDefaults() {
 
 	// Load wordlist defaults when no user-supplied credentials were provided
 	if !hasCreds && !hasPasswords && !hasKeys {
-		if defaults := DefaultCredentials(c.Protocol); len(defaults) > 0 {
+		mode := c.Mode
+		if mode == "" {
+			mode = ModeDefault
+		}
+		if defaults := DefaultCredentialsForMode(c.Protocol, mode); len(defaults) > 0 {
 			c.Credentials = append(c.Credentials, defaults...)
 		}
 	}

--- a/pkg/brutus/defaults.go
+++ b/pkg/brutus/defaults.go
@@ -8,20 +8,133 @@ import (
 //go:embed wordlists/*.txt
 var wordlistsFS embed.FS
 
+// Tier marker comments recognized in wordlist files.
+const (
+	markerCautious   = "# --- cautious ---"
+	markerExhaustive = "# --- exhaustive ---"
+)
+
+// maxCautiousFallback is the maximum number of credentials returned for
+// ModeCautious when a wordlist file has no tier markers.
+const maxCautiousFallback = 5
+
 // DefaultCredentials returns the default username:password pairs for a protocol
 // by parsing the embedded wordlist file. Returns nil if no wordlist exists for
 // the protocol. Each entry is a Credential with Username and Password set.
+//
+// This is equivalent to DefaultCredentialsForMode(protocol, ModeDefault).
 func DefaultCredentials(protocol string) []Credential {
+	return DefaultCredentialsForMode(protocol, ModeDefault)
+}
+
+// DefaultCredentialsForMode returns default credentials for a protocol filtered
+// by the specified aggressiveness mode.
+//
+// Wordlist files use optional section markers to define tier boundaries:
+//
+//	root:root           ← cautious tier (lines before first marker)
+//	admin:admin
+//	# --- cautious ---
+//	root:password       ← default tier (added for default + exhaustive)
+//	root:toor
+//	# --- exhaustive ---
+//	vendor:vendor123    ← exhaustive tier (added only for exhaustive)
+//
+// Files without markers: cautious returns the first 5 entries, default and
+// exhaustive return all entries.
+func DefaultCredentialsForMode(protocol string, mode Mode) []Credential {
 	data, err := wordlistsFS.ReadFile("wordlists/" + protocol + "_defaults.txt")
 	if err != nil {
 		return nil
 	}
-	return parseWordlist(string(data))
+	return parseWordlistTiered(string(data), mode)
+}
+
+// parseWordlistTiered parses a wordlist with optional tier markers.
+func parseWordlistTiered(content string, mode Mode) []Credential {
+	lines := strings.Split(content, "\n")
+
+	// Partition lines into three sections based on markers.
+	var cautiousLines, defaultLines, exhaustiveLines []string
+	section := "cautious" // lines before any marker are highest-confidence
+	hasMarkers := false
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if trimmed == markerCautious {
+			hasMarkers = true
+			section = "default"
+			continue
+		}
+		if trimmed == markerExhaustive {
+			hasMarkers = true
+			section = "exhaustive"
+			continue
+		}
+
+		// Skip blank lines and comments.
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		switch section {
+		case "cautious":
+			cautiousLines = append(cautiousLines, trimmed)
+		case "default":
+			defaultLines = append(defaultLines, trimmed)
+		case "exhaustive":
+			exhaustiveLines = append(exhaustiveLines, trimmed)
+		}
+	}
+
+	// When the file has no markers, all non-comment lines end up in
+	// cautiousLines. For ModeDefault and ModeExhaustive this is fine (they
+	// get everything). For ModeCautious we cap at maxCautiousFallback.
+	if !hasMarkers && mode == ModeCautious && len(cautiousLines) > maxCautiousFallback {
+		cautiousLines = cautiousLines[:maxCautiousFallback]
+	}
+
+	// Build the selected line set based on mode.
+	var selected []string
+	switch mode {
+	case ModeCautious:
+		selected = cautiousLines
+	case ModeExhaustive:
+		selected = make([]string, 0, len(cautiousLines)+len(defaultLines)+len(exhaustiveLines))
+		selected = append(selected, cautiousLines...)
+		selected = append(selected, defaultLines...)
+		selected = append(selected, exhaustiveLines...)
+	default: // ModeDefault
+		selected = make([]string, 0, len(cautiousLines)+len(defaultLines))
+		selected = append(selected, cautiousLines...)
+		selected = append(selected, defaultLines...)
+	}
+
+	return parseLines(selected)
+}
+
+// parseLines converts raw credential lines into Credential pairs.
+// Format is username:password per line. A line without a colon is treated as
+// password-only (e.g., SNMP community strings).
+func parseLines(lines []string) []Credential {
+	var creds []Credential
+	for _, line := range lines {
+		username, password, found := strings.Cut(line, ":")
+		if !found {
+			creds = append(creds, Credential{Password: line})
+		} else {
+			creds = append(creds, Credential{Username: username, Password: password})
+		}
+	}
+	return creds
 }
 
 // parseWordlist parses a wordlist file into Credential pairs.
 // Lines starting with # are comments. Format is username:password per line.
 // A line with just "community_string" (no colon) is treated as password-only.
+//
+// Deprecated: Use parseWordlistTiered for mode-aware loading.
 func parseWordlist(content string) []Credential {
 	var creds []Credential
 	for _, line := range strings.Split(content, "\n") {
@@ -31,7 +144,6 @@ func parseWordlist(content string) []Credential {
 		}
 		username, password, found := strings.Cut(line, ":")
 		if !found {
-			// No colon: treat as password-only (e.g., SNMP community strings)
 			creds = append(creds, Credential{Password: line})
 		} else {
 			creds = append(creds, Credential{Username: username, Password: password})

--- a/pkg/brutus/defaults_test.go
+++ b/pkg/brutus/defaults_test.go
@@ -252,6 +252,115 @@ func TestParseWordlist_LineWithoutColon_TreatedAsPasswordOnly(t *testing.T) {
 	}
 }
 
+// --- Tiered loading tests ---
+
+func TestParseWordlistTiered_WithMarkers(t *testing.T) {
+	content := `# Test wordlist
+root:root
+admin:admin
+# --- cautious ---
+root:password
+root:toor
+# --- exhaustive ---
+vendor:vendor123
+obscure:cred`
+
+	cautious := parseWordlistTiered(content, ModeCautious)
+	if len(cautious) != 2 {
+		t.Errorf("cautious: expected 2 credentials, got %d", len(cautious))
+	}
+
+	dflt := parseWordlistTiered(content, ModeDefault)
+	if len(dflt) != 4 {
+		t.Errorf("default: expected 4 credentials, got %d", len(dflt))
+	}
+
+	exhaustive := parseWordlistTiered(content, ModeExhaustive)
+	if len(exhaustive) != 6 {
+		t.Errorf("exhaustive: expected 6 credentials, got %d", len(exhaustive))
+	}
+}
+
+func TestParseWordlistTiered_NoMarkers_CautiousCapped(t *testing.T) {
+	content := "root:root\nroot:password\nadmin:admin\nuser:user\ntest:test\nguest:guest\nfoo:bar"
+
+	cautious := parseWordlistTiered(content, ModeCautious)
+	if len(cautious) != maxCautiousFallback {
+		t.Errorf("cautious without markers: expected %d credentials, got %d", maxCautiousFallback, len(cautious))
+	}
+
+	dflt := parseWordlistTiered(content, ModeDefault)
+	if len(dflt) != 7 {
+		t.Errorf("default without markers: expected 7 credentials, got %d", len(dflt))
+	}
+
+	exhaustive := parseWordlistTiered(content, ModeExhaustive)
+	if len(exhaustive) != 7 {
+		t.Errorf("exhaustive without markers: expected 7 credentials, got %d", len(exhaustive))
+	}
+}
+
+func TestParseWordlistTiered_NoMarkers_SmallFile(t *testing.T) {
+	content := "root:root\nadmin:admin\nuser:user"
+
+	// File has fewer than maxCautiousFallback entries — all returned.
+	cautious := parseWordlistTiered(content, ModeCautious)
+	if len(cautious) != 3 {
+		t.Errorf("cautious small file: expected 3 credentials, got %d", len(cautious))
+	}
+}
+
+func TestDefaultCredentialsForMode_BackwardCompat(t *testing.T) {
+	// DefaultCredentials() should return same count as ModeDefault.
+	protocols := []string{"ssh", "mysql", "ftp", "redis", "postgresql"}
+	for _, proto := range protocols {
+		old := DefaultCredentials(proto)
+		dflt := DefaultCredentialsForMode(proto, ModeDefault)
+		if len(old) != len(dflt) {
+			t.Errorf("%s: DefaultCredentials returned %d, DefaultCredentialsForMode(ModeDefault) returned %d",
+				proto, len(old), len(dflt))
+		}
+	}
+}
+
+func TestDefaultCredentialsForMode_CautiousSubsetOfDefault(t *testing.T) {
+	protocols := []string{"ssh", "mysql", "rdp", "http", "ftp"}
+	for _, proto := range protocols {
+		cautious := DefaultCredentialsForMode(proto, ModeCautious)
+		dflt := DefaultCredentialsForMode(proto, ModeDefault)
+		if len(cautious) >= len(dflt) {
+			t.Errorf("%s: cautious (%d) should be smaller than default (%d)",
+				proto, len(cautious), len(dflt))
+		}
+	}
+}
+
+func TestDefaultCredentialsForMode_ExhaustiveSupersetOfDefault(t *testing.T) {
+	protocols := []string{"ssh", "mysql", "rdp", "http", "ftp"}
+	for _, proto := range protocols {
+		dflt := DefaultCredentialsForMode(proto, ModeDefault)
+		exhaustive := DefaultCredentialsForMode(proto, ModeExhaustive)
+		if len(exhaustive) < len(dflt) {
+			t.Errorf("%s: exhaustive (%d) should be >= default (%d)",
+				proto, len(exhaustive), len(dflt))
+		}
+	}
+}
+
+func TestApplyDefaults_WithMode(t *testing.T) {
+	// Cautious mode should load fewer defaults than default mode.
+	cautious := &Config{Target: "x:22", Protocol: "ssh", UseDefaults: true, Mode: ModeCautious, NoBadkeys: true}
+	cautious.applyDefaults()
+
+	dflt := &Config{Target: "x:22", Protocol: "ssh", UseDefaults: true, Mode: ModeDefault, NoBadkeys: true}
+	dflt.applyDefaults()
+
+	if len(cautious.Credentials) >= len(dflt.Credentials) {
+		t.Errorf("cautious mode (%d creds) should have fewer than default mode (%d creds)",
+			len(cautious.Credentials), len(dflt.Credentials))
+	}
+}
+
 func TestDefaultCredentials_SNMP_CommunityStringsAsPasswords(t *testing.T) {
 	// SNMP uses community strings which should be in the Password field
 	creds := DefaultCredentials("snmp")

--- a/pkg/brutus/mode.go
+++ b/pkg/brutus/mode.go
@@ -20,7 +20,8 @@ import (
 )
 
 // Mode represents the aggressiveness tier for credential testing.
-// It controls wordlist depth and performance tuning presets.
+// It controls wordlist depth and performance tuning presets (threads,
+// timeout, rate limit, jitter, max attempts, and retries).
 type Mode string
 
 const (

--- a/pkg/brutus/mode.go
+++ b/pkg/brutus/mode.go
@@ -47,7 +47,7 @@ type ModePresets struct {
 }
 
 // NormalizeMode converts a user-supplied string to a validated Mode constant.
-// Unrecognised values fall back to ModeDefault.
+// Unrecognized values fall back to ModeDefault.
 func NormalizeMode(s string) Mode {
 	switch Mode(strings.ToLower(strings.TrimSpace(s))) {
 	case ModeCautious:
@@ -59,7 +59,7 @@ func NormalizeMode(s string) Mode {
 	}
 }
 
-// ValidMode returns true if s is a recognised mode string.
+// ValidMode returns true if s is a recognized mode string.
 func ValidMode(s string) bool {
 	switch Mode(strings.ToLower(strings.TrimSpace(s))) {
 	case ModeCautious, ModeDefault, ModeExhaustive:

--- a/pkg/brutus/mode.go
+++ b/pkg/brutus/mode.go
@@ -47,8 +47,8 @@ type ModePresets struct {
 	MaxRetries  int
 }
 
-// NormalizeMode converts a user-supplied string to a validated Mode constant.
-// Unrecognized values fall back to ModeDefault.
+// NormalizeMode converts a user-supplied string to a validated [Mode] constant.
+// Unrecognized values fall back to [ModeDefault].
 func NormalizeMode(s string) Mode {
 	switch Mode(strings.ToLower(strings.TrimSpace(s))) {
 	case ModeCautious:

--- a/pkg/brutus/mode.go
+++ b/pkg/brutus/mode.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package brutus
+
+import (
+	"strings"
+	"time"
+)
+
+// Mode represents the aggressiveness tier for credential testing.
+// It controls wordlist depth and performance tuning presets.
+type Mode string
+
+const (
+	// ModeCautious uses a minimal credential set, lower concurrency, and rate
+	// limiting to avoid account lockouts. Safe for production environments.
+	ModeCautious Mode = "cautious"
+
+	// ModeDefault is the standard mode balancing coverage and safety.
+	ModeDefault Mode = "default"
+
+	// ModeExhaustive uses the full credential set and higher concurrency
+	// for maximum coverage. Use in lab/CTF environments.
+	ModeExhaustive Mode = "exhaustive"
+)
+
+// ModePresets holds the performance tuning values associated with a Mode.
+type ModePresets struct {
+	Threads     int
+	Timeout     time.Duration
+	RateLimit   float64
+	Jitter      time.Duration
+	MaxAttempts int
+	MaxRetries  int
+}
+
+// NormalizeMode converts a user-supplied string to a validated Mode constant.
+// Unrecognised values fall back to ModeDefault.
+func NormalizeMode(s string) Mode {
+	switch Mode(strings.ToLower(strings.TrimSpace(s))) {
+	case ModeCautious:
+		return ModeCautious
+	case ModeExhaustive:
+		return ModeExhaustive
+	default:
+		return ModeDefault
+	}
+}
+
+// ValidMode returns true if s is a recognised mode string.
+func ValidMode(s string) bool {
+	switch Mode(strings.ToLower(strings.TrimSpace(s))) {
+	case ModeCautious, ModeDefault, ModeExhaustive:
+		return true
+	default:
+		return false
+	}
+}
+
+// Presets returns the performance tuning values for this mode.
+func (m Mode) Presets() ModePresets {
+	switch m {
+	case ModeCautious:
+		return ModePresets{
+			Threads:     5,
+			Timeout:     15 * time.Second,
+			RateLimit:   2,
+			Jitter:      500 * time.Millisecond,
+			MaxAttempts: 3,
+			MaxRetries:  1,
+		}
+	case ModeExhaustive:
+		return ModePresets{
+			Threads:     20,
+			Timeout:     10 * time.Second,
+			RateLimit:   0, // unlimited
+			Jitter:      0,
+			MaxAttempts: 0, // unlimited
+			MaxRetries:  3,
+		}
+	default: // ModeDefault
+		return ModePresets{
+			Threads:     10,
+			Timeout:     10 * time.Second,
+			RateLimit:   0, // unlimited
+			Jitter:      0,
+			MaxAttempts: 0, // unlimited
+			MaxRetries:  2,
+		}
+	}
+}

--- a/pkg/brutus/mode_test.go
+++ b/pkg/brutus/mode_test.go
@@ -1,0 +1,59 @@
+package brutus
+
+import "testing"
+
+func TestNormalizeMode(t *testing.T) {
+	tests := []struct {
+		input string
+		want  Mode
+	}{
+		{"cautious", ModeCautious},
+		{"CAUTIOUS", ModeCautious},
+		{"  Cautious  ", ModeCautious},
+		{"default", ModeDefault},
+		{"DEFAULT", ModeDefault},
+		{"exhaustive", ModeExhaustive},
+		{"EXHAUSTIVE", ModeExhaustive},
+		{"unknown", ModeDefault},
+		{"", ModeDefault},
+	}
+	for _, tt := range tests {
+		got := NormalizeMode(tt.input)
+		if got != tt.want {
+			t.Errorf("NormalizeMode(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestValidMode(t *testing.T) {
+	valid := []string{"cautious", "default", "exhaustive", "CAUTIOUS", "DEFAULT", "EXHAUSTIVE"}
+	for _, s := range valid {
+		if !ValidMode(s) {
+			t.Errorf("ValidMode(%q) = false, want true", s)
+		}
+	}
+	invalid := []string{"", "fast", "unknown"}
+	for _, s := range invalid {
+		if ValidMode(s) {
+			t.Errorf("ValidMode(%q) = true, want false", s)
+		}
+	}
+}
+
+func TestModePresets(t *testing.T) {
+	// Cautious should have lower threads and non-zero rate limit.
+	cp := ModeCautious.Presets()
+	if cp.Threads >= ModeDefault.Presets().Threads {
+		t.Errorf("cautious threads (%d) should be less than default (%d)", cp.Threads, ModeDefault.Presets().Threads)
+	}
+	if cp.RateLimit == 0 {
+		t.Error("cautious should have a non-zero rate limit")
+	}
+
+	// Exhaustive should have higher threads than default.
+	ep := ModeExhaustive.Presets()
+	dp := ModeDefault.Presets()
+	if ep.Threads <= dp.Threads {
+		t.Errorf("exhaustive threads (%d) should be greater than default (%d)", ep.Threads, dp.Threads)
+	}
+}

--- a/pkg/brutus/snmp/snmp.go
+++ b/pkg/brutus/snmp/snmp.go
@@ -27,11 +27,30 @@ func IsSNMPProtocol(protocol string) bool {
 	return protocol == "snmp"
 }
 
-// ConfigureSNMP validates the tier string and returns the corresponding community
-// strings. The caller is responsible for assigning them to config.Passwords.
-func ConfigureSNMP(tier string) ([]string, error) {
-	if !snmpplugin.ValidateTier(tier) {
-		return nil, fmt.Errorf("invalid --mode: %s (use: default, extended, full)", tier)
+// ConfigureSNMP validates the mode string and returns the corresponding community
+// strings. It accepts both the new mode names (cautious, default, exhaustive) and
+// the legacy SNMP tier names (default, extended, full).
+// The caller is responsible for assigning the result to config.Passwords.
+func ConfigureSNMP(mode string) ([]string, error) {
+	snmpTier := mapModeToSNMPTier(mode)
+	if !snmpplugin.ValidateTier(snmpTier) {
+		return nil, fmt.Errorf("invalid --mode: %s (use: cautious, default, exhaustive)", mode)
 	}
-	return snmpplugin.GetCommunityStrings(snmpplugin.Tier(tier)), nil
+	return snmpplugin.GetCommunityStrings(snmpplugin.Tier(snmpTier)), nil
+}
+
+// mapModeToSNMPTier converts the global mode names to SNMP-specific tier names.
+// The SNMP plugin has its own tier constants (default, extended, full) that
+// predate the global mode system; this mapping bridges the two.
+func mapModeToSNMPTier(mode string) string {
+	switch mode {
+	case "cautious":
+		return "default" // SNMP's smallest tier (~25 strings)
+	case "exhaustive":
+		return "full" // SNMP's largest tier (~200+ strings)
+	default:
+		// "default" passes through; legacy "extended" and "full" also pass through
+		// since the SNMP plugin's ValidateTier accepts them directly.
+		return mode
+	}
 }

--- a/pkg/brutus/snmp/snmp_test.go
+++ b/pkg/brutus/snmp/snmp_test.go
@@ -45,3 +45,37 @@ func TestConfigureSNMP(t *testing.T) {
 	_, err = ConfigureSNMP("invalid")
 	assert.Error(t, err)
 }
+
+func TestConfigureSNMP_GlobalModeNames(t *testing.T) {
+	// "cautious" maps to SNMP's "default" tier (~25 strings)
+	cautious, err := ConfigureSNMP("cautious")
+	require.NoError(t, err)
+	assert.NotEmpty(t, cautious)
+	assert.Contains(t, cautious, "public")
+
+	// "exhaustive" maps to SNMP's "full" tier (~200+ strings)
+	exhaustive, err := ConfigureSNMP("exhaustive")
+	require.NoError(t, err)
+	assert.True(t, len(exhaustive) > 50)
+
+	// exhaustive should have more strings than cautious
+	assert.Greater(t, len(exhaustive), len(cautious))
+}
+
+func TestMapModeToSNMPTier(t *testing.T) {
+	tests := []struct {
+		mode string
+		want string
+	}{
+		{"cautious", "default"},
+		{"exhaustive", "full"},
+		{"default", "default"},     // passes through
+		{"extended", "extended"},   // legacy, passes through
+		{"full", "full"},           // legacy, passes through
+	}
+	for _, tt := range tests {
+		if got := mapModeToSNMPTier(tt.mode); got != tt.want {
+			t.Errorf("mapModeToSNMPTier(%q) = %q, want %q", tt.mode, got, tt.want)
+		}
+	}
+}

--- a/pkg/brutus/snmp/snmp_test.go
+++ b/pkg/brutus/snmp/snmp_test.go
@@ -69,9 +69,9 @@ func TestMapModeToSNMPTier(t *testing.T) {
 	}{
 		{"cautious", "default"},
 		{"exhaustive", "full"},
-		{"default", "default"},     // passes through
-		{"extended", "extended"},   // legacy, passes through
-		{"full", "full"},           // legacy, passes through
+		{"default", "default"},   // passes through
+		{"extended", "extended"}, // legacy, passes through
+		{"full", "full"},         // legacy, passes through
 	}
 	for _, tt := range tests {
 		if got := mapModeToSNMPTier(tt.mode); got != tt.want {

--- a/pkg/brutus/wordlists/browser_defaults.txt
+++ b/pkg/brutus/wordlists/browser_defaults.txt
@@ -3,13 +3,14 @@
 # Common defaults for web panels, routers, IoT devices, CMSes, and appliances
 admin:admin
 admin:password
+admin:
+root:root
+# --- cautious ---
 admin:1234
 admin:12345
 admin:123456
-admin:
 admin:changeme
 admin:default
-root:root
 root:password
 root:admin
 root:toor
@@ -20,3 +21,12 @@ test:test
 administrator:administrator
 administrator:password
 manager:manager
+# --- exhaustive ---
+admin:router
+admin:public
+admin:private
+support:support
+admin:letmein
+admin:welcome
+admin:Admin123
+admin:system

--- a/pkg/brutus/wordlists/cassandra_defaults.txt
+++ b/pkg/brutus/wordlists/cassandra_defaults.txt
@@ -3,6 +3,13 @@
 cassandra:cassandra
 admin:admin
 root:root
+# --- cautious ---
 admin:password
 cassandra:admin
 cassandra:password
+# --- exhaustive ---
+cassandra:changeme
+admin:cassandra
+cassandra:123456
+dbadmin:dbadmin
+cassandra:root

--- a/pkg/brutus/wordlists/couchdb_defaults.txt
+++ b/pkg/brutus/wordlists/couchdb_defaults.txt
@@ -2,7 +2,14 @@
 # Format: username:password
 admin:admin
 admin:password
-administrator:administrator
 root:root
+# --- cautious ---
+administrator:administrator
 couchdb:couchdb
 admin:couchdb
+# --- exhaustive ---
+couchdb:password
+admin:changeme
+couchdb:admin
+admin:couch
+couchdb:couchdb123

--- a/pkg/brutus/wordlists/elasticsearch_defaults.txt
+++ b/pkg/brutus/wordlists/elasticsearch_defaults.txt
@@ -3,5 +3,12 @@
 elastic:elastic
 elastic:changeme
 elastic:password
+# --- cautious ---
 admin:admin
 elasticsearch:elasticsearch
+# --- exhaustive ---
+elastic:admin
+kibana:kibana
+elastic:elastic123
+admin:elastic
+elastic:secret

--- a/pkg/brutus/wordlists/ftp_defaults.txt
+++ b/pkg/brutus/wordlists/ftp_defaults.txt
@@ -3,7 +3,14 @@
 anonymous:
 anonymous:anonymous
 ftp:ftp
+# --- cautious ---
 admin:admin
 root:root
 user:user
 ftpuser:ftpuser
+# --- exhaustive ---
+ftp:password
+anonymous:ftp
+test:test
+upload:upload
+backup:backup

--- a/pkg/brutus/wordlists/http_defaults.txt
+++ b/pkg/brutus/wordlists/http_defaults.txt
@@ -3,8 +3,9 @@
 # Covers common web admin panels (Grafana, Jenkins, Elasticsearch, etc.)
 admin:admin
 admin:password
-admin:changeme
 admin:
+# --- cautious ---
+admin:changeme
 root:root
 root:password
 root:changeme
@@ -12,3 +13,11 @@ elastic:elastic
 elastic:changeme
 user:user
 guest:guest
+# --- exhaustive ---
+admin:admin123
+admin:Password1
+tomcat:tomcat
+admin:secret
+grafana:grafana
+jenkins:jenkins
+admin:default

--- a/pkg/brutus/wordlists/https_defaults.txt
+++ b/pkg/brutus/wordlists/https_defaults.txt
@@ -3,8 +3,9 @@
 # Same as HTTP defaults — covers TLS-enabled admin panels
 admin:admin
 admin:password
-admin:changeme
 admin:
+# --- cautious ---
+admin:changeme
 root:root
 root:password
 root:changeme
@@ -12,3 +13,11 @@ elastic:elastic
 elastic:changeme
 user:user
 guest:guest
+# --- exhaustive ---
+admin:admin123
+admin:Password1
+tomcat:tomcat
+admin:secret
+grafana:grafana
+jenkins:jenkins
+admin:default

--- a/pkg/brutus/wordlists/imap_defaults.txt
+++ b/pkg/brutus/wordlists/imap_defaults.txt
@@ -3,7 +3,14 @@
 admin@localhost:admin
 admin@localhost:password
 user@localhost:password
+# --- cautious ---
 test@localhost:test
 postmaster@localhost:password
 root@localhost:root
 webmaster@localhost:password
+# --- exhaustive ---
+admin@localhost:changeme
+mail@localhost:mail
+imap@localhost:imap
+user@localhost:user
+admin@localhost:admin123

--- a/pkg/brutus/wordlists/influxdb_defaults.txt
+++ b/pkg/brutus/wordlists/influxdb_defaults.txt
@@ -3,5 +3,12 @@
 admin:admin
 admin:password
 root:root
+# --- cautious ---
 influxdb:influxdb
 admin:influxdb
+# --- exhaustive ---
+influxdb:password
+influx:influx
+admin:changeme
+influxdb:admin
+influxdb:123456

--- a/pkg/brutus/wordlists/ldap_defaults.txt
+++ b/pkg/brutus/wordlists/ldap_defaults.txt
@@ -2,8 +2,16 @@
 # Format: username:password (plugin tries simple username first, then constructs DN)
 admin:admin
 admin:password
-administrator:administrator
 cn=admin:admin
+# --- cautious ---
+administrator:administrator
 cn=admin:password
 ldapadmin:ldapadmin
 root:root
+# --- exhaustive ---
+cn=Manager:secret
+cn=admin:changeme
+ldap:ldap
+admin:ldap
+cn=root:password
+directory:directory

--- a/pkg/brutus/wordlists/mongodb_defaults.txt
+++ b/pkg/brutus/wordlists/mongodb_defaults.txt
@@ -3,7 +3,14 @@
 admin:admin
 admin:password
 root:root
+# --- cautious ---
 root:password
 mongodb:mongodb
 user:user
 dbadmin:dbadmin
+# --- exhaustive ---
+mongo:mongo
+admin:mongo
+mongodb:password
+admin:mongodb
+root:mongo

--- a/pkg/brutus/wordlists/mssql_defaults.txt
+++ b/pkg/brutus/wordlists/mssql_defaults.txt
@@ -3,7 +3,14 @@
 sa:
 sa:sa
 sa:password
+# --- cautious ---
 sa:Password1
 sa:admin
 administrator:administrator
 admin:admin
+# --- exhaustive ---
+sa:P@ssw0rd
+sa:Admin123
+sa:sqlserver
+mssql:mssql
+sqladmin:sqladmin

--- a/pkg/brutus/wordlists/mysql_defaults.txt
+++ b/pkg/brutus/wordlists/mysql_defaults.txt
@@ -3,8 +3,15 @@
 root:
 root:root
 root:password
+# --- cautious ---
 root:toor
 root:mysql
 root:admin
 mysql:mysql
 admin:admin
+# --- exhaustive ---
+root:mysql123
+dbadmin:dbadmin
+mysql:password
+root:123456
+mysql:admin

--- a/pkg/brutus/wordlists/neo4j_defaults.txt
+++ b/pkg/brutus/wordlists/neo4j_defaults.txt
@@ -2,6 +2,13 @@
 # Format: username:password
 neo4j:neo4j
 neo4j:password
+# --- cautious ---
 neo4j:admin
 admin:admin
 neo4j:neo4j123
+# --- exhaustive ---
+neo4j:changeme
+neo4j:graph
+admin:neo4j
+neo4j:neo
+neo4j:123456

--- a/pkg/brutus/wordlists/oracle_defaults.txt
+++ b/pkg/brutus/wordlists/oracle_defaults.txt
@@ -2,9 +2,10 @@
 # Format: username:password
 sys:change_on_install
 system:manager
-system:oracle
-system:password
 scott:tiger
+system:password
+# --- cautious ---
+system:oracle
 hr:hr
 dbsnmp:dbsnmp
 outln:outln
@@ -17,3 +18,11 @@ xdb:xdb
 anonymous:anonymous
 apex_public_user:oracle
 flows_files:flows_files
+# --- exhaustive ---
+sys:oracle
+system:system
+sys:sys
+oracle:oracle
+sysman:sysman
+sys:manager
+ords_public_user:oracle

--- a/pkg/brutus/wordlists/pop3_defaults.txt
+++ b/pkg/brutus/wordlists/pop3_defaults.txt
@@ -3,7 +3,14 @@
 admin@localhost:admin
 admin@localhost:password
 user@localhost:password
+# --- cautious ---
 test@localhost:test
 postmaster@localhost:password
 root@localhost:root
 webmaster@localhost:password
+# --- exhaustive ---
+admin@localhost:changeme
+mail@localhost:mail
+pop3@localhost:pop3
+user@localhost:user
+admin@localhost:admin123

--- a/pkg/brutus/wordlists/postgresql_defaults.txt
+++ b/pkg/brutus/wordlists/postgresql_defaults.txt
@@ -1,7 +1,14 @@
 # PostgreSQL Default Credentials
 # Format: username:password
 postgres:postgres
-postgres:password
-postgres:admin
 postgres:
+postgres:password
+# --- cautious ---
+postgres:admin
 admin:admin
+# --- exhaustive ---
+postgres:postgres123
+postgres:root
+dbadmin:dbadmin
+pgsql:pgsql
+postgres:123456

--- a/pkg/brutus/wordlists/rdp_defaults.txt
+++ b/pkg/brutus/wordlists/rdp_defaults.txt
@@ -3,12 +3,20 @@
 # Common Windows/RDP default accounts
 administrator:password
 administrator:Password1
+admin:admin
+# --- cautious ---
 administrator:admin
 administrator:P@ssw0rd
-admin:admin
 admin:password
 admin:Password1
 guest:guest
 user:user
 user:password
 test:test
+# --- exhaustive ---
+administrator:Welcome1
+administrator:Passw0rd!
+administrator:Administrator
+sysadmin:sysadmin
+administrator:Admin123
+rdpuser:rdpuser

--- a/pkg/brutus/wordlists/redis_defaults.txt
+++ b/pkg/brutus/wordlists/redis_defaults.txt
@@ -4,6 +4,13 @@
 default:
 default:redis
 default:password
+# --- cautious ---
 admin:admin
 root:root
 redis:redis
+# --- exhaustive ---
+redis:password
+redis:admin
+default:admin
+cache:cache
+redis:123456

--- a/pkg/brutus/wordlists/smb_defaults.txt
+++ b/pkg/brutus/wordlists/smb_defaults.txt
@@ -1,10 +1,18 @@
 # SMB (Server Message Block) Default Credentials
 # Format: username:password (supports DOMAIN\username format)
 Administrator:
-Administrator:Administrator
 Administrator:password
+Guest:
+# --- cautious ---
+Administrator:Administrator
 Administrator:Password1
 Administrator:admin
-Guest:
 admin:admin
 root:root
+# --- exhaustive ---
+Administrator:Admin123
+Administrator:Welcome1
+smbuser:smbuser
+share:share
+Administrator:P@ssw0rd
+WORKGROUP\Administrator:password

--- a/pkg/brutus/wordlists/smtp_defaults.txt
+++ b/pkg/brutus/wordlists/smtp_defaults.txt
@@ -1,9 +1,16 @@
 # SMTP Default Credentials
 # Format: username:password (often email@domain format)
 postmaster:password
-postmaster:admin
 admin:admin
-admin@localhost:password
 root:root
+# --- cautious ---
+postmaster:admin
+admin@localhost:password
 user@localhost:password
 test@localhost:test
+# --- exhaustive ---
+smtp@localhost:smtp
+postmaster:postmaster
+admin@localhost:admin
+mail@localhost:mail
+admin:changeme

--- a/pkg/brutus/wordlists/ssh_defaults.txt
+++ b/pkg/brutus/wordlists/ssh_defaults.txt
@@ -1,10 +1,18 @@
 # SSH Default Credentials
 # Format: username:password
-root:toor
 root:root
 root:password
+admin:admin
+# --- cautious ---
+root:toor
 root:alpine
 ubuntu:ubuntu
 pi:raspberry
-admin:admin
 vagrant:vagrant
+# --- exhaustive ---
+deploy:deploy
+ec2-user:ec2-user
+centos:centos
+git:git
+test:test
+oracle:oracle

--- a/pkg/brutus/wordlists/telnet_defaults.txt
+++ b/pkg/brutus/wordlists/telnet_defaults.txt
@@ -2,10 +2,18 @@
 # Format: username:password
 admin:admin
 root:root
-administrator:administrator
 admin:password
+# --- cautious ---
+administrator:administrator
 root:password
 admin:1234
 admin:
 ubnt:ubnt
 cisco:cisco
+# --- exhaustive ---
+admin:12345
+telnetadmin:telnetadmin
+support:support
+admin:public
+root:vizxv
+user:user

--- a/pkg/brutus/wordlists/vnc_defaults.txt
+++ b/pkg/brutus/wordlists/vnc_defaults.txt
@@ -4,8 +4,16 @@
 :
 :password
 :123456
+# --- cautious ---
 :admin
 :vnc
 :Password1
 :raspberry
 :12345678
+# --- exhaustive ---
+:secret
+:changeme
+:1234
+:vncpass
+:qwerty
+:00000000


### PR DESCRIPTION
## Summary
- Introduce `Mode` type (`cautious`, `default`, `exhaustive`) with per-mode presets for threads, timeout, rate limiting, jitter, and retry behavior
- Wordlist files support tier markers (`# --- cautious ---` / `# --- exhaustive ---`) to control credential depth per mode
- Mode presets are applied first, then explicit CLI flags override them (e.g., `--mode cautious --threads 20`)
- SNMP legacy modes (`extended`, `full`) pass through to preserve backward compatibility

## Test plan
- [ ] Verify `--mode cautious` sets threads=5, timeout=15s, rate-limit=2, jitter=500ms
- [ ] Verify `--mode exhaustive` sets threads=20, timeout=10s, unlimited rate
- [ ] Verify explicit flags override mode presets (e.g., `--mode cautious --threads 20`)
- [ ] Verify SNMP `--mode extended` and `--mode full` still work correctly
- [ ] Verify invalid mode values are rejected with clear error message
- [ ] Run unit tests: `go test ./pkg/brutus/... ./pkg/brutus/snmp/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)