### PR TITLE
perf(logon): parallelize stickykeys/utilman RDP backdoor scans

### DIFF
--- a/cmd/brutus/cmd_logon.go
+++ b/cmd/brutus/cmd_logon.go
@@ -196,9 +196,7 @@ func runLogonFingerprint(targets []string, base *runConfig) ([]brutus.Result, bo
 	}
 	defer stop()
 
-	var allResults []brutus.Result
-	hasSuccess := false
-
+	var scanTargets []string
 	for i := range services {
 		nrv := brutusinput.ServiceToNervaResult(&services[i])
 		protocol := brutusinput.MapServiceToProtocol(nrv.Protocol)
@@ -206,13 +204,8 @@ func runLogonFingerprint(targets []string, base *runConfig) ([]brutus.Result, bo
 			logVerbose(base.verbose, "skipping %s:%d - not RDP (detected: %s)", nrv.IP, nrv.Port, nrv.Protocol)
 			continue
 		}
-
-		results, success := runScanSingleTarget(nrv.TargetAddr(), base)
-		allResults = append(allResults, results...)
-		if success {
-			hasSuccess = true
-		}
+		scanTargets = append(scanTargets, nrv.TargetAddr())
 	}
 
-	return allResults, hasSuccess
+	return runScanTargetsConcurrent(scanTargets, base)
 }

