### PR TITLE
rename mode: exhaustive → aggressive

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Built in Go as a single binary with zero external dependencies, Brutus integrate
 - **Zero dependencies:** Single binary, cross-platform (Linux, Windows, macOS)
 - **24 protocols:** SSH, RDP, MySQL, PostgreSQL, MSSQL, Redis, SMB, LDAP, WinRM, SNMP, HTTP Basic Auth, and more
 - **SOCKS5 proxy support:** Route all traffic through a SOCKS5 proxy with `--proxy`
-- **Aggressiveness modes:** `--mode cautious|default|exhaustive` for tuning coverage vs. safety
+- **Aggressiveness modes:** `--mode cautious|default|aggressive` for tuning coverage vs. safety
 - **Pipeline integration:** Native support for Nerva, naabu, nmap, and masscan workflows
 - **Embedded bad keys:** Built-in collection of known SSH keys (Vagrant, F5, ExaGrid, etc.)
 - **Go library:** Import directly into your security automation tools
@@ -543,7 +543,7 @@ The global `--mode` flag (`-m`) controls aggressiveness across all subcommands. 
 |------|---------|---------|------------|--------|---------|----------|
 | `cautious` | 5 | 15s | 2 req/s | 500ms | 1 | Production environments, avoid lockouts |
 | `default` | 10 | 10s | Unlimited | None | 2 | Standard testing |
-| `exhaustive` | 20 | 10s | Unlimited | None | 3 | Lab/CTF environments, maximum coverage |
+| `aggressive` | 20 | 10s | Unlimited | None | 3 | Lab/CTF environments, maximum coverage |
 
 Mode presets are applied first, then any explicit CLI flags override them:
 
@@ -552,7 +552,7 @@ Mode presets are applied first, then any explicit CLI flags override them:
 brutus creds --target dc.corp.local:445 --protocol smb -m cautious -U users.txt -P passwords.txt
 
 # Maximum coverage for a CTF
-brutus creds --target 10.10.10.100:22 --protocol ssh -m exhaustive -U users.txt -P rockyou.txt
+brutus creds --target 10.10.10.100:22 --protocol ssh -m aggressive -U users.txt -P rockyou.txt
 
 # Cautious mode but override threads
 brutus creds --target 192.168.1.100:22 --protocol ssh -m cautious --threads 20

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ brutus web --target 192.168.1.1:80 --experimental-ai
 brutus web --target 192.168.1.1:80 -c "admin:admin,root:toor"
 
 # Test SNMP community strings
-brutus snmp --target 192.168.1.1:161 --mode exhaustive
+brutus snmp --target 192.168.1.1:161 --mode aggressive
 
 # Detect Windows logon-screen backdoors
 brutus logon --target 10.0.0.50:3389
@@ -197,7 +197,7 @@ brutus logon --target 10.0.0.50:3389
 # Pipeline mode: creds skips HTTP/SNMP, web skips non-HTTP, snmp skips non-SNMP
 naabu -host 10.0.0.0/24 -silent | nerva --json | brutus creds -P passwords.txt
 naabu -host 10.0.0.0/24 -p 80,443,8080 -silent | nerva --json | brutus web --experimental-ai
-naabu -host 10.0.0.0/24 -p 161 -silent | nerva --json | brutus snmp --mode exhaustive
+naabu -host 10.0.0.0/24 -p 161 -silent | nerva --json | brutus snmp --mode aggressive
 ```
 
 ### Basic Usage
@@ -341,7 +341,7 @@ brutus creds --nmap-file scan.xml -P passwords.txt
 brutus web --nmap-file scan.xml -c "admin:admin,root:password"
 
 # Test SNMP from nmap scan
-brutus snmp --nmap-file scan.xml --mode exhaustive
+brutus snmp --nmap-file scan.xml --mode aggressive
 
 # JSON output for scripting
 brutus creds --nmap-file scan.xml --json -o results.json
@@ -597,14 +597,14 @@ The `snmp` subcommand provides dedicated SNMP v1/v2c community string testing wi
 |------|---------|----------|
 | `cautious` | ~25 | Common strings (public, private, community, etc.) |
 | `default` | ~25 | Same as cautious |
-| `exhaustive` | 200+ | Comprehensive (vendor-specific, SCADA, IP cameras, storage, etc.) |
+| `aggressive` | 200+ | Comprehensive (vendor-specific, SCADA, IP cameras, storage, etc.) |
 
 ```bash
 # Test with default community strings (~25)
 brutus snmp --target 192.168.1.1:161
 
 # Exhaustive mode for comprehensive testing (200+)
