### PR TITLE
feat(enum): add Hunter.io Domain Search subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -867,6 +867,29 @@ brutus enum generate --domain example.com --format first.last
 
 ---
 
+### Hunter.io Domain Search
+
+Discover people (email, name, job title, phone, department, seniority, confidence) associated with a domain via the Hunter.io Domain Search API. Paginates automatically until all results are retrieved.
+
+```bash
+# Requires a Hunter.io API key — set via env var (preferred, keeps key out of process list)
+export HUNTER_API_KEY=your_key_here
+
+# Discover people for a domain
+brutus enum hunter --domain example.com
+
+# Provide the key explicitly (visible in process list and shell history — prefer HUNTER_API_KEY)
+brutus enum hunter --domain example.com --api-key your_key_here
+
+# JSONL output to file (one record per person, with type:"hunter" discriminator)
+brutus enum hunter --domain example.com --output people.jsonl
+
+# Adjust pagination page size (default: 100)
+brutus enum hunter --domain example.com --limit 50
+```
+
+---
+
 ## Known Limitations
 
 ### Sticky Keys Heuristic Detection

--- a/cmd/brutus/cmd_enum.go
+++ b/cmd/brutus/cmd_enum.go
@@ -41,11 +41,13 @@ Subcommands:
   saas       Enumerate email accounts against SaaS services
   kerberos   Enumerate Active Directory users via Kerberos AS-REQ
   generate   Generate email addresses or usernames from embedded name lists
+  hunter     Discover people and emails via Hunter.io Domain Search
 
 See subcommand help for details:
   brutus enum saas --help
   brutus enum kerberos --help
