### PR TITLE
fix(ftp): handle multi-line responses and validate USER before PASS

### DIFF
--- a/internal/plugins/ftp/ftp.go
+++ b/internal/plugins/ftp/ftp.go
@@ -70,8 +70,8 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 
 	reader := bufio.NewReader(conn)
 
-	// Read welcome message (220)
-	_, err = brutus.ReadLine(reader)
+	// Read welcome message (220), consuming any multi-line banner
+	_, err = readFTPResponse(reader)
 	if err != nil {
 		result.Error = classifyAuthError(err)
 		return result
@@ -85,7 +85,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	}
 
 	// Read response (331 = need password, 230 = already logged in for anonymous)
-	response, err := brutus.ReadLine(reader)
+	response, err := readFTPResponse(reader)
 	if err != nil {
 		result.Error = classifyAuthError(err)
 		return result
@@ -97,6 +97,18 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		return result
 	}
 
+	// Only proceed to PASS if the server accepted USER and is waiting for a password.
+	// 331 = "User name okay, need password"
+	if !strings.HasPrefix(response, "331") {
+		if strings.HasPrefix(response, "530") {
+			// User rejected (e.g. user not allowed)
+			result.Error = nil
+			return result
+		}
+		result.Error = fmt.Errorf("connection error: unexpected FTP response to USER: %s", response)
+		return result
+	}
+
 	// Send PASS command
 	_, err = fmt.Fprintf(conn, "PASS %s\r\n", password)
 	if err != nil {
@@ -105,7 +117,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	}
 
 	// Read response (230 = success, 530 = failure)
-	response, err = brutus.ReadLine(reader)
+	response, err = readFTPResponse(reader)
 	if err != nil {
 		result.Error = classifyAuthError(err)
 		return result
@@ -124,6 +136,23 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	}
 
 	return result
+}
+
+// readFTPResponse reads a complete FTP response, consuming multi-line replies.
+// Multi-line FTP responses use "NNN-" for continuation lines and "NNN " (with
+// a space) for the final line (RFC 959 Section 4.2). Returns the final line.
+func readFTPResponse(reader *bufio.Reader) (string, error) {
+	for {
+		line, err := brutus.ReadLine(reader)
+		if err != nil {
+			return "", err
+		}
+		// Final line: 3-digit code followed by space (or end of string).
+		// Continuation line: 3-digit code followed by hyphen.
+		if len(line) == 3 || (len(line) > 3 && line[3] != '-') {
+			return line, nil
+		}
+	}
 }
 
 // classifyAuthError classifies FTP authentication errors.

--- a/internal/plugins/ftp/ftp_test.go
+++ b/internal/plugins/ftp/ftp_test.go
@@ -93,7 +93,7 @@ func TestReadFTPResponse(t *testing.T) {
 }
 
 // mockFTPServer starts a TCP listener that speaks a scripted FTP conversation.
