### PR TITLE
perf(logon): admission-control concurrency + indeterminate≠clean (fix silent backdoor misses)

### DIFF
--- a/cmd/brutus/cmd_logon.go
+++ b/cmd/brutus/cmd_logon.go
@@ -163,10 +163,7 @@ func runLogon(cmd *cobra.Command, args []string) error {
 			outputScanHuman(scanResults, base.useColor)
 		}
 
-		if !hasSuccess {
-			return errNoSuccess
-		}
-		return nil
+		return scanExitError(scanResults, hasSuccess)
 	}
 
 	// Interactive modes (exec or web) require a single target
@@ -181,10 +178,23 @@ func runLogon(cmd *cobra.Command, args []string) error {
 		outputScanHuman(results, base.useColor)
 	}
 
-	if !hasSuccess {
-		return errNoSuccess
+	return scanExitError(results, hasSuccess)
+}
+
+// scanExitError maps aggregated scan outcomes to the process exit error,
+// following this precedence: a success (found backdoor) → nil (exit 0);
+// otherwise any indeterminate result → errIndeterminate (exit 2);
+// otherwise → errNoSuccess (exit 1).
+func scanExitError(results []brutus.Result, hasSuccess bool) error {
+	if hasSuccess {
+		return nil
 	}
-	return nil
+	for i := range results {
+		if results[i].Indeterminate {
+			return errIndeterminate
+		}
+	}
+	return errNoSuccess
 }
 
 // runLogonFingerprint fingerprints targets with Nerva and runs logon-screen

--- a/cmd/brutus/exit_code_test.go
+++ b/cmd/brutus/exit_code_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/brutus/pkg/brutus"
+)
+
+// TestScanExitError tests the precedence rules for the scan exit error helper:
+//   - hasSuccess=true (even with an indeterminate result present) → nil
+//   - hasSuccess=false + at least one Indeterminate==true → errIndeterminate
+//   - hasSuccess=false + none indeterminate → errNoSuccess
+func TestScanExitError(t *testing.T) {
+	tests := []struct {
+		name       string
+		results    []brutus.Result
+		hasSuccess bool
+		wantErr    error // nil means no error expected
+	}{
+		{
+			name: "success true with no indeterminate results",
+			results: []brutus.Result{
+				{Success: true, Indeterminate: false},
+			},
+			hasSuccess: true,
+			wantErr:    nil,
+		},
+		{
+			name: "success true even when an indeterminate result is present",
+			results: []brutus.Result{
+				{Success: true, Indeterminate: false},
+				{Success: false, Indeterminate: true},
+			},
+			hasSuccess: true,
+			wantErr:    nil,
+		},
+		{
+			name: "success false with one indeterminate result",
+			results: []brutus.Result{
+				{Success: false, Indeterminate: true},
+			},
+			hasSuccess: false,
+			wantErr:    errIndeterminate,
+		},
+		{
+			name: "success false with multiple results one of which is indeterminate",
+			results: []brutus.Result{
+				{Success: false, Indeterminate: false},
+				{Success: false, Indeterminate: true},
+				{Success: false, Indeterminate: false},
+			},
+			hasSuccess: false,
+			wantErr:    errIndeterminate,
+		},
+		{
+			name: "success false with no indeterminate results",
+			results: []brutus.Result{
+				{Success: false, Indeterminate: false},
+				{Success: false, Indeterminate: false},
+			},
+			hasSuccess: false,
+			wantErr:    errNoSuccess,
+		},
+		{
+			name:       "success false with empty results slice",
+			results:    []brutus.Result{},
+			hasSuccess: false,
+			wantErr:    errNoSuccess,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := scanExitError(tc.results, tc.hasSuccess)
+			if tc.wantErr == nil {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.True(t, errors.Is(err, tc.wantErr),
+					"expected errors.Is(err, %v) but got %v", tc.wantErr, err)
+			}
+		})
+	}
+}

