### PR TITLE
feat(turn): add TURN server credential testing plugin

### DIFF
--- a/internal/plugins/init.go
+++ b/internal/plugins/init.go
@@ -41,6 +41,7 @@ import (
 	_ "github.com/praetorian-inc/brutus/internal/plugins/snmp"
 	_ "github.com/praetorian-inc/brutus/internal/plugins/ssh"
 	_ "github.com/praetorian-inc/brutus/internal/plugins/telnet"
+	_ "github.com/praetorian-inc/brutus/internal/plugins/turn"
 	_ "github.com/praetorian-inc/brutus/internal/plugins/vnc"
 	_ "github.com/praetorian-inc/brutus/internal/plugins/winrm"
 )

--- a/internal/plugins/turn/turn.go
+++ b/internal/plugins/turn/turn.go
@@ -110,7 +110,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 
 	// Step 1: Send unauthenticated Allocate to obtain realm and nonce.
 	txID := newTransactionID()
-	if _, err := conn.Write(buildAllocateRequest(txID)); err != nil {
+	if _, err = conn.Write(buildAllocateRequest(txID)); err != nil {
 		result.Error = brutus.WrapConnError(err)
 		return result
 	}
@@ -163,7 +163,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	for retry := 0; retry <= maxStaleRetries; retry++ {
 		txID2 := newTransactionID()
 		authReq := buildAuthenticatedAllocateRequest(txID2, username, realm, nonce, password)
-		if _, err := conn.Write(authReq); err != nil {
+		if _, err = conn.Write(authReq); err != nil {
 			result.Error = brutus.WrapConnError(err)
 			return result
 		}
@@ -243,7 +243,7 @@ func (p *Plugin) CheckUnauth(ctx context.Context, target string,
 	_ = conn.SetDeadline(time.Now().Add(timeout))
 
 	txID := newTransactionID()
-	if _, err := conn.Write(buildAllocateRequest(txID)); err != nil {
+	if _, err = conn.Write(buildAllocateRequest(txID)); err != nil {
 		return result
 	}
 

--- a/internal/plugins/turn/turn.go
+++ b/internal/plugins/turn/turn.go
@@ -385,7 +385,9 @@ func longTermKey(username, realm, password string) []byte {
 // newTransactionID generates a random 96-bit STUN transaction ID.
 func newTransactionID() [12]byte {
 	var id [12]byte
-	_, _ = rand.Read(id[:])
+	if _, err := rand.Read(id[:]); err != nil {
+		panic("turn: failed to generate transaction ID: " + err.Error())
+	}
 	return id
 }
 
@@ -396,14 +398,12 @@ func newTransactionID() [12]byte {
 // parseSTUNMessage parses a STUN message, returning the message type,
 // the 12-byte transaction ID, and a map of attribute type -> raw value bytes.
 // Per RFC 5389 §7.3.1, only the first occurrence of each attribute is kept.
-func parseSTUNMessage(data []byte) (uint16, [12]byte, map[uint16][]byte, error) {
-	var txID [12]byte
-
+func parseSTUNMessage(data []byte) (msgType uint16, txID [12]byte, attrs map[uint16][]byte, err error) {
 	if len(data) < stunHeaderSize {
 		return 0, txID, nil, fmt.Errorf("message too short: %d bytes", len(data))
 	}
 
-	msgType := binary.BigEndian.Uint16(data[0:2])
+	msgType = binary.BigEndian.Uint16(data[0:2])
 	attrLen := int(binary.BigEndian.Uint16(data[2:4]))
 	cookie := binary.BigEndian.Uint32(data[4:8])
 
@@ -418,7 +418,7 @@ func parseSTUNMessage(data []byte) (uint16, [12]byte, map[uint16][]byte, error) 
 			stunHeaderSize+attrLen, len(data))
 	}
 
-	attrs := make(map[uint16][]byte)
+	attrs = make(map[uint16][]byte)
 	offset := stunHeaderSize
 	end := stunHeaderSize + attrLen
 

--- a/internal/plugins/turn/turn.go
+++ b/internal/plugins/turn/turn.go
@@ -42,7 +42,7 @@ const (
 	msgRefreshRequest = 0x0004 // Refresh method, Request class
 
 	// STUN attribute types.
-	attrUsername            = 0x0006
+	attrUsername           = 0x0006
 	attrMessageIntegrity   = 0x0008
 	attrErrorCode          = 0x0009
 	attrLifetime           = 0x000D
@@ -53,6 +53,7 @@ const (
 	// TURN error codes.
 	codeUnauthorized = 401
 	codeStaleNonce   = 438
+	codeQuotaReached = 486
 
 	// IANA protocol number for UDP.
 	protoUDP = 17
@@ -121,9 +122,14 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		return result
 	}
 
-	msgType, attrs, err := parseSTUNMessage(buf[:n])
+	msgType, respTxID, attrs, err := parseSTUNMessage(buf[:n])
 	if err != nil {
 		result.Error = brutus.WrapConnError(err)
+		return result
+	}
+
+	if respTxID != txID {
+		result.Error = fmt.Errorf("connection error: transaction ID mismatch in initial response")
 		return result
 	}
 
@@ -131,6 +137,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	if msgType == msgAllocateSuccess {
 		result.Success = true
 		result.Banner = "[CRITICAL] TURN server accepts unauthenticated allocations"
+		deallocateUnauth(conn)
 		return result
 	}
 
@@ -167,9 +174,14 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 			return result
 		}
 
-		msgType, attrs, err = parseSTUNMessage(buf[:n])
+		msgType, respTxID, attrs, err = parseSTUNMessage(buf[:n])
 		if err != nil {
 			result.Error = brutus.WrapConnError(err)
+			return result
+		}
+
+		if respTxID != txID2 {
+			result.Error = fmt.Errorf("connection error: transaction ID mismatch in auth response")
 			return result
 		}
 
@@ -191,6 +203,11 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 					nonce = fresh
 				}
 				continue
+			case codeQuotaReached:
+				// 486 = creds were valid but allocation quota exceeded.
+				result.Success = true
+				result.Banner = "valid credentials (allocation quota reached)"
+				return result
 			default:
 				result.Error = fmt.Errorf("connection error: TURN error %d", getErrorCode(attrs))
 				return result
@@ -236,14 +253,19 @@ func (p *Plugin) CheckUnauth(ctx context.Context, target string,
 		return result
 	}
 
-	msgType, _, err := parseSTUNMessage(buf[:n])
+	msgType, respTxID, _, err := parseSTUNMessage(buf[:n])
 	if err != nil {
+		return result
+	}
+
+	if respTxID != txID {
 		return result
 	}
 
 	if msgType == msgAllocateSuccess {
 		result.Success = true
 		result.Banner = "[CRITICAL] TURN server accepts unauthenticated allocations"
+		deallocateUnauth(conn)
 	}
 
 	return result
@@ -253,12 +275,35 @@ func (p *Plugin) CheckUnauth(ctx context.Context, target string,
 // STUN Message Building
 // =============================================================================
 
-// deallocate sends a Refresh request with LIFETIME=0 to release a successful
-// TURN allocation. This prevents per-user quota exhaustion during brute force.
-// Errors are ignored (fire-and-forget before connection close).
+// deallocate sends an authenticated Refresh request with LIFETIME=0 to release
+// a successful TURN allocation. This prevents per-user quota exhaustion during
+// brute force. Errors are ignored (fire-and-forget before connection close).
 func deallocate(conn net.Conn, username, realm, nonce, password string) {
 	txID := newTransactionID()
 	_, _ = conn.Write(buildRefreshRequest(txID, username, realm, nonce, password, 0))
+}
+
+// deallocateUnauth sends an unauthenticated Refresh request with LIFETIME=0
+// to release an open-relay allocation (no credentials needed).
+func deallocateUnauth(conn net.Conn) {
+	txID := newTransactionID()
+	_, _ = conn.Write(buildUnauthRefreshRequest(txID, 0))
+}
+
+// buildUnauthRefreshRequest builds an unauthenticated TURN Refresh request.
+// Used to release open-relay allocations that were granted without credentials.
+func buildUnauthRefreshRequest(txID [12]byte, lifetime uint32) []byte {
+	lt := make([]byte, 4)
+	binary.BigEndian.PutUint32(lt, lifetime)
+	attrs := encodeAttr(attrLifetime, lt)
+
+	msg := make([]byte, stunHeaderSize+len(attrs))
+	binary.BigEndian.PutUint16(msg[0:2], msgRefreshRequest)
+	binary.BigEndian.PutUint16(msg[2:4], uint16(len(attrs)))
+	binary.BigEndian.PutUint32(msg[4:8], magicCookie)
+	copy(msg[8:20], txID[:])
+	copy(msg[stunHeaderSize:], attrs)
+	return msg
 }
 
 // buildRefreshRequest builds an authenticated TURN Refresh request.
@@ -348,11 +393,14 @@ func newTransactionID() [12]byte {
 // STUN Message Parsing
 // =============================================================================
 
-// parseSTUNMessage parses a STUN message, returning the message type and
-// a map of attribute type -> raw value bytes.
-func parseSTUNMessage(data []byte) (uint16, map[uint16][]byte, error) {
+// parseSTUNMessage parses a STUN message, returning the message type,
+// the 12-byte transaction ID, and a map of attribute type -> raw value bytes.
+// Per RFC 5389 §7.3.1, only the first occurrence of each attribute is kept.
+func parseSTUNMessage(data []byte) (uint16, [12]byte, map[uint16][]byte, error) {
+	var txID [12]byte
+
 	if len(data) < stunHeaderSize {
-		return 0, nil, fmt.Errorf("message too short: %d bytes", len(data))
+		return 0, txID, nil, fmt.Errorf("message too short: %d bytes", len(data))
 	}
 
 	msgType := binary.BigEndian.Uint16(data[0:2])
@@ -360,11 +408,13 @@ func parseSTUNMessage(data []byte) (uint16, map[uint16][]byte, error) {
 	cookie := binary.BigEndian.Uint32(data[4:8])
 
 	if cookie != magicCookie {
-		return 0, nil, fmt.Errorf("invalid magic cookie: 0x%08x", cookie)
+		return 0, txID, nil, fmt.Errorf("invalid magic cookie: 0x%08x", cookie)
 	}
 
+	copy(txID[:], data[8:20])
+
 	if stunHeaderSize+attrLen > len(data) {
-		return 0, nil, fmt.Errorf("truncated message: need %d bytes, have %d",
+		return 0, txID, nil, fmt.Errorf("truncated message: need %d bytes, have %d",
 			stunHeaderSize+attrLen, len(data))
 	}
 
@@ -383,7 +433,11 @@ func parseSTUNMessage(data []byte) (uint16, map[uint16][]byte, error) {
 
 		val := make([]byte, aLen)
 		copy(val, data[offset:offset+aLen])
-		attrs[aType] = val
+
+		// RFC 5389 §15: keep only the first occurrence of each attribute.
+		if _, exists := attrs[aType]; !exists {
+			attrs[aType] = val
+		}
 
 		// Advance past value + padding to 4-byte boundary.
 		offset += aLen
@@ -392,7 +446,7 @@ func parseSTUNMessage(data []byte) (uint16, map[uint16][]byte, error) {
 		}
 	}
 
-	return msgType, attrs, nil
+	return msgType, txID, attrs, nil
 }
 
 // getErrorCode extracts the numeric error code from an ERROR-CODE attribute.

--- a/internal/plugins/turn/turn.go
+++ b/internal/plugins/turn/turn.go
@@ -1,0 +1,440 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package turn
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/md5"
+	"crypto/rand"
+	"crypto/sha1"
+	"encoding/binary"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/praetorian-inc/brutus/pkg/brutus"
+)
+
+// STUN/TURN protocol constants (RFC 5389, RFC 5766).
+const (
+	stunHeaderSize = 20
+	magicCookie    = 0x2112A442
+
+	// STUN message types (method | class).
+	msgAllocateRequest = 0x0003 // Allocate method, Request class
+	msgAllocateSuccess = 0x0103 // Allocate method, Success Response class
+	msgAllocateError   = 0x0113 // Allocate method, Error Response class
+
+	// STUN message types — Refresh method.
+	msgRefreshRequest = 0x0004 // Refresh method, Request class
+
+	// STUN attribute types.
+	attrUsername            = 0x0006
+	attrMessageIntegrity   = 0x0008
+	attrErrorCode          = 0x0009
+	attrLifetime           = 0x000D
+	attrRealm              = 0x0014
+	attrNonce              = 0x0015
+	attrRequestedTransport = 0x0019
+
+	// TURN error codes.
+	codeUnauthorized = 401
+	codeStaleNonce   = 438
+
+	// IANA protocol number for UDP.
+	protoUDP = 17
+
+	// Maximum STUN message size for UDP.
+	maxMessageSize = 1500
+
+	// maxStaleRetries is the number of times to retry on 438 Stale Nonce
+	// before giving up. Nonces are connection-scoped and time-limited;
+	// a retry with the fresh nonce from the 438 response usually succeeds.
+	maxStaleRetries = 3
+)
+
+func init() {
+	brutus.Register("turn", func() brutus.Plugin {
+		return &Plugin{}
+	})
+}
+
+// Plugin implements TURN credential testing via the STUN long-term
+// credential mechanism (RFC 5389 Section 10.2, RFC 5766).
+type Plugin struct{}
+
+// Name returns the protocol name.
+func (p *Plugin) Name() string {
+	return "turn"
+}
+
+// Test attempts TURN authentication by sending an Allocate request and
+// validating credentials via the long-term credential mechanism.
+//
+// Returns Result with:
+//   - Success=true, Error=nil: Valid credentials (Allocate succeeded)
+//   - Success=false, Error=nil: Invalid credentials (401 after auth attempt)
+//   - Success=false, Error!=nil: Connection/network error
+func (p *Plugin) Test(ctx context.Context, target, username, password string,
+	timeout time.Duration, pluginCfg brutus.PluginConfig) *brutus.Result {
+	start := time.Now()
+
+	result := brutus.NewResult("turn", target, username, password)
+	defer func() { result.Duration = time.Since(start) }()
+
+	host, port := brutus.ParseTarget(target, "3478")
+	addr := net.JoinHostPort(host, port)
+
+	conn, err := brutus.DialWithProxy(ctx, "udp", addr, timeout, pluginCfg.ProxyURL)
+	if err != nil {
+		result.Error = brutus.WrapConnError(err)
+		return result
+	}
+	defer func() { _ = conn.Close() }()
+
+	_ = conn.SetDeadline(time.Now().Add(timeout))
+
+	// Step 1: Send unauthenticated Allocate to obtain realm and nonce.
+	txID := newTransactionID()
+	if _, err := conn.Write(buildAllocateRequest(txID)); err != nil {
+		result.Error = brutus.WrapConnError(err)
+		return result
+	}
+
+	buf := make([]byte, maxMessageSize)
+	n, err := conn.Read(buf)
+	if err != nil {
+		result.Error = brutus.WrapConnError(err)
+		return result
+	}
+
+	msgType, attrs, err := parseSTUNMessage(buf[:n])
+	if err != nil {
+		result.Error = brutus.WrapConnError(err)
+		return result
+	}
+
+	// Unexpected success without credentials means open relay.
+	if msgType == msgAllocateSuccess {
+		result.Success = true
+		result.Banner = "[CRITICAL] TURN server accepts unauthenticated allocations"
+		return result
+	}
+
+	if msgType != msgAllocateError {
+		result.Error = fmt.Errorf("connection error: unexpected STUN response type 0x%04x", msgType)
+		return result
+	}
+
+	if getErrorCode(attrs) != codeUnauthorized {
+		result.Error = fmt.Errorf("connection error: expected 401 challenge, got %d", getErrorCode(attrs))
+		return result
+	}
+
+	realm := getStringAttr(attrs, attrRealm)
+	nonce := getStringAttr(attrs, attrNonce)
+	if realm == "" || nonce == "" {
+		result.Error = fmt.Errorf("connection error: 401 response missing realm or nonce")
+		return result
+	}
+
+	// Step 2: Send authenticated Allocate with MESSAGE-INTEGRITY.
+	// Retry on 438 Stale Nonce with the fresh nonce from the response.
+	for retry := 0; retry <= maxStaleRetries; retry++ {
+		txID2 := newTransactionID()
+		authReq := buildAuthenticatedAllocateRequest(txID2, username, realm, nonce, password)
+		if _, err := conn.Write(authReq); err != nil {
+			result.Error = brutus.WrapConnError(err)
+			return result
+		}
+
+		n, err = conn.Read(buf)
+		if err != nil {
+			result.Error = brutus.WrapConnError(err)
+			return result
+		}
+
+		msgType, attrs, err = parseSTUNMessage(buf[:n])
+		if err != nil {
+			result.Error = brutus.WrapConnError(err)
+			return result
+		}
+
+		switch msgType {
+		case msgAllocateSuccess:
+			result.Success = true
+			// Release the allocation to avoid hitting per-user quota limits.
+			deallocate(conn, username, realm, nonce, password)
+			return result
+		case msgAllocateError:
+			switch getErrorCode(attrs) {
+			case codeUnauthorized:
+				// Invalid credentials -- auth failure.
+				result.Error = nil
+				return result
+			case codeStaleNonce:
+				// Nonce expired -- extract fresh nonce and retry.
+				if fresh := getStringAttr(attrs, attrNonce); fresh != "" {
+					nonce = fresh
+				}
+				continue
+			default:
+				result.Error = fmt.Errorf("connection error: TURN error %d", getErrorCode(attrs))
+				return result
+			}
+		default:
+			result.Error = fmt.Errorf("connection error: unexpected response type 0x%04x", msgType)
+			return result
+		}
+	}
+
+	// Exhausted stale-nonce retries.
+	result.Error = fmt.Errorf("connection error: stale nonce persisted after %d retries", maxStaleRetries)
+	return result
+}
+
+// CheckUnauth probes for TURN servers that accept unauthenticated Allocate
+// requests, indicating an open relay misconfiguration.
+func (p *Plugin) CheckUnauth(ctx context.Context, target string,
+	timeout time.Duration, pluginCfg brutus.PluginConfig) *brutus.Result {
+	result := brutus.NewResult("turn", target, "(unauthenticated)", "")
+	start := time.Now()
+	defer func() { result.Duration = time.Since(start) }()
+
+	host, port := brutus.ParseTarget(target, "3478")
+	addr := net.JoinHostPort(host, port)
+
+	conn, err := brutus.DialWithProxy(ctx, "udp", addr, timeout, pluginCfg.ProxyURL)
+	if err != nil {
+		return result
+	}
+	defer func() { _ = conn.Close() }()
+
+	_ = conn.SetDeadline(time.Now().Add(timeout))
+
+	txID := newTransactionID()
+	if _, err := conn.Write(buildAllocateRequest(txID)); err != nil {
+		return result
+	}
+
+	buf := make([]byte, maxMessageSize)
+	n, err := conn.Read(buf)
+	if err != nil {
+		return result
+	}
+
+	msgType, _, err := parseSTUNMessage(buf[:n])
+	if err != nil {
+		return result
+	}
+
+	if msgType == msgAllocateSuccess {
+		result.Success = true
+		result.Banner = "[CRITICAL] TURN server accepts unauthenticated allocations"
+	}
+
+	return result
+}
+
+// =============================================================================
+// STUN Message Building
+// =============================================================================
+
+// deallocate sends a Refresh request with LIFETIME=0 to release a successful
+// TURN allocation. This prevents per-user quota exhaustion during brute force.
+// Errors are ignored (fire-and-forget before connection close).
+func deallocate(conn net.Conn, username, realm, nonce, password string) {
+	txID := newTransactionID()
+	_, _ = conn.Write(buildRefreshRequest(txID, username, realm, nonce, password, 0))
+}
+
+// buildRefreshRequest builds an authenticated TURN Refresh request.
+// Setting lifetime to 0 requests immediate deallocation.
+func buildRefreshRequest(txID [12]byte, username, realm, nonce, password string, lifetime uint32) []byte {
+	var attrs []byte
+	lt := make([]byte, 4)
+	binary.BigEndian.PutUint32(lt, lifetime)
+	attrs = append(attrs, encodeAttr(attrLifetime, lt)...)
+	attrs = append(attrs, encodeStringAttr(attrUsername, username)...)
+	attrs = append(attrs, encodeStringAttr(attrRealm, realm)...)
+	attrs = append(attrs, encodeStringAttr(attrNonce, nonce)...)
+
+	return buildAuthenticatedMessage(msgRefreshRequest, txID, attrs, username, realm, password)
+}
+
+// buildAllocateRequest builds an unauthenticated TURN Allocate request.
+// Contains only the REQUESTED-TRANSPORT attribute (UDP).
+func buildAllocateRequest(txID [12]byte) []byte {
+	transport := []byte{protoUDP, 0, 0, 0} // protocol + 3 bytes RFFU
+	attrs := encodeAttr(attrRequestedTransport, transport)
+
+	msg := make([]byte, stunHeaderSize+len(attrs))
+	binary.BigEndian.PutUint16(msg[0:2], msgAllocateRequest)
+	binary.BigEndian.PutUint16(msg[2:4], uint16(len(attrs)))
+	binary.BigEndian.PutUint32(msg[4:8], magicCookie)
+	copy(msg[8:20], txID[:])
+	copy(msg[stunHeaderSize:], attrs)
+	return msg
+}
+
+// buildAuthenticatedAllocateRequest builds an Allocate request with
+// long-term credential MESSAGE-INTEGRITY (RFC 5389 Section 15.4).
+func buildAuthenticatedAllocateRequest(txID [12]byte, username, realm, nonce, password string) []byte {
+	// Build attributes (order: REQUESTED-TRANSPORT, USERNAME, REALM, NONCE).
+	var attrs []byte
+	attrs = append(attrs, encodeAttr(attrRequestedTransport, []byte{protoUDP, 0, 0, 0})...)
+	attrs = append(attrs, encodeStringAttr(attrUsername, username)...)
+	attrs = append(attrs, encodeStringAttr(attrRealm, realm)...)
+	attrs = append(attrs, encodeStringAttr(attrNonce, nonce)...)
+
+	return buildAuthenticatedMessage(msgAllocateRequest, txID, attrs, username, realm, password)
+}
+
+// buildAuthenticatedMessage builds a STUN message with MESSAGE-INTEGRITY.
+// The attrs slice contains pre-encoded attributes (before MI). The header
+// length field is adjusted per RFC 5389 Section 15.4 before computing the
+// HMAC-SHA1 over the message.
+func buildAuthenticatedMessage(msgType uint16, txID [12]byte, attrs []byte, username, realm, password string) []byte {
+	// MI attribute = 4-byte header + 20-byte HMAC = 24 bytes.
+	const miAttrSize = 24
+	msg := make([]byte, stunHeaderSize+len(attrs))
+	binary.BigEndian.PutUint16(msg[0:2], msgType)
+	binary.BigEndian.PutUint16(msg[2:4], uint16(len(attrs)+miAttrSize))
+	binary.BigEndian.PutUint32(msg[4:8], magicCookie)
+	copy(msg[8:20], txID[:])
+	copy(msg[stunHeaderSize:], attrs)
+
+	// Compute HMAC-SHA1 over the message (with adjusted length).
+	key := longTermKey(username, realm, password)
+	mac := hmac.New(sha1.New, key)
+	mac.Write(msg)
+	integrity := mac.Sum(nil)
+
+	// Append MESSAGE-INTEGRITY attribute.
+	msg = append(msg, encodeAttr(attrMessageIntegrity, integrity)...)
+	return msg
+}
+
+// longTermKey derives the STUN long-term credential key:
+//
+//	key = MD5(username ":" realm ":" password)
+func longTermKey(username, realm, password string) []byte {
+	h := md5.New()
+	h.Write([]byte(username + ":" + realm + ":" + password))
+	return h.Sum(nil)
+}
+
+// newTransactionID generates a random 96-bit STUN transaction ID.
+func newTransactionID() [12]byte {
+	var id [12]byte
+	_, _ = rand.Read(id[:])
+	return id
+}
+
+// =============================================================================
+// STUN Message Parsing
+// =============================================================================
+
+// parseSTUNMessage parses a STUN message, returning the message type and
+// a map of attribute type -> raw value bytes.
+func parseSTUNMessage(data []byte) (uint16, map[uint16][]byte, error) {
+	if len(data) < stunHeaderSize {
+		return 0, nil, fmt.Errorf("message too short: %d bytes", len(data))
+	}
+
+	msgType := binary.BigEndian.Uint16(data[0:2])
+	attrLen := int(binary.BigEndian.Uint16(data[2:4]))
+	cookie := binary.BigEndian.Uint32(data[4:8])
+
+	if cookie != magicCookie {
+		return 0, nil, fmt.Errorf("invalid magic cookie: 0x%08x", cookie)
+	}
+
+	if stunHeaderSize+attrLen > len(data) {
+		return 0, nil, fmt.Errorf("truncated message: need %d bytes, have %d",
+			stunHeaderSize+attrLen, len(data))
+	}
+
+	attrs := make(map[uint16][]byte)
+	offset := stunHeaderSize
+	end := stunHeaderSize + attrLen
+
+	for offset+4 <= end {
+		aType := binary.BigEndian.Uint16(data[offset : offset+2])
+		aLen := int(binary.BigEndian.Uint16(data[offset+2 : offset+4]))
+		offset += 4
+
+		if offset+aLen > end {
+			break
+		}
+
+		val := make([]byte, aLen)
+		copy(val, data[offset:offset+aLen])
+		attrs[aType] = val
+
+		// Advance past value + padding to 4-byte boundary.
+		offset += aLen
+		if pad := aLen % 4; pad != 0 {
+			offset += 4 - pad
+		}
+	}
+
+	return msgType, attrs, nil
+}
+
+// getErrorCode extracts the numeric error code from an ERROR-CODE attribute.
+// Returns 0 if the attribute is missing or malformed.
+func getErrorCode(attrs map[uint16][]byte) int {
+	data, ok := attrs[attrErrorCode]
+	if !ok || len(data) < 4 {
+		return 0
+	}
+	class := int(data[2] & 0x07)
+	number := int(data[3])
+	return class*100 + number
+}
+
+// getStringAttr extracts a string attribute value. Returns "" if missing.
+func getStringAttr(attrs map[uint16][]byte, attrType uint16) string {
+	data, ok := attrs[attrType]
+	if !ok {
+		return ""
+	}
+	return string(data)
+}
+
+// =============================================================================
+// STUN Attribute Encoding
+// =============================================================================
+
+// encodeAttr encodes a STUN attribute with TLV format and 4-byte padding.
+func encodeAttr(attrType uint16, value []byte) []byte {
+	padLen := 0
+	if mod := len(value) % 4; mod != 0 {
+		padLen = 4 - mod
+	}
+
+	buf := make([]byte, 4+len(value)+padLen)
+	binary.BigEndian.PutUint16(buf[0:2], attrType)
+	binary.BigEndian.PutUint16(buf[2:4], uint16(len(value)))
+	copy(buf[4:], value)
+	return buf
+}
+
+// encodeStringAttr encodes a string-valued STUN attribute.
+func encodeStringAttr(attrType uint16, value string) []byte {
+	return encodeAttr(attrType, []byte(value))
+}

--- a/internal/plugins/turn/turn_test.go
+++ b/internal/plugins/turn/turn_test.go
@@ -1,0 +1,495 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package turn
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/brutus/pkg/brutus"
+)
+
+func TestPlugin_Name(t *testing.T) {
+	p := &Plugin{}
+	assert.Equal(t, "turn", p.Name())
+}
+
+// =============================================================================
+// Mock TURN Server
+// =============================================================================
+
+// mockTURNServer starts a UDP listener that runs a scripted TURN conversation.
+func mockTURNServer(t *testing.T, handler func(pc net.PacketConn)) (addr string, cleanup func()) {
+	t.Helper()
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handler(pc)
+	}()
+
+	cleanup = func() {
+		_ = pc.Close()
+		<-done
+	}
+	return pc.LocalAddr().String(), cleanup
+}
+
+// stunRecv reads one STUN message from the PacketConn.
+func stunRecv(pc net.PacketConn) ([]byte, net.Addr) {
+	buf := make([]byte, maxMessageSize)
+	n, addr, _ := pc.ReadFrom(buf)
+	return buf[:n], addr
+}
+
+// stunSend writes a STUN message to the given address.
+func stunSend(pc net.PacketConn, msg []byte, addr net.Addr) {
+	_, _ = pc.WriteTo(msg, addr)
+}
+
+// extractTxID extracts the 12-byte transaction ID from a STUN message.
+func extractTxID(msg []byte) [12]byte {
+	var txID [12]byte
+	if len(msg) >= stunHeaderSize {
+		copy(txID[:], msg[8:20])
+	}
+	return txID
+}
+
+// buildMockErrorResponse builds a STUN error response for testing.
+func buildMockErrorResponse(txID [12]byte, code int, realm, nonce string) []byte {
+	class := byte(code / 100)
+	number := byte(code % 100)
+	errData := []byte{0, 0, class, number}
+
+	var attrs []byte
+	attrs = append(attrs, encodeAttr(attrErrorCode, errData)...)
+	if realm != "" {
+		attrs = append(attrs, encodeStringAttr(attrRealm, realm)...)
+	}
+	if nonce != "" {
+		attrs = append(attrs, encodeStringAttr(attrNonce, nonce)...)
+	}
+
+	msg := make([]byte, stunHeaderSize+len(attrs))
+	binary.BigEndian.PutUint16(msg[0:2], msgAllocateError)
+	binary.BigEndian.PutUint16(msg[2:4], uint16(len(attrs)))
+	binary.BigEndian.PutUint32(msg[4:8], magicCookie)
+	copy(msg[8:20], txID[:])
+	copy(msg[stunHeaderSize:], attrs)
+	return msg
+}
+
+// buildMockSuccessResponse builds a STUN success response for testing.
+func buildMockSuccessResponse(txID [12]byte) []byte {
+	msg := make([]byte, stunHeaderSize)
+	binary.BigEndian.PutUint16(msg[0:2], msgAllocateSuccess)
+	binary.BigEndian.PutUint16(msg[2:4], 0)
+	binary.BigEndian.PutUint32(msg[4:8], magicCookie)
+	copy(msg[8:20], txID[:])
+	return msg
+}
+
+// =============================================================================
+// Plugin Tests
+// =============================================================================
+
+func TestPlugin_Test_ValidCredentials(t *testing.T) {
+	refreshReceived := make(chan struct{}, 1)
+
+	addr, cleanup := mockTURNServer(t, func(pc net.PacketConn) {
+		// Receive unauthenticated Allocate.
+		msg, client := stunRecv(pc)
+		txID := extractTxID(msg)
+		// Send 401 challenge with realm and nonce.
+		stunSend(pc, buildMockErrorResponse(txID, 401, "example.com", "testnonce"), client)
+
+		// Receive authenticated Allocate.
+		msg, client = stunRecv(pc)
+		txID = extractTxID(msg)
+		// Send success.
+		stunSend(pc, buildMockSuccessResponse(txID), client)
+
+		// Expect deallocation Refresh (LIFETIME=0).
+		msg, _ = stunRecv(pc)
+		if len(msg) >= stunHeaderSize {
+			msgType := binary.BigEndian.Uint16(msg[0:2])
+			if msgType == msgRefreshRequest {
+				refreshReceived <- struct{}{}
+			}
+		}
+	})
+	defer cleanup()
+
+	p := &Plugin{}
+	result := p.Test(context.Background(), addr, "admin", "password", 5*time.Second, brutus.PluginConfig{})
+
+	assert.True(t, result.Success)
+	assert.Nil(t, result.Error)
+	assert.Equal(t, "turn", result.Protocol)
+	assert.Equal(t, addr, result.Target)
+	assert.Equal(t, "admin", result.Username)
+	assert.Equal(t, "password", result.Password)
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
+
+	// Verify deallocation was sent.
+	select {
+	case <-refreshReceived:
+		// OK — deallocation Refresh was received.
+	case <-time.After(2 * time.Second):
+		t.Error("expected Refresh(LIFETIME=0) deallocation after success")
+	}
+}
+
+func TestPlugin_Test_InvalidCredentials(t *testing.T) {
+	addr, cleanup := mockTURNServer(t, func(pc net.PacketConn) {
+		// Receive unauthenticated Allocate.
+		msg, client := stunRecv(pc)
+		txID := extractTxID(msg)
+		// Send 401 challenge.
+		stunSend(pc, buildMockErrorResponse(txID, 401, "example.com", "testnonce"), client)
+
+		// Receive authenticated Allocate.
+		msg, client = stunRecv(pc)
+		txID = extractTxID(msg)
+		// Reject: bad credentials.
+		stunSend(pc, buildMockErrorResponse(txID, 401, "", ""), client)
+	})
+	defer cleanup()
+
+	p := &Plugin{}
+	result := p.Test(context.Background(), addr, "admin", "wrong", 5*time.Second, brutus.PluginConfig{})
+
+	assert.False(t, result.Success)
+	assert.Nil(t, result.Error, "auth failure should return nil error")
+	assert.Equal(t, "turn", result.Protocol)
+}
+
+func TestPlugin_Test_StaleNonce_RetrySucceeds(t *testing.T) {
+	addr, cleanup := mockTURNServer(t, func(pc net.PacketConn) {
+		// Receive unauthenticated Allocate.
+		msg, client := stunRecv(pc)
+		txID := extractTxID(msg)
+		// Send 401 challenge.
+		stunSend(pc, buildMockErrorResponse(txID, 401, "example.com", "oldnonce"), client)
+
+		// Receive authenticated Allocate — respond with 438 Stale Nonce.
+		msg, client = stunRecv(pc)
+		txID = extractTxID(msg)
+		stunSend(pc, buildMockErrorResponse(txID, 438, "example.com", "freshnonce"), client)
+
+		// Receive retried Allocate with fresh nonce — accept.
+		msg, client = stunRecv(pc)
+		txID = extractTxID(msg)
+		stunSend(pc, buildMockSuccessResponse(txID), client)
+
+		// Consume deallocation Refresh.
+		stunRecv(pc)
+	})
+	defer cleanup()
+
+	p := &Plugin{}
+	result := p.Test(context.Background(), addr, "admin", "pass", 5*time.Second, brutus.PluginConfig{})
+
+	assert.True(t, result.Success)
+	assert.Nil(t, result.Error)
+}
+
+func TestPlugin_Test_StaleNonce_ExhaustedRetries(t *testing.T) {
+	addr, cleanup := mockTURNServer(t, func(pc net.PacketConn) {
+		// Receive unauthenticated Allocate.
+		msg, client := stunRecv(pc)
+		txID := extractTxID(msg)
+		stunSend(pc, buildMockErrorResponse(txID, 401, "example.com", "nonce0"), client)
+
+		// Keep returning 438 for every retry.
+		for i := 0; i <= maxStaleRetries; i++ {
+			msg, client = stunRecv(pc)
+			txID = extractTxID(msg)
+			stunSend(pc, buildMockErrorResponse(txID, 438, "example.com", fmt.Sprintf("nonce%d", i+1)), client)
+		}
+	})
+	defer cleanup()
+
+	p := &Plugin{}
+	result := p.Test(context.Background(), addr, "admin", "pass", 5*time.Second, brutus.PluginConfig{})
+
+	assert.False(t, result.Success)
+	assert.NotNil(t, result.Error)
+	assert.Contains(t, result.Error.Error(), "connection error")
+	assert.Contains(t, result.Error.Error(), "stale nonce persisted")
+}
+
+func TestPlugin_Test_ConnectionError(t *testing.T) {
+	p := &Plugin{}
+	ctx := context.Background()
+
+	// Use a blackhole IP that won't respond (will timeout).
+	result := p.Test(ctx, "198.51.100.1:3478", "admin", "pass", 500*time.Millisecond, brutus.PluginConfig{})
+
+	assert.False(t, result.Success)
+	assert.NotNil(t, result.Error)
+	assert.Contains(t, result.Error.Error(), "connection error")
+}
+
+func TestPlugin_Test_UnauthSuccess_DuringTest(t *testing.T) {
+	// Server responds with success to the unauthenticated request (open relay).
+	addr, cleanup := mockTURNServer(t, func(pc net.PacketConn) {
+		msg, client := stunRecv(pc)
+		txID := extractTxID(msg)
+		stunSend(pc, buildMockSuccessResponse(txID), client)
+	})
+	defer cleanup()
+
+	p := &Plugin{}
+	result := p.Test(context.Background(), addr, "admin", "pass", 5*time.Second, brutus.PluginConfig{})
+
+	assert.True(t, result.Success)
+	assert.Nil(t, result.Error)
+	assert.Contains(t, result.Banner, "unauthenticated")
+}
+
+func TestPlugin_Test_NonSTUNResponse(t *testing.T) {
+	addr, cleanup := mockTURNServer(t, func(pc net.PacketConn) {
+		_, client := stunRecv(pc)
+		// Send garbage (not a STUN message).
+		stunSend(pc, []byte("HTTP/1.1 200 OK\r\n"), client)
+	})
+	defer cleanup()
+
+	p := &Plugin{}
+	result := p.Test(context.Background(), addr, "admin", "pass", 5*time.Second, brutus.PluginConfig{})
+
+	assert.False(t, result.Success)
+	assert.NotNil(t, result.Error)
+	assert.Contains(t, result.Error.Error(), "connection error")
+}
+
+func TestPlugin_Test_MissingRealmOrNonce(t *testing.T) {
+	addr, cleanup := mockTURNServer(t, func(pc net.PacketConn) {
+		msg, client := stunRecv(pc)
+		txID := extractTxID(msg)
+		// Send 401 without realm or nonce.
+		stunSend(pc, buildMockErrorResponse(txID, 401, "", ""), client)
+	})
+	defer cleanup()
+
+	p := &Plugin{}
+	result := p.Test(context.Background(), addr, "admin", "pass", 5*time.Second, brutus.PluginConfig{})
+
+	assert.False(t, result.Success)
+	assert.NotNil(t, result.Error)
+	assert.Contains(t, result.Error.Error(), "missing realm or nonce")
+}
+
+// =============================================================================
+// UnauthChecker Tests
+// =============================================================================
+
+func TestPlugin_CheckUnauth_OpenRelay(t *testing.T) {
+	addr, cleanup := mockTURNServer(t, func(pc net.PacketConn) {
+		msg, client := stunRecv(pc)
+		txID := extractTxID(msg)
+		// Accept allocation without credentials.
+		stunSend(pc, buildMockSuccessResponse(txID), client)
+	})
+	defer cleanup()
+
+	p := &Plugin{}
+	result := p.CheckUnauth(context.Background(), addr, 5*time.Second, brutus.PluginConfig{})
+
+	assert.True(t, result.Success)
+	assert.Contains(t, result.Banner, "[CRITICAL]")
+	assert.Contains(t, result.Banner, "unauthenticated")
+}
+
+func TestPlugin_CheckUnauth_Secure(t *testing.T) {
+	addr, cleanup := mockTURNServer(t, func(pc net.PacketConn) {
+		msg, client := stunRecv(pc)
+		txID := extractTxID(msg)
+		// Properly require auth.
+		stunSend(pc, buildMockErrorResponse(txID, 401, "example.com", "nonce123"), client)
+	})
+	defer cleanup()
+
+	p := &Plugin{}
+	result := p.CheckUnauth(context.Background(), addr, 5*time.Second, brutus.PluginConfig{})
+
+	assert.False(t, result.Success)
+	assert.Empty(t, result.Banner)
+}
+
+func TestPlugin_CheckUnauth_Unreachable(t *testing.T) {
+	p := &Plugin{}
+	result := p.CheckUnauth(context.Background(), "198.51.100.1:3478", 500*time.Millisecond, brutus.PluginConfig{})
+
+	assert.False(t, result.Success)
+}
+
+// =============================================================================
+// STUN Encoding/Parsing Unit Tests
+// =============================================================================
+
+func TestBuildAllocateRequest(t *testing.T) {
+	txID := [12]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
+	msg := buildAllocateRequest(txID)
+
+	// Verify header.
+	assert.Equal(t, uint16(msgAllocateRequest), binary.BigEndian.Uint16(msg[0:2]))
+	assert.Equal(t, uint32(magicCookie), binary.BigEndian.Uint32(msg[4:8]))
+	assert.Equal(t, txID[:], msg[8:20])
+
+	// Parse and verify attributes.
+	_, attrs, err := parseSTUNMessage(msg)
+	require.NoError(t, err)
+	require.Contains(t, attrs, uint16(attrRequestedTransport))
+	assert.Equal(t, byte(protoUDP), attrs[attrRequestedTransport][0])
+}
+
+func TestParseSTUNMessage_Valid(t *testing.T) {
+	txID := [12]byte{0xAA, 0xBB, 0xCC, 0xDD, 0, 0, 0, 0, 0, 0, 0, 0}
+	resp := buildMockErrorResponse(txID, 401, "myrealm", "mynonce")
+
+	msgType, attrs, err := parseSTUNMessage(resp)
+	require.NoError(t, err)
+	assert.Equal(t, uint16(msgAllocateError), msgType)
+	assert.Equal(t, 401, getErrorCode(attrs))
+	assert.Equal(t, "myrealm", getStringAttr(attrs, attrRealm))
+	assert.Equal(t, "mynonce", getStringAttr(attrs, attrNonce))
+}
+
+func TestParseSTUNMessage_TooShort(t *testing.T) {
+	_, _, err := parseSTUNMessage([]byte{0, 0, 0})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "too short")
+}
+
+func TestParseSTUNMessage_BadCookie(t *testing.T) {
+	msg := make([]byte, stunHeaderSize)
+	binary.BigEndian.PutUint32(msg[4:8], 0xDEADBEEF)
+	_, _, err := parseSTUNMessage(msg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "magic cookie")
+}
+
+func TestParseSTUNMessage_Truncated(t *testing.T) {
+	msg := make([]byte, stunHeaderSize)
+	binary.BigEndian.PutUint16(msg[2:4], 100) // claims 100 bytes of attrs
+	binary.BigEndian.PutUint32(msg[4:8], magicCookie)
+	_, _, err := parseSTUNMessage(msg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "truncated")
+}
+
+func TestGetErrorCode(t *testing.T) {
+	tests := []struct {
+		name string
+		code int
+	}{
+		{"unauthorized", 401},
+		{"stale nonce", 438},
+		{"forbidden", 403},
+		{"quota reached", 486},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			class := byte(tt.code / 100)
+			number := byte(tt.code % 100)
+			attrs := map[uint16][]byte{
+				attrErrorCode: {0, 0, class, number},
+			}
+			assert.Equal(t, tt.code, getErrorCode(attrs))
+		})
+	}
+}
+
+func TestGetErrorCode_Missing(t *testing.T) {
+	assert.Equal(t, 0, getErrorCode(map[uint16][]byte{}))
+}
+
+func TestGetStringAttr_Missing(t *testing.T) {
+	assert.Equal(t, "", getStringAttr(map[uint16][]byte{}, attrRealm))
+}
+
+func TestLongTermKey(t *testing.T) {
+	// RFC 5389 long-term key = MD5("user:realm:pass").
+	key := longTermKey("user", "realm", "pass")
+	assert.Len(t, key, 16, "MD5 key should be 16 bytes")
+}
+
+func TestEncodeAttr_Padding(t *testing.T) {
+	// 3-byte value should be padded to 4 bytes.
+	attr := encodeAttr(0x0006, []byte("abc"))
+	assert.Len(t, attr, 8) // 4 header + 3 value + 1 padding
+
+	// Length field should be 3 (actual length, not padded).
+	assert.Equal(t, uint16(3), binary.BigEndian.Uint16(attr[2:4]))
+
+	// 4-byte value needs no padding.
+	attr = encodeAttr(0x0006, []byte("abcd"))
+	assert.Len(t, attr, 8) // 4 header + 4 value
+}
+
+func TestBuildAuthenticatedAllocateRequest(t *testing.T) {
+	txID := [12]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
+	msg := buildAuthenticatedAllocateRequest(txID, "user", "realm", "nonce", "pass")
+
+	// Should parse without error.
+	msgType, attrs, err := parseSTUNMessage(msg)
+	require.NoError(t, err)
+	assert.Equal(t, uint16(msgAllocateRequest), msgType)
+
+	// Should contain expected attributes.
+	assert.Contains(t, attrs, uint16(attrRequestedTransport))
+	assert.Contains(t, attrs, uint16(attrUsername))
+	assert.Contains(t, attrs, uint16(attrRealm))
+	assert.Contains(t, attrs, uint16(attrNonce))
+	assert.Contains(t, attrs, uint16(attrMessageIntegrity))
+
+	// Verify attribute values.
+	assert.Equal(t, "user", string(attrs[attrUsername]))
+	assert.Equal(t, "realm", string(attrs[attrRealm]))
+	assert.Equal(t, "nonce", string(attrs[attrNonce]))
+	assert.Len(t, attrs[attrMessageIntegrity], 20, "HMAC-SHA1 should be 20 bytes")
+}
+
+func TestBuildRefreshRequest(t *testing.T) {
+	txID := [12]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
+	msg := buildRefreshRequest(txID, "user", "realm", "nonce", "pass", 0)
+
+	msgType, attrs, err := parseSTUNMessage(msg)
+	require.NoError(t, err)
+	assert.Equal(t, uint16(msgRefreshRequest), msgType)
+
+	// Should contain LIFETIME=0.
+	require.Contains(t, attrs, uint16(attrLifetime))
+	assert.Equal(t, uint32(0), binary.BigEndian.Uint32(attrs[attrLifetime]))
+
+	// Should contain auth attributes and MESSAGE-INTEGRITY.
+	assert.Contains(t, attrs, uint16(attrUsername))
+	assert.Contains(t, attrs, uint16(attrRealm))
+	assert.Contains(t, attrs, uint16(attrNonce))
+	assert.Contains(t, attrs, uint16(attrMessageIntegrity))
+	assert.Len(t, attrs[attrMessageIntegrity], 20)
+}

--- a/internal/plugins/turn/turn_test.go
+++ b/internal/plugins/turn/turn_test.go
@@ -16,6 +16,8 @@ package turn
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha1"
 	"encoding/binary"
 	"fmt"
 	"net"
@@ -162,6 +164,100 @@ func TestPlugin_Test_ValidCredentials(t *testing.T) {
 	}
 }
 
+func TestPlugin_Test_ValidCredentials_VerifyHMAC(t *testing.T) {
+	const (
+		testRealm    = "example.com"
+		testNonce    = "testnonce"
+		testUsername = "admin"
+		testPassword = "secret"
+	)
+	hmacValid := make(chan bool, 1)
+
+	addr, cleanup := mockTURNServer(t, func(pc net.PacketConn) {
+		// Receive unauthenticated Allocate.
+		msg, client := stunRecv(pc)
+		txID := extractTxID(msg)
+		// Send 401 challenge.
+		stunSend(pc, buildMockErrorResponse(txID, 401, testRealm, testNonce), client)
+
+		// Receive authenticated Allocate — verify MESSAGE-INTEGRITY.
+		msg, client = stunRecv(pc)
+		txID = extractTxID(msg)
+
+		// Server-side HMAC verification: recompute over everything
+		// before the MESSAGE-INTEGRITY attribute and compare.
+		_, _, attrs, err := parseSTUNMessage(msg)
+		if err != nil {
+			hmacValid <- false
+			stunSend(pc, buildMockErrorResponse(txID, 401, "", ""), client)
+			return
+		}
+
+		miData, hasMI := attrs[attrMessageIntegrity]
+		if !hasMI || len(miData) != 20 {
+			hmacValid <- false
+			stunSend(pc, buildMockErrorResponse(txID, 401, "", ""), client)
+			return
+		}
+
+		// Find MI attribute offset: scan for attrMessageIntegrity type.
+		miOffset := -1
+		offset := stunHeaderSize
+		attrLen := int(binary.BigEndian.Uint16(msg[2:4]))
+		end := stunHeaderSize + attrLen
+		for offset+4 <= end {
+			aType := binary.BigEndian.Uint16(msg[offset : offset+2])
+			aLen := int(binary.BigEndian.Uint16(msg[offset+2 : offset+4]))
+			if aType == attrMessageIntegrity {
+				miOffset = offset
+				break
+			}
+			offset += 4 + aLen
+			if pad := aLen % 4; pad != 0 {
+				offset += 4 - pad
+			}
+		}
+		if miOffset < 0 {
+			hmacValid <- false
+			stunSend(pc, buildMockErrorResponse(txID, 401, "", ""), client)
+			return
+		}
+
+		// Per RFC 5389 §15.4: adjust header length to include MI only,
+		// then compute HMAC over msg[0:miOffset].
+		adjustedMsg := make([]byte, miOffset)
+		copy(adjustedMsg, msg[:miOffset])
+		binary.BigEndian.PutUint16(adjustedMsg[2:4], uint16(miOffset-stunHeaderSize+24))
+
+		key := longTermKey(testUsername, testRealm, testPassword)
+		mac := hmac.New(sha1.New, key)
+		mac.Write(adjustedMsg)
+		expected := mac.Sum(nil)
+
+		hmacValid <- hmac.Equal(expected, miData)
+
+		// Accept the request.
+		stunSend(pc, buildMockSuccessResponse(txID), client)
+
+		// Consume deallocation.
+		stunRecv(pc)
+	})
+	defer cleanup()
+
+	p := &Plugin{}
+	result := p.Test(context.Background(), addr, testUsername, testPassword, 5*time.Second, brutus.PluginConfig{})
+
+	assert.True(t, result.Success)
+	assert.Nil(t, result.Error)
+
+	select {
+	case valid := <-hmacValid:
+		assert.True(t, valid, "server-side MESSAGE-INTEGRITY HMAC verification failed")
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not receive HMAC verification result")
+	}
+}
+
 func TestPlugin_Test_InvalidCredentials(t *testing.T) {
 	addr, cleanup := mockTURNServer(t, func(pc net.PacketConn) {
 		// Receive unauthenticated Allocate.
@@ -184,6 +280,30 @@ func TestPlugin_Test_InvalidCredentials(t *testing.T) {
 	assert.False(t, result.Success)
 	assert.Nil(t, result.Error, "auth failure should return nil error")
 	assert.Equal(t, "turn", result.Protocol)
+}
+
+func TestPlugin_Test_QuotaReached(t *testing.T) {
+	addr, cleanup := mockTURNServer(t, func(pc net.PacketConn) {
+		// Receive unauthenticated Allocate.
+		msg, client := stunRecv(pc)
+		txID := extractTxID(msg)
+		// Send 401 challenge.
+		stunSend(pc, buildMockErrorResponse(txID, 401, "example.com", "testnonce"), client)
+
+		// Receive authenticated Allocate.
+		msg, client = stunRecv(pc)
+		txID = extractTxID(msg)
+		// 486 = creds were valid but quota exceeded.
+		stunSend(pc, buildMockErrorResponse(txID, 486, "", ""), client)
+	})
+	defer cleanup()
+
+	p := &Plugin{}
+	result := p.Test(context.Background(), addr, "admin", "password", 5*time.Second, brutus.PluginConfig{})
+
+	assert.True(t, result.Success)
+	assert.Nil(t, result.Error)
+	assert.Contains(t, result.Banner, "quota")
 }
 
 func TestPlugin_Test_StaleNonce_RetrySucceeds(t *testing.T) {
@@ -254,11 +374,22 @@ func TestPlugin_Test_ConnectionError(t *testing.T) {
 }
 
 func TestPlugin_Test_UnauthSuccess_DuringTest(t *testing.T) {
+	refreshReceived := make(chan struct{}, 1)
+
 	// Server responds with success to the unauthenticated request (open relay).
 	addr, cleanup := mockTURNServer(t, func(pc net.PacketConn) {
 		msg, client := stunRecv(pc)
 		txID := extractTxID(msg)
 		stunSend(pc, buildMockSuccessResponse(txID), client)
+
+		// Expect unauthenticated deallocation Refresh.
+		msg, _ = stunRecv(pc)
+		if len(msg) >= stunHeaderSize {
+			msgType := binary.BigEndian.Uint16(msg[0:2])
+			if msgType == msgRefreshRequest {
+				refreshReceived <- struct{}{}
+			}
+		}
 	})
 	defer cleanup()
 
@@ -268,6 +399,32 @@ func TestPlugin_Test_UnauthSuccess_DuringTest(t *testing.T) {
 	assert.True(t, result.Success)
 	assert.Nil(t, result.Error)
 	assert.Contains(t, result.Banner, "unauthenticated")
+
+	select {
+	case <-refreshReceived:
+		// OK — unauthenticated deallocation was sent.
+	case <-time.After(2 * time.Second):
+		t.Error("expected unauthenticated Refresh(LIFETIME=0) after open-relay detection")
+	}
+}
+
+func TestPlugin_Test_TransactionIDMismatch(t *testing.T) {
+	addr, cleanup := mockTURNServer(t, func(pc net.PacketConn) {
+		// Receive unauthenticated Allocate.
+		msg, client := stunRecv(pc)
+		_ = extractTxID(msg)
+		// Respond with a DIFFERENT transaction ID.
+		wrongTxID := [12]byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}
+		stunSend(pc, buildMockErrorResponse(wrongTxID, 401, "example.com", "testnonce"), client)
+	})
+	defer cleanup()
+
+	p := &Plugin{}
+	result := p.Test(context.Background(), addr, "admin", "pass", 5*time.Second, brutus.PluginConfig{})
+
+	assert.False(t, result.Success)
+	assert.NotNil(t, result.Error)
+	assert.Contains(t, result.Error.Error(), "transaction ID mismatch")
 }
 
 func TestPlugin_Test_NonSTUNResponse(t *testing.T) {
@@ -308,11 +465,22 @@ func TestPlugin_Test_MissingRealmOrNonce(t *testing.T) {
 // =============================================================================
 
 func TestPlugin_CheckUnauth_OpenRelay(t *testing.T) {
+	refreshReceived := make(chan struct{}, 1)
+
 	addr, cleanup := mockTURNServer(t, func(pc net.PacketConn) {
 		msg, client := stunRecv(pc)
 		txID := extractTxID(msg)
 		// Accept allocation without credentials.
 		stunSend(pc, buildMockSuccessResponse(txID), client)
+
+		// Expect unauthenticated deallocation Refresh.
+		msg, _ = stunRecv(pc)
+		if len(msg) >= stunHeaderSize {
+			msgType := binary.BigEndian.Uint16(msg[0:2])
+			if msgType == msgRefreshRequest {
+				refreshReceived <- struct{}{}
+			}
+		}
 	})
 	defer cleanup()
 
@@ -322,6 +490,13 @@ func TestPlugin_CheckUnauth_OpenRelay(t *testing.T) {
 	assert.True(t, result.Success)
 	assert.Contains(t, result.Banner, "[CRITICAL]")
 	assert.Contains(t, result.Banner, "unauthenticated")
+
+	select {
+	case <-refreshReceived:
+		// OK — deallocation was sent.
+	case <-time.After(2 * time.Second):
+		t.Error("expected unauthenticated Refresh(LIFETIME=0) after open-relay detection")
+	}
 }
 
 func TestPlugin_CheckUnauth_Secure(t *testing.T) {
@@ -361,8 +536,9 @@ func TestBuildAllocateRequest(t *testing.T) {
 	assert.Equal(t, txID[:], msg[8:20])
 
 	// Parse and verify attributes.
-	_, attrs, err := parseSTUNMessage(msg)
+	_, respTxID, attrs, err := parseSTUNMessage(msg)
 	require.NoError(t, err)
+	assert.Equal(t, txID, respTxID)
 	require.Contains(t, attrs, uint16(attrRequestedTransport))
 	assert.Equal(t, byte(protoUDP), attrs[attrRequestedTransport][0])
 }
@@ -371,16 +547,26 @@ func TestParseSTUNMessage_Valid(t *testing.T) {
 	txID := [12]byte{0xAA, 0xBB, 0xCC, 0xDD, 0, 0, 0, 0, 0, 0, 0, 0}
 	resp := buildMockErrorResponse(txID, 401, "myrealm", "mynonce")
 
-	msgType, attrs, err := parseSTUNMessage(resp)
+	msgType, respTxID, attrs, err := parseSTUNMessage(resp)
 	require.NoError(t, err)
 	assert.Equal(t, uint16(msgAllocateError), msgType)
+	assert.Equal(t, txID, respTxID)
 	assert.Equal(t, 401, getErrorCode(attrs))
 	assert.Equal(t, "myrealm", getStringAttr(attrs, attrRealm))
 	assert.Equal(t, "mynonce", getStringAttr(attrs, attrNonce))
 }
 
+func TestParseSTUNMessage_ReturnsTxID(t *testing.T) {
+	txID := [12]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C}
+	resp := buildMockSuccessResponse(txID)
+
+	_, respTxID, _, err := parseSTUNMessage(resp)
+	require.NoError(t, err)
+	assert.Equal(t, txID, respTxID)
+}
+
 func TestParseSTUNMessage_TooShort(t *testing.T) {
-	_, _, err := parseSTUNMessage([]byte{0, 0, 0})
+	_, _, _, err := parseSTUNMessage([]byte{0, 0, 0})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "too short")
 }
@@ -388,7 +574,7 @@ func TestParseSTUNMessage_TooShort(t *testing.T) {
 func TestParseSTUNMessage_BadCookie(t *testing.T) {
 	msg := make([]byte, stunHeaderSize)
 	binary.BigEndian.PutUint32(msg[4:8], 0xDEADBEEF)
-	_, _, err := parseSTUNMessage(msg)
+	_, _, _, err := parseSTUNMessage(msg)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "magic cookie")
 }
@@ -397,9 +583,26 @@ func TestParseSTUNMessage_Truncated(t *testing.T) {
 	msg := make([]byte, stunHeaderSize)
 	binary.BigEndian.PutUint16(msg[2:4], 100) // claims 100 bytes of attrs
 	binary.BigEndian.PutUint32(msg[4:8], magicCookie)
-	_, _, err := parseSTUNMessage(msg)
+	_, _, _, err := parseSTUNMessage(msg)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "truncated")
+}
+
+func TestParseSTUNMessage_DuplicateAttribute(t *testing.T) {
+	// Build a message with duplicate REALM attributes; first should win.
+	var attrs []byte
+	attrs = append(attrs, encodeStringAttr(attrRealm, "first")...)
+	attrs = append(attrs, encodeStringAttr(attrRealm, "second")...)
+
+	msg := make([]byte, stunHeaderSize+len(attrs))
+	binary.BigEndian.PutUint16(msg[0:2], msgAllocateError)
+	binary.BigEndian.PutUint16(msg[2:4], uint16(len(attrs)))
+	binary.BigEndian.PutUint32(msg[4:8], magicCookie)
+	copy(msg[stunHeaderSize:], attrs)
+
+	_, _, parsed, err := parseSTUNMessage(msg)
+	require.NoError(t, err)
+	assert.Equal(t, "first", getStringAttr(parsed, attrRealm), "should keep first occurrence per RFC 5389 §15")
 }
 
 func TestGetErrorCode(t *testing.T) {
@@ -456,9 +659,10 @@ func TestBuildAuthenticatedAllocateRequest(t *testing.T) {
 	msg := buildAuthenticatedAllocateRequest(txID, "user", "realm", "nonce", "pass")
 
 	// Should parse without error.
-	msgType, attrs, err := parseSTUNMessage(msg)
+	msgType, respTxID, attrs, err := parseSTUNMessage(msg)
 	require.NoError(t, err)
 	assert.Equal(t, uint16(msgAllocateRequest), msgType)
+	assert.Equal(t, txID, respTxID)
 
 	// Should contain expected attributes.
 	assert.Contains(t, attrs, uint16(attrRequestedTransport))
@@ -478,9 +682,10 @@ func TestBuildRefreshRequest(t *testing.T) {
 	txID := [12]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
 	msg := buildRefreshRequest(txID, "user", "realm", "nonce", "pass", 0)
 
-	msgType, attrs, err := parseSTUNMessage(msg)
+	msgType, respTxID, attrs, err := parseSTUNMessage(msg)
 	require.NoError(t, err)
 	assert.Equal(t, uint16(msgRefreshRequest), msgType)
+	assert.Equal(t, txID, respTxID)
 
 	// Should contain LIFETIME=0.
 	require.Contains(t, attrs, uint16(attrLifetime))
@@ -492,4 +697,20 @@ func TestBuildRefreshRequest(t *testing.T) {
 	assert.Contains(t, attrs, uint16(attrNonce))
 	assert.Contains(t, attrs, uint16(attrMessageIntegrity))
 	assert.Len(t, attrs[attrMessageIntegrity], 20)
+}
+
+func TestBuildUnauthRefreshRequest(t *testing.T) {
+	txID := [12]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
+	msg := buildUnauthRefreshRequest(txID, 0)
+
+	msgType, respTxID, attrs, err := parseSTUNMessage(msg)
+	require.NoError(t, err)
+	assert.Equal(t, uint16(msgRefreshRequest), msgType)
+	assert.Equal(t, txID, respTxID)
+
+	// Should contain LIFETIME=0 but no auth attributes.
+	require.Contains(t, attrs, uint16(attrLifetime))
+	assert.Equal(t, uint32(0), binary.BigEndian.Uint32(attrs[attrLifetime]))
+	assert.NotContains(t, attrs, uint16(attrUsername))
+	assert.NotContains(t, attrs, uint16(attrMessageIntegrity))
 }

--- a/internal/plugins/turn/turn_test.go
+++ b/internal/plugins/turn/turn_test.go
@@ -384,9 +384,16 @@ func TestPlugin_Test_UnauthSuccess_DuringTest(t *testing.T) {
 
 		// Expect unauthenticated deallocation Refresh.
 		msg, _ = stunRecv(pc)
-		if len(msg) >= stunHeaderSize {
+		_, _, refreshAttrs, parseErr := parseSTUNMessage(msg)
+		if parseErr == nil {
 			msgType := binary.BigEndian.Uint16(msg[0:2])
-			if msgType == msgRefreshRequest {
+			lifetime, hasLifetime := refreshAttrs[attrLifetime]
+			_, hasUsername := refreshAttrs[attrUsername]
+			_, hasMI := refreshAttrs[attrMessageIntegrity]
+			if msgType == msgRefreshRequest &&
+				hasLifetime && len(lifetime) == 4 &&
+				binary.BigEndian.Uint32(lifetime) == 0 &&
+				!hasUsername && !hasMI {
 				refreshReceived <- struct{}{}
 			}
 		}
@@ -402,9 +409,9 @@ func TestPlugin_Test_UnauthSuccess_DuringTest(t *testing.T) {
 
 	select {
 	case <-refreshReceived:
-		// OK — unauthenticated deallocation was sent.
+		// OK — unauthenticated deallocation with LIFETIME=0 and no auth attrs.
 	case <-time.After(2 * time.Second):
-		t.Error("expected unauthenticated Refresh(LIFETIME=0) after open-relay detection")
+		t.Error("expected unauthenticated Refresh(LIFETIME=0, no auth attrs) after open-relay detection")
 	}
 }
 
@@ -475,9 +482,16 @@ func TestPlugin_CheckUnauth_OpenRelay(t *testing.T) {
 
 		// Expect unauthenticated deallocation Refresh.
 		msg, _ = stunRecv(pc)
-		if len(msg) >= stunHeaderSize {
+		_, _, refreshAttrs, parseErr := parseSTUNMessage(msg)
+		if parseErr == nil {
 			msgType := binary.BigEndian.Uint16(msg[0:2])
-			if msgType == msgRefreshRequest {
+			lifetime, hasLifetime := refreshAttrs[attrLifetime]
+			_, hasUsername := refreshAttrs[attrUsername]
+			_, hasMI := refreshAttrs[attrMessageIntegrity]
+			if msgType == msgRefreshRequest &&
+				hasLifetime && len(lifetime) == 4 &&
+				binary.BigEndian.Uint32(lifetime) == 0 &&
+				!hasUsername && !hasMI {
 				refreshReceived <- struct{}{}
 			}
 		}
@@ -493,9 +507,9 @@ func TestPlugin_CheckUnauth_OpenRelay(t *testing.T) {
 
 	select {
 	case <-refreshReceived:
-		// OK — deallocation was sent.
+		// OK — deallocation with LIFETIME=0 and no auth attrs.
 	case <-time.After(2 * time.Second):
-		t.Error("expected unauthenticated Refresh(LIFETIME=0) after open-relay detection")
+		t.Error("expected unauthenticated Refresh(LIFETIME=0, no auth attrs) after open-relay detection")
 	}
 }
 

--- a/pkg/brutus/input/nerva.go
+++ b/pkg/brutus/input/nerva.go
@@ -85,7 +85,6 @@ func MapServiceToProtocol(service string) string {
 
 		"snmp": "snmp",
 		"turn": "turn",
-		"stun": "turn",
 
 		"docker":     "docker",
 		"kubernetes": "kubernetes",

--- a/pkg/brutus/input/nerva.go
+++ b/pkg/brutus/input/nerva.go
@@ -84,6 +84,8 @@ func MapServiceToProtocol(service string) string {
 		"pop3": "pop3",
 
 		"snmp": "snmp",
+		"turn": "turn",
+		"stun": "turn",
 
 		"docker":     "docker",
 		"kubernetes": "kubernetes",

--- a/pkg/brutus/wordlists/turn_defaults.txt
+++ b/pkg/brutus/wordlists/turn_defaults.txt
@@ -1,0 +1,21 @@
+# TURN Server Default Credentials
+# Format: username:password
+# Note: TURN uses realm-based auth; these are common defaults seen in the wild
+
+# coturn defaults and common tutorial passwords
+coturn:coturn
+user:pass
+turn:turn
+# --- cautious ---
+admin:admin
+test:test
+test:test123
+webrtc:webrtc
+# --- exhaustive ---
+admin:password
+turn:password
+turn:turnserver
+user:password
+media:media
+conference:conference
+jitsi:jitsi

--- a/pkg/brutus/wordlists/turn_defaults.txt
+++ b/pkg/brutus/wordlists/turn_defaults.txt
@@ -11,7 +11,7 @@ admin:admin
 test:test
 test:test123
 webrtc:webrtc
-# --- exhaustive ---
+# --- aggressive ---
 admin:password
 turn:password
 turn:turnserver


### PR DESCRIPTION
## Summary

- Add TURN/STUN long-term credential brute-forcing plugin (RFC 5389/5766)
- Raw STUN message building — zero new dependencies
- Implements `Plugin` (credential testing) and `UnauthChecker` (open relay detection) interfaces
- Stale nonce (438) retry loop with fresh nonce extraction, deallocation via `Refresh(LIFETIME=0)` after success
- 24 unit tests with mock UDP TURN server, all passing with `-race`

## Details

**Protocol flow per credential attempt:**
1. Send unauthenticated Allocate → server returns 401 with realm + nonce
2. Compute `key = MD5(username:realm:password)`, build authenticated Allocate with `MESSAGE-INTEGRITY` (HMAC-SHA1)
3. Success response = valid creds, 401 = invalid, 438 = retry with fresh nonce

**Files:**
- `internal/plugins/turn/turn.go` — plugin implementation (STUN encoding/parsing, auth flow, deallocation)
- `internal/plugins/turn/turn_test.go` — 24 tests covering valid/invalid creds, stale nonce retry, open relay detection, connection errors, STUN encoding edge cases
- `pkg/brutus/wordlists/turn_defaults.txt` — tiered default credentials (coturn, common tutorial passwords)
- `internal/plugins/init.go` — registration import

## Test plan

- [x] `go test -v -race -count=1 ./internal/plugins/turn/...` — 24/24 pass
- [x] `go test -count=1 ./pkg/brutus/...` — existing tests unaffected
- [x] `go build ./internal/plugins/turn/...` — compiles clean
- [ ] Integration test against a real coturn instance (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)