-// handler receives the server-side conn and runs the FTP dialogue.
+// handler receives the server-side conn and runs the FTP dialog.
 func mockFTPServer(t *testing.T, handler func(conn net.Conn)) (addr string, cleanup func()) {
 	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")

--- a/internal/plugins/ftp/ftp_test.go
+++ b/internal/plugins/ftp/ftp_test.go
@@ -15,10 +15,17 @@
 package ftp
 
 import (
+	"bufio"
+	"context"
 	"errors"
+	"fmt"
+	"net"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/praetorian-inc/brutus/pkg/brutus"
 )
@@ -35,6 +42,176 @@ func TestClassifyError(t *testing.T) {
 	assert.NotNil(t, result)
 	assert.Contains(t, result.Error(), "connection error")
 	assert.Contains(t, result.Error(), "connection refused")
+}
+
+func TestReadFTPResponse(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "single-line response",
+			input: "220 Ready\r\n",
+			want:  "220 Ready",
+		},
+		{
+			name:  "multi-line response",
+			input: "220-Welcome to FTP\r\n220-Please read the terms\r\n220 Ready\r\n",
+			want:  "220 Ready",
+		},
+		{
+			name:  "code only",
+			input: "220\r\n",
+			want:  "220",
+		},
+		{
+			name:  "multi-line with code-only final",
+			input: "220-Banner line\r\n220\r\n",
+			want:  "220",
+		},
+		{
+			name:    "empty input EOF",
+			input:   "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := bufio.NewReader(strings.NewReader(tt.input))
+			got, err := readFTPResponse(reader)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// mockFTPServer starts a TCP listener that speaks a scripted FTP conversation.
+// handler receives the server-side conn and runs the FTP dialogue.
+func mockFTPServer(t *testing.T, handler func(conn net.Conn)) (string, func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		conn, acceptErr := ln.Accept()
+		if acceptErr != nil {
+			return
+		}
+		defer conn.Close()
+		handler(conn)
+	}()
+
+	cleanup := func() {
+		ln.Close()
+		<-done
+	}
+	return ln.Addr().String(), cleanup
+}
+
+func TestPlugin_SingleLineBanner_Success(t *testing.T) {
+	addr, cleanup := mockFTPServer(t, func(conn net.Conn) {
+		reader := bufio.NewReader(conn)
+		fmt.Fprint(conn, "220 Ready\r\n")
+		reader.ReadString('\n') // USER
+		fmt.Fprint(conn, "331 Password required\r\n")
+		reader.ReadString('\n') // PASS
+		fmt.Fprint(conn, "230 Login successful\r\n")
+	})
+	defer cleanup()
+
+	p := &Plugin{}
+	result := p.Test(context.Background(), addr, "admin", "admin", 5*time.Second, brutus.PluginConfig{})
+	assert.True(t, result.Success)
+	assert.Nil(t, result.Error)
+}
+
+func TestPlugin_MultiLineBanner_Success(t *testing.T) {
+	addr, cleanup := mockFTPServer(t, func(conn net.Conn) {
+		reader := bufio.NewReader(conn)
+		fmt.Fprint(conn, "220-Welcome to FTP\r\n220-Please read our policy\r\n220 Ready\r\n")
+		reader.ReadString('\n') // USER
+		fmt.Fprint(conn, "331 Password required\r\n")
+		reader.ReadString('\n') // PASS
+		fmt.Fprint(conn, "230 Login successful\r\n")
+	})
+	defer cleanup()
+
+	p := &Plugin{}
+	result := p.Test(context.Background(), addr, "admin", "admin", 5*time.Second, brutus.PluginConfig{})
+	assert.True(t, result.Success)
+	assert.Nil(t, result.Error)
+}
+
+func TestPlugin_MultiLineBanner_AuthFailure(t *testing.T) {
+	addr, cleanup := mockFTPServer(t, func(conn net.Conn) {
+		reader := bufio.NewReader(conn)
+		fmt.Fprint(conn, "220-Welcome\r\n220 Ready\r\n")
+		reader.ReadString('\n') // USER
+		fmt.Fprint(conn, "331 Password required\r\n")
+		reader.ReadString('\n') // PASS
+		fmt.Fprint(conn, "530 Login incorrect\r\n")
+	})
+	defer cleanup()
+
+	p := &Plugin{}
+	result := p.Test(context.Background(), addr, "admin", "wrong", 5*time.Second, brutus.PluginConfig{})
+	assert.False(t, result.Success)
+	assert.Nil(t, result.Error, "auth failure should not return error")
+}
+
+func TestPlugin_Anonymous_230_After_USER(t *testing.T) {
+	addr, cleanup := mockFTPServer(t, func(conn net.Conn) {
+		reader := bufio.NewReader(conn)
+		fmt.Fprint(conn, "220 Ready\r\n")
+		reader.ReadString('\n') // USER
+		fmt.Fprint(conn, "230 Anonymous login ok\r\n")
+	})
+	defer cleanup()
+
+	p := &Plugin{}
+	result := p.Test(context.Background(), addr, "anonymous", "", 5*time.Second, brutus.PluginConfig{})
+	assert.True(t, result.Success)
+	assert.Nil(t, result.Error)
+}
+
+func TestPlugin_USER_Rejected_530(t *testing.T) {
+	addr, cleanup := mockFTPServer(t, func(conn net.Conn) {
+		reader := bufio.NewReader(conn)
+		fmt.Fprint(conn, "220 Ready\r\n")
+		reader.ReadString('\n') // USER
+		fmt.Fprint(conn, "530 User not allowed\r\n")
+	})
+	defer cleanup()
+
+	p := &Plugin{}
+	result := p.Test(context.Background(), addr, "blocked", "pass", 5*time.Second, brutus.PluginConfig{})
+	assert.False(t, result.Success)
+	assert.Nil(t, result.Error, "530 after USER is auth failure, not connection error")
+}
+
+func TestPlugin_USER_UnexpectedResponse(t *testing.T) {
+	addr, cleanup := mockFTPServer(t, func(conn net.Conn) {
+		reader := bufio.NewReader(conn)
+		fmt.Fprint(conn, "220 Ready\r\n")
+		reader.ReadString('\n') // USER
+		fmt.Fprint(conn, "500 Syntax error\r\n")
+	})
+	defer cleanup()
+
+	p := &Plugin{}
+	result := p.Test(context.Background(), addr, "admin", "pass", 5*time.Second, brutus.PluginConfig{})
+	assert.False(t, result.Success)
+	assert.NotNil(t, result.Error)
+	assert.Contains(t, result.Error.Error(), "unexpected FTP response to USER")
 }
 
 func TestClassifyAuthError(t *testing.T) {

--- a/internal/plugins/ftp/ftp_test.go
+++ b/internal/plugins/ftp/ftp_test.go
@@ -94,7 +94,7 @@ func TestReadFTPResponse(t *testing.T) {
 
 // mockFTPServer starts a TCP listener that speaks a scripted FTP conversation.
 // handler receives the server-side conn and runs the FTP dialogue.
-func mockFTPServer(t *testing.T, handler func(conn net.Conn)) (string, func()) {
+func mockFTPServer(t *testing.T, handler func(conn net.Conn)) (addr string, cleanup func()) {
 	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
@@ -106,25 +106,35 @@ func mockFTPServer(t *testing.T, handler func(conn net.Conn)) (string, func()) {
 		if acceptErr != nil {
 			return
 		}
-		defer conn.Close()
+		defer func() { _ = conn.Close() }()
 		handler(conn)
 	}()
 
-	cleanup := func() {
-		ln.Close()
+	cleanup = func() {
+		_ = ln.Close()
 		<-done
 	}
 	return ln.Addr().String(), cleanup
 }
 
+// ftpSend writes an FTP response line to the connection.
+func ftpSend(conn net.Conn, msg string) {
+	_, _ = fmt.Fprint(conn, msg)
+}
+
+// ftpRecv reads one line from the connection (consumes a client command).
+func ftpRecv(reader *bufio.Reader) {
+	_, _ = reader.ReadString('\n')
+}
+
 func TestPlugin_SingleLineBanner_Success(t *testing.T) {
 	addr, cleanup := mockFTPServer(t, func(conn net.Conn) {
 		reader := bufio.NewReader(conn)
-		fmt.Fprint(conn, "220 Ready\r\n")
-		reader.ReadString('\n') // USER
-		fmt.Fprint(conn, "331 Password required\r\n")
-		reader.ReadString('\n') // PASS
-		fmt.Fprint(conn, "230 Login successful\r\n")
+		ftpSend(conn, "220 Ready\r\n")
+		ftpRecv(reader) // USER
+		ftpSend(conn, "331 Password required\r\n")
+		ftpRecv(reader) // PASS
+		ftpSend(conn, "230 Login successful\r\n")
 	})
 	defer cleanup()
 
@@ -137,11 +147,11 @@ func TestPlugin_SingleLineBanner_Success(t *testing.T) {
 func TestPlugin_MultiLineBanner_Success(t *testing.T) {
 	addr, cleanup := mockFTPServer(t, func(conn net.Conn) {
 		reader := bufio.NewReader(conn)
-		fmt.Fprint(conn, "220-Welcome to FTP\r\n220-Please read our policy\r\n220 Ready\r\n")
-		reader.ReadString('\n') // USER
-		fmt.Fprint(conn, "331 Password required\r\n")
-		reader.ReadString('\n') // PASS
-		fmt.Fprint(conn, "230 Login successful\r\n")
+		ftpSend(conn, "220-Welcome to FTP\r\n220-Please read our policy\r\n220 Ready\r\n")
+		ftpRecv(reader) // USER
+		ftpSend(conn, "331 Password required\r\n")
+		ftpRecv(reader) // PASS
+		ftpSend(conn, "230 Login successful\r\n")
 	})
 	defer cleanup()
 
@@ -154,11 +164,11 @@ func TestPlugin_MultiLineBanner_Success(t *testing.T) {
 func TestPlugin_MultiLineBanner_AuthFailure(t *testing.T) {
 	addr, cleanup := mockFTPServer(t, func(conn net.Conn) {
 		reader := bufio.NewReader(conn)
-		fmt.Fprint(conn, "220-Welcome\r\n220 Ready\r\n")
-		reader.ReadString('\n') // USER
-		fmt.Fprint(conn, "331 Password required\r\n")
-		reader.ReadString('\n') // PASS
-		fmt.Fprint(conn, "530 Login incorrect\r\n")
+		ftpSend(conn, "220-Welcome\r\n220 Ready\r\n")
+		ftpRecv(reader) // USER
+		ftpSend(conn, "331 Password required\r\n")
+		ftpRecv(reader) // PASS
+		ftpSend(conn, "530 Login incorrect\r\n")
 	})
 	defer cleanup()
 
@@ -171,9 +181,9 @@ func TestPlugin_MultiLineBanner_AuthFailure(t *testing.T) {
 func TestPlugin_Anonymous_230_After_USER(t *testing.T) {
 	addr, cleanup := mockFTPServer(t, func(conn net.Conn) {
 		reader := bufio.NewReader(conn)
-		fmt.Fprint(conn, "220 Ready\r\n")
-		reader.ReadString('\n') // USER
-		fmt.Fprint(conn, "230 Anonymous login ok\r\n")
+		ftpSend(conn, "220 Ready\r\n")
+		ftpRecv(reader) // USER
+		ftpSend(conn, "230 Anonymous login ok\r\n")
 	})
 	defer cleanup()
 
@@ -186,9 +196,9 @@ func TestPlugin_Anonymous_230_After_USER(t *testing.T) {
 func TestPlugin_USER_Rejected_530(t *testing.T) {
 	addr, cleanup := mockFTPServer(t, func(conn net.Conn) {
 		reader := bufio.NewReader(conn)
-		fmt.Fprint(conn, "220 Ready\r\n")
-		reader.ReadString('\n') // USER
-		fmt.Fprint(conn, "530 User not allowed\r\n")
+		ftpSend(conn, "220 Ready\r\n")
+		ftpRecv(reader) // USER
+		ftpSend(conn, "530 User not allowed\r\n")
 	})
 	defer cleanup()
 
@@ -201,9 +211,9 @@ func TestPlugin_USER_Rejected_530(t *testing.T) {
 func TestPlugin_USER_UnexpectedResponse(t *testing.T) {
 	addr, cleanup := mockFTPServer(t, func(conn net.Conn) {
 		reader := bufio.NewReader(conn)
-		fmt.Fprint(conn, "220 Ready\r\n")
-		reader.ReadString('\n') // USER
-		fmt.Fprint(conn, "500 Syntax error\r\n")
+		ftpSend(conn, "220 Ready\r\n")
+		ftpRecv(reader) // USER
+		ftpSend(conn, "500 Syntax error\r\n")
 	})
 	defer cleanup()
 

--- a/pkg/brutus/brutus.go
+++ b/pkg/brutus/brutus.go
@@ -255,12 +255,6 @@ func (c *Config) applyDefaults() {
 		return
 	}
 
-	// Normalize mode (empty string → ModeDefault for backward compat).
-	mode := c.Mode
-	if mode == "" {
-		mode = ModeDefault
-	}
-
 	hasCreds := len(c.Credentials) > 0
 	hasPasswords := len(c.Passwords) > 0
 	hasKeys := len(c.Keys) > 0


### PR DESCRIPTION
## Summary
- Fixes FTP plugin failing with `503 Login with USER first` on servers that send multi-line welcome banners (RFC 959 §4.2)
- Adds `readFTPResponse()` that consumes `NNN-` continuation lines and returns the final response line, replacing raw `ReadLine` calls
- Validates the USER response is `331` before sending PASS; handles `530` as auth failure; treats unexpected codes as connection errors
- Adds unit tests for `readFTPResponse` and integration tests with a mock FTP server covering multi-line banners, auth success/failure, anonymous login, and USER rejection

Closes #129

## Test plan
- [ ] CI passes (unit tests + lint)
- [ ] `TestReadFTPResponse` validates single-line, multi-line, code-only, and EOF cases
- [ ] `TestPlugin_MultiLineBanner_Success` confirms multi-line banner no longer desynchronizes the protocol
- [ ] `TestPlugin_USER_Rejected_530` confirms 530 after USER is treated as auth failure
- [ ] `TestPlugin_USER_UnexpectedResponse` confirms non-331/230/530 USER response is an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)