--- a/cmd/brutus/runner.go
+++ b/cmd/brutus/runner.go
@@ -23,6 +23,9 @@ import (
 	"strings"
 	"syscall"
 
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/time/rate"
+
 	"github.com/praetorian-inc/brutus/pkg/brutus"
 	brutusinput "github.com/praetorian-inc/brutus/pkg/brutus/input"
 	"github.com/praetorian-inc/brutus/pkg/brutus/logon"
@@ -456,8 +459,7 @@ func runStickyKeysInteractive(target string, base *runConfig) ([]brutus.Result, 
 // backdoor detection) on RDP targets. Accepts the same three line formats as
 // runFromStdin: Nerva JSON, URI scheme, and bare host:port.
 func runScanFromStdin(base *runConfig) ([]brutus.Result, bool) {
-	var allResults []brutus.Result
-	hasSuccess := false
+	var scanTargets []string
 	var bareTargets []string
 
 	scanner := bufio.NewScanner(os.Stdin)
@@ -479,22 +481,13 @@ func runScanFromStdin(base *runConfig) ([]brutus.Result, bool) {
 			if base.protocolFilter != nil && !base.protocolFilter(protocol) {
 				continue
 			}
-			target := parsed.NervaResult.TargetAddr()
-			results, success := runScanSingleTarget(target, base)
-			allResults = append(allResults, results...)
-			if success {
-				hasSuccess = true
-			}
+			scanTargets = append(scanTargets, parsed.NervaResult.TargetAddr())
 
 		case brutusinput.StdinLineURI:
 			if base.protocolFilter != nil && !base.protocolFilter(parsed.Protocol) {
 				continue
 			}
-			results, success := runScanSingleTarget(parsed.HostPort, base)
-			allResults = append(allResults, results...)
-			if success {
-				hasSuccess = true
-			}
+			scanTargets = append(scanTargets, parsed.HostPort)
 
 		case brutusinput.StdinLineHostPort:
 			bareTargets = append(bareTargets, parsed.Raw)
@@ -504,6 +497,8 @@ func runScanFromStdin(base *runConfig) ([]brutus.Result, bool) {
 	if err := scanner.Err(); err != nil {
 		errMsg(base.useColor, "reading stdin: %v", err)
 	}
+
+	allResults, hasSuccess := runScanTargetsConcurrent(scanTargets, base)
 
 	// Batch-fingerprint bare targets, then scan any discovered RDP services.
 	if len(bareTargets) > 0 {
@@ -523,6 +518,74 @@ func runScanSingleTarget(target string, base *runConfig) ([]brutus.Result, bool)
 	defer stop()
 
 	return logon.DetectBackdoors(ctx, target, base.timeout, base.aiMode)
+}
+
+// scanTargetFn performs detection for a single target. It is a package-level
+// variable so tests can substitute a fake without a live RDP server.
+var scanTargetFn = func(ctx context.Context, target string, base *runConfig) ([]brutus.Result, bool) {
+	return logon.DetectBackdoors(ctx, target, base.timeout, base.aiMode)
+}
+
+// runScanTargetsConcurrent runs sticky-keys/utilman detection across many targets
+// in parallel, bounded by base.threads. This is the scan-path equivalent of the
+// credential brute-force worker pool (pkg/brutus/workers.go): on the detection path
+// --threads controls host-level concurrency, because there is exactly one probe per
+// host (credential-level threading does not apply). Results are returned in input
+// order so output stays deterministic regardless of completion order.
+func runScanTargetsConcurrent(targets []string, base *runConfig) ([]brutus.Result, bool) {
+	if len(targets) == 0 {
+		return nil, false
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	threads := base.threads
+	if threads < 1 {
+		threads = 1
+	}
+
+	// Optional rate limiting across host scans, mirroring the brute-force path.
+	// --rate-limit caps how many host scans may start per second (0 = unlimited).
+	var limiter *rate.Limiter
+	if base.rateLimit > 0 {
+		limiter = rate.NewLimiter(rate.Limit(base.rateLimit), 1)
+	}
+
+	perTarget := make([][]brutus.Result, len(targets))
+	success := make([]bool, len(targets))
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(threads)
+
+	for i := range targets {
+		i, target := i, targets[i]
+		g.Go(func() error {
+			if limiter != nil {
+				if err := limiter.Wait(ctx); err != nil {
+					return nil // context cancelled; stop quietly
+				}
+			}
+			if ctx.Err() != nil {
+				return nil
+			}
+			results, ok := scanTargetFn(ctx, target, base)
+			perTarget[i] = results
+			success[i] = ok
+			return nil
+		})
+	}
+	_ = g.Wait()
+
+	var all []brutus.Result
+	hasSuccess := false
+	for i := range targets {
+		all = append(all, perTarget[i]...)
+		if success[i] {
+			hasSuccess = true
+		}
+	}
+	return all, hasSuccess
 }
 
 // runFromNmapFile loads targets from an nmap XML file and processes each
@@ -613,8 +676,7 @@ func runScanFromNmapFile(base *runConfig) ([]brutus.Result, bool) {
 		return nil, false
 	}
 
-	var allResults []brutus.Result
-	hasSuccess := false
+	var scanTargets []string
 	for _, nrv := range nmapResults {
 		if nrv.Protocol == "" {
 			continue
@@ -622,13 +684,9 @@ func runScanFromNmapFile(base *runConfig) ([]brutus.Result, bool) {
 		if base.protocolFilter != nil && !base.protocolFilter(nrv.Protocol) {
 			continue
 		}
-		res, success := runScanSingleTarget(nrv.TargetAddr(), base)
-		allResults = append(allResults, res...)
-		if success {
-			hasSuccess = true
-		}
+		scanTargets = append(scanTargets, nrv.TargetAddr())
 	}
-	return allResults, hasSuccess
+	return runScanTargetsConcurrent(scanTargets, base)
 }
 
 // runScanFromMasscanFile loads masscan results and fingerprints them with

--- a/cmd/brutus/runner.go
+++ b/cmd/brutus/runner.go
@@ -517,7 +517,7 @@ func runScanSingleTarget(target string, base *runConfig) ([]brutus.Result, bool)
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	return logon.DetectBackdoors(ctx, target, base.timeout, base.aiMode)
+	return scanTargetFn(ctx, target, base)
 }
 
 // scanTargetFn performs detection for a single target. It is a package-level
@@ -559,19 +559,19 @@ func runScanTargetsConcurrent(targets []string, base *runConfig) ([]brutus.Resul
 	g.SetLimit(threads)
 
 	for i := range targets {
-		i, target := i, targets[i]
+		idx, target := i, targets[i]
 		g.Go(func() error {
 			if limiter != nil {
 				if err := limiter.Wait(ctx); err != nil {
-					return nil // context cancelled; stop quietly
+					return nil // context canceled; stop quietly
 				}
 			}
 			if ctx.Err() != nil {
 				return nil
 			}
 			results, ok := scanTargetFn(ctx, target, base)
-			perTarget[i] = results
-			success[i] = ok
+			perTarget[idx] = results
+			success[idx] = ok
 			return nil
 		})
 	}

--- a/cmd/brutus/scan_concurrency_test.go
+++ b/cmd/brutus/scan_concurrency_test.go
@@ -1,0 +1,124 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/praetorian-inc/brutus/pkg/brutus"
+)
+
+// withScanTargetFn swaps the package-level scanTargetFn seam for the duration of
+// a test and restores the original via the returned cleanup function.
+func withScanTargetFn(t *testing.T, fn func(ctx context.Context, target string, base *runConfig) ([]brutus.Result, bool)) {
+	t.Helper()
+	orig := scanTargetFn
+	scanTargetFn = fn
+	t.Cleanup(func() { scanTargetFn = orig })
+}
+
+// TestRunScanTargetsConcurrent_PreservesInputOrder verifies that results are
+// aggregated in the same order as the input targets, regardless of which
+// goroutine finishes first. Each fake scan returns two results (mirroring the
+// real sticky-keys + utilman pair) so we assert the flattened order.
+func TestRunScanTargetsConcurrent_PreservesInputOrder(t *testing.T) {
+	withScanTargetFn(t, func(_ context.Context, target string, _ *runConfig) ([]brutus.Result, bool) {
+		return []brutus.Result{
+			{Target: target, ScanType: "sticky_keys"},
+			{Target: target, ScanType: "utilman"},
+		}, false
+	})
+
+	targets := []string{"a:3389", "b:3389", "c:3389", "d:3389", "e:3389"}
+	base := &runConfig{baseConfigOptions: &baseConfigOptions{threads: 3}}
+
+	results, _ := runScanTargetsConcurrent(targets, base)
+
+	// Two results per target, flattened in input order.
+	expectedOrder := []string{
+		"a:3389", "a:3389",
+		"b:3389", "b:3389",
+		"c:3389", "c:3389",
+		"d:3389", "d:3389",
+		"e:3389", "e:3389",
+	}
+	actualOrder := make([]string, len(results))
+	for i := range results {
+		actualOrder[i] = results[i].Target
+	}
+	assert.Equal(t, expectedOrder, actualOrder)
+}
+
+// TestRunScanTargetsConcurrent_BoundedByThreads verifies that concurrency is
+// bounded by base.threads and that parallelism actually occurs. We track peak
+// observed concurrency with an atomic counter incremented on entry and
+// decremented on exit, with a small sleep to force overlap.
+func TestRunScanTargetsConcurrent_BoundedByThreads(t *testing.T) {
+	const threads = 5
+
+	var current, peak atomic.Int32
+
+	withScanTargetFn(t, func(_ context.Context, target string, _ *runConfig) ([]brutus.Result, bool) {
+		n := current.Add(1)
+		for {
+			p := peak.Load()
+			if n <= p || peak.CompareAndSwap(p, n) {
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+		current.Add(-1)
+		return []brutus.Result{{Target: target}}, false
+	})
+
+	targets := make([]string, 20)
+	for i := range targets {
+		targets[i] = "host:3389"
+	}
+	base := &runConfig{baseConfigOptions: &baseConfigOptions{threads: threads}}
+
+	runScanTargetsConcurrent(targets, base)
+
+	observed := int(peak.Load())
+	// Never exceed the configured limit, and prove real parallelism occurred.
+	assert.LessOrEqual(t, observed, threads, "peak concurrency must not exceed threads")
+	assert.GreaterOrEqual(t, observed, 2, "expected parallel execution, not serial")
+}
+
+// TestRunScanTargetsConcurrent_HasSuccess verifies hasSuccess is true iff at
+// least one fake scan reports success.
+func TestRunScanTargetsConcurrent_HasSuccess(t *testing.T) {
+	base := &runConfig{baseConfigOptions: &baseConfigOptions{threads: 4}}
+	targets := []string{"a:3389", "b:3389", "c:3389"}
+
+	// No target succeeds.
+	withScanTargetFn(t, func(_ context.Context, target string, _ *runConfig) ([]brutus.Result, bool) {
+		return []brutus.Result{{Target: target}}, false
+	})
+	_, hasSuccess := runScanTargetsConcurrent(targets, base)
+	assert.False(t, hasSuccess, "no target succeeded, hasSuccess must be false")
+
+	// Exactly one target (b) succeeds.
+	withScanTargetFn(t, func(_ context.Context, target string, _ *runConfig) ([]brutus.Result, bool) {
+		return []brutus.Result{{Target: target}}, target == "b:3389"
+	})
+	_, hasSuccess = runScanTargetsConcurrent(targets, base)
+	assert.True(t, hasSuccess, "one target succeeded, hasSuccess must be true")
+}

--- a/pkg/brutus/logon/logon.go
+++ b/pkg/brutus/logon/logon.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/praetorian-inc/brutus/internal/plugins/rdp"
@@ -39,16 +40,26 @@ const (
 func DetectBackdoors(ctx context.Context, target string, timeout time.Duration, aiMode bool) ([]brutus.Result, bool) {
 	noVision := !aiMode
 
-	stickyResult := rdp.DetectStickyKeys(ctx, target, timeout, "(sticky-keys)", noVision)
-	results := []brutus.Result{*stickyResult}
-	hasSuccess := stickyResult.Success
+	// Sticky keys and utilman detection use independent RDP connections and WASM
+	// instances (each instance has isolated linear memory; see
+	// internal/plugins/rdp/wasm.go), so the two checks run concurrently to halve
+	// per-host wall-clock time. Output order (sticky first, utilman second) is
+	// preserved regardless of which goroutine finishes first.
+	var stickyResult, utilmanResult *brutus.Result
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		stickyResult = rdp.DetectStickyKeys(ctx, target, timeout, "(sticky-keys)", noVision)
+	}()
+	go func() {
+		defer wg.Done()
+		utilmanResult = rdp.DetectUtilman(ctx, target, timeout, "(utilman)", noVision)
+	}()
+	wg.Wait()
 
-	utilmanResult := rdp.DetectUtilman(ctx, target, timeout, "(utilman)", noVision)
-	results = append(results, *utilmanResult)
-	if utilmanResult.Success {
-		hasSuccess = true
-	}
-
+	results := []brutus.Result{*stickyResult, *utilmanResult}
+	hasSuccess := stickyResult.Success || utilmanResult.Success
 	return results, hasSuccess
 }
 


### PR DESCRIPTION
## Problem

A ShadowServer researcher reported that `brutus stickykeys` was unusably slow for surveying internet-exposed RDP hosts: **10 hosts took 2m32s** even with `--threads 200 --rate-limit 0`.

Root cause — `--threads` did nothing on the scan path:

1. **No host-level concurrency.** `brutus stickykeys` (alias of `logon`) detect mode runs `runScanFromStdin` → a strictly serial `for` loop over hosts. `Config.Threads` is only consumed by the *credential* brute-force pool in `pkg/brutus/workers.go`, so `--threads 200` parallelized nothing for a detection survey (one probe per host).
2. **Two sequential RDP sessions per host** — sticky keys, then utilman.
3. Each detection session burns a large fixed wall-clock budget (`session.go`: baseline `pumpSession` 5s + `Sleep(1.5s)` + response `pumpSession` 3s; `pumpSession` never returns early).

10 hosts × ~15s, serial ≈ 2m32s. ✔ math closes.

## Fix (Tiers 1 + 2)

- **Host-level worker pool** (`cmd/brutus/runner.go`): new `runScanTargetsConcurrent` using the existing `errgroup` + `SetLimit(threads)` + `rate.Limiter` pattern from `workers.go`, with input-order result aggregation. On the scan path, **`--threads` now controls host concurrency**. `runScanFromStdin`, `runScanFromNmapFile`, and `runLogonFingerprint` collect targets then scan concurrently. A `scanTargetFn` seam keeps the pool unit-testable without a live RDP server.
- **Per-host parallelism** (`pkg/brutus/logon/logon.go`): `DetectBackdoors` runs sticky-keys + utilman concurrently (independent WASM instances with isolated linear memory), halving per-host time while preserving output order.

Safe because the RDP WASM engine is concurrency-safe by design (singleton immutable compiled module, per-instance isolated memory, context-routed host state); the credential path already runs instances concurrently.

## Impact

10 hosts at `--threads 200` collapse from one-at-a-time to a single concurrent batch — ~150s → roughly the cost of the slowest single host, with Tier 2 halving that. This is what makes an internet-wide survey feasible.

Note: peak WASM instances scale as ~`threads × 2` (each with its own linear memory + socket); tune `--threads`/`--rate-limit` to the host's RAM/FD limits for large runs.

## Not included

**Tier 3** — early-returning `pumpSession` on a "frame quiet" heuristic (the biggest remaining per-host win, ~8s → ~1-2s) — deferred to a separate PR because it risks half-rendered screenshots → false negatives and needs careful tuning.

## Testing

- New `cmd/brutus/scan_concurrency_test.go`: input-order preservation, bounded-and-real parallelism (peak ≤ threads, ≥ 2), success aggregation.
- `go build ./...`, `go vet`, full `pkg/brutus` + `cmd/brutus` test suites, and `go test -race` on the new tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)