### PR TITLE
fix: add nervaNoAuth param to runSingleTarget to fix build

### DIFF
--- a/cmd/brutus/runner.go
+++ b/cmd/brutus/runner.go
@@ -64,7 +64,7 @@ func runFromTargetsFile(targets []string, base *runConfig, jsonOut bool) ([]brut
 			printTargetInfo(target, protocol, base, aiCreds)
 		}
 
-		results, success := runSingleTarget(target, protocol, base.tlsMode, base, aiCreds)
+		results, success := runSingleTarget(target, protocol, base.tlsMode, base, aiCreds, false)
 		allResults = append(allResults, results...)
 		if success {
 			hasSuccess = true
@@ -206,7 +206,7 @@ func processNervaResult(nrv *brutusinput.NervaResult, base *runConfig, jsonOut b
 		protocol, aiCreds = web.RouteHTTP(target, protocol, base.timeout, base.tlsMode, base.llmConfig)
 	}
 
-	results, success := runSingleTarget(target, protocol, targetTLSMode, base, aiCreds)
+	results, success := runSingleTarget(target, protocol, targetTLSMode, base, aiCreds, false)
 
 	if !jsonOut {
 		outputValidOnly(results, base.useColor)
@@ -244,7 +244,7 @@ func processURITarget(parsed *brutusinput.ParsedStdinLine, base *runConfig, json
 		printTargetInfo(target, protocol, base, aiCreds)
 	}
 
-	results, success := runSingleTarget(target, protocol, targetTLSMode, base, aiCreds)
+	results, success := runSingleTarget(target, protocol, targetTLSMode, base, aiCreds, false)
 
 	if !jsonOut {
 		outputValidOnly(results, base.useColor)
@@ -263,7 +263,7 @@ func isUnauthOnlyProtocol(protocol string) bool {
 }
 
 // runSingleTarget runs brutus against a single target.
-func runSingleTarget(target, protocol, tlsMode string, base *runConfig, aiCreds []brutus.Credential) ([]brutus.Result, bool) {
+func runSingleTarget(target, protocol, tlsMode string, base *runConfig, aiCreds []brutus.Credential, nervaNoAuth bool) ([]brutus.Result, bool) {
 	// Unauth-only protocols: run CheckUnauthAccess directly, skip brute force
 	if isUnauthOnlyProtocol(protocol) {
 		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -296,7 +296,7 @@ func runSingleTarget(target, protocol, tlsMode string, base *runConfig, aiCreds 
 		MaxAttempts:     base.maxAttempts,
 		MaxRetries:      base.maxRetries,
 		Verbose:         base.verbose,
-		SkipUnauthCheck: false,
+		SkipUnauthCheck: nervaNoAuth,
 		Mode:            brutus.NormalizeMode(base.mode),
 		ProxyURL:        base.proxyURL,
 	}


### PR DESCRIPTION
## Summary
- The merge of `feat/socks-proxy` (PR #116) introduced a 6th `nervaNoAuth` bool argument in calls to `runSingleTarget` from `fingerprint.go` and `root.go`, but the function signature in `runner.go` was not updated to accept it
- This broke **CI** and **Unauthenticated Access Tests** on `main` with `too many arguments in call to runSingleTarget`
- Adds the `nervaNoAuth bool` parameter to `runSingleTarget` and wires it to `SkipUnauthCheck` so Nerva-detected unauthenticated access skips the redundant `CheckUnauth` probe
- Existing call sites without Nerva context pass `false`

## Test plan
- [ ] CI workflow passes (compilation + unit tests)
- [ ] Unauthenticated Access Tests workflow passes
- [ ] Lint workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)