-brutus snmp --target 10.0.0.1:161 --mode exhaustive
+brutus snmp --target 10.0.0.1:161 --mode aggressive
 
 # Custom community strings
 brutus snmp --target 192.168.1.1:161 -c "mycommunity,secretstring"
@@ -613,7 +613,7 @@ brutus snmp --target 192.168.1.1:161 -c "mycommunity,secretstring"
 brutus snmp --target 192.168.1.1:161 -C community-strings.txt
 
 # Pipeline mode
-naabu -host 10.0.0.0/24 -p 161 -silent | nerva --json | brutus snmp --mode exhaustive
+naabu -host 10.0.0.0/24 -p 161 -silent | nerva --json | brutus snmp --mode aggressive
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -603,7 +603,7 @@ The `snmp` subcommand provides dedicated SNMP v1/v2c community string testing wi
 # Test with default community strings (~25)
 brutus snmp --target 192.168.1.1:161
 
-# Exhaustive mode for comprehensive testing (200+)
+# Aggressive mode for comprehensive testing (200+)
 brutus snmp --target 10.0.0.1:161 --mode aggressive
 
 # Custom community strings

--- a/cmd/brutus/cmd_snmp.go
+++ b/cmd/brutus/cmd_snmp.go
@@ -29,17 +29,14 @@ switches, and other SNMP-enabled infrastructure.
 
 Community strings are selected by mode:
   cautious    ~25 common strings (public, private, community, etc.)
-  default     ~75 strings (adds vendor-specific: Cisco, HP, Juniper, etc.)
-  aggressive  ~200+ strings (comprehensive: SCADA, IP cameras, storage, etc.)
+  default     ~25 strings (same as cautious)
+  aggressive  ~200+ strings (comprehensive: vendor-specific, SCADA, IP cameras, storage, etc.)
 
 Custom community strings can also be provided via -c or -C.`,
 	Example: `  # Test with default community strings
   brutus snmp --target 192.168.1.1:161
 
-  # Use default mode for more coverage
-  brutus snmp --target 192.168.1.1:161 --mode default
-
-  # Aggressive mode for comprehensive testing
+  # Aggressive mode for comprehensive testing (~200+ strings)
   brutus snmp --target 10.0.0.1:161 --mode aggressive
 
   # Custom community strings
@@ -49,10 +46,10 @@ Custom community strings can also be provided via -c or -C.`,
   naabu -host 10.0.0.0/24 -p 161 -silent | nerva --json | brutus snmp
 
   # Targets file
-  brutus snmp --targets-file snmp-hosts.txt --mode extended
+  brutus snmp --targets-file snmp-hosts.txt --mode aggressive
 
   # Import targets from nmap XML scan (only SNMP services tested)
-  brutus snmp --nmap-file scan.xml --mode extended`,
+  brutus snmp --nmap-file scan.xml --mode aggressive`,
 	RunE: runSNMP,
 }
 

--- a/cmd/brutus/cmd_snmp.go
+++ b/cmd/brutus/cmd_snmp.go
@@ -30,7 +30,7 @@ switches, and other SNMP-enabled infrastructure.
 Community strings are selected by mode:
   cautious    ~25 common strings (public, private, community, etc.)
   default     ~75 strings (adds vendor-specific: Cisco, HP, Juniper, etc.)
-  exhaustive  ~200+ strings (comprehensive: SCADA, IP cameras, storage, etc.)
+  aggressive  ~200+ strings (comprehensive: SCADA, IP cameras, storage, etc.)
 
 Custom community strings can also be provided via -c or -C.`,
 	Example: `  # Test with default community strings
@@ -39,8 +39,8 @@ Custom community strings can also be provided via -c or -C.`,
   # Use default mode for more coverage
   brutus snmp --target 192.168.1.1:161 --mode default
 
-  # Exhaustive mode for comprehensive testing
-  brutus snmp --target 10.0.0.1:161 --mode exhaustive
+  # Aggressive mode for comprehensive testing
+  brutus snmp --target 10.0.0.1:161 --mode aggressive
 
   # Custom community strings
   brutus snmp --target 192.168.1.1:161 -c "mycommunity,secretstring"