-  brutus enum generate --help`,
+  brutus enum generate --help
+  brutus enum hunter --help`,
 	Example: `  # SaaS email enumeration
   brutus enum saas --domain praetorian.com -e test@praetorian.com
 
@@ -53,7 +55,10 @@ See subcommand help for details:
   brutus enum kerberos --dc 10.0.0.1 --domain CORP.LOCAL -u administrator
 
   # Generate emails for enumeration
-  brutus enum generate --domain example.com --format flast`,
+  brutus enum generate --domain example.com --format flast
+
+  # Discover people via Hunter.io
+  brutus enum hunter --domain example.com`,
 }
 
 var enumGenerateCmd = &cobra.Command{
@@ -96,6 +101,7 @@ func init() {
 	enumCmd.AddCommand(enumGenerateCmd)
 	enumCmd.AddCommand(enumSaasCmd)
 	enumCmd.AddCommand(enumKerberosCmd)
+	enumCmd.AddCommand(enumHunterCmd)
 }
 
 // runEnumGenerate handles the "enum generate" subcommand.

--- a/cmd/brutus/cmd_enum_hunter.go
+++ b/cmd/brutus/cmd_enum_hunter.go
@@ -1,0 +1,139 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/spf13/cobra"
+
+	"github.com/praetorian-inc/brutus/pkg/enum/hunter"
+)
+
+// File-local flag variables for the hunter subcommand.
+// Separate from flagEnumDomain to avoid cross-command state bleed.
+var (
+	flagHunterDomain string
+	flagHunterAPIKey string
+	flagHunterLimit  int
+)
+
+var enumHunterCmd = &cobra.Command{
+	Use:   "hunter",
+	Short: "Discover people and emails for a domain via Hunter.io Domain Search",
+	Long: `Query the Hunter.io Domain Search API to discover people associated with a
+domain: email, name, job title, phone, department, seniority, confidence, and
+sources. Standalone — does not feed the saas enumeration pipeline.
+
+Requires a Hunter.io API key via the HUNTER_API_KEY environment variable
+(or the --api-key flag).`,
+	Example: `  # Discover people for a domain (key from HUNTER_API_KEY)
+  brutus enum hunter --domain example.com
+
+  # Provide the key explicitly (note: visible in process list / shell history)
+  brutus enum hunter -d example.com --api-key abc123
+
+  # JSONL output to a file
+  brutus enum hunter -d example.com -o people.jsonl`,
+	RunE: runEnumHunter,
+}
+
+func init() {
+	f := enumHunterCmd.Flags()
+	f.StringVarP(&flagHunterDomain, "domain", "d", "", "Domain to search (required)")
+	f.StringVar(&flagHunterAPIKey, "api-key", "",
+		"Hunter.io API key (overrides HUNTER_API_KEY; WARNING: visible in process list and shell history — prefer HUNTER_API_KEY)")
+	f.IntVar(&flagHunterLimit, "limit", 100, "Results per API page (pagination page size)")
+	_ = enumHunterCmd.MarkFlagRequired("domain")
+}
+
+// runEnumHunter implements the "enum hunter" subcommand.
+func runEnumHunter(cmd *cobra.Command, args []string) error {
+	useColor := isColorEnabled(flagNoColor)
+
+	if flagHunterDomain == "" {
+		return fmt.Errorf("--domain/-d is required")
+	}
+
+	apiKey, err := resolveHunterAPIKey(flagHunterAPIKey)
+	if err != nil {
+		return err
+	}
+
+	jsonWriter, forceJSON, closeOutput, err := setupOutputWriter(flagOutputFile)
+	if err != nil {
+		return err
+	}
+	defer closeOutput()
+	if forceJSON {
+		flagJSON = true
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if !flagQuiet && !flagJSON {
+		fmt.Fprintf(os.Stderr, "%s Querying Hunter.io Domain Search for %s...\n",
+			dim(useColor, SymbolInfo), flagHunterDomain)
+	}
+
+	client := hunter.NewClient(apiKey, flagTimeout, flagHunterLimit)
+	result, err := client.Search(ctx, flagHunterDomain)
+	if err != nil {
+		return classifyHunterError(err)
+	}
+
+	// Verbose: log counts only — never log the key or URL (P0-1 security requirement).
+	logVerbose(flagVerbose, "Hunter returned %d people (total available: %d)",
+		len(result.People), result.Total)
+
+	if flagJSON {
+		outputHunterJSONL(jsonWriter, result)
+	} else {
+		outputHunterHuman(os.Stdout, result, useColor)
+	}
+	return nil
+}
+
+// resolveHunterAPIKey returns the flag value if set, else HUNTER_API_KEY env var.
+// The key is never logged (P0-1 security requirement).
+func resolveHunterAPIKey(flagValue string) (string, error) {
+	if flagValue != "" {
+		return flagValue, nil
+	}
+	if key := os.Getenv("HUNTER_API_KEY"); key != "" {
+		return key, nil
+	}
+	return "", fmt.Errorf("Hunter.io API key required: set HUNTER_API_KEY or pass --api-key")
+}
+
+// classifyHunterError converts hunter sentinel errors into actionable, key-free messages.
+func classifyHunterError(err error) error {
+	switch {
+	case errors.Is(err, hunter.ErrUnauthorized):
+		return fmt.Errorf("hunter: invalid or missing API key (check HUNTER_API_KEY / --api-key)")
+	case errors.Is(err, hunter.ErrRateLimited):
+		return fmt.Errorf("hunter: rate limit exceeded — wait and retry, or lower --limit")
+	case errors.Is(err, hunter.ErrLegalReasons):
+		return fmt.Errorf("hunter: results unavailable for legal reasons (HTTP 451)")
+	default:
+		return fmt.Errorf("hunter domain search failed: %w", err)
+	}
+}

--- a/cmd/brutus/cmd_enum_hunter_test.go
+++ b/cmd/brutus/cmd_enum_hunter_test.go
@@ -1,0 +1,352 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/brutus/pkg/enum/hunter"
+)
+
+// ---------------------------------------------------------------------------
+// Task 4: resolveHunterAPIKey + classifyHunterError
+// ---------------------------------------------------------------------------
+
+func TestResolveHunterAPIKey(t *testing.T) {
+	tests := []struct {
+		name      string
+		flagValue string
+		envValue  string
+		wantKey   string
+		wantErr   bool
+	}{
+		{
+			name:      "flag value takes priority over env",
+			flagValue: "flag-key",
+			envValue:  "env-key",
+			wantKey:   "flag-key",
+		},
+		{
+			name:      "env var used when flag is empty",
+			flagValue: "",
+			envValue:  "env-key",
+			wantKey:   "env-key",
+		},
+		{
+			name:      "error when both empty",
+			flagValue: "",
+			envValue:  "",
+			wantErr:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HUNTER_API_KEY", tc.envValue)
+			key, err := resolveHunterAPIKey(tc.flagValue)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "HUNTER_API_KEY")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantKey, key)
+		})
+	}
+}
+
+func TestClassifyHunterError(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		wantContain string
+	}{
+		{
+			name:        "ErrUnauthorized maps to key message",
+			err:         &hunter.APIError{StatusCode: 401, Details: "No valid API key"},
+			wantContain: "invalid or missing API key",
+		},
+		{
+			name:        "ErrRateLimited maps to rate limit message",
+			err:         &hunter.APIError{StatusCode: 429, Details: "rate limit"},
+			wantContain: "rate limit exceeded",
+		},
+		{
+			name:        "ErrLegalReasons maps to legal message",
+			err:         &hunter.APIError{StatusCode: 451, Details: "legal"},
+			wantContain: "legal reasons",
+		},
+		{
+			name:        "generic error is wrapped",
+			err:         &hunter.APIError{StatusCode: 500, Details: "server error"},
+			wantContain: "hunter domain search failed",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := classifyHunterError(tc.err)
+			require.Error(t, result)
+			assert.Contains(t, result.Error(), tc.wantContain)
+			// Key must never appear in error messages (P0-1 security requirement).
+			assert.NotContains(t, result.Error(), "api_key")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Task 5: Command registration
+// ---------------------------------------------------------------------------
+
+func TestEnumHunterRegistered(t *testing.T) {
+	var found bool
+	for _, cmd := range enumCmd.Commands() {
+		if cmd.Use != "hunter" {
+			continue
+		}
+		found = true
+
+		domainFlag := cmd.Flags().Lookup("domain")
+		require.NotNil(t, domainFlag, "--domain flag must exist")
+
+		apiKeyFlag := cmd.Flags().Lookup("api-key")
+		require.NotNil(t, apiKeyFlag, "--api-key flag must exist")
+
+		limitFlag := cmd.Flags().Lookup("limit")
+		require.NotNil(t, limitFlag, "--limit flag must exist")
+
+		// Verify -d shorthand exists.
+		domainShort := cmd.Flags().ShorthandLookup("d")
+		require.NotNil(t, domainShort, "-d shorthand must exist")
+
+		// Verify --domain is marked required via cobra annotation.
+		annotations := domainFlag.Annotations
+		_, isRequired := annotations["cobra_annotation_bash_completion_one_required_flag"]
+		assert.True(t, isRequired, "--domain must be marked as required")
+		break
+	}
+	require.True(t, found, "hunter subcommand must be registered with enumCmd")
+}
+
+// ---------------------------------------------------------------------------
+// Task 6: outputHunterJSONL + outputHunterHuman + sanitizeTerminal + truncate
+// ---------------------------------------------------------------------------
+
+func TestOutputHunterJSONL(t *testing.T) {
+	t.Run("single person emits one JSONL line", func(t *testing.T) {
+		result := &hunter.DomainResult{
+			Domain:       "example.com",
+			Organization: "Example Corp",
+			People: []hunter.Person{
+				{
+					Email:      "alice@example.com",
+					FirstName:  "Alice",
+					LastName:   "Smith",
+					Position:   "Engineer",
+					Confidence: 90,
+					Type:       "personal",
+				},
+			},
+			Total: 1,
+		}
+		var buf bytes.Buffer
+		outputHunterJSONL(&buf, result)
+
+		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+		require.Len(t, lines, 1, "expected exactly 1 JSONL line")
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[0]), &obj))
+		assert.Equal(t, "hunter", obj["type"])
+		assert.Equal(t, "alice@example.com", obj["email"])
+		assert.Equal(t, float64(90), obj["confidence"])
+		assert.Equal(t, "Example Corp", obj["organization"])
+		assert.Equal(t, "example.com", obj["domain"])
+	})
+
+	t.Run("omitempty drops blank fields", func(t *testing.T) {
+		result := &hunter.DomainResult{
+			Domain: "test.com",
+			People: []hunter.Person{
+				{Email: "bob@test.com", Confidence: 50},
+			},
+		}
+		var buf bytes.Buffer
+		outputHunterJSONL(&buf, result)
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &obj))
+		// Empty string fields with omitempty must not appear.
+		_, hasFirstName := obj["first_name"]
+		assert.False(t, hasFirstName, "empty first_name should be omitted")
+		_, hasOrg := obj["organization"]
+		assert.False(t, hasOrg, "empty organization should be omitted")
+		_, hasSources := obj["sources"]
+		assert.False(t, hasSources, "nil sources should be omitted")
+	})
+
+	t.Run("empty result emits zero lines", func(t *testing.T) {
+		result := &hunter.DomainResult{Domain: "empty.com"}
+		var buf bytes.Buffer
+		outputHunterJSONL(&buf, result)
+		assert.Empty(t, strings.TrimSpace(buf.String()), "empty result must produce no JSONL output")
+	})
+
+	t.Run("multiple people emit multiple lines each valid JSON", func(t *testing.T) {
+		result := &hunter.DomainResult{
+			Domain: "multi.com",
+			People: []hunter.Person{
+				{Email: "a@multi.com", Confidence: 80},
+				{Email: "b@multi.com", Confidence: 60},
+				{Email: "c@multi.com", Confidence: 40},
+			},
+		}
+		var buf bytes.Buffer
+		outputHunterJSONL(&buf, result)
+
+		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+		require.Len(t, lines, 3)
+		for i, line := range lines {
+			var obj map[string]interface{}
+			require.NoError(t, json.Unmarshal([]byte(line), &obj), "line %d must be valid JSON", i)
+			assert.Equal(t, "hunter", obj["type"])
+		}
+	})
+}
+
+func TestOutputHunterHuman(t *testing.T) {
+	t.Run("renders table header and person row", func(t *testing.T) {
+		result := &hunter.DomainResult{
+			Domain:       "example.com",
+			Organization: "Example Corp",
+			People: []hunter.Person{
+				{
+					Email:      "alice@example.com",
+					FirstName:  "Alice",
+					LastName:   "Smith",
+					Position:   "Engineer",
+					Phone:      "+1-555-0100",
+					Department: "Engineering",
+					Confidence: 90,
+				},
+			},
+			Total: 1,
+		}
+		var buf bytes.Buffer
+		outputHunterHuman(&buf, result, false)
+		out := buf.String()
+		assert.Contains(t, out, "Email")
+		assert.Contains(t, out, "alice@example.com")
+		assert.Contains(t, out, "Example Corp")
+	})
+
+	t.Run("graceful empty result message", func(t *testing.T) {
+		result := &hunter.DomainResult{Domain: "empty.com", Total: 0}
+		var buf bytes.Buffer
+		outputHunterHuman(&buf, result, false)
+		out := buf.String()
+		assert.Contains(t, out, "No people found")
+	})
+}
+
+func TestSanitizeTerminal(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "strips ESC cursor movement sequence",
+			input: "hello\x1b[2Jworld",
+			want:  "helloworld",
+		},
+		{
+			name:  "strips lone ESC",
+			input: "ab\x1bcd",
+			want:  "abcd",
+		},
+		{
+			name:  "strips C0 control chars",
+			input: "ab\x00\x01\x02cd",
+			want:  "abcd",
+		},
+		{
+			name:  "strips tab and newline (C0)",
+			input: "ab\tcd\nef",
+			want:  "abcdef",
+		},
+		{
+			name:  "preserves printable ASCII and spaces",
+			input: "Alice Smith",
+			want:  "Alice Smith",
+		},
+		{
+			name:  "strips C1 control chars",
+			input: "ab\x80\x9fcd",
+			want:  "abcd",
+		},
+		{
+			name:  "handles empty string",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "strips full ANSI erase sequence",
+			input: "\x1b[2Jsome text\x1b[H",
+			want:  "some text",
+		},
+		{
+			name:  "preserves valid non-ASCII UTF-8 (accented Latin)",
+			input: "\u00c5ngstr\u00f6m",
+			want:  "\u00c5ngstr\u00f6m",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeTerminal(tc.input)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		max  int
+		want string
+	}{
+		{"short string unchanged", "hello", 10, "hello"},
+		{"exact length unchanged", "hello", 5, "hello"},
+		{"truncates with ellipsis", "hello world", 8, "hello w\u2026"},
+		{"max 1 returns single char", "abc", 1, "a"},
+		{"empty string unchanged", "", 5, ""},
+		{"unicode handled correctly", "\u65e5\u672c\u8a9e\u30c6\u30b9\u30c8", 4, "\u65e5\u672c\u8a9e\u2026"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := truncate(tc.s, tc.max)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/cmd/brutus/cmd_enum_output.go
+++ b/cmd/brutus/cmd_enum_output.go
@@ -19,8 +19,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
+	"unicode/utf8"
 
 	"github.com/praetorian-inc/brutus/pkg/enum"
+	"github.com/praetorian-inc/brutus/pkg/enum/hunter"
 )
 
 // outputDNSReconHuman displays DNS TXT recon results in human-readable format.
@@ -177,6 +180,167 @@ func outputEnumJSONL(w io.Writer, results []enum.Result) {
 		}
 		if err := enc.Encode(jr); err != nil {
 			fmt.Fprintf(os.Stderr, "Error encoding enum JSON: %v\n", err)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Hunter.io output functions
+// ---------------------------------------------------------------------------
+
+// sanitizeTerminal strips C0/C1 control code points, ESC (U+001B), and full
+// ANSI/VT100 escape sequences from s before rendering attacker-controlled
+// strings in the human table (P0-4 security requirement). It decodes
+// rune-by-rune via utf8.DecodeRune so that valid non-ASCII UTF-8 (e.g. accented
+// Latin, CJK) is preserved while raw invalid bytes and genuine control code
+// points are dropped. encoding/json already escapes control chars, so JSONL
+// output is safe.
+func sanitizeTerminal(s string) string {
+	var out strings.Builder
+	i := 0
+	b := []byte(s)
+	for i < len(b) {
+		r, size := utf8.DecodeRune(b[i:])
+		// Invalid UTF-8 byte (raw C1, etc.) — drop single byte.
+		if r == utf8.RuneError && size == 1 {
+			i++
+			continue
+		}
+		// C0 control code points (U+0000-U+001F), which includes ESC (U+001B) —
+		// strip, then consume any escape sequence payload that follows ESC.
+		if r < 0x20 {
+			i += size
+			if r == 0x1B && i < len(b) {
+				next := b[i]
+				if next == '[' {
+					// CSI sequence: consume up through the final byte (A-Z, a-z, or @).
+					i++ // skip '['
+					for i < len(b) {
+						ch := b[i]
+						i++
+						if (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') || ch == '@' {
+							break
+						}
+					}
+				} else if next == ']' {
+					// OSC sequence: consume until ST (ESC \\) or BEL.
+					i++
+					for i < len(b) {
+						ch := b[i]
+						i++
+						if ch == 0x07 || ch == 0x1B {
+							break
+						}
+					}
+				} else {
+					// Lone ESC (followed by a printable char, not [ or ]): strip
+					// only the ESC itself. The next byte stays — it is NOT part of
+					// a recognised escape sequence and must be kept.
+				}
+			}
+			continue
+		}
+		// C1 control code points (U+0080-U+009F, valid 2-byte UTF-8) — strip.
+		if r >= 0x80 && r <= 0x9F {
+			i += size
+			continue
+		}
+		// Keep valid rune.
+		out.WriteRune(r)
+		i += size
+	}
+	return out.String()
+}
+
+// truncate shortens s to at most max runes, appending "\u2026" (…) when cut.
+func truncate(s string, max int) string {
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	if max <= 1 {
+		return string(r[:max])
+	}
+	return string(r[:max-1]) + "\u2026"
+}
+
+// outputHunterHuman renders Hunter.io domain search results as an aligned table.
+// All attacker-controlled strings are sanitized via sanitizeTerminal (P0-4).
+func outputHunterHuman(w io.Writer, result *hunter.DomainResult, useColor bool) {
+	fmt.Fprintf(w, "\n%s %s\n", dim(useColor, SymbolInfo),
+		heading(useColor, "Hunter.io: "+sanitizeTerminal(result.Domain)))
+	if result.Organization != "" {
+		fmt.Fprintf(w, "  Organization: %s\n", sanitizeTerminal(result.Organization))
+	}
+	fmt.Fprintf(w, "  People found: %d (total available: %d)\n", len(result.People), result.Total)
+
+	if len(result.People) == 0 {
+		fmt.Fprintf(w, "\n  %s No people found for this domain\n", dim(useColor, SymbolInfo))
+		fmt.Fprintln(w)
+		return
+	}
+
+	// Header row.
+	fmt.Fprintf(w, "\n  %s%-32s %-22s %-22s %-16s %-12s %-5s%s\n",
+		colorIf(useColor, ColorBold),
+		"Email", "Name", "Title", "Phone", "Dept", "Conf",
+		colorIf(useColor, ColorReset))
+
+	for i := range result.People {
+		p := &result.People[i]
+		name := strings.TrimSpace(sanitizeTerminal(p.FirstName) + " " + sanitizeTerminal(p.LastName))
+		fmt.Fprintf(w, "  %s%-32s%s %-22s %-22s %-16s %-12s %s%3d%s\n",
+			colorIf(useColor, ColorGreen),
+			truncate(sanitizeTerminal(p.Email), 32),
+			colorIf(useColor, ColorReset),
+			truncate(name, 22),
+			truncate(sanitizeTerminal(p.Position), 22),
+			truncate(sanitizeTerminal(p.Phone), 16),
+			truncate(sanitizeTerminal(p.Department), 12),
+			colorIf(useColor, ColorCyan), p.Confidence, colorIf(useColor, ColorReset))
+	}
+	fmt.Fprintln(w)
+}
+
+// outputHunterJSONL writes one JSON object per discovered person.
+// encoding/json already escapes control characters, so no sanitization needed.
+func outputHunterJSONL(w io.Writer, result *hunter.DomainResult) {
+	type hunterJSON struct {
+		Type         string   `json:"type"`
+		Domain       string   `json:"domain"`
+		Organization string   `json:"organization,omitempty"`
+		Email        string   `json:"email"`
+		FirstName    string   `json:"first_name,omitempty"`
+		LastName     string   `json:"last_name,omitempty"`
+		Position     string   `json:"position,omitempty"`
+		Seniority    string   `json:"seniority,omitempty"`
+		Department   string   `json:"department,omitempty"`
+		Phone        string   `json:"phone_number,omitempty"`
+		Confidence   int      `json:"confidence"`
+		EmailType    string   `json:"email_type,omitempty"`
+		Sources      []string `json:"sources,omitempty"`
+	}
+
+	enc := json.NewEncoder(w)
+	for i := range result.People {
+		p := &result.People[i]
+		jr := hunterJSON{
+			Type:         "hunter",
+			Domain:       result.Domain,
+			Organization: result.Organization,
+			Email:        p.Email,
+			FirstName:    p.FirstName,
+			LastName:     p.LastName,
+			Position:     p.Position,
+			Seniority:    p.Seniority,
+			Department:   p.Department,
+			Phone:        p.Phone,
+			Confidence:   p.Confidence,
+			EmailType:    p.Type,
+			Sources:      p.Sources,
+		}
+		if err := enc.Encode(jr); err != nil {
+			fmt.Fprintf(os.Stderr, "Error encoding hunter JSON: %v\n", err)
 		}
 	}
 }

--- a/pkg/enum/hunter/hunter.go
+++ b/pkg/enum/hunter/hunter.go
@@ -1,0 +1,281 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package hunter provides a client for the Hunter.io Domain Search API.
+// It handles pagination, typed errors, and context cancellation.
+package hunter
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/praetorian-inc/brutus/pkg/enum"
+)
+
+// Sentinel errors for use with errors.Is by callers.
+var (
+	ErrUnauthorized = errors.New("invalid or missing API key")
+	ErrRateLimited  = errors.New("rate limit exceeded")
+	ErrLegalReasons = errors.New("unavailable for legal reasons")
+)
+
+const (
+	defaultBaseURL  = "https://api.hunter.io/v2/domain-search"
+	defaultPageSize = 100
+)
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+// Person is one discovered contact for the domain.
+type Person struct {
+	Email      string
+	FirstName  string
+	LastName   string
+	Position   string
+	Seniority  string
+	Department string
+	Phone      string
+	Confidence int
+	Type       string
+	Sources    []string
+}
+
+// DomainResult is the aggregated, de-paginated result for a domain.
+type DomainResult struct {
+	Domain       string
+	Organization string
+	People       []Person
+	Total        int
+}
+
+// APIError is returned for any non-200 HTTP status from Hunter.io.
+type APIError struct {
+	StatusCode int
+	Details    string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("hunter API error (HTTP %d): %s", e.StatusCode, e.Details)
+}
+
+// Unwrap returns the matching sentinel error for 401/429/451, nil otherwise.
+// This enables errors.Is(err, hunter.ErrUnauthorized) in callers.
+func (e *APIError) Unwrap() error {
+	switch e.StatusCode {
+	case http.StatusUnauthorized:
+		return ErrUnauthorized
+	case http.StatusTooManyRequests:
+		return ErrRateLimited
+	case http.StatusUnavailableForLegalReasons:
+		return ErrLegalReasons
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+// Client holds state for querying the Hunter.io Domain Search API.
+type Client struct {
+	apiKey     string
+	httpClient *http.Client
+	baseURL    string
+	pageSize   int
+}
+
+// NewClient builds a Hunter client. timeout is the per-request HTTP budget.
+// pageSize <= 0 falls back to defaultPageSize.
+func NewClient(apiKey string, timeout time.Duration, pageSize int) *Client {
+	if pageSize <= 0 {
+		pageSize = defaultPageSize
+	}
+	return &Client{
+		apiKey:     apiKey,
+		httpClient: enum.NewEnumHTTPClient(timeout),
+		baseURL:    defaultBaseURL,
+		pageSize:   pageSize,
+	}
+}
+
+// Search runs Domain Search for domain, following pagination until exhausted,
+// and returns the aggregated DomainResult. Honors ctx cancellation between pages.
+func (c *Client) Search(ctx context.Context, domain string) (*DomainResult, error) {
+	offset := 0
+	result := &DomainResult{Domain: domain}
+
+	for {
+		page, err := c.fetchPage(ctx, domain, offset)
+		if err != nil {
+			return nil, err
+		}
+
+		if offset == 0 {
+			result.Organization = page.Data.Organization
+			result.Total = page.Meta.Results
+		}
+
+		for _, e := range page.Data.Emails {
+			result.People = append(result.People, toPerson(e))
+		}
+
+		fetched := len(page.Data.Emails)
+		offset += fetched
+
+		// Termination: empty page, short final page, or reached known total.
+		if fetched == 0 {
+			break
+		}
+		if fetched < c.pageSize {
+			break
+		}
+		if result.Total > 0 && offset >= result.Total {
+			break
+		}
+
+		// Honor context cancellation before issuing the next request.
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+	}
+
+	return result, nil
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+// fetchPage performs a single paginated GET request to the Hunter.io API.
+// The api_key is embedded in the query string per the Hunter API contract.
+// The full URL is never logged to prevent key leakage (P0-1 security requirement).
+func (c *Client) fetchPage(ctx context.Context, domain string, offset int) (*apiResponse, error) {
+	// Build query string — api_key goes here per Hunter's spec.
+	q := url.Values{
+		"domain":  {domain},
+		"api_key": {c.apiKey},
+		"limit":   {strconv.Itoa(c.pageSize)},
+		"offset":  {strconv.Itoa(offset)},
+	}
+	rawURL := c.baseURL + "?" + q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("building hunter request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("hunter request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Bounded read — reuses enum.ReadResponseBody (P0-3 security requirement).
+	body, err := enum.ReadResponseBody(resp, 0)
+	if err != nil {
+		return nil, fmt.Errorf("reading hunter response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		// Extract details from error envelope if present.
+		var errResp apiResponse
+		details := resp.Status
+		if json.Unmarshal(body, &errResp) == nil && len(errResp.Errors) > 0 {
+			details = errResp.Errors[0].Details
+		}
+		return nil, &APIError{StatusCode: resp.StatusCode, Details: details}
+	}
+
+	var page apiResponse
+	if err := json.Unmarshal(body, &page); err != nil {
+		return nil, fmt.Errorf("decoding hunter response: %w", err)
+	}
+	return &page, nil
+}
+
+// toPerson converts the API email struct to the public Person type.
+func toPerson(e apiEmail) Person {
+	sources := make([]string, len(e.Sources))
+	for i, s := range e.Sources {
+		sources[i] = s.URI
+	}
+	if len(sources) == 0 {
+		sources = nil
+	}
+	return Person{
+		Email:      e.Value,
+		FirstName:  e.FirstName,
+		LastName:   e.LastName,
+		Position:   e.Position,
+		Seniority:  e.Seniority,
+		Department: e.Department,
+		Phone:      e.Phone,
+		Confidence: e.Confidence,
+		Type:       e.Type,
+		Sources:    sources,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// JSON-mapping structs (unexported — map exactly to Hunter API response shape)
+// ---------------------------------------------------------------------------
+
+type apiResponse struct {
+	Data   apiData    `json:"data"`
+	Meta   apiMeta    `json:"meta"`
+	Errors []apiError `json:"errors"`
+}
+
+type apiData struct {
+	Domain       string     `json:"domain"`
+	Organization string     `json:"organization"`
+	Emails       []apiEmail `json:"emails"`
+}
+
+type apiEmail struct {
+	Value      string      `json:"value"`
+	Type       string      `json:"type"`
+	Confidence int         `json:"confidence"`
+	FirstName  string      `json:"first_name"`
+	LastName   string      `json:"last_name"`
+	Position   string      `json:"position"`
+	Seniority  string      `json:"seniority"`
+	Department string      `json:"department"`
+	Phone      string      `json:"phone_number"`
+	Sources    []apiSource `json:"sources"`
+}
+
+type apiSource struct {
+	URI string `json:"uri"`
+}
+
+type apiMeta struct {
+	Results int `json:"results"`
+	Limit   int `json:"limit"`
+	Offset  int `json:"offset"`
+}
+
+type apiError struct {
+	ID      string `json:"id"`
+	Code    int    `json:"code"`
+	Details string `json:"details"`
+}

--- a/pkg/enum/hunter/hunter_test.go
+++ b/pkg/enum/hunter/hunter_test.go
@@ -1,0 +1,367 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hunter
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Task 1: toPerson + APIError/Unwrap
+// ---------------------------------------------------------------------------
+
+func TestToPerson(t *testing.T) {
+	src := apiEmail{
+		Value:      "alice@example.com",
+		Type:       "personal",
+		Confidence: 90,
+		FirstName:  "Alice",
+		LastName:   "Smith",
+		Position:   "Engineer",
+		Seniority:  "senior",
+		Department: "Engineering",
+		Phone:      "+1-555-0100",
+		Sources: []apiSource{
+			{URI: "https://example.com/alice"},
+			{URI: "https://linkedin.com/in/alice"},
+		},
+	}
+	got := toPerson(src)
+	assert.Equal(t, "alice@example.com", got.Email)
+	assert.Equal(t, "personal", got.Type)
+	assert.Equal(t, 90, got.Confidence)
+	assert.Equal(t, "Alice", got.FirstName)
+	assert.Equal(t, "Smith", got.LastName)
+	assert.Equal(t, "Engineer", got.Position)
+	assert.Equal(t, "senior", got.Seniority)
+	assert.Equal(t, "Engineering", got.Department)
+	assert.Equal(t, "+1-555-0100", got.Phone)
+	assert.Equal(t, []string{"https://example.com/alice", "https://linkedin.com/in/alice"}, got.Sources)
+}
+
+func TestAPIError_Unwrap(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		sentinel   error
+		wantIs     bool
+	}{
+		{"401 maps to ErrUnauthorized", http.StatusUnauthorized, ErrUnauthorized, true},
+		{"429 maps to ErrRateLimited", http.StatusTooManyRequests, ErrRateLimited, true},
+		{"451 maps to ErrLegalReasons", http.StatusUnavailableForLegalReasons, ErrLegalReasons, true},
+		{"500 does not map to ErrUnauthorized", http.StatusInternalServerError, ErrUnauthorized, false},
+		{"500 does not map to ErrRateLimited", http.StatusInternalServerError, ErrRateLimited, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := &APIError{StatusCode: tc.statusCode, Details: "test"}
+			assert.Equal(t, tc.wantIs, errors.Is(err, tc.sentinel))
+		})
+	}
+}
+
+func TestAPIError_Error(t *testing.T) {
+	err := &APIError{StatusCode: 401, Details: "No valid API key"}
+	assert.Contains(t, err.Error(), "401")
+	assert.Contains(t, err.Error(), "No valid API key")
+}
+
+// ---------------------------------------------------------------------------
+// Task 2: fetchPage - single-page success + error mapping
+// ---------------------------------------------------------------------------
+
+func makeResponse(domain, org string, emails []apiEmail, total, limit, offset int) []byte {
+	resp := apiResponse{
+		Data: apiData{
+			Domain:       domain,
+			Organization: org,
+			Emails:       emails,
+		},
+		Meta: apiMeta{
+			Results: total,
+			Limit:   limit,
+			Offset:  offset,
+		},
+	}
+	b, _ := json.Marshal(resp)
+	return b
+}
+
+func makeErrorResponse(details string) []byte {
+	resp := apiResponse{
+		Errors: []apiError{{ID: "err", Code: 1, Details: details}},
+	}
+	b, _ := json.Marshal(resp)
+	return b
+}
+
+func newTestClient(baseURL string) *Client {
+	c := NewClient("testkey", 5*time.Second, 10)
+	c.baseURL = baseURL
+	return c
+}
+
+func TestFetchPage_200Decode(t *testing.T) {
+	emails := []apiEmail{
+		{Value: "a@example.com", Confidence: 80, FirstName: "A", Sources: []apiSource{{URI: "https://src1.com"}}},
+		{Value: "b@example.com", Confidence: 70},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		assert.Equal(t, "testkey", q.Get("api_key"))
+		assert.Equal(t, "example.com", q.Get("domain"))
+		assert.Equal(t, "10", q.Get("limit"))
+		assert.Equal(t, "0", q.Get("offset"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(makeResponse("example.com", "Example Corp", emails, 2, 10, 0))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	page, err := c.fetchPage(context.Background(), "example.com", 0)
+	require.NoError(t, err)
+	assert.Equal(t, "Example Corp", page.Data.Organization)
+	assert.Len(t, page.Data.Emails, 2)
+	assert.Equal(t, "a@example.com", page.Data.Emails[0].Value)
+	assert.Equal(t, 80, page.Data.Emails[0].Confidence)
+	assert.Equal(t, "https://src1.com", page.Data.Emails[0].Sources[0].URI)
+}
+
+func TestFetchPage_401_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write(makeErrorResponse("No valid API key"))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	_, err := c.fetchPage(context.Background(), "example.com", 0)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrUnauthorized), "expected ErrUnauthorized, got %v", err)
+
+	var apiErr *APIError
+	require.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, 401, apiErr.StatusCode)
+	assert.Contains(t, apiErr.Details, "No valid API key")
+}
+
+func TestFetchPage_429_RateLimited(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write(makeErrorResponse("rate limit exceeded"))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	_, err := c.fetchPage(context.Background(), "example.com", 0)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrRateLimited))
+}
+
+func TestFetchPage_451_LegalReasons(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnavailableForLegalReasons)
+		_, _ = w.Write(makeErrorResponse("unavailable for legal reasons"))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	_, err := c.fetchPage(context.Background(), "example.com", 0)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrLegalReasons))
+}
+
+func TestFetchPage_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("not-json{{{"))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	_, err := c.fetchPage(context.Background(), "example.com", 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decoding hunter response")
+}
+
+func TestFetchPage_QueryParams(t *testing.T) {
+	var capturedURL *url.URL
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedURL = r.URL
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(makeResponse("test.io", "Test", nil, 0, 10, 0))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	_, err := c.fetchPage(context.Background(), "test.io", 5)
+	require.NoError(t, err)
+
+	q := capturedURL.Query()
+	assert.Equal(t, "test.io", q.Get("domain"))
+	assert.Equal(t, "testkey", q.Get("api_key"))
+	assert.Equal(t, "10", q.Get("limit"))
+	assert.Equal(t, "5", q.Get("offset"))
+}
+
+// ---------------------------------------------------------------------------
+// Task 3: Search pagination loop
+// ---------------------------------------------------------------------------
+
+func pagedServer(t *testing.T, allEmails []apiEmail, total, pageSize, midErrOffset int) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var requestCount atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		q := r.URL.Query()
+		offset := 0
+		_, _ = fmt.Sscanf(q.Get("offset"), "%d", &offset)
+
+		if midErrOffset > 0 && offset >= midErrOffset {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write(makeErrorResponse("rate limit"))
+			return
+		}
+
+		end := offset + pageSize
+		if end > len(allEmails) {
+			end = len(allEmails)
+		}
+		page := allEmails[offset:end]
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(makeResponse("example.com", "Example Corp", page, total, pageSize, offset))
+	}))
+
+	return srv, &requestCount
+}
+
+func TestSearch_Pagination(t *testing.T) {
+	email := func(v string) apiEmail {
+		return apiEmail{Value: v, Confidence: 75}
+	}
+
+	tests := []struct {
+		name         string
+		allEmails    []apiEmail
+		total        int
+		pageSize     int
+		midErrOffset int
+		wantPeople   int
+		wantRequests int32
+		wantErr      error
+	}{
+		{
+			name:         "single page 3 emails",
+			allEmails:    []apiEmail{email("a@e.com"), email("b@e.com"), email("c@e.com")},
+			total:        3,
+			pageSize:     100,
+			wantPeople:   3,
+			wantRequests: 1,
+		},
+		{
+			name: "two full pages plus short final pageSize 2 total 5",
+			allEmails: []apiEmail{
+				email("a@e.com"), email("b@e.com"),
+				email("c@e.com"), email("d@e.com"),
+				email("e@e.com"),
+			},
+			total:        5,
+			pageSize:     2,
+			wantPeople:   5,
+			wantRequests: 3,
+		},
+		{
+			name:         "empty domain zero people one request",
+			allEmails:    []apiEmail{},
+			total:        0,
+			pageSize:     100,
+			wantPeople:   0,
+			wantRequests: 1,
+		},
+		{
+			name: "mid pagination 429 stops early",
+			allEmails: []apiEmail{
+				email("a@e.com"), email("b@e.com"),
+				email("c@e.com"),
+			},
+			total:        3,
+			pageSize:     2,
+			midErrOffset: 2,
+			wantErr:      ErrRateLimited,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, reqCount := pagedServer(t, tc.allEmails, tc.total, tc.pageSize, tc.midErrOffset)
+			defer srv.Close()
+
+			c := newTestClient(srv.URL)
+			c.pageSize = tc.pageSize
+
+			result, err := c.Search(context.Background(), "example.com")
+
+			if tc.wantErr != nil {
+				require.Error(t, err)
+				assert.True(t, errors.Is(err, tc.wantErr), "expected %v, got %v", tc.wantErr, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantPeople, len(result.People))
+			assert.Equal(t, tc.wantRequests, reqCount.Load())
+			if tc.total > 0 {
+				assert.Equal(t, "Example Corp", result.Organization)
+				assert.Equal(t, tc.total, result.Total)
+			}
+		})
+	}
+}
+
+func TestSearch_ContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		offset := 0
+		_, _ = fmt.Sscanf(r.URL.Query().Get("offset"), "%d", &offset)
+		// Slow server: sleep longer than ctx timeout so cancellation fires mid-request.
+		time.Sleep(200 * time.Millisecond)
+		emails := []apiEmail{{Value: fmt.Sprintf("user%d@e.com", offset), Confidence: 80}}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(makeResponse("example.com", "Corp", emails, 100, 1, offset))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	c.pageSize = 1
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := c.Search(ctx, "example.com")
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary

- Adds `brutus enum hunter --domain <domain>` to discover people and email addresses associated with a domain via the [Hunter.io Domain Search API](https://hunter.io/api-documentation/v2#domain-search)
- New `pkg/enum/hunter` package: paginated client, typed sentinel errors (`ErrUnauthorized`, `ErrRateLimited`, `ErrLegalReasons`), context cancellation between pages; reuses `enum.NewEnumHTTPClient` / `enum.ReadResponseBody`
- API key resolved from `HUNTER_API_KEY` env var or `--api-key` flag; key never logged or included in error messages (P0-1)
- Human table output with terminal-injection sanitization (`sanitizeTerminal` uses `utf8.DecodeRune` to preserve valid non-ASCII UTF-8 while stripping C0/C1 controls and ANSI sequences); JSONL output with `omitempty` on optional fields
- 27 tests across `pkg/enum/hunter` and `cmd/brutus`; zero new dependencies

## Test plan

- [ ] `go test ./pkg/enum/hunter/... -race -v` — 13 tests: toPerson, APIError/Unwrap, fetchPage (200, 401, 429, 451, malformed JSON, query params), Search pagination (single page, multi-page, empty, mid-429), context cancellation
- [ ] `go test ./cmd/brutus/... -run "Hunter\|hunter\|Sanitize\|sanitize\|Truncate\|truncate\|Resolve\|Classify" -race -v` — 14 tests: resolveHunterAPIKey, classifyHunterError, command registration, outputHunterJSONL (single/omitempty/empty/multi), outputHunterHuman (table/empty), sanitizeTerminal (ESC, lone ESC, C0, C1 raw bytes, accented Latin round-trip), truncate
- [ ] `brutus enum hunter --domain example.com` (requires `HUNTER_API_KEY`) — confirms human table renders correctly
- [ ] `brutus enum hunter --domain example.com -o out.jsonl` — confirms JSONL file output
- [ ] `brutus enum hunter` (no `--domain`) — confirms required-flag error
- [ ] `brutus enum hunter --domain x` (no key set) — confirms `HUNTER_API_KEY` error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)