### PR TITLE
feat: add GPON OLT default credentials to exhaustive wordlists

### DIFF
--- a/pkg/brutus/wordlists/browser_defaults.txt
+++ b/pkg/brutus/wordlists/browser_defaults.txt
@@ -30,3 +30,8 @@ admin:letmein
 admin:welcome
 admin:Admin123
 admin:system
+# GPON OLT vendors
+admin:Xpon@Olt9417#
+root:admin123
+zte:zte
+GEPON:GEPON

--- a/pkg/brutus/wordlists/http_defaults.txt
+++ b/pkg/brutus/wordlists/http_defaults.txt
@@ -21,3 +21,5 @@ admin:secret
 grafana:grafana
 jenkins:jenkins
 admin:default
+# GPON OLT vendors
+admin:Xpon@Olt9417#

--- a/pkg/brutus/wordlists/https_defaults.txt
+++ b/pkg/brutus/wordlists/https_defaults.txt
@@ -21,3 +21,5 @@ admin:secret
 grafana:grafana
 jenkins:jenkins
 admin:default
+# GPON OLT vendors
+admin:Xpon@Olt9417#

--- a/pkg/brutus/wordlists/mysql_defaults.txt
+++ b/pkg/brutus/wordlists/mysql_defaults.txt
@@ -15,3 +15,5 @@ dbadmin:dbadmin
 mysql:password
 root:123456
 mysql:admin
+# GPON OLT vendors (Cloud EMS)
+root:vsol2019

--- a/pkg/brutus/wordlists/ssh_defaults.txt
+++ b/pkg/brutus/wordlists/ssh_defaults.txt
@@ -16,3 +16,7 @@ centos:centos
 git:git
 test:test
 oracle:oracle
+# GPON OLT vendors
+admin:Xpon@Olt9417#
+root:admin123
+zte:zte

--- a/pkg/brutus/wordlists/telnet_defaults.txt
+++ b/pkg/brutus/wordlists/telnet_defaults.txt
@@ -17,3 +17,8 @@ support:support
 admin:public
 root:vizxv
 user:user
+# GPON OLT vendors
+admin:Xpon@Olt9417#
+root:admin123
+zte:zte
+GEPON:GEPON


### PR DESCRIPTION
## Summary

- Add VSOL, Huawei, ZTE, and Fiberhome GPON OLT default credentials to the exhaustive tier of browser, HTTP, HTTPS, SSH, telnet, and MySQL wordlists
- Based on [Quarkslab's security research](https://blog.quarkslab.com/how-olts-may-have-exposed-entire-isp-networks.html) on VSOL OLT devices and vendor documentation
- SNMP `private` community string already covered in existing `snmp_defaults.txt`

### Credentials added

| Vendor | Credential | Protocols | Source |
|--------|-----------|-----------|--------|
| VSOL (all models) | `admin:Xpon@Olt9417#` | browser, http, https, ssh, telnet | [Quarkslab](https://blog.quarkslab.com/how-olts-may-have-exposed-entire-isp-networks.html) |
| VSOL Cloud EMS | `root:vsol2019` | mysql | Quarkslab |
| Huawei MA5800/5600T | `root:admin123` | browser, ssh, telnet | [Huawei docs](https://forum.huawei.com/enterprise/en/what-is-the-default-password-of-olt/thread/447537-100181) |
| ZTE C300/C320 | `zte:zte` | browser, ssh, telnet | [SmartOLT](https://www.smartolt.com/zte-olt-initial-setup.html) |
| Fiberhome AN5516 | `GEPON:GEPON` | browser, telnet | [Router-Switch](https://blog.router-switch.com/2020/09/fiberhome-olt-commands/) |

Fixes 10T-281

https://linear.app/praetorianlabs/issue/10T-281/add-oltgpon-default-credential-testing-vsol-snmp-web

## Test plan

- [ ] Verify `go test ./pkg/brutus/ -run TestDefault` passes (all wordlist loading tests)
- [ ] Verify exhaustive mode loads the new GPON OLT credentials for each affected protocol
- [ ] Verify cautious and default modes are unaffected (new entries are exhaustive-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)