--- a/cmd/brutus/main.go
+++ b/cmd/brutus/main.go
@@ -37,8 +37,17 @@ var (
 // printing an error message.
 var errNoSuccess = errors.New("no successful credentials found")
 
+// errIndeterminate is a sentinel error returned when a scan completed but at
+// least one host produced an indeterminate result (e.g. CPU-starved render or
+// failed connect) and nothing succeeded. It signals main() to exit with code 2
+// (distinct from a clean-nothing exit 1) so callers can rerun the affected hosts.
+var errIndeterminate = errors.New("indeterminate results; rerun")
+
 func main() {
 	if err := rootCmd.Execute(); err != nil {
+		if errors.Is(err, errIndeterminate) {
+			os.Exit(2)
+		}
 		if errors.Is(err, errNoSuccess) {
 			os.Exit(1)
 		}

--- a/cmd/brutus/output.go
+++ b/cmd/brutus/output.go
@@ -387,6 +387,8 @@ func outputScanHuman(results []brutus.Result, useColor bool) {
 			color, symbol = ColorRed, SymbolError
 		case "[HIGH]":
 			color, symbol = ColorYellow, SymbolWarning
+		case "[WARN]":
+			color, symbol = ColorYellow, SymbolWarning
 		}
 
 		if useColor {
@@ -400,12 +402,13 @@ func outputScanHuman(results []brutus.Result, useColor bool) {
 // outputScanJSONL writes scan results as JSONL for pipeline consumption.
 func outputScanJSONL(w io.Writer, results []brutus.Result) {
 	type ScanResult struct {
-		Protocol string `json:"protocol"`
-		Target   string `json:"target"`
-		ScanType string `json:"scan_type"`
-		Finding  string `json:"finding"`
-		Banner   string `json:"banner"`
-		Success  bool   `json:"success"`
+		Protocol      string `json:"protocol"`
+		Target        string `json:"target"`
+		ScanType      string `json:"scan_type"`
+		Finding       string `json:"finding"`
+		Banner        string `json:"banner"`
+		Success       bool   `json:"success"`
+		Indeterminate bool   `json:"indeterminate"`
 	}
 
 	enc := json.NewEncoder(w)
@@ -416,12 +419,13 @@ func outputScanJSONL(w io.Writer, results []brutus.Result) {
 			scanType = "sticky_keys" // default for backward compatibility
 		}
 		sr := ScanResult{
-			Protocol: r.Protocol,
-			Target:   r.Target,
-			ScanType: scanType,
-			Finding:  extractFinding(r.Banner),
-			Banner:   r.Banner,
-			Success:  r.Success,
+			Protocol:      r.Protocol,
+			Target:        r.Target,
+			ScanType:      scanType,
+			Finding:       extractFinding(r.Banner),
+			Banner:        r.Banner,
+			Success:       r.Success,
+			Indeterminate: r.Indeterminate,
 		}
 		if err := enc.Encode(sr); err != nil {
 			fmt.Fprintf(os.Stderr, "Error encoding scan JSON: %v\n", err)
@@ -451,7 +455,7 @@ func splitLines(s string) []string {
 
 // extractFinding extracts the severity tag from a banner string.
 func extractFinding(banner string) string {
-	for _, tag := range []string{"[CRITICAL]", "[HIGH]", "[INFO]"} {
+	for _, tag := range []string{"[CRITICAL]", "[HIGH]", "[WARN]", "[INFO]"} {
 		if strings.Contains(banner, tag) {
 			return tag
 		}

--- a/cmd/brutus/runner.go
+++ b/cmd/brutus/runner.go
@@ -570,10 +570,16 @@ func runScanTargetsConcurrent(targets []string, base *runConfig) ([]brutus.Resul
 		g.Go(func() error {
 			if limiter != nil {
 				if err := limiter.Wait(ctx); err != nil {
-					return nil // context canceled; stop quietly
+					// Context cancelled while queued: the host never ran, so it
+					// must read as INDETERMINATE, never silently disappear.
+					perTarget[idx] = logon.CancelledResults(target)
+					success[idx] = false
+					return nil
 				}
 			}
 			if ctx.Err() != nil {
+				perTarget[idx] = logon.CancelledResults(target)
+				success[idx] = false
 				return nil
 			}
 			results, ok := scanTargetFn(ctx, target, base)

--- a/cmd/brutus/runner.go
+++ b/cmd/brutus/runner.go
@@ -533,12 +533,17 @@ var scanTargetFn = func(ctx context.Context, target string, base *runConfig) ([]
 // host (credential-level threading does not apply). Results are returned in input
 // order so output stays deterministic regardless of completion order.
 func runScanTargetsConcurrent(targets []string, base *runConfig) ([]brutus.Result, bool) {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	return runScanTargetsConcurrentCtx(ctx, targets, base)
+}
+
+// runScanTargetsConcurrentCtx is runScanTargetsConcurrent with an injectable
+// context, so tests can drive cancellation without sending real signals.
+func runScanTargetsConcurrentCtx(ctx context.Context, targets []string, base *runConfig) ([]brutus.Result, bool) {
 	if len(targets) == 0 {
 		return nil, false
 	}
-
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
 
 	threads := base.threads
 	if threads < 1 {

--- a/cmd/brutus/runner.go
+++ b/cmd/brutus/runner.go
@@ -545,6 +545,13 @@ func runScanTargetsConcurrent(targets []string, base *runConfig) ([]brutus.Resul
 		threads = 1
 	}
 
+	// RDP decode is CPU-bound and process-wide bounded to ~decodeSlotCount cores
+	// (pkg/brutus/logon admission control), so cranking --threads far above that
+	// budget adds queueing, not throughput. Warn once on the scan path only.
+	if slots := logon.DecodeSlotCount(); int64(threads) > 4*slots {
+		warnMsg(base.useColor, "high --threads won't speed up CPU-bound RDP decode; decode is bounded to ~%d cores.", slots)
+	}
+
 	// Optional rate limiting across host scans, mirroring the brute-force path.
 	// --rate-limit caps how many host scans may start per second (0 = unlimited).
 	var limiter *rate.Limiter

--- a/cmd/brutus/runner.go
+++ b/cmd/brutus/runner.go
@@ -523,7 +523,7 @@ func runScanSingleTarget(target string, base *runConfig) ([]brutus.Result, bool)
 // scanTargetFn performs detection for a single target. It is a package-level
 // variable so tests can substitute a fake without a live RDP server.
 var scanTargetFn = func(ctx context.Context, target string, base *runConfig) ([]brutus.Result, bool) {
-	return logon.DetectBackdoors(ctx, target, base.timeout, base.aiMode)
+	return logon.DetectBackdoors(ctx, target, base.timeout, base.aiMode, base.maxRetries)
 }
 
 // runScanTargetsConcurrent runs sticky-keys/utilman detection across many targets

--- a/cmd/brutus/runner_cancel_test.go
+++ b/cmd/brutus/runner_cancel_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/brutus/pkg/brutus"
+)
+
+// TestRunScanTargetsConcurrent_CancelledIndexIndeterminate verifies that every
+// target emits non-nil, INDETERMINATE results when the context is already
+// cancelled on entry — no target may silently vanish (emit nil/empty results)
+// when the run is cancelled (invariant I5/I6).
+//
+// This test is RED until the developer adds an injectable-context entry point:
+//
+//	func runScanTargetsConcurrentCtx(ctx context.Context, targets []string, base *runConfig) ([]brutus.Result, bool)
+//
+// with the existing runScanTargetsConcurrent wrapping it via its own
+// signal.NotifyContext.
+func TestRunScanTargetsConcurrent_CancelledIndexIndeterminate(t *testing.T) {
+	// Install a scan fake that records invocations. The point of this test is
+	// that the fake must NOT be called for any target — cancellation must
+	// short-circuit before any per-target scan work begins.
+	scanInvoked := false
+	withScanTargetFn(t, func(_ context.Context, target string, _ *runConfig) ([]brutus.Result, bool) {
+		scanInvoked = true
+		return []brutus.Result{
+			{Target: target, ScanType: "sticky_keys"},
+			{Target: target, ScanType: "utilman"},
+		}, false
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel so every goroutine sees ctx.Err() != nil immediately
+
+	targets := []string{"10.0.0.1:3389", "10.0.0.2:3389"}
+	base := &runConfig{baseConfigOptions: &baseConfigOptions{
+		threads: 4,
+		timeout: 5 * time.Second,
+	}}
+
+	results, hasSuccess := runScanTargetsConcurrentCtx(ctx, targets, base)
+
+	// Every target must contribute results — no silent nil/empty.
+	require.NotNil(t, results, "results slice must not be nil")
+	assert.Equal(t, len(targets)*2, len(results),
+		"each target must contribute exactly 2 results (sticky + utilman)")
+
+	// Every result must be INDETERMINATE — hosts never ran.
+	for i, r := range results {
+		assert.True(t, r.Indeterminate,
+			"result[%d] (target %s) must be Indeterminate (scan was cancelled)", i, r.Target)
+		assert.False(t, r.Success,
+			"result[%d] must not be Success (scan was cancelled)", i)
+	}
+
+	assert.False(t, hasSuccess, "cancelled scan must not report success")
+	assert.False(t, scanInvoked,
+		"scanTargetFn must not be invoked when context is cancelled before any target runs")
+}

--- a/internal/plugins/rdp/detect.go
+++ b/internal/plugins/rdp/detect.go
@@ -269,9 +269,7 @@ func (p *Plugin) runStickyKeysDetection(ctx context.Context, inst *wasmInstance,
 	// Cardinal false-negative guard: only a "clean" verdict on a render that
 	// never stabilized is suspect. Positive verdicts (confirmed/likely/
 	// vulnerable) already saw the window and are never downgraded.
-	if result.OverallVerdict == "clean" && !stabilized {
-		result.OverallVerdict = verdictIndeterminate
-	}
+	result.OverallVerdict = stabilizedVerdict(result.OverallVerdict, stabilized)
 
 	return result, nil
 }
@@ -327,11 +325,18 @@ func (p *Plugin) runUtilmanDetection(ctx context.Context, inst *wasmInstance, ad
 	// Cardinal false-negative guard: only a "clean" verdict on a render that
 	// never stabilized is suspect. Positive verdicts (confirmed/likely/
 	// vulnerable) already saw the window and are never downgraded.
-	if result.OverallVerdict == "clean" && !stabilized {
-		result.OverallVerdict = verdictIndeterminate
-	}
+	result.OverallVerdict = stabilizedVerdict(result.OverallVerdict, stabilized)
 
 	return result, nil
+}
+
+// stabilizedVerdict downgrades a clean verdict to indeterminate when the
+// render never stabilized; all other verdicts (including positives) pass through.
+func stabilizedVerdict(verdict string, stabilized bool) string {
+	if verdict == "clean" && !stabilized {
+		return verdictIndeterminate
+	}
+	return verdict
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/plugins/rdp/detect.go
+++ b/internal/plugins/rdp/detect.go
@@ -37,17 +37,28 @@ import (
 func DetectStickyKeys(ctx context.Context, target string, timeout time.Duration, username string, noVision bool) *brutus.Result {
 	plugin := &Plugin{}
 	stickyResult := plugin.RunStickyKeysCheck(ctx, target, timeout, noVision)
+	result := mapStickyResult(stickyResult, username)
+	result.Target = target
+	return result
+}
 
-	result := brutus.NewResult("rdp", target, username, "")
-
+// mapStickyResult interprets a StickyKeysResult into a standardized brutus.Result
+// suitable for CLI output. It is the single source of verdict→banner mapping,
+// reused by both the per-check entry point and the shared-connection path.
+func mapStickyResult(stickyResult *StickyKeysResult, username string) *brutus.Result {
+	result := brutus.NewResult("rdp", "", username, "")
 	result.ScanType = "sticky_keys"
+
 	if stickyResult == nil {
 		result.Error = fmt.Errorf("sticky keys check returned nil")
 		return result
 	}
 
 	if !stickyResult.Performed {
-		result.Banner = fmt.Sprintf("[INFO] Sticky keys check skipped: %s", stickyResult.SkipReason)
+		// A failed connect/instance is NOT a benign skip — it produced no
+		// verdict, so surface it loudly as indeterminate (rerun), not clean.
+		result.Banner = fmt.Sprintf("[WARN] Sticky keys check INDETERMINATE (could not connect — rerun): %s", stickyResult.SkipReason)
+		result.Indeterminate = true
 		return result
 	}
 
@@ -62,6 +73,10 @@ func DetectStickyKeys(ctx context.Context, target string, timeout time.Duration,
 	case "vulnerable":
 		result.Banner = "[INFO] Non-NLA target, sticky keys triggers normally (no backdoor)"
 		result.Success = true
+	case verdictIndeterminate:
+		result.Banner = "[WARN] Sticky keys check INDETERMINATE (render did not stabilize — rerun)"
+		result.Indeterminate = true
+		// Success stays false
 	case "clean":
 		result.Banner = "[INFO] Sticky keys check: clean (no response to 5x Shift)"
 		// Success stays false
@@ -81,17 +96,28 @@ func DetectStickyKeys(ctx context.Context, target string, timeout time.Duration,
 func DetectUtilman(ctx context.Context, target string, timeout time.Duration, username string, noVision bool) *brutus.Result {
 	plugin := &Plugin{}
 	utilmanResult := plugin.RunUtilmanCheck(ctx, target, timeout, noVision)
+	result := mapUtilmanResult(utilmanResult, username)
+	result.Target = target
+	return result
+}
 
-	result := brutus.NewResult("rdp", target, username, "")
-
+// mapUtilmanResult interprets a UtilmanResult into a standardized brutus.Result
+// suitable for CLI output. It is the single source of verdict→banner mapping,
+// reused by both the per-check entry point and the shared-connection path.
+func mapUtilmanResult(utilmanResult *UtilmanResult, username string) *brutus.Result {
+	result := brutus.NewResult("rdp", "", username, "")
 	result.ScanType = "utilman"
+
 	if utilmanResult == nil {
 		result.Error = fmt.Errorf("utilman check returned nil")
 		return result
 	}
 
 	if !utilmanResult.Performed {
-		result.Banner = fmt.Sprintf("[INFO] Utilman check skipped: %s", utilmanResult.SkipReason)
+		// A failed connect/instance is NOT a benign skip — it produced no
+		// verdict, so surface it loudly as indeterminate (rerun), not clean.
+		result.Banner = fmt.Sprintf("[WARN] Utilman check INDETERMINATE (could not connect — rerun): %s", utilmanResult.SkipReason)
+		result.Indeterminate = true
 		return result
 	}
 
@@ -106,6 +132,10 @@ func DetectUtilman(ctx context.Context, target string, timeout time.Duration, us
 	case "vulnerable":
 		result.Banner = "[INFO] Non-NLA target, utilman triggers normally (no backdoor)"
 		result.Success = true
+	case verdictIndeterminate:
+		result.Banner = "[WARN] Utilman check INDETERMINATE (render did not stabilize — rerun)"
+		result.Indeterminate = true
+		// Success stays false
 	case "clean":
 		result.Banner = "[INFO] Utilman check: clean (no response to Win+U)"
 		// Success stays false
@@ -218,7 +248,7 @@ func (p *Plugin) runStickyKeysDetection(ctx context.Context, inst *wasmInstance,
 		}
 	}()
 
-	baseline, response, width, height, err := p.runSession(ctx, inst, connHandle, 1024, 768)
+	baseline, response, width, height, stabilized, err := p.runSession(ctx, inst, connHandle, 1024, 768)
 	if err != nil {
 		result.Performed = false
 		result.SkipReason = fmt.Sprintf("session failed: %v", err)
@@ -233,6 +263,14 @@ func (p *Plugin) runStickyKeysDetection(ctx context.Context, inst *wasmInstance,
 	}
 	*result = runStickyKeysAnalysis(ctx, baseline, response, width, height, visionAPIKey)
 	result.Performed = true
+	result.Stabilized = stabilized
+
+	// Cardinal false-negative guard: only a "clean" verdict on a render that
+	// never stabilized is suspect. Positive verdicts (confirmed/likely/
+	// vulnerable) already saw the window and are never downgraded.
+	if result.OverallVerdict == "clean" && !stabilized {
+		result.OverallVerdict = verdictIndeterminate
+	}
 
 	return result, nil
 }
@@ -267,7 +305,7 @@ func (p *Plugin) runUtilmanDetection(ctx context.Context, inst *wasmInstance, ad
 		}
 	}()
 
-	baseline, response, width, height, err := p.runUtilmanSession(ctx, inst, connHandle, 1024, 768)
+	baseline, response, width, height, stabilized, err := p.runUtilmanSession(ctx, inst, connHandle, 1024, 768)
 	if err != nil {
 		result.Performed = false
 		result.SkipReason = fmt.Sprintf("session failed: %v", err)
@@ -282,6 +320,14 @@ func (p *Plugin) runUtilmanDetection(ctx context.Context, inst *wasmInstance, ad
 	}
 	*result = runUtilmanAnalysis(ctx, baseline, response, width, height, visionAPIKey)
 	result.Performed = true
+	result.Stabilized = stabilized
+
+	// Cardinal false-negative guard: only a "clean" verdict on a render that
+	// never stabilized is suspect. Positive verdicts (confirmed/likely/
+	// vulnerable) already saw the window and are never downgraded.
+	if result.OverallVerdict == "clean" && !stabilized {
+		result.OverallVerdict = verdictIndeterminate
+	}
 
 	return result, nil
 }

--- a/internal/plugins/rdp/detect.go
+++ b/internal/plugins/rdp/detect.go
@@ -348,9 +348,9 @@ func formatStickyKeysBanner(existingBanner string, result *StickyKeysResult) str
 		if banner != "" {
 			banner += "\n"
 		}
-		if result.SkipReason != "" {
-			banner += "[INFO] Sticky keys check skipped: " + result.SkipReason
-		}
+		// A failed connect/instance is NOT a benign skip — it produced no
+		// verdict, so surface it loudly as indeterminate (rerun), not clean.
+		banner += fmt.Sprintf("[WARN] Sticky keys check INDETERMINATE (could not connect — rerun): %s", result.SkipReason)
 		return banner
 	}
 
@@ -376,6 +376,8 @@ func formatStickyKeysBanner(existingBanner string, result *StickyKeysResult) str
 	case "vulnerable":
 		banner += "[INFO] Non-NLA RDP target. Sticky Keys triggers normally (no backdoor detected).\n"
 		banner += "Target is vulnerable if sethc.exe is later replaced."
+	case verdictIndeterminate:
+		banner += "[WARN] Sticky keys check INDETERMINATE (render did not stabilize — rerun)"
 	case "clean":
 		banner += "[INFO] Sticky keys check: clean (no response to 5x Shift)."
 	}
@@ -393,9 +395,9 @@ func formatUtilmanBanner(existingBanner string, result *UtilmanResult) string {
 		if banner != "" {
 			banner += "\n"
 		}
-		if result.SkipReason != "" {
-			banner += "[INFO] Utilman check skipped: " + result.SkipReason
-		}
+		// A failed connect/instance is NOT a benign skip — it produced no
+		// verdict, so surface it loudly as indeterminate (rerun), not clean.
+		banner += fmt.Sprintf("[WARN] Utilman check INDETERMINATE (could not connect — rerun): %s", result.SkipReason)
 		return banner
 	}
 
@@ -421,6 +423,8 @@ func formatUtilmanBanner(existingBanner string, result *UtilmanResult) string {
 	case "vulnerable":
 		banner += "[INFO] Non-NLA RDP target. Utilman triggers normally (no backdoor detected).\n"
 		banner += "Target is vulnerable if utilman.exe is later replaced."
+	case verdictIndeterminate:
+		banner += "[WARN] Utilman check INDETERMINATE (render did not stabilize — rerun)"
 	case "clean":
 		banner += "[INFO] Utilman check: clean (no response to Win+U)."
 	}

--- a/internal/plugins/rdp/detect.go
+++ b/internal/plugins/rdp/detect.go
@@ -175,7 +175,7 @@ func (p *Plugin) RunStickyKeysCheck(ctx context.Context, target string, timeout 
 	}
 	defer func() { _ = inst.close(ctx) }()
 
-	stickyResult, err := p.runStickyKeysDetection(ctx, inst, addr, noVision)
+	stickyResult, err := p.runStickyKeysDetection(ctx, inst, addr, noVision, timeout)
 	if err != nil {
 		return &StickyKeysResult{Performed: false, SkipReason: fmt.Sprintf("detection failed: %v", err)}
 	}
@@ -206,7 +206,7 @@ func (p *Plugin) RunUtilmanCheck(ctx context.Context, target string, timeout tim
 	}
 	defer func() { _ = inst.close(ctx) }()
 
-	utilmanResult, err := p.runUtilmanDetection(ctx, inst, addr, noVision)
+	utilmanResult, err := p.runUtilmanDetection(ctx, inst, addr, noVision, timeout)
 	if err != nil {
 		return &UtilmanResult{Performed: false, SkipReason: fmt.Sprintf("detection failed: %v", err)}
 	}
@@ -219,7 +219,8 @@ func (p *Plugin) RunUtilmanCheck(ctx context.Context, target string, timeout tim
 // ---------------------------------------------------------------------------
 
 // runStickyKeysDetection performs the full detection sequence on a non-NLA connection.
-func (p *Plugin) runStickyKeysDetection(ctx context.Context, inst *wasmInstance, addr string, noVision bool) (*StickyKeysResult, error) {
+// timeout is the per-host budget passed to each session pump phase.
+func (p *Plugin) runStickyKeysDetection(ctx context.Context, inst *wasmInstance, addr string, noVision bool, timeout time.Duration) (*StickyKeysResult, error) {
 	result := &StickyKeysResult{Performed: true}
 
 	cfg := rdpConfig{
@@ -248,7 +249,7 @@ func (p *Plugin) runStickyKeysDetection(ctx context.Context, inst *wasmInstance,
 		}
 	}()
 
-	baseline, response, width, height, stabilized, err := p.runSession(ctx, inst, connHandle, 1024, 768)
+	baseline, response, width, height, stabilized, err := p.runSession(ctx, inst, connHandle, 1024, 768, timeout)
 	if err != nil {
 		result.Performed = false
 		result.SkipReason = fmt.Sprintf("session failed: %v", err)
@@ -276,7 +277,8 @@ func (p *Plugin) runStickyKeysDetection(ctx context.Context, inst *wasmInstance,
 }
 
 // runUtilmanDetection performs the full utilman detection sequence on a non-NLA connection.
-func (p *Plugin) runUtilmanDetection(ctx context.Context, inst *wasmInstance, addr string, noVision bool) (*UtilmanResult, error) {
+// timeout is the per-host budget passed to each session pump phase.
+func (p *Plugin) runUtilmanDetection(ctx context.Context, inst *wasmInstance, addr string, noVision bool, timeout time.Duration) (*UtilmanResult, error) {
 	result := &UtilmanResult{Performed: true}
 
 	cfg := rdpConfig{
@@ -305,7 +307,7 @@ func (p *Plugin) runUtilmanDetection(ctx context.Context, inst *wasmInstance, ad
 		}
 	}()
 
-	baseline, response, width, height, stabilized, err := p.runUtilmanSession(ctx, inst, connHandle, 1024, 768)
+	baseline, response, width, height, stabilized, err := p.runUtilmanSession(ctx, inst, connHandle, 1024, 768, timeout)
 	if err != nil {
 		result.Performed = false
 		result.SkipReason = fmt.Sprintf("session failed: %v", err)

--- a/internal/plugins/rdp/detect_test.go
+++ b/internal/plugins/rdp/detect_test.go
@@ -215,6 +215,69 @@ func TestMapUtilmanResult(t *testing.T) {
 	}
 }
 
+// TestStabilizedVerdict verifies the cardinal false-negative guard (I2): only a
+// "clean" verdict on an unstabilized render is downgraded to "indeterminate".
+// Positive verdicts (backdoor_confirmed, backdoor_likely, vulnerable) must never
+// be downgraded regardless of stabilization, and "indeterminate" input is left
+// unchanged.
+//
+// This test is RED until the developer extracts the inline guard at
+// detect.go:272-274 / 330-332 into:
+//
+//	func stabilizedVerdict(verdict string, stabilized bool) string
+func TestStabilizedVerdict(t *testing.T) {
+	tests := []struct {
+		name       string
+		verdict    string
+		stabilized bool
+		want       string
+	}{
+		{
+			name:       "clean unstabilized -> indeterminate (cardinal flip)",
+			verdict:    "clean",
+			stabilized: false,
+			want:       verdictIndeterminate,
+		},
+		{
+			name:       "clean stabilized -> clean (no flip)",
+			verdict:    "clean",
+			stabilized: true,
+			want:       "clean",
+		},
+		{
+			name:       "backdoor_confirmed unstabilized -> unchanged (positive never downgraded)",
+			verdict:    "backdoor_confirmed",
+			stabilized: false,
+			want:       "backdoor_confirmed",
+		},
+		{
+			name:       "backdoor_likely unstabilized -> unchanged (positive never downgraded)",
+			verdict:    "backdoor_likely",
+			stabilized: false,
+			want:       "backdoor_likely",
+		},
+		{
+			name:       "vulnerable unstabilized -> unchanged (positive never downgraded)",
+			verdict:    "vulnerable",
+			stabilized: false,
+			want:       "vulnerable",
+		},
+		{
+			name:       "indeterminate unstabilized -> unchanged (already indeterminate)",
+			verdict:    verdictIndeterminate,
+			stabilized: false,
+			want:       verdictIndeterminate,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := stabilizedVerdict(tc.verdict, tc.stabilized)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 // TestScanTypeLabeling verifies that StickyKeys and Utilman scans
 // are labeled with distinct scan_type values for JSONL output.
 func TestScanTypeLabeling(t *testing.T) {

--- a/internal/plugins/rdp/detect_test.go
+++ b/internal/plugins/rdp/detect_test.go
@@ -31,7 +31,8 @@ func TestDetectStickyKeys_ConnectionError(t *testing.T) {
 	assert.Equal(t, "127.0.0.1:1", result.Target)
 	assert.Equal(t, "(sticky-keys)", result.Username)
 	assert.False(t, result.Success)
-	assert.Contains(t, result.Banner, "skipped")
+	assert.Contains(t, result.Banner, "INDETERMINATE")
+	assert.True(t, result.Indeterminate)
 }
 
 func TestDetectStickyKeys_ResultFields(t *testing.T) {
@@ -53,7 +54,8 @@ func TestDetectUtilman_ConnectionError(t *testing.T) {
 	assert.Equal(t, "127.0.0.1:1", result.Target)
 	assert.Equal(t, "(utilman)", result.Username)
 	assert.False(t, result.Success)
-	assert.Contains(t, result.Banner, "skipped")
+	assert.Contains(t, result.Banner, "INDETERMINATE")
+	assert.True(t, result.Indeterminate)
 }
 
 func TestDetectUtilman_ResultFields(t *testing.T) {
@@ -64,6 +66,153 @@ func TestDetectUtilman_ResultFields(t *testing.T) {
 	assert.Equal(t, "(utilman)", result.Username)
 	assert.Equal(t, "rdp", result.Protocol)
 	assert.Equal(t, "198.51.100.1:3389", result.Target)
+}
+
+// TestMapStickyResult tests the mapping from StickyKeysResult to brutus.Result,
+// covering the indeterminate, not-performed, clean, and confirmed cases.
+func TestMapStickyResult(t *testing.T) {
+	tests := []struct {
+		name              string
+		input             *StickyKeysResult
+		username          string
+		wantIndeterminate bool
+		wantSuccess       bool
+		wantBannerContain string
+		wantBannerExclude string
+	}{
+		{
+			name: "performed indeterminate verdict",
+			input: &StickyKeysResult{
+				Performed:      true,
+				OverallVerdict: "indeterminate",
+			},
+			username:          "testuser",
+			wantIndeterminate: true,
+			wantSuccess:       false,
+			wantBannerContain: "INDETERMINATE",
+		},
+		{
+			name: "not performed (dial fail with skip reason)",
+			input: &StickyKeysResult{
+				Performed:  false,
+				SkipReason: "connection refused",
+			},
+			username:          "testuser",
+			wantIndeterminate: true,
+			wantSuccess:       false,
+			wantBannerContain: "INDETERMINATE",
+			wantBannerExclude: "skipped",
+		},
+		{
+			name: "clean verdict",
+			input: &StickyKeysResult{
+				Performed:      true,
+				OverallVerdict: "clean",
+			},
+			username:          "testuser",
+			wantIndeterminate: false,
+			wantSuccess:       false,
+		},
+		{
+			name: "backdoor_confirmed verdict",
+			input: &StickyKeysResult{
+				Performed:      true,
+				OverallVerdict: "backdoor_confirmed",
+				Confidence:     0.99,
+			},
+			username:          "testuser",
+			wantIndeterminate: false,
+			wantSuccess:       true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := mapStickyResult(tc.input, tc.username)
+			assert.NotNil(t, result)
+			assert.Equal(t, tc.wantIndeterminate, result.Indeterminate, "Indeterminate mismatch")
+			assert.Equal(t, tc.wantSuccess, result.Success, "Success mismatch")
+			if tc.wantBannerContain != "" {
+				assert.Contains(t, result.Banner, tc.wantBannerContain)
+			}
+			if tc.wantBannerExclude != "" {
+				assert.NotContains(t, result.Banner, tc.wantBannerExclude)
+			}
+		})
+	}
+}
+
+// TestMapUtilmanResult mirrors TestMapStickyResult for the utilman mapper.
+func TestMapUtilmanResult(t *testing.T) {
+	tests := []struct {
+		name              string
+		input             *UtilmanResult
+		username          string
+		wantIndeterminate bool
+		wantSuccess       bool
+		wantBannerContain string
+		wantBannerExclude string
+	}{
+		{
+			name: "performed indeterminate verdict",
+			input: &UtilmanResult{
+				Performed:      true,
+				OverallVerdict: "indeterminate",
+			},
+			username:          "testuser",
+			wantIndeterminate: true,
+			wantSuccess:       false,
+			wantBannerContain: "INDETERMINATE",
+		},
+		{
+			name: "not performed (dial fail with skip reason)",
+			input: &UtilmanResult{
+				Performed:  false,
+				SkipReason: "connection refused",
+			},
+			username:          "testuser",
+			wantIndeterminate: true,
+			wantSuccess:       false,
+			wantBannerContain: "INDETERMINATE",
+			wantBannerExclude: "skipped",
+		},
+		{
+			name: "clean verdict",
+			input: &UtilmanResult{
+				Performed:      true,
+				OverallVerdict: "clean",
+			},
+			username:          "testuser",
+			wantIndeterminate: false,
+			wantSuccess:       false,
+		},
+		{
+			name: "backdoor_confirmed verdict",
+			input: &UtilmanResult{
+				Performed:      true,
+				OverallVerdict: "backdoor_confirmed",
+				Confidence:     0.99,
+			},
+			username:          "testuser",
+			wantIndeterminate: false,
+			wantSuccess:       true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := mapUtilmanResult(tc.input, tc.username)
+			assert.NotNil(t, result)
+			assert.Equal(t, tc.wantIndeterminate, result.Indeterminate, "Indeterminate mismatch")
+			assert.Equal(t, tc.wantSuccess, result.Success, "Success mismatch")
+			if tc.wantBannerContain != "" {
+				assert.Contains(t, result.Banner, tc.wantBannerContain)
+			}
+			if tc.wantBannerExclude != "" {
+				assert.NotContains(t, result.Banner, tc.wantBannerExclude)
+			}
+		})
+	}
 }
 
 // TestScanTypeLabeling verifies that StickyKeys and Utilman scans

--- a/internal/plugins/rdp/rdp_test.go
+++ b/internal/plugins/rdp/rdp_test.go
@@ -242,13 +242,14 @@ func TestFormatUtilmanBanner_Clean(t *testing.T) {
 	assert.Contains(t, banner, "Utilman check: clean")
 }
 
-func TestFormatUtilmanBanner_Skipped(t *testing.T) {
+func TestFormatUtilmanBanner_Indeterminate(t *testing.T) {
 	result := &UtilmanResult{
 		Performed:  false,
 		SkipReason: "connection failed",
 	}
 	banner := formatUtilmanBanner("", result)
-	assert.Contains(t, banner, "Utilman check skipped")
+	assert.Contains(t, banner, "INDETERMINATE")
+	assert.Contains(t, banner, "rerun")
 	assert.Contains(t, banner, "connection failed")
 }
 

--- a/internal/plugins/rdp/session.go
+++ b/internal/plugins/rdp/session.go
@@ -71,8 +71,9 @@ const stableFrames = 3
 // sends 5x Shift key presses, then captures the post-keystroke bitmap.
 // Returns (baseline_rgba, response_rgba, width, height, stabilized, error).
 // stabilized reflects whether the response pump observed a settled framebuffer.
+// timeout is the per-host budget applied to each pump phase (baseline and response).
 func (p *Plugin) runSession(ctx context.Context, inst *wasmInstance, connHandle uint32,
-	width, height uint32) (baselineRGBA, responseRGBA []byte, outWidth, outHeight uint32, stabilized bool, err error) {
+	width, height uint32, timeout time.Duration) (baselineRGBA, responseRGBA []byte, outWidth, outHeight uint32, stabilized bool, err error) {
 
 	callCtx := inst.callCtx(ctx)
 
@@ -99,7 +100,7 @@ func (p *Plugin) runSession(ctx context.Context, inst *wasmInstance, connHandle 
 	}()
 
 	// Pump session to get initial login screen (baseline stabilization is ignored).
-	if _, pumpErr := p.pumpSession(ctx, inst, sessHandle, 5*time.Second); pumpErr != nil {
+	if _, pumpErr := p.pumpSession(ctx, inst, sessHandle, timeout); pumpErr != nil {
 		return nil, nil, 0, 0, false, fmt.Errorf("pump baseline: %w", pumpErr)
 	}
 
@@ -124,7 +125,7 @@ func (p *Plugin) runSession(ctx context.Context, inst *wasmInstance, connHandle 
 	// Wait for response and pump — give cmd.exe time to render before capturing.
 	// The exec.go path uses 1s sleep + 2s WaitForFrame; we mirror that here.
 	time.Sleep(1500 * time.Millisecond)
-	stabilized, pumpErr := p.pumpSession(ctx, inst, sessHandle, 3*time.Second)
+	stabilized, pumpErr := p.pumpSession(ctx, inst, sessHandle, timeout)
 	if pumpErr != nil {
 		// Non-fatal -- target might not respond
 		_ = pumpErr
@@ -143,8 +144,9 @@ func (p *Plugin) runSession(ctx context.Context, inst *wasmInstance, connHandle 
 // sends Win+U to trigger the Utility Manager (utilman.exe), then captures the post-keystroke bitmap.
 // Returns (baseline_rgba, response_rgba, width, height, stabilized, error).
 // stabilized reflects whether the response pump observed a settled framebuffer.
+// timeout is the per-host budget applied to each pump phase (baseline and response).
 func (p *Plugin) runUtilmanSession(ctx context.Context, inst *wasmInstance, connHandle uint32,
-	width, height uint32) (baselineRGBA, responseRGBA []byte, outWidth, outHeight uint32, stabilized bool, err error) {
+	width, height uint32, timeout time.Duration) (baselineRGBA, responseRGBA []byte, outWidth, outHeight uint32, stabilized bool, err error) {
 
 	callCtx := inst.callCtx(ctx)
 
@@ -171,7 +173,7 @@ func (p *Plugin) runUtilmanSession(ctx context.Context, inst *wasmInstance, conn
 	}()
 
 	// Pump session to get initial login screen (baseline stabilization is ignored).
-	if _, pumpErr := p.pumpSession(ctx, inst, sessHandle, 5*time.Second); pumpErr != nil {
+	if _, pumpErr := p.pumpSession(ctx, inst, sessHandle, timeout); pumpErr != nil {
 		return nil, nil, 0, 0, false, fmt.Errorf("pump baseline: %w", pumpErr)
 	}
 
@@ -201,7 +203,7 @@ func (p *Plugin) runUtilmanSession(ctx context.Context, inst *wasmInstance, conn
 
 	// Wait for response and pump — give cmd.exe time to render before capturing.
 	time.Sleep(1500 * time.Millisecond)
-	stabilized, pumpErr := p.pumpSession(ctx, inst, sessHandle, 3*time.Second)
+	stabilized, pumpErr := p.pumpSession(ctx, inst, sessHandle, timeout)
 	if pumpErr != nil {
 		// Non-fatal -- target might not respond
 		_ = pumpErr

--- a/internal/plugins/rdp/session.go
+++ b/internal/plugins/rdp/session.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"hash/crc32"
 	"io"
 	"net"
 	"time"
@@ -33,11 +34,16 @@ const (
 	stateSessionNeedRecv = 27
 )
 
+// verdictIndeterminate marks a check whose render never stabilized, so a
+// "clean" reading cannot be trusted (distinct from a benign clean verdict).
+const verdictIndeterminate = "indeterminate"
+
 // StickyKeysResult holds the outcome of sticky keys detection.
 type StickyKeysResult struct {
 	Performed       bool
+	Stabilized      bool // response pump observed N consecutive no-change frames
 	SkipReason      string
-	OverallVerdict  string  // "backdoor_confirmed", "backdoor_likely", "vulnerable", "clean"
+	OverallVerdict  string  // "backdoor_confirmed", "backdoor_likely", "vulnerable", "clean", "indeterminate"
 	Confidence      float64 // 0.0-1.0
 	HeuristicResult string
 	VisionResult    string
@@ -46,8 +52,9 @@ type StickyKeysResult struct {
 // UtilmanResult holds the outcome of utilman backdoor detection.
 type UtilmanResult struct {
 	Performed       bool
+	Stabilized      bool // response pump observed N consecutive no-change frames
 	SkipReason      string
-	OverallVerdict  string  // "backdoor_confirmed", "backdoor_likely", "vulnerable", "clean"
+	OverallVerdict  string  // "backdoor_confirmed", "backdoor_likely", "vulnerable", "clean", "indeterminate"
 	Confidence      float64 // 0.0-1.0
 	HeuristicResult string
 	VisionResult    string
@@ -56,26 +63,31 @@ type UtilmanResult struct {
 // leftShiftScancode is the scancode for Left Shift key (used for sticky keys detection).
 const leftShiftScancode = 0x2A
 
+// stableFrames is the number of consecutive identical frame hashes that signal
+// the framebuffer has stopped changing (render complete).
+const stableFrames = 3
+
 // runSession creates a session from the connector, pumps it to receive the login screen bitmap,
 // sends 5x Shift key presses, then captures the post-keystroke bitmap.
-// Returns (baseline_rgba, response_rgba, width, height, error).
+// Returns (baseline_rgba, response_rgba, width, height, stabilized, error).
+// stabilized reflects whether the response pump observed a settled framebuffer.
 func (p *Plugin) runSession(ctx context.Context, inst *wasmInstance, connHandle uint32,
-	width, height uint32) (baselineRGBA, responseRGBA []byte, outWidth, outHeight uint32, err error) {
+	width, height uint32) (baselineRGBA, responseRGBA []byte, outWidth, outHeight uint32, stabilized bool, err error) {
 
 	callCtx := inst.callCtx(ctx)
 
 	// Create session from connector
 	sessionNewFn := inst.mod.ExportedFunction("session_new")
 	if sessionNewFn == nil {
-		return nil, nil, 0, 0, fmt.Errorf("session_new not exported")
+		return nil, nil, 0, 0, false, fmt.Errorf("session_new not exported")
 	}
 	results, err := sessionNewFn.Call(callCtx, uint64(connHandle), uint64(width), uint64(height))
 	if err != nil {
-		return nil, nil, 0, 0, fmt.Errorf("session_new: %w", err)
+		return nil, nil, 0, 0, false, fmt.Errorf("session_new: %w", err)
 	}
 	sessHandle := uint32(results[0])
 	if sessHandle == 0 {
-		return nil, nil, 0, 0, fmt.Errorf("session_new returned null handle")
+		return nil, nil, 0, 0, false, fmt.Errorf("session_new returned null handle")
 	}
 
 	// Ensure cleanup
@@ -86,25 +98,25 @@ func (p *Plugin) runSession(ctx context.Context, inst *wasmInstance, connHandle 
 		}
 	}()
 
-	// Pump session to get initial login screen
-	if pumpErr := p.pumpSession(ctx, inst, sessHandle, 5*time.Second); pumpErr != nil {
-		return nil, nil, 0, 0, fmt.Errorf("pump baseline: %w", pumpErr)
+	// Pump session to get initial login screen (baseline stabilization is ignored).
+	if _, pumpErr := p.pumpSession(ctx, inst, sessHandle, 5*time.Second); pumpErr != nil {
+		return nil, nil, 0, 0, false, fmt.Errorf("pump baseline: %w", pumpErr)
 	}
 
 	// Capture baseline frame
 	baseline, err := p.captureFrame(ctx, inst, sessHandle)
 	if err != nil {
-		return nil, nil, 0, 0, fmt.Errorf("capture baseline: %w", err)
+		return nil, nil, 0, 0, false, fmt.Errorf("capture baseline: %w", err)
 	}
 
 	// Send 5x Shift key to trigger sticky keys
 	for i := 0; i < 5; i++ {
 		if keyErr := p.sendKey(ctx, inst, sessHandle, leftShiftScancode, true); keyErr != nil {
-			return nil, nil, 0, 0, fmt.Errorf("send shift press %d: %w", i+1, keyErr)
+			return nil, nil, 0, 0, false, fmt.Errorf("send shift press %d: %w", i+1, keyErr)
 		}
 		time.Sleep(50 * time.Millisecond)
 		if keyErr := p.sendKey(ctx, inst, sessHandle, leftShiftScancode, false); keyErr != nil {
-			return nil, nil, 0, 0, fmt.Errorf("send shift release %d: %w", i+1, keyErr)
+			return nil, nil, 0, 0, false, fmt.Errorf("send shift release %d: %w", i+1, keyErr)
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
@@ -112,7 +124,8 @@ func (p *Plugin) runSession(ctx context.Context, inst *wasmInstance, connHandle 
 	// Wait for response and pump — give cmd.exe time to render before capturing.
 	// The exec.go path uses 1s sleep + 2s WaitForFrame; we mirror that here.
 	time.Sleep(1500 * time.Millisecond)
-	if pumpErr := p.pumpSession(ctx, inst, sessHandle, 3*time.Second); pumpErr != nil {
+	stabilized, pumpErr := p.pumpSession(ctx, inst, sessHandle, 3*time.Second)
+	if pumpErr != nil {
 		// Non-fatal -- target might not respond
 		_ = pumpErr
 	}
@@ -120,32 +133,33 @@ func (p *Plugin) runSession(ctx context.Context, inst *wasmInstance, connHandle 
 	// Capture response frame
 	response, err := p.captureFrame(ctx, inst, sessHandle)
 	if err != nil {
-		return nil, nil, 0, 0, fmt.Errorf("capture response: %w", err)
+		return nil, nil, 0, 0, false, fmt.Errorf("capture response: %w", err)
 	}
 
-	return baseline, response, width, height, nil
+	return baseline, response, width, height, stabilized, nil
 }
 
 // runUtilmanSession creates a session from the connector, pumps it to receive the login screen bitmap,
 // sends Win+U to trigger the Utility Manager (utilman.exe), then captures the post-keystroke bitmap.
-// Returns (baseline_rgba, response_rgba, width, height, error).
+// Returns (baseline_rgba, response_rgba, width, height, stabilized, error).
+// stabilized reflects whether the response pump observed a settled framebuffer.
 func (p *Plugin) runUtilmanSession(ctx context.Context, inst *wasmInstance, connHandle uint32,
-	width, height uint32) (baselineRGBA, responseRGBA []byte, outWidth, outHeight uint32, err error) {
+	width, height uint32) (baselineRGBA, responseRGBA []byte, outWidth, outHeight uint32, stabilized bool, err error) {
 
 	callCtx := inst.callCtx(ctx)
 
 	// Create session from connector
 	sessionNewFn := inst.mod.ExportedFunction("session_new")
 	if sessionNewFn == nil {
-		return nil, nil, 0, 0, fmt.Errorf("session_new not exported")
+		return nil, nil, 0, 0, false, fmt.Errorf("session_new not exported")
 	}
 	results, err := sessionNewFn.Call(callCtx, uint64(connHandle), uint64(width), uint64(height))
 	if err != nil {
-		return nil, nil, 0, 0, fmt.Errorf("session_new: %w", err)
+		return nil, nil, 0, 0, false, fmt.Errorf("session_new: %w", err)
 	}
 	sessHandle := uint32(results[0])
 	if sessHandle == 0 {
-		return nil, nil, 0, 0, fmt.Errorf("session_new returned null handle")
+		return nil, nil, 0, 0, false, fmt.Errorf("session_new returned null handle")
 	}
 
 	// Ensure cleanup
@@ -156,38 +170,39 @@ func (p *Plugin) runUtilmanSession(ctx context.Context, inst *wasmInstance, conn
 		}
 	}()
 
-	// Pump session to get initial login screen
-	if pumpErr := p.pumpSession(ctx, inst, sessHandle, 5*time.Second); pumpErr != nil {
-		return nil, nil, 0, 0, fmt.Errorf("pump baseline: %w", pumpErr)
+	// Pump session to get initial login screen (baseline stabilization is ignored).
+	if _, pumpErr := p.pumpSession(ctx, inst, sessHandle, 5*time.Second); pumpErr != nil {
+		return nil, nil, 0, 0, false, fmt.Errorf("pump baseline: %w", pumpErr)
 	}
 
 	// Capture baseline frame
 	baseline, err := p.captureFrame(ctx, inst, sessHandle)
 	if err != nil {
-		return nil, nil, 0, 0, fmt.Errorf("capture baseline: %w", err)
+		return nil, nil, 0, 0, false, fmt.Errorf("capture baseline: %w", err)
 	}
 
 	// Send Win+U to trigger Utility Manager (utilman.exe)
 	// Key sequence: press Win, press U, release U, release Win
 	if keyErr := p.sendKey(ctx, inst, sessHandle, leftWinScancode, true); keyErr != nil {
-		return nil, nil, 0, 0, fmt.Errorf("send win press: %w", keyErr)
+		return nil, nil, 0, 0, false, fmt.Errorf("send win press: %w", keyErr)
 	}
 	time.Sleep(50 * time.Millisecond)
 	if keyErr := p.sendKey(ctx, inst, sessHandle, uKeyScancode, true); keyErr != nil {
-		return nil, nil, 0, 0, fmt.Errorf("send u press: %w", keyErr)
+		return nil, nil, 0, 0, false, fmt.Errorf("send u press: %w", keyErr)
 	}
 	time.Sleep(50 * time.Millisecond)
 	if keyErr := p.sendKey(ctx, inst, sessHandle, uKeyScancode, false); keyErr != nil {
-		return nil, nil, 0, 0, fmt.Errorf("send u release: %w", keyErr)
+		return nil, nil, 0, 0, false, fmt.Errorf("send u release: %w", keyErr)
 	}
 	time.Sleep(50 * time.Millisecond)
 	if keyErr := p.sendKey(ctx, inst, sessHandle, leftWinScancode, false); keyErr != nil {
-		return nil, nil, 0, 0, fmt.Errorf("send win release: %w", keyErr)
+		return nil, nil, 0, 0, false, fmt.Errorf("send win release: %w", keyErr)
 	}
 
 	// Wait for response and pump — give cmd.exe time to render before capturing.
 	time.Sleep(1500 * time.Millisecond)
-	if pumpErr := p.pumpSession(ctx, inst, sessHandle, 3*time.Second); pumpErr != nil {
+	stabilized, pumpErr := p.pumpSession(ctx, inst, sessHandle, 3*time.Second)
+	if pumpErr != nil {
 		// Non-fatal -- target might not respond
 		_ = pumpErr
 	}
@@ -195,10 +210,10 @@ func (p *Plugin) runUtilmanSession(ctx context.Context, inst *wasmInstance, conn
 	// Capture response frame
 	response, err := p.captureFrame(ctx, inst, sessHandle)
 	if err != nil {
-		return nil, nil, 0, 0, fmt.Errorf("capture response: %w", err)
+		return nil, nil, 0, 0, false, fmt.Errorf("capture response: %w", err)
 	}
 
-	return baseline, response, width, height, nil
+	return baseline, response, width, height, stabilized, nil
 }
 
 // readRDPFrame reads a single complete RDP PDU from the connection.
@@ -274,18 +289,26 @@ func readRDPFrame(r io.Reader) ([]byte, error) {
 	return frame, nil
 }
 
-// pumpSession drives the session state machine until a frame is available or timeout.
-func (p *Plugin) pumpSession(ctx context.Context, inst *wasmInstance, sessHandle uint32, timeout time.Duration) error {
+// pumpSession drives the session state machine until the framebuffer stabilizes
+// or the deadline expires. It returns stabilized=true if it observed
+// `stableFrames` consecutive frame-available steps with no pixel change before
+// the deadline; false if the deadline cut it off while frames were still
+// changing.
+func (p *Plugin) pumpSession(ctx context.Context, inst *wasmInstance, sessHandle uint32, timeout time.Duration) (stabilized bool, err error) {
 	callCtx := inst.callCtx(ctx)
 	sessionStepFn := inst.mod.ExportedFunction("session_step")
 	if sessionStepFn == nil {
-		return fmt.Errorf("session_step not exported")
+		return false, fmt.Errorf("session_step not exported")
 	}
 
 	deadline := time.Now().Add(timeout)
 	conn := inst.activeConn()
 	// Reset read deadline when we exit so subsequent operations are not affected.
 	defer func() { _ = conn.SetReadDeadline(time.Time{}) }()
+
+	var lastHash uint32
+	var haveHash bool
+	consecutiveStable := 0
 
 	for time.Now().Before(deadline) {
 		// Set per-frame read deadline
@@ -297,25 +320,25 @@ func (p *Plugin) pumpSession(ctx context.Context, inst *wasmInstance, sessHandle
 			if netErr, ok := readErr.(net.Error); ok && netErr.Timeout() {
 				continue // Timeout is OK, just loop
 			}
-			return fmt.Errorf("read frame: %w", readErr)
+			return false, fmt.Errorf("read frame: %w", readErr)
 		}
 
 		// Write complete frame to WASM
 		inputPtr, inputLen, err := inst.writeToWasm(callCtx, frame)
 		if err != nil {
-			return fmt.Errorf("write to wasm: %w", err)
+			return false, fmt.Errorf("write to wasm: %w", err)
 		}
 
 		outPtrSlot, _, err := inst.writeToWasm(callCtx, make([]byte, 4))
 		if err != nil {
 			inst.freeInWasm(callCtx, inputPtr, inputLen)
-			return fmt.Errorf("alloc out ptr: %w", err)
+			return false, fmt.Errorf("alloc out ptr: %w", err)
 		}
 		outLenSlot, _, err := inst.writeToWasm(callCtx, make([]byte, 4))
 		if err != nil {
 			inst.freeInWasm(callCtx, inputPtr, inputLen)
 			inst.freeInWasm(callCtx, outPtrSlot, 4)
-			return fmt.Errorf("alloc out len: %w", err)
+			return false, fmt.Errorf("alloc out len: %w", err)
 		}
 
 		results, err := sessionStepFn.Call(callCtx,
@@ -329,7 +352,7 @@ func (p *Plugin) pumpSession(ctx context.Context, inst *wasmInstance, sessHandle
 		if err != nil {
 			inst.freeInWasm(callCtx, outPtrSlot, 4)
 			inst.freeInWasm(callCtx, outLenSlot, 4)
-			return fmt.Errorf("session_step: %w", err)
+			return false, fmt.Errorf("session_step: %w", err)
 		}
 
 		state := uint32(results[0])
@@ -338,9 +361,24 @@ func (p *Plugin) pumpSession(ctx context.Context, inst *wasmInstance, sessHandle
 		case stateFrameAvailable:
 			inst.freeInWasm(callCtx, outPtrSlot, 4)
 			inst.freeInWasm(callCtx, outLenSlot, 4)
-			// Don't return — RDP sends the screen incrementally across many
-			// frames.  Keep pumping until timeout to accumulate all bitmap
-			// updates into the DecodedImage framebuffer.
+			// Don't return on the first frame — RDP sends the screen
+			// incrementally across many frames. Hash the framebuffer and track
+			// consecutive no-change frames; once it stops changing for
+			// `stableFrames` steps the render is complete and we can return the
+			// slot sooner.
+			if frameData, capErr := p.captureFrame(ctx, inst, sessHandle); capErr == nil {
+				h := crc32.ChecksumIEEE(frameData)
+				if haveHash && h == lastHash {
+					consecutiveStable++
+				} else {
+					consecutiveStable = 0
+				}
+				lastHash = h
+				haveHash = true
+				if consecutiveStable >= stableFrames {
+					return true, nil
+				}
+			}
 
 		case stateSessionNeedSend:
 			sendData := readOutputFromSlots(callCtx, inst, outPtrSlot, outLenSlot)
@@ -348,7 +386,7 @@ func (p *Plugin) pumpSession(ctx context.Context, inst *wasmInstance, sessHandle
 			inst.freeInWasm(callCtx, outLenSlot, 4)
 			if len(sendData) > 0 {
 				if _, writeErr := conn.Write(sendData); writeErr != nil {
-					return fmt.Errorf("tcp write: %w", writeErr)
+					return false, fmt.Errorf("tcp write: %w", writeErr)
 				}
 			}
 
@@ -361,7 +399,7 @@ func (p *Plugin) pumpSession(ctx context.Context, inst *wasmInstance, sessHandle
 			errBytes := readOutputFromSlots(callCtx, inst, outPtrSlot, outLenSlot)
 			inst.freeInWasm(callCtx, outPtrSlot, 4)
 			inst.freeInWasm(callCtx, outLenSlot, 4)
-			return fmt.Errorf("session error: %s", string(errBytes))
+			return false, fmt.Errorf("session error: %s", string(errBytes))
 
 		default:
 			inst.freeInWasm(callCtx, outPtrSlot, 4)
@@ -369,7 +407,7 @@ func (p *Plugin) pumpSession(ctx context.Context, inst *wasmInstance, sessHandle
 		}
 	}
 
-	return nil // Timeout is not fatal
+	return stabilized, nil // Timeout is not fatal; stabilized stays false if frames were still changing
 }
 
 // captureFrame reads the current RGBA frame buffer from the WASM session.

--- a/pkg/brutus/brutus.go
+++ b/pkg/brutus/brutus.go
@@ -126,6 +126,7 @@ type Result struct {
 	Password string        // password tested
 	Key      []byte        // SSH key (Phase 1B, nil in 1A)
 	Success  bool          // authentication succeeded?
+	Indeterminate bool     // check could not produce a clean/dirty verdict; rerun
 	Error    error         // connection/network error (nil for auth failure)
 	Duration time.Duration // test duration
 

--- a/pkg/brutus/brutus.go
+++ b/pkg/brutus/brutus.go
@@ -120,15 +120,15 @@ type Config struct {
 
 // Result contains the outcome of testing a single credential.
 type Result struct {
-	Protocol string        // protocol used
-	Target   string        // target tested
-	Username string        // username tested
-	Password string        // password tested
-	Key      []byte        // SSH key (Phase 1B, nil in 1A)
-	Success  bool          // authentication succeeded?
-	Indeterminate bool     // check could not produce a clean/dirty verdict; rerun
-	Error    error         // connection/network error (nil for auth failure)
-	Duration time.Duration // test duration
+	Protocol      string        // protocol used
+	Target        string        // target tested
+	Username      string        // username tested
+	Password      string        // password tested
+	Key           []byte        // SSH key (Phase 1B, nil in 1A)
+	Success       bool          // authentication succeeded?
+	Indeterminate bool          // check could not produce a clean/dirty verdict; rerun
+	Error         error         // connection/network error (nil for auth failure)
+	Duration      time.Duration // test duration
 
 	// Banner and LLM suggestion tracking
 	Banner            string   // service banner (if captured)

--- a/pkg/brutus/logon/admission.go
+++ b/pkg/brutus/logon/admission.go
@@ -18,13 +18,20 @@ import (
 	"context"
 	"fmt"
 	"runtime"
-	"sync"
 	"time"
 
 	"golang.org/x/sync/semaphore"
 
 	"github.com/praetorian-inc/brutus/internal/plugins/rdp"
 	"github.com/praetorian-inc/brutus/pkg/brutus"
+)
+
+// detectSticky and detectUtilman are swappable seam vars over the RDP check
+// entry points so tests can substitute fakes (see sequential_test.go) that
+// record invocation order without a live RDP server.
+var (
+	detectSticky  = rdp.DetectStickyKeys
+	detectUtilman = rdp.DetectUtilman
 )
 
 // decodeSlotsPerCPU sizes the process-wide decode-slot budget relative to
@@ -59,23 +66,15 @@ func DecodeSlotCount() int64 {
 var runDetection = func(ctx context.Context, target string, timeout time.Duration, aiMode bool) ([]brutus.Result, bool) {
 	noVision := !aiMode
 
-	// Sticky keys and utilman detection use independent RDP connections and WASM
-	// instances (each instance has isolated linear memory; see
-	// internal/plugins/rdp/wasm.go), so the two checks run concurrently to halve
-	// per-host wall-clock time. Output order (sticky first, utilman second) is
-	// preserved regardless of which goroutine finishes first.
-	var stickyResult, utilmanResult *brutus.Result
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		stickyResult = rdp.DetectStickyKeys(ctx, target, timeout, "(sticky-keys)", noVision)
-	}()
-	go func() {
-		defer wg.Done()
-		utilmanResult = rdp.DetectUtilman(ctx, target, timeout, "(utilman)", noVision)
-	}()
-	wg.Wait()
+	// Sticky keys and utilman detection run sequentially under the single held
+	// decode slot: sticky first, then utilman. The shared-connection design was
+	// infeasible (the Rust FFI moves the ConnectionResult out on the first
+	// session_new), so each check still opens its own RDP connection and WASM
+	// instance. Running them one at a time keeps the decode-slot bound accurate
+	// (one decoder per slot, not two concurrent). Both checks always run — a
+	// positive sticky result never suppresses the utilman check.
+	stickyResult := detectSticky(ctx, target, timeout, "(sticky-keys)", noVision)
+	utilmanResult := detectUtilman(ctx, target, timeout, "(utilman)", noVision)
 
 	results := []brutus.Result{*stickyResult, *utilmanResult}
 	hasSuccess := stickyResult.Success || utilmanResult.Success

--- a/pkg/brutus/logon/admission.go
+++ b/pkg/brutus/logon/admission.go
@@ -81,10 +81,10 @@ var runDetection = func(ctx context.Context, target string, timeout time.Duratio
 	return results, hasSuccess
 }
 
-// cancelledResults returns the sticky + utilman result pair for a host whose
+// CancelledResults returns the sticky + utilman result pair for a host whose
 // decode slot was never acquired (context cancelled while queued). The host did
 // not run, so it must read as INDETERMINATE — never silently clean.
-func cancelledResults(target string) []brutus.Result {
+func CancelledResults(target string) []brutus.Result {
 	const banner = "[WARN] %s check INDETERMINATE (scan cancelled before start — rerun)"
 	return []brutus.Result{
 		{

--- a/pkg/brutus/logon/admission.go
+++ b/pkg/brutus/logon/admission.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logon
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/semaphore"
+
+	"github.com/praetorian-inc/brutus/internal/plugins/rdp"
+	"github.com/praetorian-inc/brutus/pkg/brutus"
+)
+
+// decodeSlotsPerCPU sizes the process-wide decode-slot budget relative to
+// GOMAXPROCS. The RDP detection body is a mix of CPU-bound WASM decode and
+// blocking I/O, so we allow modestly more in-flight sessions than cores.
+const decodeSlotsPerCPU = 1.5
+
+// decodeSlots bounds how many DetectBackdoors detection bodies may run
+// concurrently across the whole process. It is process-wide (not per-errgroup)
+// so the gate spans both the host fan-out errgroup and the single-target path.
+var decodeSlots = semaphore.NewWeighted(decodeSlotCount())
+
+// decodeSlotCount returns the number of concurrent decode slots, at least 1.
+func decodeSlotCount() int64 {
+	n := int64(float64(runtime.GOMAXPROCS(0)) * decodeSlotsPerCPU)
+	if n < 1 {
+		n = 1
+	}
+	return n
+}
+
+// DecodeSlotCount exposes the configured decode-slot budget for callers that
+// want to warn when host concurrency greatly exceeds the CPU-bound decode bound.
+func DecodeSlotCount() int64 {
+	return decodeSlotCount()
+}
+
+// runDetection holds the post-acquire detection body. It is a package-level var
+// (paralleling scanTargetFn in cmd/brutus) so tests can swap it for a fake that
+// records peak concurrency without a live RDP server. DetectBackdoors acquires a
+// decode slot before invoking it.
+var runDetection = func(ctx context.Context, target string, timeout time.Duration, aiMode bool) ([]brutus.Result, bool) {
+	noVision := !aiMode
+
+	// Sticky keys and utilman detection use independent RDP connections and WASM
+	// instances (each instance has isolated linear memory; see
+	// internal/plugins/rdp/wasm.go), so the two checks run concurrently to halve
+	// per-host wall-clock time. Output order (sticky first, utilman second) is
+	// preserved regardless of which goroutine finishes first.
+	var stickyResult, utilmanResult *brutus.Result
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		stickyResult = rdp.DetectStickyKeys(ctx, target, timeout, "(sticky-keys)", noVision)
+	}()
+	go func() {
+		defer wg.Done()
+		utilmanResult = rdp.DetectUtilman(ctx, target, timeout, "(utilman)", noVision)
+	}()
+	wg.Wait()
+
+	results := []brutus.Result{*stickyResult, *utilmanResult}
+	hasSuccess := stickyResult.Success || utilmanResult.Success
+	return results, hasSuccess
+}
+
+// cancelledResults returns the sticky + utilman result pair for a host whose
+// decode slot was never acquired (context cancelled while queued). The host did
+// not run, so it must read as INDETERMINATE — never silently clean.
+func cancelledResults(target string) []brutus.Result {
+	const banner = "[WARN] %s check INDETERMINATE (scan cancelled before start — rerun)"
+	return []brutus.Result{
+		{
+			Protocol:      "rdp",
+			Target:        target,
+			Username:      "(sticky-keys)",
+			ScanType:      "sticky_keys",
+			Indeterminate: true,
+			Banner:        fmt.Sprintf(banner, "Sticky keys"),
+		},
+		{
+			Protocol:      "rdp",
+			Target:        target,
+			Username:      "(utilman)",
+			ScanType:      "utilman",
+			Indeterminate: true,
+			Banner:        fmt.Sprintf(banner, "Utilman"),
+		},
+	}
+}

--- a/pkg/brutus/logon/admission_test.go
+++ b/pkg/brutus/logon/admission_test.go
@@ -82,7 +82,7 @@ func TestDecodeSlotBound(t *testing.T) {
 	for i := 0; i < goroutines; i++ {
 		go func() {
 			defer wg.Done()
-			DetectBackdoors(context.Background(), "host:3389", 5*time.Second, false)
+			DetectBackdoors(context.Background(), "host:3389", 5*time.Second, false, 0)
 		}()
 	}
 	wg.Wait()

--- a/pkg/brutus/logon/admission_test.go
+++ b/pkg/brutus/logon/admission_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logon
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sync/semaphore"
+
+	"github.com/praetorian-inc/brutus/pkg/brutus"
+)
+
+// withDecodeSlots replaces the process-wide decode semaphore with one of size n
+// for the duration of the test, restoring the original in t.Cleanup.
+func withDecodeSlots(t *testing.T, n int64) {
+	t.Helper()
+	orig := decodeSlots
+	decodeSlots = semaphore.NewWeighted(n)
+	t.Cleanup(func() { decodeSlots = orig })
+}
+
+// TestDecodeSlotBound verifies that the process-wide weighted semaphore
+// (decodeSlots) bounds the number of concurrent post-acquire detection
+// bodies to the configured slot count, while still allowing real parallelism.
+//
+// The test mirrors the pattern in cmd/brutus/scan_concurrency_test.go:
+// swap a package-level seam (runDetection) with a fake that records peak
+// concurrency, fire many concurrent DetectBackdoors calls, then assert the
+// bound holds and real parallelism occurred.
+func TestDecodeSlotBound(t *testing.T) {
+	const slotCount int64 = 4
+	const goroutines = 50
+
+	// Shrink decodeSlots to a known small size for the duration of this test.
+	withDecodeSlots(t, slotCount)
+
+	// Swap runDetection with a fake that:
+	//   - increments an atomic counter on entry
+	//   - records peak via compare-and-update
+	//   - sleeps 10ms to ensure overlap
+	//   - decrements on exit
+	//   - returns a benign 2-result slice (sticky + utilman)
+	var current, peak atomic.Int64
+	origRunDetection := runDetection
+	runDetection = func(ctx context.Context, target string, timeout time.Duration, aiMode bool) ([]brutus.Result, bool) {
+		n := current.Add(1)
+		for {
+			p := peak.Load()
+			if n <= p || peak.CompareAndSwap(p, n) {
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+		current.Add(-1)
+		return []brutus.Result{
+			{Target: target, ScanType: "sticky_keys"},
+			{Target: target, ScanType: "utilman"},
+		}, false
+	}
+	t.Cleanup(func() { runDetection = origRunDetection })
+
+	// Fire goroutines concurrent DetectBackdoors calls.
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			DetectBackdoors(context.Background(), "host:3389", 5*time.Second, false)
+		}()
+	}
+	wg.Wait()
+
+	observed := peak.Load()
+	// The semaphore must cap concurrency at the slot count.
+	assert.LessOrEqual(t, observed, slotCount,
+		"peak concurrency (%d) must not exceed decodeSlots (%d)", observed, slotCount)
+	// Prove real parallelism; if everything ran serially this would be 1.
+	assert.GreaterOrEqual(t, observed, int64(2),
+		"expected parallel execution under the semaphore, not serial (peak=%d)", observed)
+}

--- a/pkg/brutus/logon/logon.go
+++ b/pkg/brutus/logon/logon.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/praetorian-inc/brutus/internal/plugins/rdp"
@@ -37,30 +36,19 @@ const (
 
 // DetectBackdoors runs sticky keys and utilman detection against a single RDP
 // target. Returns results and whether any backdoor was found.
+//
+// A process-wide decode slot (admission.go) is acquired before any dial so that
+// queued hosts spend zero pump budget; the slot bounds concurrent WASM-decode
+// sessions independently of the host errgroup's --threads limit.
 func DetectBackdoors(ctx context.Context, target string, timeout time.Duration, aiMode bool) ([]brutus.Result, bool) {
-	noVision := !aiMode
+	if err := decodeSlots.Acquire(ctx, 1); err != nil {
+		// Context cancelled while queued: the host never ran, so it must read
+		// as indeterminate, never silently clean.
+		return cancelledResults(target), false
+	}
+	defer decodeSlots.Release(1)
 
-	// Sticky keys and utilman detection use independent RDP connections and WASM
-	// instances (each instance has isolated linear memory; see
-	// internal/plugins/rdp/wasm.go), so the two checks run concurrently to halve
-	// per-host wall-clock time. Output order (sticky first, utilman second) is
-	// preserved regardless of which goroutine finishes first.
-	var stickyResult, utilmanResult *brutus.Result
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		stickyResult = rdp.DetectStickyKeys(ctx, target, timeout, "(sticky-keys)", noVision)
-	}()
-	go func() {
-		defer wg.Done()
-		utilmanResult = rdp.DetectUtilman(ctx, target, timeout, "(utilman)", noVision)
-	}()
-	wg.Wait()
-
-	results := []brutus.Result{*stickyResult, *utilmanResult}
-	hasSuccess := stickyResult.Success || utilmanResult.Success
-	return results, hasSuccess
+	return runDetection(ctx, target, timeout, aiMode)
 }
 
 // ExecConfig holds parameters for sticky-keys command execution.

--- a/pkg/brutus/logon/logon.go
+++ b/pkg/brutus/logon/logon.go
@@ -39,8 +39,14 @@ const (
 //
 // A process-wide decode slot (admission.go) is acquired before any dial so that
 // queued hosts spend zero pump budget; the slot bounds concurrent WASM-decode
-// sessions independently of the host errgroup's --threads limit.
-func DetectBackdoors(ctx context.Context, target string, timeout time.Duration, aiMode bool) ([]brutus.Result, bool) {
+// sessions independently of the host errgroup's --threads limit. The slot is
+// held across retries: a retrying host is exactly the one that needs CPU, and
+// re-queueing it risks unbounded latency.
+//
+// Retries are keyed on the INDETERMINATE outcome only. A found backdoor
+// (hasSuccess) and a stabilized clean render are both final verdicts and are
+// returned immediately; retrying a positive would risk masking a real backdoor.
+func DetectBackdoors(ctx context.Context, target string, timeout time.Duration, aiMode bool, maxRetries int) ([]brutus.Result, bool) {
 	if err := decodeSlots.Acquire(ctx, 1); err != nil {
 		// Context cancelled while queued: the host never ran, so it must read
 		// as indeterminate, never silently clean.
@@ -48,7 +54,44 @@ func DetectBackdoors(ctx context.Context, target string, timeout time.Duration, 
 	}
 	defer decodeSlots.Release(1)
 
+	attempts := maxRetries + 1
+	for attempt := 0; attempt < attempts; attempt++ {
+		if attempt > 0 {
+			retryBackoff(ctx, attempt)
+		}
+		results, hasSuccess := runDetection(ctx, target, timeout, aiMode)
+		if hasSuccess || !anyIndeterminate(results) || attempt == attempts-1 {
+			return results, hasSuccess
+		}
+	}
+	// attempts is always >= 1, so the loop always returns; unreachable.
 	return runDetection(ctx, target, timeout, aiMode)
+}
+
+// anyIndeterminate reports whether any result could not produce a clean/dirty
+// verdict (e.g. a CPU-starved render). Such hosts are eligible for retry.
+func anyIndeterminate(results []brutus.Result) bool {
+	for i := range results {
+		if results[i].Indeterminate {
+			return true
+		}
+	}
+	return false
+}
+
+// retryBackoff sleeps a capped exponential delay before a retry attempt,
+// returning early if the context is cancelled. attempt is 1-based.
+func retryBackoff(ctx context.Context, attempt int) {
+	const base = 100 * time.Millisecond
+	const cap = 2 * time.Second
+	delay := base << (attempt - 1)
+	if delay > cap || delay <= 0 {
+		delay = cap
+	}
+	select {
+	case <-time.After(delay):
+	case <-ctx.Done():
+	}
 }
 
 // ExecConfig holds parameters for sticky-keys command execution.

--- a/pkg/brutus/logon/logon.go
+++ b/pkg/brutus/logon/logon.go
@@ -50,7 +50,7 @@ func DetectBackdoors(ctx context.Context, target string, timeout time.Duration, 
 	if err := decodeSlots.Acquire(ctx, 1); err != nil {
 		// Context cancelled while queued: the host never ran, so it must read
 		// as indeterminate, never silently clean.
-		return cancelledResults(target), false
+		return CancelledResults(target), false
 	}
 	defer decodeSlots.Release(1)
 
@@ -64,8 +64,9 @@ func DetectBackdoors(ctx context.Context, target string, timeout time.Duration, 
 			return results, hasSuccess
 		}
 	}
-	// attempts is always >= 1, so the loop always returns; unreachable.
-	return runDetection(ctx, target, timeout, aiMode)
+	// attempts is always >= 1, so the loop's final iteration always returns;
+	// this is unreachable and exists only to satisfy the compiler.
+	panic("unreachable: DetectBackdoors loop must return")
 }
 
 // anyIndeterminate reports whether any result could not produce a clean/dirty

--- a/pkg/brutus/logon/logon_cancel_test.go
+++ b/pkg/brutus/logon/logon_cancel_test.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logon
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/brutus/pkg/brutus"
+)
+
+// TestDetectBackdoors_CancelledWhileQueued verifies the cardinal-property
+// protection at the admission-control gate: when the context is already
+// cancelled before DetectBackdoors is called, the semaphore Acquire fails and
+// the host must read as INDETERMINATE — never silently clean or empty.
+//
+// This covers the previously-uncovered branch at logon.go:50-53.
+func TestDetectBackdoors_CancelledWhileQueued(t *testing.T) {
+	// Use the minimum semaphore size (1 slot) so Acquire is always attempted,
+	// giving us a deterministic cancelled-acquire on the pre-cancelled context.
+	withDecodeSlots(t, 1)
+
+	// Swap runDetection with a fake that records whether it was ever invoked.
+	// The cardinal property requires it is NOT invoked when the ctx is cancelled
+	// before the Acquire — the host never ran, so no detection work happens.
+	var detectionInvoked atomic.Bool
+	origRunDetection := runDetection
+	runDetection = func(ctx context.Context, target string, timeout time.Duration, aiMode bool) ([]brutus.Result, bool) {
+		detectionInvoked.Store(true)
+		return []brutus.Result{}, false
+	}
+	t.Cleanup(func() { runDetection = origRunDetection })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before the call — Acquire must fail immediately
+
+	results, hasSuccess := DetectBackdoors(ctx, "1.2.3.4:3389", 5*time.Second, false, 0)
+
+	// The host never ran; both results must be INDETERMINATE.
+	require.Len(t, results, 2, "cancelled context must produce exactly 2 results (sticky + utilman)")
+	assert.False(t, hasSuccess, "no scan ran; hasSuccess must be false")
+
+	for i, r := range results {
+		assert.True(t, r.Indeterminate, "result[%d] must be Indeterminate (never ran)", i)
+		assert.False(t, r.Success, "result[%d] must not be Success (never ran)", i)
+	}
+
+	// The detection body must NEVER have been called — cancellation must
+	// short-circuit before any RDP work begins.
+	assert.False(t, detectionInvoked.Load(),
+		"runDetection must not be invoked when context is cancelled before Acquire")
+}
+
+// TestCancelledResults verifies the full content of the CancelledResults helper:
+// 2 results, correct ScanType/username/protocol/target/Indeterminate/Success,
+// and banners that carry both "INDETERMINATE" and "cancelled" (the rerun signal).
+// Testing content (not just length) satisfies the avoiding-low-value-tests
+// requirement — length-only assertions would miss a regression that drops
+// Indeterminate: true.
+func TestCancelledResults(t *testing.T) {
+	const target = "1.2.3.4:3389"
+
+	results := CancelledResults(target)
+
+	require.Len(t, results, 2, "CancelledResults must return exactly 2 results (sticky + utilman)")
+
+	sticky := results[0]
+	utilman := results[1]
+
+	// Structural: ScanType distinguishes the two checks.
+	assert.Equal(t, "sticky_keys", sticky.ScanType, "first result must be sticky_keys")
+	assert.Equal(t, "utilman", utilman.ScanType, "second result must be utilman")
+
+	// Usernames match the strings used by the real detection path.
+	assert.Equal(t, "(sticky-keys)", sticky.Username, "sticky username must be (sticky-keys)")
+	assert.Equal(t, "(utilman)", utilman.Username, "utilman username must be (utilman)")
+
+	// Both results must identify the target host and protocol.
+	assert.Equal(t, target, sticky.Target, "sticky Target must equal input target")
+	assert.Equal(t, target, utilman.Target, "utilman Target must equal input target")
+	assert.Equal(t, "rdp", sticky.Protocol, "sticky Protocol must be rdp")
+	assert.Equal(t, "rdp", utilman.Protocol, "utilman Protocol must be rdp")
+
+	// Cardinal-property assertions: both must be INDETERMINATE and not Success.
+	assert.True(t, sticky.Indeterminate, "sticky result must be Indeterminate")
+	assert.True(t, utilman.Indeterminate, "utilman result must be Indeterminate")
+	assert.False(t, sticky.Success, "sticky result must not be Success")
+	assert.False(t, utilman.Success, "utilman result must not be Success")
+
+	// Banners must carry both "INDETERMINATE" (cardinal signal) and "cancelled"
+	// (the rerun signal that tells the operator why the host was not scanned).
+	assert.Contains(t, sticky.Banner, "INDETERMINATE",
+		"sticky banner must contain INDETERMINATE")
+	assert.Contains(t, sticky.Banner, "cancelled",
+		"sticky banner must contain cancelled (rerun signal)")
+	assert.Contains(t, utilman.Banner, "INDETERMINATE",
+		"utilman banner must contain INDETERMINATE")
+	assert.Contains(t, utilman.Banner, "cancelled",
+		"utilman banner must contain cancelled (rerun signal)")
+}

--- a/pkg/brutus/logon/retry_test.go
+++ b/pkg/brutus/logon/retry_test.go
@@ -1,0 +1,161 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logon
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/brutus/pkg/brutus"
+)
+
+// indeterminateResults returns a pair of results (sticky+utilman) both marked
+// Indeterminate, simulating a stabilization failure (e.g. CPU-starved render).
+func indeterminateResults(target string) ([]brutus.Result, bool) {
+	return []brutus.Result{
+		{Target: target, ScanType: "sticky_keys", Indeterminate: true,
+			Banner: "[WARN] Sticky keys check INDETERMINATE (render did not stabilize — rerun)"},
+		{Target: target, ScanType: "utilman", Indeterminate: true,
+			Banner: "[WARN] Utilman check INDETERMINATE (render did not stabilize — rerun)"},
+	}, false
+}
+
+// cleanResults returns a pair of results (sticky+utilman) both clean (not
+// indeterminate, no backdoor found) — simulating a stabilized, negative render.
+func cleanResults(target string) ([]brutus.Result, bool) {
+	return []brutus.Result{
+		{Target: target, ScanType: "sticky_keys", Indeterminate: false},
+		{Target: target, ScanType: "utilman", Indeterminate: false},
+	}, false
+}
+
+// foundResults returns a pair of results where the sticky check indicates a
+// backdoor was found (hasSuccess=true).
+func foundResults(target string) ([]brutus.Result, bool) {
+	return []brutus.Result{
+		{Target: target, ScanType: "sticky_keys", Indeterminate: false, Success: true,
+			Banner: "[CRITICAL] Sticky keys backdoor confirmed"},
+		{Target: target, ScanType: "utilman", Indeterminate: false},
+	}, true
+}
+
+// TestDetectBackdoors_RetriesIndeterminate verifies that DetectBackdoors retries
+// when the first attempt returns indeterminate results and stops when a
+// non-indeterminate result is returned.
+//
+// Scenario: attempt 0 → indeterminate; attempt 1 → clean (non-indeterminate).
+// With maxRetries=2 the loop allows up to 3 total attempts. It must stop at 2
+// because the second attempt is no longer indeterminate.
+func TestDetectBackdoors_RetriesIndeterminate(t *testing.T) {
+	const target = "host:3389"
+
+	var attempts atomic.Int32
+	origRunDetection := runDetection
+	runDetection = func(ctx context.Context, tgt string, timeout time.Duration, aiMode bool) ([]brutus.Result, bool) {
+		n := int(attempts.Add(1))
+		if n == 1 {
+			return indeterminateResults(tgt)
+		}
+		return cleanResults(tgt)
+	}
+	t.Cleanup(func() { runDetection = origRunDetection })
+
+	results, hasSuccess := DetectBackdoors(context.Background(), target, 5*time.Second, false, 2)
+
+	require.Len(t, results, 2, "expected 2 results (sticky + utilman)")
+	assert.Equal(t, int32(2), attempts.Load(), "expected exactly 2 attempts: indeterminate on 0, clean on 1")
+	assert.False(t, hasSuccess, "no backdoor found")
+	assert.False(t, results[0].Indeterminate, "final sticky result must not be indeterminate")
+	assert.False(t, results[1].Indeterminate, "final utilman result must not be indeterminate")
+}
+
+// TestDetectBackdoors_NoRetryOnFoundBackdoor verifies that a positive (backdoor
+// found) result on the first attempt is returned immediately without retrying.
+// A found backdoor is a final verdict — retrying would be incorrect.
+func TestDetectBackdoors_NoRetryOnFoundBackdoor(t *testing.T) {
+	const target = "host:3389"
+
+	var attempts atomic.Int32
+	origRunDetection := runDetection
+	runDetection = func(ctx context.Context, tgt string, timeout time.Duration, aiMode bool) ([]brutus.Result, bool) {
+		attempts.Add(1)
+		return foundResults(tgt)
+	}
+	t.Cleanup(func() { runDetection = origRunDetection })
+
+	results, hasSuccess := DetectBackdoors(context.Background(), target, 5*time.Second, false, 2)
+
+	require.Len(t, results, 2)
+	assert.Equal(t, int32(1), attempts.Load(), "backdoor found: must not retry (exactly 1 attempt)")
+	assert.True(t, hasSuccess, "backdoor found, hasSuccess must be true")
+	assert.True(t, results[0].Success, "sticky result must carry Success=true")
+}
+
+// TestDetectBackdoors_NoRetryOnStabilizedClean verifies that a stabilized clean
+// result (non-indeterminate, no backdoor) on the first attempt is returned
+// immediately without retrying. A stabilized clean is a final verdict.
+func TestDetectBackdoors_NoRetryOnStabilizedClean(t *testing.T) {
+	const target = "host:3389"
+
+	var attempts atomic.Int32
+	origRunDetection := runDetection
+	runDetection = func(ctx context.Context, tgt string, timeout time.Duration, aiMode bool) ([]brutus.Result, bool) {
+		attempts.Add(1)
+		return cleanResults(tgt)
+	}
+	t.Cleanup(func() { runDetection = origRunDetection })
+
+	results, hasSuccess := DetectBackdoors(context.Background(), target, 5*time.Second, false, 2)
+
+	require.Len(t, results, 2)
+	assert.Equal(t, int32(1), attempts.Load(), "clean non-indeterminate: must not retry (exactly 1 attempt)")
+	assert.False(t, hasSuccess)
+	assert.False(t, results[0].Indeterminate)
+	assert.False(t, results[1].Indeterminate)
+}
+
+// TestDetectBackdoors_AttemptCap verifies that when every attempt returns
+// indeterminate, DetectBackdoors stops after exactly maxRetries+1 total attempts
+// and returns the final (still-indeterminate) result.
+//
+// With maxRetries=2: allowed attempts = 3. The last result is returned even
+// though it is still indeterminate.
+func TestDetectBackdoors_AttemptCap(t *testing.T) {
+	const target = "host:3389"
+	const maxRetries = 2
+
+	var attempts atomic.Int32
+	origRunDetection := runDetection
+	runDetection = func(ctx context.Context, tgt string, timeout time.Duration, aiMode bool) ([]brutus.Result, bool) {
+		attempts.Add(1)
+		return indeterminateResults(tgt)
+	}
+	t.Cleanup(func() { runDetection = origRunDetection })
+
+	results, hasSuccess := DetectBackdoors(context.Background(), target, 5*time.Second, false, maxRetries)
+
+	require.Len(t, results, 2)
+	assert.Equal(t, int32(maxRetries+1), attempts.Load(),
+		"always-indeterminate: attempts must equal maxRetries+1 (%d)", maxRetries+1)
+	assert.False(t, hasSuccess, "no backdoor found even after all retries")
+	// The final result is still indeterminate — caller must surface this to the user.
+	assert.True(t, results[0].Indeterminate, "final result still indeterminate after cap")
+	assert.True(t, results[1].Indeterminate, "final result still indeterminate after cap")
+}

--- a/pkg/brutus/logon/sequential_test.go
+++ b/pkg/brutus/logon/sequential_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logon
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/brutus/pkg/brutus"
+)
+
+// TestSequential verifies that runDetection (the fallback sequential form
+// introduced in Phase D) runs sticky keys THEN utilman in order, under the
+// single held decode slot, with no early-exit: even when the sticky fake
+// returns a positive backdoor result the utilman fake is still invoked.
+//
+// To fail correctly (RED): this file references the package-level seam vars
+// detectSticky and detectUtilman that D2 will add to logon. Until those vars
+// exist, the package will not compile and `go test -run TestSequential` fails
+// with "undefined: detectSticky" / "undefined: detectUtilman".
+//
+// Seam-var signatures assumed (developer must match exactly):
+//
+//	var detectSticky  = rdp.DetectStickyKeys   // func(ctx context.Context, target string, timeout time.Duration, username string, noVision bool) *brutus.Result
+//	var detectUtilman = rdp.DetectUtilman      // func(ctx context.Context, target string, timeout time.Duration, username string, noVision bool) *brutus.Result
+func TestSequential(t *testing.T) {
+	// Use a small semaphore so the decode slot is available.
+	withDecodeSlots(t, 1)
+
+	// stickyDone is set to true by the sticky fake immediately before it returns.
+	// The utilman fake reads this flag: if the sequential impl is correct, sticky
+	// must have finished before utilman starts, so the flag must already be true
+	// when utilman begins. A parallel impl would race and this assertion would
+	// fail intermittently (or consistently under the race detector).
+	var stickyDone atomic.Bool
+
+	// invocationOrder records which fake was called, in the order calls happen.
+	var invocationOrder []string
+
+	// origSticky / origUtilman are saved so Cleanup can restore them.
+	origSticky := detectSticky
+	origUtilman := detectUtilman
+	t.Cleanup(func() {
+		detectSticky = origSticky
+		detectUtilman = origUtilman
+	})
+
+	// Sticky fake: returns a positive (backdoor_confirmed / Success=true) result
+	// so we can assert that a positive sticky does NOT suppress the utilman check.
+	detectSticky = func(ctx context.Context, target string, timeout time.Duration, username string, noVision bool) *brutus.Result {
+		invocationOrder = append(invocationOrder, "sticky")
+		// Signal that sticky has finished its work.
+		stickyDone.Store(true)
+		return &brutus.Result{
+			Protocol: "rdp",
+			Target:   target,
+			Username: username,
+			ScanType: "sticky_keys",
+			Success:  true,
+			Banner:   "[CRITICAL] Sticky keys backdoor CONFIRMED (confidence: 100%)",
+		}
+	}
+
+	// Utilman fake: asserts that sticky completed before utilman started.
+	detectUtilman = func(ctx context.Context, target string, timeout time.Duration, username string, noVision bool) *brutus.Result {
+		// If sticky did not finish before utilman began, the sequential ordering
+		// guarantee is violated. This assertion fires inside the fake so that a
+		// parallel implementation causes the test to fail during DetectBackdoors.
+		assert.True(t, stickyDone.Load(),
+			"utilman fake called before stickyDone was set: execution was not sequential")
+		invocationOrder = append(invocationOrder, "utilman")
+		return &brutus.Result{
+			Protocol: "rdp",
+			Target:   target,
+			Username: username,
+			ScanType: "utilman",
+			Success:  false,
+			Banner:   "[INFO] Utilman check: clean (no response to Win+U)",
+		}
+	}
+
+	const target = "127.0.0.1:3389"
+	results, _ := DetectBackdoors(context.Background(), target, 5*time.Second, false, 0 /*maxRetries*/)
+
+	// --- Assertion 1: both checks ran (no early-exit) ---
+	require.Len(t, results, 2,
+		"expected exactly 2 results (sticky + utilman), got %d", len(results))
+
+	// --- Assertion 2: both fakes were invoked ---
+	assert.Contains(t, invocationOrder, "sticky", "sticky fake was never called")
+	assert.Contains(t, invocationOrder, "utilman",
+		"utilman fake was never called — early-exit on positive sticky is forbidden")
+
+	// --- Assertion 3: sticky-first ordering in the result slice ---
+	require.Equal(t, 2, len(invocationOrder),
+		"expected exactly 2 fake invocations, got %d", len(invocationOrder))
+	assert.Equal(t, "sticky", invocationOrder[0],
+		"first result must be sticky keys, got %q", invocationOrder[0])
+	assert.Equal(t, "utilman", invocationOrder[1],
+		"second result must be utilman, got %q", invocationOrder[1])
+
+	// --- Assertion 4: result slice order is sticky-first ---
+	assert.Equal(t, "sticky_keys", results[0].ScanType,
+		"results[0].ScanType must be sticky_keys")
+	assert.Equal(t, "utilman", results[1].ScanType,
+		"results[1].ScanType must be utilman")
+
+	// --- Assertion 5: utilman ran even though sticky returned Success=true ---
+	assert.True(t, results[0].Success, "sticky result should be Success=true (positive fake)")
+	// utilman fake returns Success=false; we just care it was called
+}

--- a/pkg/brutus/mode.go
+++ b/pkg/brutus/mode.go
@@ -93,7 +93,10 @@ func (m Mode) Presets() ModePresets {
 		}
 	default: // ModeDefault
 		return ModePresets{
-			Threads:     10,
+			Threads: 10,
+			// With admission control bounding concurrent WASM decode, the pump
+			// budget is spent on real CPU rather than starvation, so 10s is
+			// sufficient for the logon render; no value change needed.
 			Timeout:     10 * time.Second,
 			RateLimit:   0, // unlimited
 			Jitter:      0,


### PR DESCRIPTION
## Summary

After #163 parallelized the `brutus logon`/`stickykeys` RDP backdoor scan, the tool could **silently report a compromised host as clean** under load. QA against 10 hosts with 20 planted backdoors saw as few as **13 of 20** detected with `--threads 200 --timeout 3s`, while the pre-#163 serial build was reliably 20/20.

**Root cause — CPU-starved render truncation.** Detection pumps RDP frames into a WASM decoder for a wall-clock budget, then diffs the rendered "before/after" screen. The decode is CPU-bound but every deadline is wall-clock. At `--threads 200`, each host ran two concurrent decoders → ~400 WASM decoders oversubscribing the CPU, so the pump completed too few decode iterations before its budget expired. The "after" screen was half-rendered, the popped `cmd` window not yet decoded, and the diff showed nothing → verdict `clean`, `Performed: true`. A confident false-negative, invisible to error handling and not fixable by tuning timeouts.

This PR keeps the ~17× performance win while making the scan correct and fail-safe.

## What changed

- **Indeterminate ≠ clean (safety net).** `pumpSession` now reports whether the framebuffer stabilized (3 consecutive identical frames). A `clean` verdict on a non-stabilized render becomes `indeterminate`; a failed connection is a loud `[WARN] INDETERMINATE (… — rerun)` instead of a benign `[INFO] skipped`. Surfaced via a JSON `indeterminate` field and a new **exit code 2** (`0` = backdoor found, `2` = some host indeterminate/rerun, `1` = clean-nothing). **Positive verdicts are never downgraded** (false-negative guard).
- **Admission control.** A process-wide weighted semaphore (~1.5× `GOMAXPROCS`) bounds concurrent WASM-decode sessions. `--threads` still drives network fan-out; the semaphore caps decoders. Crucially the per-host timeout starts on slot acquire, not session start, so a queued host burns zero budget. A queued-then-cancelled host returns indeterminate, never clean.
- **Retries wired into the detection path.** `--retries` now retries the per-host detection while the result is indeterminate (holding the decode slot, capped backoff) — it never retries a found backdoor or a stabilized clean. The frame-pump now honors `--timeout` instead of hardcoded 5s/3s constants.
- **One connection per host.** Sticky and utilman now run sequentially under one decode slot (the shared-single-connector design is structurally impossible — the IronRDP WASM FFI moves the connection result out on the first `session_new`). Each check keeps its own fresh connection, eliminating inter-check screen-state contamination, and the decode bound is now accurate (one concurrent decoder per slot). Both checks always run and are reported (full attribution of `sethc.exe` vs `utilman.exe`).

## Out of scope (deferred)

Scan modes (`any` fast-triage / `sticky` / `utilman`-only) and the associated early-exit optimization — noted as a follow-up.

## Testing

- New unit/concurrency tests: indeterminate mapping, exit-code precedence, admission-control bound (50 goroutines vs N slots), retry-on-indeterminate (incl. no-retry on positive/clean and attempt cap), sequential ordering (fails under `-race` if parallel), cancelled-while-queued → indeterminate, `stabilizedVerdict` guard, runner cancel paths.
- `go build ./...`, `go vet ./...`, gofmt clean; full `-race` suite green on the changed packages.

## Reviewer notes

- Exit code 2 is new externally-observable behavior (existing 0/1 cases unchanged except the formerly-silent starved/failed host).
- `decodeSlotsPerCPU = 1.5` is a starting constant; may want field calibration.
- The `rdp.Plugin.Test()` (brute-force) sibling path was also updated to surface indeterminate rather than drop it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