--- a/cmd/brutus/config.go
+++ b/cmd/brutus/config.go
@@ -40,7 +40,7 @@ type baseConfigOptions struct {
 	jitter           time.Duration // Random delay variance for rate limiting
 	maxAttempts      int
 	maxRetries       int
-	mode             string // Aggressiveness tier: cautious, default, exhaustive
+	mode             string // Aggressiveness tier: cautious, default, aggressive
 	anthropicKey     string // ANTHROPIC_API_KEY (read once in main)
 	perplexityKey    string // PERPLEXITY_API_KEY (read once in main)
 	proxyURL         string // SOCKS5 proxy URL (e.g., "socks5://127.0.0.1:1080")

--- a/cmd/brutus/flags.go
+++ b/cmd/brutus/flags.go
@@ -125,7 +125,7 @@ func registerSharedFlags(cmd *cobra.Command) {
 	pf.IntVar(&flagRetries, "retries", 2, "Max retries on connection error (0 = disabled)")
 
 	// Mode
-	pf.StringVarP(&flagMode, "mode", "m", "default", "Aggressiveness tier: cautious, default, exhaustive")
+	pf.StringVarP(&flagMode, "mode", "m", "default", "Aggressiveness tier: cautious, default, aggressive")
 
 	// Proxy
 	pf.StringVar(&flagProxy, "proxy", "", "SOCKS5 proxy URL (e.g., socks5://127.0.0.1:1080 or socks5://user:pass@host:port)")

--- a/cmd/brutus/root.go
+++ b/cmd/brutus/root.go
@@ -65,7 +65,7 @@ func init() {
 		// mode system. Skip strict validation for SNMP so legacy modes pass
 		// through to ConfigureSNMP which handles the mapping.
 		if cmd.Name() != "snmp" && !brutus.ValidMode(flagMode) {
-			return fmt.Errorf("invalid --mode %q (valid: cautious, default, exhaustive)", flagMode)
+			return fmt.Errorf("invalid --mode %q (valid: cautious, default, aggressive)", flagMode)
 		}
 		return nil
 	}

--- a/pkg/brutus/defaults.go
+++ b/pkg/brutus/defaults.go
@@ -11,7 +11,7 @@ var wordlistsFS embed.FS
 // Tier marker comments recognized in wordlist files.
 const (
 	markerCautious   = "# --- cautious ---"
-	markerExhaustive = "# --- exhaustive ---"
+	markerAggressive = "# --- aggressive ---"
 )
 
 // maxCautiousFallback is the maximum number of credentials returned for
@@ -35,13 +35,13 @@ func DefaultCredentials(protocol string) []Credential {
 //	root:root           ← cautious tier (lines before first marker)
 //	admin:admin
 //	# --- cautious ---
-//	root:password       ← default tier (added for default + exhaustive)
+//	root:password       ← default tier (added for default + aggressive)
 //	root:toor
-//	# --- exhaustive ---
-//	vendor:vendor123    ← exhaustive tier (added only for exhaustive)
+//	# --- aggressive ---
+//	vendor:vendor123    ← aggressive tier (added only for aggressive)
 //
 // Files without markers: cautious returns the first 5 entries, default and
-// exhaustive return all entries.
+// aggressive return all entries.
 func DefaultCredentialsForMode(protocol string, mode Mode) []Credential {
 	data, err := wordlistsFS.ReadFile("wordlists/" + protocol + "_defaults.txt")
 	if err != nil {
@@ -55,7 +55,7 @@ func parseWordlistTiered(content string, mode Mode) []Credential {
 	lines := strings.Split(content, "\n")
 
 	// Partition lines into three sections based on markers.
-	var cautiousLines, defaultLines, exhaustiveLines []string
+	var cautiousLines, defaultLines, aggressiveLines []string
 	section := "cautious" // lines before any marker are highest-confidence
 	hasMarkers := false
 
@@ -67,9 +67,9 @@ func parseWordlistTiered(content string, mode Mode) []Credential {
 			section = "default"
 			continue
 		}
-		if trimmed == markerExhaustive {
+		if trimmed == markerAggressive {
 			hasMarkers = true
-			section = "exhaustive"
+			section = "aggressive"
 			continue
 		}
 
@@ -83,13 +83,13 @@ func parseWordlistTiered(content string, mode Mode) []Credential {
 			cautiousLines = append(cautiousLines, trimmed)
 		case "default":
 			defaultLines = append(defaultLines, trimmed)
-		case "exhaustive":
-			exhaustiveLines = append(exhaustiveLines, trimmed)
+		case "aggressive":
+			aggressiveLines = append(aggressiveLines, trimmed)
 		}
 	}
 
 	// When the file has no markers, all non-comment lines end up in
-	// cautiousLines. For ModeDefault and ModeExhaustive this is fine (they
+	// cautiousLines. For ModeDefault and ModeAggressive this is fine (they
 	// get everything). For ModeCautious we cap at maxCautiousFallback.
 	if !hasMarkers && mode == ModeCautious && len(cautiousLines) > maxCautiousFallback {
 		cautiousLines = cautiousLines[:maxCautiousFallback]
@@ -100,11 +100,11 @@ func parseWordlistTiered(content string, mode Mode) []Credential {
 	switch mode {
 	case ModeCautious:
 		selected = cautiousLines
-	case ModeExhaustive:
-		selected = make([]string, 0, len(cautiousLines)+len(defaultLines)+len(exhaustiveLines))
+	case ModeAggressive:
+		selected = make([]string, 0, len(cautiousLines)+len(defaultLines)+len(aggressiveLines))
 		selected = append(selected, cautiousLines...)
 		selected = append(selected, defaultLines...)
-		selected = append(selected, exhaustiveLines...)
+		selected = append(selected, aggressiveLines...)
 	default: // ModeDefault
 		selected = make([]string, 0, len(cautiousLines)+len(defaultLines))
 		selected = append(selected, cautiousLines...)

--- a/pkg/brutus/defaults_test.go
+++ b/pkg/brutus/defaults_test.go
@@ -261,7 +261,7 @@ admin:admin
 # --- cautious ---
 root:password
 root:toor
-# --- exhaustive ---
+# --- aggressive ---
 vendor:vendor123
 obscure:cred`
 
@@ -275,9 +275,9 @@ obscure:cred`
 		t.Errorf("default: expected 4 credentials, got %d", len(dflt))
 	}
 
-	exhaustive := parseWordlistTiered(content, ModeExhaustive)
-	if len(exhaustive) != 6 {
-		t.Errorf("exhaustive: expected 6 credentials, got %d", len(exhaustive))
+	aggressive := parseWordlistTiered(content, ModeAggressive)
+	if len(aggressive) != 6 {
+		t.Errorf("aggressive: expected 6 credentials, got %d", len(aggressive))
 	}
 }
 
@@ -294,9 +294,9 @@ func TestParseWordlistTiered_NoMarkers_CautiousCapped(t *testing.T) {
 		t.Errorf("default without markers: expected 7 credentials, got %d", len(dflt))
 	}
 
-	exhaustive := parseWordlistTiered(content, ModeExhaustive)
-	if len(exhaustive) != 7 {
-		t.Errorf("exhaustive without markers: expected 7 credentials, got %d", len(exhaustive))
+	aggressive := parseWordlistTiered(content, ModeAggressive)
+	if len(aggressive) != 7 {
+		t.Errorf("aggressive without markers: expected 7 credentials, got %d", len(aggressive))
 	}
 }
 
@@ -335,14 +335,14 @@ func TestDefaultCredentialsForMode_CautiousSubsetOfDefault(t *testing.T) {
 	}
 }
 
-func TestDefaultCredentialsForMode_ExhaustiveSupersetOfDefault(t *testing.T) {
+func TestDefaultCredentialsForMode_AggressiveSupersetOfDefault(t *testing.T) {
 	protocols := []string{"ssh", "mysql", "rdp", "http", "ftp"}
 	for _, proto := range protocols {
 		dflt := DefaultCredentialsForMode(proto, ModeDefault)
-		exhaustive := DefaultCredentialsForMode(proto, ModeExhaustive)
-		if len(exhaustive) < len(dflt) {
-			t.Errorf("%s: exhaustive (%d) should be >= default (%d)",
-				proto, len(exhaustive), len(dflt))
+		aggressive := DefaultCredentialsForMode(proto, ModeAggressive)
+		if len(aggressive) < len(dflt) {
+			t.Errorf("%s: aggressive (%d) should be >= default (%d)",
+				proto, len(aggressive), len(dflt))
 		}
 	}
 }

--- a/pkg/brutus/mode.go
+++ b/pkg/brutus/mode.go
@@ -32,9 +32,9 @@ const (
 	// ModeDefault is the standard mode balancing coverage and safety.
 	ModeDefault Mode = "default"
 
-	// ModeExhaustive uses the full credential set and higher concurrency
+	// ModeAggressive uses the full credential set and higher concurrency
 	// for maximum coverage. Use in lab/CTF environments.
-	ModeExhaustive Mode = "exhaustive"
+	ModeAggressive Mode = "aggressive"
 )
 
 // ModePresets holds the performance tuning values associated with a Mode.
@@ -53,8 +53,8 @@ func NormalizeMode(s string) Mode {
 	switch Mode(strings.ToLower(strings.TrimSpace(s))) {
 	case ModeCautious:
 		return ModeCautious
-	case ModeExhaustive:
-		return ModeExhaustive
+	case ModeAggressive:
+		return ModeAggressive
 	default:
 		return ModeDefault
 	}
@@ -63,7 +63,7 @@ func NormalizeMode(s string) Mode {
 // ValidMode returns true if s is a recognized mode string.
 func ValidMode(s string) bool {
 	switch Mode(strings.ToLower(strings.TrimSpace(s))) {
-	case ModeCautious, ModeDefault, ModeExhaustive:
+	case ModeCautious, ModeDefault, ModeAggressive:
 		return true
 	default:
 		return false
@@ -82,7 +82,7 @@ func (m Mode) Presets() ModePresets {
 			MaxAttempts: 3,
 			MaxRetries:  1,
 		}
-	case ModeExhaustive:
+	case ModeAggressive:
 		return ModePresets{
 			Threads:     20,
 			Timeout:     10 * time.Second,

--- a/pkg/brutus/mode_test.go
+++ b/pkg/brutus/mode_test.go
@@ -12,8 +12,8 @@ func TestNormalizeMode(t *testing.T) {
 		{"  Cautious  ", ModeCautious},
 		{"default", ModeDefault},
 		{"DEFAULT", ModeDefault},
-		{"exhaustive", ModeExhaustive},
-		{"EXHAUSTIVE", ModeExhaustive},
+		{"aggressive", ModeAggressive},
+		{"AGGRESSIVE", ModeAggressive},
 		{"unknown", ModeDefault},
 		{"", ModeDefault},
 	}
@@ -26,7 +26,7 @@ func TestNormalizeMode(t *testing.T) {
 }
 
 func TestValidMode(t *testing.T) {
-	valid := []string{"cautious", "default", "exhaustive", "CAUTIOUS", "DEFAULT", "EXHAUSTIVE"}
+	valid := []string{"cautious", "default", "aggressive", "CAUTIOUS", "DEFAULT", "AGGRESSIVE"}
 	for _, s := range valid {
 		if !ValidMode(s) {
 			t.Errorf("ValidMode(%q) = false, want true", s)
@@ -50,10 +50,10 @@ func TestModePresets(t *testing.T) {
 		t.Error("cautious should have a non-zero rate limit")
 	}
 
-	// Exhaustive should have higher threads than default.
-	ep := ModeExhaustive.Presets()
+	// Aggressive should have higher threads than default.
+	ep := ModeAggressive.Presets()
 	dp := ModeDefault.Presets()
 	if ep.Threads <= dp.Threads {
-		t.Errorf("exhaustive threads (%d) should be greater than default (%d)", ep.Threads, dp.Threads)
+		t.Errorf("aggressive threads (%d) should be greater than default (%d)", ep.Threads, dp.Threads)
 	}
 }

--- a/pkg/brutus/snmp/snmp.go
+++ b/pkg/brutus/snmp/snmp.go
@@ -28,13 +28,13 @@ func IsSNMPProtocol(protocol string) bool {
 }
 
 // ConfigureSNMP validates the mode string and returns the corresponding community
-// strings. It accepts both the new mode names (cautious, default, exhaustive) and
+// strings. It accepts both the new mode names (cautious, default, aggressive) and
 // the legacy SNMP tier names (default, extended, full).
 // The caller is responsible for assigning the result to config.Passwords.
 func ConfigureSNMP(mode string) ([]string, error) {
 	snmpTier := mapModeToSNMPTier(mode)
 	if !snmpplugin.ValidateTier(snmpTier) {
-		return nil, fmt.Errorf("invalid --mode: %s (use: cautious, default, exhaustive)", mode)
+		return nil, fmt.Errorf("invalid --mode: %s (use: cautious, default, aggressive)", mode)
 	}
 	return snmpplugin.GetCommunityStrings(snmpplugin.Tier(snmpTier)), nil
 }
@@ -46,7 +46,7 @@ func mapModeToSNMPTier(mode string) string {
 	switch mode {
 	case "cautious":
 		return "default" // SNMP's smallest tier (~25 strings)
-	case "exhaustive":
+	case "aggressive":
 		return "full" // SNMP's largest tier (~200+ strings)
 	default:
 		// "default" passes through; legacy "extended" and "full" also pass through

--- a/pkg/brutus/snmp/snmp.go
+++ b/pkg/brutus/snmp/snmp.go
@@ -34,7 +34,7 @@ func IsSNMPProtocol(protocol string) bool {
 func ConfigureSNMP(mode string) ([]string, error) {
 	snmpTier := mapModeToSNMPTier(mode)
 	if !snmpplugin.ValidateTier(snmpTier) {
-		return nil, fmt.Errorf("invalid --mode: %s (use: cautious, default, aggressive)", mode)
+		return nil, fmt.Errorf("invalid --mode: %s (use: cautious, default, aggressive, extended, full)", mode)
 	}
 	return snmpplugin.GetCommunityStrings(snmpplugin.Tier(snmpTier)), nil
 }

--- a/pkg/brutus/snmp/snmp_test.go
+++ b/pkg/brutus/snmp/snmp_test.go
@@ -53,13 +53,13 @@ func TestConfigureSNMP_GlobalModeNames(t *testing.T) {
 	assert.NotEmpty(t, cautious)
 	assert.Contains(t, cautious, "public")
 
-	// "exhaustive" maps to SNMP's "full" tier (~200+ strings)
-	exhaustive, err := ConfigureSNMP("exhaustive")
+	// "aggressive" maps to SNMP's "full" tier (~200+ strings)
+	aggressive, err := ConfigureSNMP("aggressive")
 	require.NoError(t, err)
-	assert.True(t, len(exhaustive) > 50)
+	assert.True(t, len(aggressive) > 50)
 
-	// exhaustive should have more strings than cautious
-	assert.Greater(t, len(exhaustive), len(cautious))
+	// aggressive should have more strings than cautious
+	assert.Greater(t, len(aggressive), len(cautious))
 }
 
 func TestMapModeToSNMPTier(t *testing.T) {
@@ -68,7 +68,7 @@ func TestMapModeToSNMPTier(t *testing.T) {
 		want string
 	}{
 		{"cautious", "default"},
-		{"exhaustive", "full"},
+		{"aggressive", "full"},
 		{"default", "default"},   // passes through
 		{"extended", "extended"}, // legacy, passes through
 		{"full", "full"},         // legacy, passes through

--- a/pkg/brutus/wordlists/browser_defaults.txt
+++ b/pkg/brutus/wordlists/browser_defaults.txt
@@ -21,7 +21,7 @@ test:test
 administrator:administrator
 administrator:password
 manager:manager
-# --- exhaustive ---
+# --- aggressive ---
 admin:router
 admin:public
 admin:private

--- a/pkg/brutus/wordlists/cassandra_defaults.txt
+++ b/pkg/brutus/wordlists/cassandra_defaults.txt
@@ -7,7 +7,7 @@ root:root
 admin:password
 cassandra:admin
 cassandra:password
-# --- exhaustive ---
+# --- aggressive ---
 cassandra:changeme
 admin:cassandra
 cassandra:123456

--- a/pkg/brutus/wordlists/couchdb_defaults.txt
+++ b/pkg/brutus/wordlists/couchdb_defaults.txt
@@ -7,7 +7,7 @@ root:root
 administrator:administrator
 couchdb:couchdb
 admin:couchdb
-# --- exhaustive ---
+# --- aggressive ---
 couchdb:password
 admin:changeme
 couchdb:admin

--- a/pkg/brutus/wordlists/elasticsearch_defaults.txt
+++ b/pkg/brutus/wordlists/elasticsearch_defaults.txt
@@ -6,7 +6,7 @@ elastic:password
 # --- cautious ---
 admin:admin
 elasticsearch:elasticsearch
-# --- exhaustive ---
+# --- aggressive ---
 elastic:admin
 kibana:kibana
 elastic:elastic123

--- a/pkg/brutus/wordlists/ftp_defaults.txt
+++ b/pkg/brutus/wordlists/ftp_defaults.txt
@@ -8,7 +8,7 @@ admin:admin
 root:root
 user:user
 ftpuser:ftpuser
-# --- exhaustive ---
+# --- aggressive ---
 ftp:password
 anonymous:ftp
 test:test

--- a/pkg/brutus/wordlists/http_defaults.txt
+++ b/pkg/brutus/wordlists/http_defaults.txt
@@ -13,7 +13,7 @@ elastic:elastic
 elastic:changeme
 user:user
 guest:guest
-# --- exhaustive ---
+# --- aggressive ---
 admin:admin123
 admin:Password1
 tomcat:tomcat

--- a/pkg/brutus/wordlists/https_defaults.txt
+++ b/pkg/brutus/wordlists/https_defaults.txt
@@ -13,7 +13,7 @@ elastic:elastic
 elastic:changeme
 user:user
 guest:guest
-# --- exhaustive ---
+# --- aggressive ---
 admin:admin123
 admin:Password1
 tomcat:tomcat

--- a/pkg/brutus/wordlists/imap_defaults.txt
+++ b/pkg/brutus/wordlists/imap_defaults.txt
@@ -8,7 +8,7 @@ test@localhost:test
 postmaster@localhost:password
 root@localhost:root
 webmaster@localhost:password
-# --- exhaustive ---
+# --- aggressive ---
 admin@localhost:changeme
 mail@localhost:mail
 imap@localhost:imap

--- a/pkg/brutus/wordlists/influxdb_defaults.txt
+++ b/pkg/brutus/wordlists/influxdb_defaults.txt
@@ -6,7 +6,7 @@ root:root
 # --- cautious ---
 influxdb:influxdb
 admin:influxdb
-# --- exhaustive ---
+# --- aggressive ---
 influxdb:password
 influx:influx
 admin:changeme

--- a/pkg/brutus/wordlists/ldap_defaults.txt
+++ b/pkg/brutus/wordlists/ldap_defaults.txt
@@ -8,7 +8,7 @@ administrator:administrator
 cn=admin:password
 ldapadmin:ldapadmin
 root:root
-# --- exhaustive ---
+# --- aggressive ---
 cn=Manager:secret
 cn=admin:changeme
 ldap:ldap

--- a/pkg/brutus/wordlists/mongodb_defaults.txt
+++ b/pkg/brutus/wordlists/mongodb_defaults.txt
@@ -8,7 +8,7 @@ root:password
 mongodb:mongodb
 user:user
 dbadmin:dbadmin
-# --- exhaustive ---
+# --- aggressive ---
 mongo:mongo
 admin:mongo
 mongodb:password

--- a/pkg/brutus/wordlists/mssql_defaults.txt
+++ b/pkg/brutus/wordlists/mssql_defaults.txt
@@ -8,7 +8,7 @@ sa:Password1
 sa:admin
 administrator:administrator
 admin:admin
-# --- exhaustive ---
+# --- aggressive ---
 sa:P@ssw0rd
 sa:Admin123
 sa:sqlserver

--- a/pkg/brutus/wordlists/mysql_defaults.txt
+++ b/pkg/brutus/wordlists/mysql_defaults.txt
@@ -9,7 +9,7 @@ root:mysql
 root:admin
 mysql:mysql
 admin:admin
-# --- exhaustive ---
+# --- aggressive ---
 root:mysql123
 dbadmin:dbadmin
 mysql:password

--- a/pkg/brutus/wordlists/neo4j_defaults.txt
+++ b/pkg/brutus/wordlists/neo4j_defaults.txt
@@ -6,7 +6,7 @@ neo4j:password
 neo4j:admin
 admin:admin
 neo4j:neo4j123
-# --- exhaustive ---
+# --- aggressive ---
 neo4j:changeme
 neo4j:graph
 admin:neo4j

--- a/pkg/brutus/wordlists/oracle_defaults.txt
+++ b/pkg/brutus/wordlists/oracle_defaults.txt
@@ -18,7 +18,7 @@ xdb:xdb
 anonymous:anonymous
 apex_public_user:oracle
 flows_files:flows_files
-# --- exhaustive ---
+# --- aggressive ---
 sys:oracle
 system:system
 sys:sys

--- a/pkg/brutus/wordlists/pop3_defaults.txt
+++ b/pkg/brutus/wordlists/pop3_defaults.txt
@@ -8,7 +8,7 @@ test@localhost:test
 postmaster@localhost:password
 root@localhost:root
 webmaster@localhost:password
-# --- exhaustive ---
+# --- aggressive ---
 admin@localhost:changeme
 mail@localhost:mail
 pop3@localhost:pop3

--- a/pkg/brutus/wordlists/postgresql_defaults.txt
+++ b/pkg/brutus/wordlists/postgresql_defaults.txt
@@ -6,7 +6,7 @@ postgres:password
 # --- cautious ---
 postgres:admin
 admin:admin
-# --- exhaustive ---
+# --- aggressive ---
 postgres:postgres123
 postgres:root
 dbadmin:dbadmin

--- a/pkg/brutus/wordlists/rdp_defaults.txt
+++ b/pkg/brutus/wordlists/rdp_defaults.txt
@@ -13,7 +13,7 @@ guest:guest
 user:user
 user:password
 test:test
-# --- exhaustive ---
+# --- aggressive ---
 administrator:Welcome1
 administrator:Passw0rd!
 administrator:Administrator

--- a/pkg/brutus/wordlists/redis_defaults.txt
+++ b/pkg/brutus/wordlists/redis_defaults.txt
@@ -8,7 +8,7 @@ default:password
 admin:admin
 root:root
 redis:redis
-# --- exhaustive ---
+# --- aggressive ---
 redis:password
 redis:admin
 default:admin

--- a/pkg/brutus/wordlists/smb_defaults.txt
+++ b/pkg/brutus/wordlists/smb_defaults.txt
@@ -9,7 +9,7 @@ Administrator:Password1
 Administrator:admin
 admin:admin
 root:root
-# --- exhaustive ---
+# --- aggressive ---
 Administrator:Admin123
 Administrator:Welcome1
 smbuser:smbuser

--- a/pkg/brutus/wordlists/smtp_defaults.txt
+++ b/pkg/brutus/wordlists/smtp_defaults.txt
@@ -8,7 +8,7 @@ postmaster:admin
 admin@localhost:password
 user@localhost:password
 test@localhost:test
-# --- exhaustive ---
+# --- aggressive ---
 smtp@localhost:smtp
 postmaster:postmaster
 admin@localhost:admin

--- a/pkg/brutus/wordlists/ssh_defaults.txt
+++ b/pkg/brutus/wordlists/ssh_defaults.txt
@@ -9,7 +9,7 @@ root:alpine
 ubuntu:ubuntu
 pi:raspberry
 vagrant:vagrant
-# --- exhaustive ---
+# --- aggressive ---
 deploy:deploy
 ec2-user:ec2-user
 centos:centos

--- a/pkg/brutus/wordlists/telnet_defaults.txt
+++ b/pkg/brutus/wordlists/telnet_defaults.txt
@@ -10,7 +10,7 @@ admin:1234
 admin:
 ubnt:ubnt
 cisco:cisco
-# --- exhaustive ---
+# --- aggressive ---
 admin:12345
 telnetadmin:telnetadmin
 support:support

--- a/pkg/brutus/wordlists/vnc_defaults.txt
+++ b/pkg/brutus/wordlists/vnc_defaults.txt
@@ -10,7 +10,7 @@
 :Password1
 :raspberry
 :12345678
-# --- exhaustive ---
+# --- aggressive ---
 :secret
 :changeme
 :1234


### PR DESCRIPTION
## Summary
- Renames the `exhaustive` aggressiveness mode to `aggressive` across the entire codebase
- Aligns CLI naming with the intended semantics from the roadmap ([10T-296](https://linear.app/praetorianlabs/issue/10T-296))
- "Aggressive" better communicates the risk profile to operators than "exhaustive" which reads as merely thorough

## Changes (35 files)
- **Mode constants**: `ModeExhaustive` → `ModeAggressive`, value `"exhaustive"` → `"aggressive"`
- **CLI flags/help**: `--mode cautious|default|exhaustive` → `--mode cautious|default|aggressive`
- **Wordlist tier markers**: `# --- exhaustive ---` → `# --- aggressive ---` (24 wordlist files)
- **SNMP tier mapping**: `"exhaustive"` → `"aggressive"` maps to SNMP's `"full"` tier
- **Tests**: All mode tests, defaults tests, and SNMP tests updated
- **README**: Mode table and examples updated

## Test plan
- [ ] CI passes (go test, go vet, linting)
- [ ] `brutus creds --mode aggressive` works as before
- [ ] `brutus snmp --mode aggressive` maps to full tier
- [ ] `brutus creds --mode exhaustive` is rejected with clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)