### PR TITLE
feat(rdp): behavioral nonce-confirmation + region classifier + ambiguity→indeterminate (fix no-Vision specificity)

### DIFF
--- a/internal/plugins/rdp/analyze.go
+++ b/internal/plugins/rdp/analyze.go
@@ -47,6 +47,12 @@ const (
 	consoleMaxLeftFrac  = 0.25 // minX/width  <= this -> left-anchored
 	consoleMaxTopFrac   = 0.25 // minY/height <= this -> top-anchored
 	dialogMinCenterFrac = 0.30 // box center within [0.30,0.70] of both axes -> centered
+
+	// nonceMinChangedPixels: minimum pixels that must change inside the box after
+	// typing the nonce to count as a shell echo. Set well above single-cursor-cell
+	// blink noise (a text cell is ~8x16 px) so a blinking caret alone never confirms;
+	// an echoed command line + new prompt changes thousands of pixels.
+	nonceMinChangedPixels = 500
 )
 
 // changedBox is the bounding box of significantly-changed pixels plus its fill ratio.
@@ -305,6 +311,41 @@ func decideVerdict(heuristic string, region regionSignal, nonce nonceResult) str
 	// Any uncertain backdoor_likely case (unconfirmed or skipped) is honest indeterminate,
 	// never clean.
 	return verdictIndeterminate
+}
+
+// verifyEcho reports whether typing the nonce produced a shell-like text render inside
+// the candidate box. It is a pure function over the pre-type and post-type framebuffers
+// plus the box: it counts pixels whose brightness changed (same brightness-diff logic as
+// analyzeBackdoorResponse) scoped to the box region, and returns nonceConfirmed when the
+// changed count clears nonceMinChangedPixels (a real shell echoes the line + new prompt),
+// else nonceUnconfirmed (a static dialog renders nothing new).
+func verifyEcho(beforeType, afterType []byte, width, height uint32, box changedBox) nonceResult {
+	w, h := int(width), int(height)
+	if w == 0 || h == 0 || box.maxX <= box.minX || box.maxY <= box.minY {
+		return nonceUnconfirmed
+	}
+
+	changed := 0
+	for y := box.minY; y <= box.maxY; y++ {
+		for x := box.minX; x <= box.maxX; x++ {
+			idx := (y*w + x) * 4
+			if idx+2 >= len(beforeType) || idx+2 >= len(afterType) {
+				continue
+			}
+			diff := pixelBrightness(beforeType, idx) - pixelBrightness(afterType, idx)
+			if diff < 0 {
+				diff = -diff
+			}
+			if diff > changeThreshold {
+				changed++
+			}
+		}
+	}
+
+	if changed >= nonceMinChangedPixels {
+		return nonceConfirmed
+	}
+	return nonceUnconfirmed
 }
 
 // rgbaToPNG converts RGBA pixel data to a PNG byte buffer.

--- a/internal/plugins/rdp/analyze.go
+++ b/internal/plugins/rdp/analyze.go
@@ -405,6 +405,13 @@ func runStickyKeysAnalysis(ctx context.Context, baseline, response []byte,
 				return result
 			}
 
+			// If Vision says "vulnerable" (normal Ease of Access on non-NLA), respect that
+			if visionVerdict == "vulnerable" {
+				result.OverallVerdict = "vulnerable"
+				result.Confidence = 0.8 // High confidence when Vision confirms normal behavior
+				return result
+			}
+
 			if visionVerdict == "clean" && verdict == "backdoor_likely" {
 				// Heuristic says backdoor, Vision says clean -- downgrade
 				result.OverallVerdict = "vulnerable"

--- a/internal/plugins/rdp/analyze.go
+++ b/internal/plugins/rdp/analyze.go
@@ -53,6 +53,12 @@ const (
 	// blink noise (a text cell is ~8x16 px) so a blinking caret alone never confirms;
 	// an echoed command line + new prompt changes thousands of pixels.
 	nonceMinChangedPixels = 500
+
+	// confirmedConsoleConfidence: when a backdoor is behaviorally confirmed AND the
+	// changed region is console-shaped (geometry corroborates the echo), report
+	// near-certain confidence. Geometry only RAISES confidence on an already-confirmed
+	// positive; it never lowers a verdict (cardinal rule — echo beats geometry).
+	confirmedConsoleConfidence = 0.95
 )
 
 // changedBox is the bounding box of significantly-changed pixels plus its fill ratio.
@@ -294,12 +300,13 @@ func classifyRegion(response []byte, width, height uint32, box changedBox) regio
 	return regionUnknown
 }
 
-// decideVerdict combines the heuristic verdict, the region signal, and the behavioral
-// nonce result into a final verdict. It is the single source of truth for the cardinal
-// rule: no "backdoor_likely" input ever yields "clean". Pure -> unit-testable.
+// decideVerdict combines the heuristic verdict and the behavioral nonce result into a
+// final verdict. It is the single source of truth for the cardinal rule: no
+// "backdoor_likely" input ever yields "clean". The region signal is intentionally NOT
+// consulted here — geometry must never change the verdict; it only enriches confidence
+// and the diagnostic banner (see regionConfidenceAndNote). region is retained in the
+// signature for call-site symmetry but is deliberately ignored. Pure -> unit-testable.
 func decideVerdict(heuristic string, region regionSignal, nonce nonceResult) string {
-	_ = region // region is informational; the cardinal rule does not depend on it.
-
 	if heuristic != "backdoor_likely" {
 		return heuristic
 	}
@@ -311,6 +318,39 @@ func decideVerdict(heuristic string, region regionSignal, nonce nonceResult) str
 	// Any uncertain backdoor_likely case (unconfirmed or skipped) is honest indeterminate,
 	// never clean.
 	return verdictIndeterminate
+}
+
+// regionConfidenceAndNote enriches an already-decided verdict with the geometry signal.
+// It NEVER changes the verdict (cardinal rule) — it only (a) raises confidence when a
+// confirmed backdoor is also console-shaped, and (b) returns an operator-facing note so
+// the banner explains what the geometry showed. Echo always beats geometry: a
+// dialog-shaped or unknown-shaped region that is still behaviorally confirmed stays
+// confirmed; the note just records the (non-corroborating) geometry. For an unconfirmed
+// (indeterminate) verdict the note tells the operator what to expect on a rerun.
+// Pure -> unit-testable; baseConfidence is returned unchanged unless a boost applies.
+func regionConfidenceAndNote(verdict string, region regionSignal, baseConfidence float64) (confidence float64, note string) {
+	switch verdict {
+	case "backdoor_confirmed":
+		switch region {
+		case regionConsoleLike:
+			return confirmedConsoleConfidence, "console-shaped + behaviorally confirmed"
+		case regionDialogLike:
+			return baseConfidence, "dialog-shaped but behaviorally confirmed (echo beats geometry)"
+		default:
+			return baseConfidence, "geometry inconclusive but behaviorally confirmed (echo beats geometry)"
+		}
+	case verdictIndeterminate:
+		switch region {
+		case regionConsoleLike:
+			return baseConfidence, "console-shaped, unconfirmed — rerun"
+		case regionDialogLike:
+			return baseConfidence, "dialog-shaped, unconfirmed — rerun"
+		default:
+			return baseConfidence, "geometry inconclusive, unconfirmed — rerun"
+		}
+	default:
+		return baseConfidence, ""
+	}
 }
 
 // verifyEcho reports whether typing the nonce produced a shell-like text render inside
@@ -422,11 +462,13 @@ func runStickyKeysAnalysis(ctx context.Context, baseline, response []byte,
 	}
 
 	// No-Vision (or inconclusive Vision) baseline: combine heuristic + pre-filter signal
-	// + behavioral nonce result via the cardinal-rule decision table.
+	// + behavioral nonce result via the cardinal-rule decision table. The region signal
+	// never changes the verdict (decideVerdict ignores it); it only enriches confidence
+	// and the diagnostic banner via regionConfidenceAndNote.
 	_, _, box := detectChangedRectangle(baseline, response, width, height)
 	region := classifyRegion(response, width, height, box)
 	result.OverallVerdict = decideVerdict(verdict, region, nonce)
-	result.Confidence = confidence
+	result.Confidence, result.RegionNote = regionConfidenceAndNote(result.OverallVerdict, region, confidence)
 	return result
 }
 
@@ -475,10 +517,12 @@ func runUtilmanAnalysis(ctx context.Context, baseline, response []byte,
 	}
 
 	// No-Vision (or inconclusive Vision) baseline: combine heuristic + pre-filter signal
-	// + behavioral nonce result via the cardinal-rule decision table.
+	// + behavioral nonce result via the cardinal-rule decision table. The region signal
+	// never changes the verdict (decideVerdict ignores it); it only enriches confidence
+	// and the diagnostic banner via regionConfidenceAndNote.
 	_, _, box := detectChangedRectangle(baseline, response, width, height)
 	region := classifyRegion(response, width, height, box)
 	result.OverallVerdict = decideVerdict(verdict, region, nonce)
-	result.Confidence = confidence
+	result.Confidence, result.RegionNote = regionConfidenceAndNote(result.OverallVerdict, region, confidence)
 	return result
 }

--- a/internal/plugins/rdp/analyze.go
+++ b/internal/plugins/rdp/analyze.go
@@ -33,6 +33,48 @@ const (
 	maxChangedPercent = 80.0
 )
 
+const (
+	// Brightness inside the box: a console is mostly dark, a dialog mostly light.
+	consoleMaxMeanBrightness = 90  // <= this (0-255) reads as a dark console body
+	dialogMinMeanBrightness  = 140 // >= this reads as a light dialog body
+
+	// Size: console fills a large fraction of the screen; dialog is small.
+	consoleMinAreaFrac = 0.18 // box area / screen area >= this  -> console-sized
+	dialogMaxAreaFrac  = 0.12 // box area / screen area <= this  -> dialog-sized
+
+	// Position: console anchors top-left; dialog is centered. Measured on the box's
+	// top-left corner as a fraction of screen dimensions.
+	consoleMaxLeftFrac  = 0.25 // minX/width  <= this -> left-anchored
+	consoleMaxTopFrac   = 0.25 // minY/height <= this -> top-anchored
+	dialogMinCenterFrac = 0.30 // box center within [0.30,0.70] of both axes -> centered
+)
+
+// changedBox is the bounding box of significantly-changed pixels plus its fill ratio.
+type changedBox struct {
+	minX, minY, maxX, maxY int
+	fillRatio              float64
+	changedCount           int
+}
+
+// regionSignal is the pre-filter's read of the changed region.
+type regionSignal int
+
+const (
+	regionUnknown     regionSignal = iota // box present but signals don't agree
+	regionConsoleLike                     // large + dark + top-left-ish  -> corroborates backdoor
+	regionDialogLike                      // small + light + centered     -> corroborates dialog
+)
+
+// nonceResult is the tri-state outcome of behavioral confirmation. Only "confirmed"
+// is decisive-positive; the other two are NEVER clean.
+type nonceResult int
+
+const (
+	nonceSkipped     nonceResult = iota // heuristic didn't see a backdoor-like box; not attempted
+	nonceConfirmed                      // new shell-like text rendered after typing -> real shell
+	nonceUnconfirmed                    // no new render OR type/capture failed -> ambiguous
+)
+
 // bitmapDiff computes the absolute difference between two RGBA buffers.
 // Returns a diff buffer of the same size where each pixel is the max channel diff.
 func bitmapDiff(baseline, response []byte, width, height uint32) []byte {
@@ -74,6 +116,25 @@ func pixelBrightness(buf []byte, i int) int {
 	return (int(buf[i]) + int(buf[i+1]) + int(buf[i+2])) / 3
 }
 
+// meanBoxBrightness returns the mean pixel brightness inside box (inclusive bounds).
+func meanBoxBrightness(buf []byte, w int, box changedBox) int {
+	sum, count := 0, 0
+	for y := box.minY; y <= box.maxY; y++ {
+		for x := box.minX; x <= box.maxX; x++ {
+			idx := (y*w + x) * 4
+			if idx+2 >= len(buf) {
+				continue
+			}
+			sum += pixelBrightness(buf, idx)
+			count++
+		}
+	}
+	if count == 0 {
+		return 0
+	}
+	return sum / count
+}
+
 // analyzeBackdoorResponse analyzes the difference between baseline and response frames.
 // It detects any new rectangular region (dark for cmd.exe, blue for PowerShell, etc.)
 // that appeared after sending a trigger keystroke (5x Shift for sticky keys, Win+U for utilman).
@@ -112,7 +173,7 @@ func analyzeBackdoorResponse(baseline, response []byte, width, height uint32) (v
 	}
 
 	// Check if changed pixels form a rectangular region (characteristic of a terminal window)
-	isRect, rectScore := detectChangedRectangle(baseline, response, width, height)
+	isRect, rectScore, _ := detectChangedRectangle(baseline, response, width, height)
 
 	if isRect && changedPercent > 3.0 {
 		confidence := math.Min(0.85, changedPercent/20.0+rectScore*0.5)
@@ -129,8 +190,9 @@ func analyzeBackdoorResponse(baseline, response []byte, width, height uint32) (v
 }
 
 // detectChangedRectangle checks if significantly changed pixels form a rectangular region.
-// Returns (isRectangular, score) where score is 0-1 indicating rectangularity (fill ratio).
-func detectChangedRectangle(baseline, response []byte, width, height uint32) (isRectangular bool, score float64) {
+// Returns (isRectangular, score, box) where score is 0-1 indicating rectangularity (fill
+// ratio) and box is the bounding box of changed pixels (previously discarded).
+func detectChangedRectangle(baseline, response []byte, width, height uint32) (isRectangular bool, score float64, box changedBox) {
 	w := int(width)
 	h := int(height)
 
@@ -168,7 +230,7 @@ func detectChangedRectangle(baseline, response []byte, width, height uint32) (is
 	}
 
 	if changedCount == 0 || maxX <= minX || maxY <= minY {
-		return false, 0
+		return false, 0, changedBox{}
 	}
 
 	// Calculate what fraction of the bounding box is filled with changed pixels.
@@ -176,10 +238,73 @@ func detectChangedRectangle(baseline, response []byte, width, height uint32) (is
 	boundingArea := (maxX - minX + 1) * (maxY - minY + 1)
 	fillRatio := float64(changedCount) / float64(boundingArea)
 
+	box = changedBox{
+		minX:         minX,
+		minY:         minY,
+		maxX:         maxX,
+		maxY:         maxY,
+		fillRatio:    fillRatio,
+		changedCount: changedCount,
+	}
+
 	// Threshold: >40% fill and at least 1% of total screen area.
 	// Lowered from 60% to catch terminal windows with thin borders and sparse content.
 	isRectangular = fillRatio > 0.4 && boundingArea > (w*h/100)
-	return isRectangular, fillRatio
+	return isRectangular, fillRatio, box
+}
+
+// classifyRegion inspects the changed bounding box for console-vs-dialog signals.
+// It NEVER returns a verdict — only a signal that decideVerdict consults. A real console
+// is large, dark, and top-left anchored; the legit accessibility dialog is small, light,
+// and centered. Conjunctions (not any-of) keep it conservative.
+func classifyRegion(response []byte, width, height uint32, box changedBox) regionSignal {
+	w, h := int(width), int(height)
+	if w == 0 || h == 0 || box.maxX <= box.minX || box.maxY <= box.minY {
+		return regionUnknown
+	}
+
+	mean := meanBoxBrightness(response, w, box)
+	areaFrac := float64((box.maxX-box.minX+1)*(box.maxY-box.minY+1)) / float64(w*h)
+	leftFrac := float64(box.minX) / float64(w)
+	topFrac := float64(box.minY) / float64(h)
+	centerXFrac := float64(box.minX+box.maxX) / 2.0 / float64(w)
+	centerYFrac := float64(box.minY+box.maxY) / 2.0 / float64(h)
+
+	dark := mean <= consoleMaxMeanBrightness
+	large := areaFrac >= consoleMinAreaFrac
+	topLeft := leftFrac <= consoleMaxLeftFrac && topFrac <= consoleMaxTopFrac
+	if dark && large && topLeft {
+		return regionConsoleLike
+	}
+
+	light := mean >= dialogMinMeanBrightness
+	small := areaFrac <= dialogMaxAreaFrac
+	centered := centerXFrac >= dialogMinCenterFrac && centerXFrac <= 1-dialogMinCenterFrac &&
+		centerYFrac >= dialogMinCenterFrac && centerYFrac <= 1-dialogMinCenterFrac
+	if light && small && centered {
+		return regionDialogLike
+	}
+
+	return regionUnknown
+}
+
+// decideVerdict combines the heuristic verdict, the region signal, and the behavioral
+// nonce result into a final verdict. It is the single source of truth for the cardinal
+// rule: no "backdoor_likely" input ever yields "clean". Pure -> unit-testable.
+func decideVerdict(heuristic string, region regionSignal, nonce nonceResult) string {
+	_ = region // region is informational; the cardinal rule does not depend on it.
+
+	if heuristic != "backdoor_likely" {
+		return heuristic
+	}
+
+	if nonce == nonceConfirmed {
+		return "backdoor_confirmed"
+	}
+
+	// Any uncertain backdoor_likely case (unconfirmed or skipped) is honest indeterminate,
+	// never clean.
+	return verdictIndeterminate
 }
 
 // rgbaToPNG converts RGBA pixel data to a PNG byte buffer.
@@ -212,7 +337,7 @@ func rgbaToPNG(rgba []byte, width, height uint32) ([]byte, error) {
 
 // runStickyKeysAnalysis performs the dual-check: heuristic first, then Vision API if available.
 func runStickyKeysAnalysis(ctx context.Context, baseline, response []byte,
-	width, height uint32, visionAPIKey string) StickyKeysResult {
+	width, height uint32, visionAPIKey string, nonce nonceResult) StickyKeysResult {
 
 	result := StickyKeysResult{Performed: true}
 
@@ -248,15 +373,18 @@ func runStickyKeysAnalysis(ctx context.Context, baseline, response []byte,
 		}
 	}
 
-	// Use heuristic result as final
-	result.OverallVerdict = verdict
+	// No-Vision (or inconclusive Vision) baseline: combine heuristic + pre-filter signal
+	// + behavioral nonce result via the cardinal-rule decision table.
+	_, _, box := detectChangedRectangle(baseline, response, width, height)
+	region := classifyRegion(response, width, height, box)
+	result.OverallVerdict = decideVerdict(verdict, region, nonce)
 	result.Confidence = confidence
 	return result
 }
 
 // runUtilmanAnalysis performs the dual-check for utilman backdoor: heuristic first, then Vision API.
 func runUtilmanAnalysis(ctx context.Context, baseline, response []byte,
-	width, height uint32, visionAPIKey string) UtilmanResult {
+	width, height uint32, visionAPIKey string, nonce nonceResult) UtilmanResult {
 
 	result := UtilmanResult{Performed: true}
 
@@ -298,8 +426,11 @@ func runUtilmanAnalysis(ctx context.Context, baseline, response []byte,
 		}
 	}
 
-	// Use heuristic result as final
-	result.OverallVerdict = verdict
+	// No-Vision (or inconclusive Vision) baseline: combine heuristic + pre-filter signal
+	// + behavioral nonce result via the cardinal-rule decision table.
+	_, _, box := detectChangedRectangle(baseline, response, width, height)
+	region := classifyRegion(response, width, height, box)
+	result.OverallVerdict = decideVerdict(verdict, region, nonce)
 	result.Confidence = confidence
 	return result
 }

--- a/internal/plugins/rdp/analyze.go
+++ b/internal/plugins/rdp/analyze.go
@@ -48,17 +48,30 @@ const (
 	consoleMaxTopFrac   = 0.25 // minY/height <= this -> top-anchored
 	dialogMinCenterFrac = 0.30 // box center within [0.30,0.70] of both axes -> centered
 
-	// nonceMinChangedPixels: minimum pixels that must change inside the box after
-	// typing the nonce to count as a shell echo. Set well above single-cursor-cell
-	// blink noise (a text cell is ~8x16 px) so a blinking caret alone never confirms;
-	// an echoed command line + new prompt changes thousands of pixels.
-	nonceMinChangedPixels = 500
-
-	// confirmedConsoleConfidence: when a backdoor is behaviorally confirmed AND the
-	// changed region is console-shaped (geometry corroborates the echo), report
-	// near-certain confidence. Geometry only RAISES confidence on an already-confirmed
-	// positive; it never lowers a verdict (cardinal rule — echo beats geometry).
+	// confirmedConsoleConfidence: when a backdoor is confirmed AND the changed region
+	// is console-shaped (geometry corroborates the detection), report near-certain
+	// confidence. Geometry only RAISES confidence on an already-confirmed positive; it
+	// never lowers a verdict (cardinal rule).
 	confirmedConsoleConfidence = 0.95
+)
+
+const (
+	// darkBrightnessMax: a pixel counts as "dark" when its brightness is below this.
+	// Generalizes beyond pure black (#000000) so themed/blue consoles (e.g. the
+	// #012456 PowerShell background, brightness ~31) still register as dark — avoiding
+	// the false negatives a pure-black threshold (Sticky-Keys-Slayer) would miss.
+	darkBrightnessMax = 60
+
+	// darkDeltaCleanMaxFrac: a new-dark-pixel delta below this fraction of the screen
+	// reads as clean (no console appeared — light dialog or nothing). CARDINAL RULE:
+	// only a delta below this may yield "clean".
+	darkDeltaCleanMaxFrac = 0.01
+
+	// darkDeltaConsoleMinFrac / darkDeltaConsoleMaxFrac: a new-dark-pixel delta inside
+	// this band reads as a console-sized dark window appearing -> backdoor_likely.
+	// Below the band (small) or above it (full-screen) is ambiguous -> indeterminate.
+	darkDeltaConsoleMinFrac = 0.04
+	darkDeltaConsoleMaxFrac = 0.65
 )
 
 // changedBox is the bounding box of significantly-changed pixels plus its fill ratio.
@@ -75,16 +88,6 @@ const (
 	regionUnknown     regionSignal = iota // box present but signals don't agree
 	regionConsoleLike                     // large + dark + top-left-ish  -> corroborates backdoor
 	regionDialogLike                      // small + light + centered     -> corroborates dialog
-)
-
-// nonceResult is the tri-state outcome of behavioral confirmation. Only "confirmed"
-// is decisive-positive; the other two are NEVER clean.
-type nonceResult int
-
-const (
-	nonceSkipped     nonceResult = iota // heuristic didn't see a backdoor-like box; not attempted
-	nonceConfirmed                      // new shell-like text rendered after typing -> real shell
-	nonceUnconfirmed                    // no new render OR type/capture failed -> ambiguous
 )
 
 // bitmapDiff computes the absolute difference between two RGBA buffers.
@@ -145,6 +148,48 @@ func meanBoxBrightness(buf []byte, w int, box changedBox) int {
 		return 0
 	}
 	return sum / count
+}
+
+// darkPixelCount counts pixels whose brightness is below darkBrightnessMax (i.e. "dark").
+func darkPixelCount(buf []byte, width, height uint32) int {
+	total := int(width) * int(height)
+	count := 0
+	for i := 0; i < total*4; i += 4 {
+		if i+2 >= len(buf) {
+			break
+		}
+		if pixelBrightness(buf, i) < darkBrightnessMax {
+			count++
+		}
+	}
+	return count
+}
+
+// darkDeltaVerdict is the PRIMARY discriminator (Sticky-Keys-Slayer-style): it measures
+// how many NEW dark pixels appeared between baseline and response. A dark console window
+// appearing produces a console-sized band of new dark pixels; the legit (light)
+// accessibility dialog produces almost none. CARDINAL RULE: only a near-zero delta
+// (< darkDeltaCleanMaxFrac) yields "clean"; any ambiguous darkening (below the band or
+// full-screen above it) is "indeterminate", never clean. Pure -> unit-testable.
+func darkDeltaVerdict(baseline, response []byte, width, height uint32) string {
+	total := int(width) * int(height)
+	if total == 0 {
+		return verdictIndeterminate
+	}
+
+	delta := darkPixelCount(response, width, height) - darkPixelCount(baseline, width, height)
+	if delta < 0 {
+		delta = 0
+	}
+	frac := float64(delta) / float64(total)
+
+	if frac < darkDeltaCleanMaxFrac {
+		return "clean"
+	}
+	if frac >= darkDeltaConsoleMinFrac && frac <= darkDeltaConsoleMaxFrac {
+		return "backdoor_likely"
+	}
+	return verdictIndeterminate
 }
 
 // analyzeBackdoorResponse analyzes the difference between baseline and response frames.
@@ -300,24 +345,14 @@ func classifyRegion(response []byte, width, height uint32, box changedBox) regio
 	return regionUnknown
 }
 
-// decideVerdict combines the heuristic verdict and the behavioral nonce result into a
-// final verdict. It is the single source of truth for the cardinal rule: no
-// "backdoor_likely" input ever yields "clean". The region signal is intentionally NOT
-// consulted here — geometry must never change the verdict; it only enriches confidence
-// and the diagnostic banner (see regionConfidenceAndNote). region is retained in the
-// signature for call-site symmetry but is deliberately ignored. Pure -> unit-testable.
-func decideVerdict(heuristic string, region regionSignal, nonce nonceResult) string {
-	if heuristic != "backdoor_likely" {
-		return heuristic
-	}
-
-	if nonce == nonceConfirmed {
-		return "backdoor_confirmed"
-	}
-
-	// Any uncertain backdoor_likely case (unconfirmed or skipped) is honest indeterminate,
-	// never clean.
-	return verdictIndeterminate
+// decideVerdict is the single source of truth for the cardinal rule: it passes the
+// dark-delta verdict straight through and NEVER maps a positive (backdoor_likely) to
+// "clean". The region signal is intentionally NOT consulted here — geometry must never
+// change the verdict; it only enriches confidence and the diagnostic banner (see
+// regionConfidenceAndNote). region is retained in the signature for call-site symmetry
+// but is deliberately ignored. Pure -> unit-testable.
+func decideVerdict(verdict string, region regionSignal) string {
+	return verdict
 }
 
 // regionConfidenceAndNote enriches an already-decided verdict with the geometry signal.
@@ -333,11 +368,11 @@ func regionConfidenceAndNote(verdict string, region regionSignal, baseConfidence
 	case "backdoor_confirmed":
 		switch region {
 		case regionConsoleLike:
-			return confirmedConsoleConfidence, "console-shaped + behaviorally confirmed"
+			return confirmedConsoleConfidence, "console-shaped + dark-region confirmed"
 		case regionDialogLike:
-			return baseConfidence, "dialog-shaped but behaviorally confirmed (echo beats geometry)"
+			return baseConfidence, "dialog-shaped but dark-region confirmed (dark-delta beats geometry)"
 		default:
-			return baseConfidence, "geometry inconclusive but behaviorally confirmed (echo beats geometry)"
+			return baseConfidence, "geometry inconclusive but dark-region confirmed (dark-delta beats geometry)"
 		}
 	case verdictIndeterminate:
 		switch region {
@@ -351,41 +386,6 @@ func regionConfidenceAndNote(verdict string, region regionSignal, baseConfidence
 	default:
 		return baseConfidence, ""
 	}
-}
-
-// verifyEcho reports whether typing the nonce produced a shell-like text render inside
-// the candidate box. It is a pure function over the pre-type and post-type framebuffers
-// plus the box: it counts pixels whose brightness changed (same brightness-diff logic as
-// analyzeBackdoorResponse) scoped to the box region, and returns nonceConfirmed when the
-// changed count clears nonceMinChangedPixels (a real shell echoes the line + new prompt),
-// else nonceUnconfirmed (a static dialog renders nothing new).
-func verifyEcho(beforeType, afterType []byte, width, height uint32, box changedBox) nonceResult {
-	w, h := int(width), int(height)
-	if w == 0 || h == 0 || box.maxX <= box.minX || box.maxY <= box.minY {
-		return nonceUnconfirmed
-	}
-
-	changed := 0
-	for y := box.minY; y <= box.maxY; y++ {
-		for x := box.minX; x <= box.maxX; x++ {
-			idx := (y*w + x) * 4
-			if idx+2 >= len(beforeType) || idx+2 >= len(afterType) {
-				continue
-			}
-			diff := pixelBrightness(beforeType, idx) - pixelBrightness(afterType, idx)
-			if diff < 0 {
-				diff = -diff
-			}
-			if diff > changeThreshold {
-				changed++
-			}
-		}
-	}
-
-	if changed >= nonceMinChangedPixels {
-		return nonceConfirmed
-	}
-	return nonceUnconfirmed
 }
 
 // rgbaToPNG converts RGBA pixel data to a PNG byte buffer.
@@ -416,14 +416,19 @@ func rgbaToPNG(rgba []byte, width, height uint32) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// runStickyKeysAnalysis performs the dual-check: heuristic first, then Vision API if available.
+// runStickyKeysAnalysis performs the dual-check: dark-delta heuristic first, then Vision
+// API if available. The dark-pixel-delta discriminator is the primary heuristic (it
+// distinguishes the dark cmd console from the light legit dialog); Vision still wins when
+// present (confirmed/vulnerable branches sit above the heuristic verdict).
 func runStickyKeysAnalysis(ctx context.Context, baseline, response []byte,
-	width, height uint32, visionAPIKey string, nonce nonceResult) StickyKeysResult {
+	width, height uint32, visionAPIKey string) StickyKeysResult {
 
 	result := StickyKeysResult{Performed: true}
 
-	// Step 1: Heuristic analysis
-	verdict, confidence, description := analyzeBackdoorResponse(baseline, response, width, height)
+	// Step 1: Primary heuristic — dark-pixel-delta discriminator. The changed-pixels
+	// description is kept for the diagnostic banner; the VERDICT comes from darkDeltaVerdict.
+	verdict := darkDeltaVerdict(baseline, response, width, height)
+	_, confidence, description := analyzeBackdoorResponse(baseline, response, width, height)
 	result.HeuristicResult = description
 
 	if verdict == "clean" {
@@ -432,7 +437,7 @@ func runStickyKeysAnalysis(ctx context.Context, baseline, response []byte,
 		return result
 	}
 
-	// Step 2: Try Vision API for confirmation if key available
+	// Step 2: Try Vision API for confirmation if key available (Vision wins when present).
 	if visionAPIKey != "" {
 		pngData, err := rgbaToPNG(response, width, height)
 		if err == nil {
@@ -461,25 +466,28 @@ func runStickyKeysAnalysis(ctx context.Context, baseline, response []byte,
 		}
 	}
 
-	// No-Vision (or inconclusive Vision) baseline: combine heuristic + pre-filter signal
-	// + behavioral nonce result via the cardinal-rule decision table. The region signal
-	// never changes the verdict (decideVerdict ignores it); it only enriches confidence
-	// and the diagnostic banner via regionConfidenceAndNote.
+	// No-Vision (or inconclusive Vision) baseline: pass the dark-delta verdict through
+	// decideVerdict (cardinal rule — a positive never becomes clean). The region signal
+	// never changes the verdict; it only enriches confidence and the diagnostic banner
+	// via regionConfidenceAndNote.
 	_, _, box := detectChangedRectangle(baseline, response, width, height)
 	region := classifyRegion(response, width, height, box)
-	result.OverallVerdict = decideVerdict(verdict, region, nonce)
+	result.OverallVerdict = decideVerdict(verdict, region)
 	result.Confidence, result.RegionNote = regionConfidenceAndNote(result.OverallVerdict, region, confidence)
 	return result
 }
 
-// runUtilmanAnalysis performs the dual-check for utilman backdoor: heuristic first, then Vision API.
+// runUtilmanAnalysis performs the dual-check for utilman backdoor: dark-delta heuristic
+// first, then Vision API. Same wiring as runStickyKeysAnalysis.
 func runUtilmanAnalysis(ctx context.Context, baseline, response []byte,
-	width, height uint32, visionAPIKey string, nonce nonceResult) UtilmanResult {
+	width, height uint32, visionAPIKey string) UtilmanResult {
 
 	result := UtilmanResult{Performed: true}
 
-	// Step 1: Heuristic analysis (same pixel diff logic as sticky keys)
-	verdict, confidence, description := analyzeBackdoorResponse(baseline, response, width, height)
+	// Step 1: Primary heuristic — dark-pixel-delta discriminator. The changed-pixels
+	// description is kept for the diagnostic banner; the VERDICT comes from darkDeltaVerdict.
+	verdict := darkDeltaVerdict(baseline, response, width, height)
+	_, confidence, description := analyzeBackdoorResponse(baseline, response, width, height)
 	result.HeuristicResult = description
 
 	if verdict == "clean" {
@@ -488,7 +496,7 @@ func runUtilmanAnalysis(ctx context.Context, baseline, response []byte,
 		return result
 	}
 
-	// Step 2: Try Vision API for confirmation if key available
+	// Step 2: Try Vision API for confirmation if key available (Vision wins when present).
 	if visionAPIKey != "" {
 		pngData, err := rgbaToPNG(response, width, height)
 		if err == nil {
@@ -516,13 +524,13 @@ func runUtilmanAnalysis(ctx context.Context, baseline, response []byte,
 		}
 	}
 
-	// No-Vision (or inconclusive Vision) baseline: combine heuristic + pre-filter signal
-	// + behavioral nonce result via the cardinal-rule decision table. The region signal
-	// never changes the verdict (decideVerdict ignores it); it only enriches confidence
-	// and the diagnostic banner via regionConfidenceAndNote.
+	// No-Vision (or inconclusive Vision) baseline: pass the dark-delta verdict through
+	// decideVerdict (cardinal rule — a positive never becomes clean). The region signal
+	// never changes the verdict; it only enriches confidence and the diagnostic banner
+	// via regionConfidenceAndNote.
 	_, _, box := detectChangedRectangle(baseline, response, width, height)
 	region := classifyRegion(response, width, height, box)
-	result.OverallVerdict = decideVerdict(verdict, region, nonce)
+	result.OverallVerdict = decideVerdict(verdict, region)
 	result.Confidence, result.RegionNote = regionConfidenceAndNote(result.OverallVerdict, region, confidence)
 	return result
 }

--- a/internal/plugins/rdp/analyze_test.go
+++ b/internal/plugins/rdp/analyze_test.go
@@ -147,7 +147,7 @@ func TestRunUtilmanAnalysis_Clean(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	result := runUtilmanAnalysis(ctx, baseline, response, w, h, "", nonceSkipped)
+	result := runUtilmanAnalysis(ctx, baseline, response, w, h, "")
 	assert.True(t, result.Performed)
 	assert.Equal(t, "clean", result.OverallVerdict)
 }
@@ -209,6 +209,17 @@ func paintBox(buf []byte, w int, x0, y0, x1, y1 int, gray byte) {
 	}
 }
 
+// paintBoxRGB fills a rectangular region with explicit RGB values.
+// Used for themed-console tests (e.g. PowerShell blue, brightness ~31).
+func paintBoxRGB(buf []byte, w int, x0, y0, x1, y1 int, r, g, b byte) {
+	for y := y0; y < y1; y++ {
+		for x := x0; x < x1; x++ {
+			idx := (y*w + x) * 4
+			buf[idx], buf[idx+1], buf[idx+2], buf[idx+3] = r, g, b, 255
+		}
+	}
+}
+
 func TestClassifyRegion_ConsoleLike(t *testing.T) {
 	w, h := uint32(1000), uint32(1000)
 	resp := make([]byte, int(w)*int(h)*4)
@@ -237,7 +248,10 @@ func TestClassifyRegion_Unknown(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// A3: decideVerdict — full 7-row table + cardinal rule
+// A3: decideVerdict — pass-through + cardinal rule
+// decideVerdict(verdict, region) is now a pure pass-through: whatever verdict
+// comes in (from darkDeltaVerdict) goes out unchanged. The cardinal rule is
+// that a "backdoor_likely" verdict must never become "clean".
 // ---------------------------------------------------------------------------
 
 func TestDecideVerdict(t *testing.T) {
@@ -245,33 +259,40 @@ func TestDecideVerdict(t *testing.T) {
 		name      string
 		heuristic string
 		region    regionSignal
-		nonce     nonceResult
 		want      string
 	}{
-		{"clean heuristic stays clean", "clean", regionUnknown, nonceSkipped, "clean"},
-		{"confirmed echo + console", "backdoor_likely", regionConsoleLike, nonceConfirmed, "backdoor_confirmed"},
-		{"confirmed echo beats dialog geometry", "backdoor_likely", regionDialogLike, nonceConfirmed, "backdoor_confirmed"},
-		{"console but no echo -> rerun", "backdoor_likely", regionConsoleLike, nonceUnconfirmed, verdictIndeterminate},
-		{"dialog + no echo -> rerun (the FP fix)", "backdoor_likely", regionDialogLike, nonceUnconfirmed, verdictIndeterminate},
-		{"unknown + no echo -> rerun", "backdoor_likely", regionUnknown, nonceUnconfirmed, verdictIndeterminate},
-		{"backdoor box but nonce skipped -> rerun", "backdoor_likely", regionConsoleLike, nonceSkipped, verdictIndeterminate},
+		// Pass-through: clean stays clean regardless of region.
+		{"clean stays clean (unknown region)", "clean", regionUnknown, "clean"},
+		{"clean stays clean (console region)", "clean", regionConsoleLike, "clean"},
+		{"clean stays clean (dialog region)", "clean", regionDialogLike, "clean"},
+		// Pass-through: backdoor_likely stays backdoor_likely.
+		{"backdoor_likely stays (unknown region)", "backdoor_likely", regionUnknown, "backdoor_likely"},
+		{"backdoor_likely stays (console region)", "backdoor_likely", regionConsoleLike, "backdoor_likely"},
+		{"backdoor_likely stays (dialog region)", "backdoor_likely", regionDialogLike, "backdoor_likely"},
+		// Pass-through: indeterminate stays indeterminate.
+		{"indeterminate stays (unknown region)", verdictIndeterminate, regionUnknown, verdictIndeterminate},
+		{"indeterminate stays (console region)", verdictIndeterminate, regionConsoleLike, verdictIndeterminate},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := decideVerdict(tc.heuristic, tc.region, tc.nonce)
+			got := decideVerdict(tc.heuristic, tc.region)
 			assert.Equal(t, tc.want, got)
+			// CARDINAL RULE: a backdoor_likely in must never yield clean out.
 			if tc.heuristic == "backdoor_likely" {
-				assert.NotEqual(t, "clean", got, "CARDINAL RULE: backdoor box must never become clean")
+				assert.NotEqual(t, "clean", got, "CARDINAL RULE: backdoor_likely must never become clean")
 			}
 		})
 	}
 }
 
 // ---------------------------------------------------------------------------
-// A4: runStickyKeysAnalysis — dialog-shaped frame → indeterminate (not backdoor_likely)
+// A4: runStickyKeysAnalysis — light/small/centered dialog → clean
+// A light legit dialog (gray 200) adds almost no dark pixels, so the
+// dark-delta discriminator correctly returns "clean", not indeterminate.
+// This is the better outcome vs. the old behavioral approach.
 // ---------------------------------------------------------------------------
 
-func TestRunStickyKeysAnalysis_DialogShape_NoVision_Indeterminate(t *testing.T) {
+func TestRunStickyKeysAnalysis_LightDialog_NoVision_Clean(t *testing.T) {
 	w, h := uint32(1000), uint32(1000)
 	size := int(w) * int(h) * 4
 	baseline := make([]byte, size)
@@ -280,43 +301,178 @@ func TestRunStickyKeysAnalysis_DialogShape_NoVision_Indeterminate(t *testing.T) 
 	}
 	response := make([]byte, size)
 	copy(response, baseline)
-	paintBox(response, int(w), 390, 390, 610, 610, 200) // light small centered (220×220 = 4.84% area, trips heuristic but classifies as dialog)
-	res := runStickyKeysAnalysis(context.Background(), baseline, response, w, h, "", nonceSkipped)
-	assert.Equal(t, verdictIndeterminate, res.OverallVerdict)
-	assert.NotEqual(t, "clean", res.OverallVerdict)
+	// Light small centered dialog (220×220 = 4.84% area, gray 200).
+	// Gray 200 >> darkBrightnessMax(60), so adds zero dark pixels → clean.
+	paintBox(response, int(w), 390, 390, 610, 610, 200)
+	res := runStickyKeysAnalysis(context.Background(), baseline, response, w, h, "")
+	assert.Equal(t, "clean", res.OverallVerdict)
+	assert.NotEqual(t, "backdoor_likely", res.OverallVerdict,
+		"a light legit dialog must not be flagged as backdoor_likely")
 }
 
 // ---------------------------------------------------------------------------
-// B1: verifyEcho — pure pixel-diff confirms or denies a shell echo
+// B: dark-pixel-delta core logic — new tests for the primary discriminator
 // ---------------------------------------------------------------------------
 
-func TestVerifyEcho_Confirmed(t *testing.T) {
-	w, h := uint32(1000), uint32(1000)
+// TestDarkPixelCount verifies the count of pixels below darkBrightnessMax.
+func TestDarkPixelCount(t *testing.T) {
+	w, h := uint32(10), uint32(10) // 100 pixels
 	size := int(w) * int(h) * 4
-	before := make([]byte, size)
-	paintBox(before, int(w), 0, 0, 600, 600, 0) // dark console
-	after := make([]byte, size)
-	copy(after, before)
-	// new text rendered inside box (rows of light pixels = echoed line + prompt)
-	paintBox(after, int(w), 10, 500, 590, 560, 230)
-	box := changedBox{minX: 0, minY: 0, maxX: 599, maxY: 599}
-	assert.Equal(t, nonceConfirmed, verifyEcho(before, after, w, h, box))
+	buf := make([]byte, size)
+
+	// Fill all pixels with mid-gray (brightness 128, well above threshold 60).
+	for i := 0; i < size; i += 4 {
+		buf[i], buf[i+1], buf[i+2], buf[i+3] = 128, 128, 128, 255
+	}
+	assert.Equal(t, 0, darkPixelCount(buf, w, h), "mid-gray pixels should not count as dark")
+
+	// Paint a 5×5 block with pure black (brightness 0 < 60).
+	for y := 0; y < 5; y++ {
+		for x := 0; x < 5; x++ {
+			idx := (y*int(w) + x) * 4
+			buf[idx], buf[idx+1], buf[idx+2], buf[idx+3] = 0, 0, 0, 255
+		}
+	}
+	assert.Equal(t, 25, darkPixelCount(buf, w, h), "5×5 black block must count as 25 dark pixels")
+
+	// Paint 3 more pixels with brightness exactly at the threshold (60 is NOT dark; must be < 60).
+	// brightness = (59+59+59)/3 = 59 < 60 → dark.
+	buf[100], buf[101], buf[102] = 59, 59, 59 // pixel at offset 100 (pixel 25)
+	assert.Equal(t, 26, darkPixelCount(buf, w, h), "pixel with brightness 59 must count as dark")
+
+	// A pixel with brightness exactly 60 is NOT dark (threshold is strict <).
+	buf[104], buf[105], buf[106] = 60, 60, 60 // pixel 26
+	assert.Equal(t, 26, darkPixelCount(buf, w, h), "pixel with brightness exactly 60 must NOT count as dark")
 }
 
-func TestVerifyEcho_Unconfirmed(t *testing.T) {
+// TestDarkDeltaVerdict exercises the primary discriminator end-to-end with 1000×1000 frames.
+// Baseline is mid-gray (128) everywhere; the response adds various shapes.
+func TestDarkDeltaVerdict(t *testing.T) {
 	w, h := uint32(1000), uint32(1000)
 	size := int(w) * int(h) * 4
-	before := make([]byte, size)
-	paintBox(before, int(w), 430, 430, 570, 570, 200) // static dialog
-	after := make([]byte, size)
-	copy(after, before) // nothing changed
-	box := changedBox{minX: 430, minY: 430, maxX: 569, maxY: 569}
-	assert.Equal(t, nonceUnconfirmed, verifyEcho(before, after, w, h, box))
+
+	// Construct a reusable mid-gray baseline.
+	baseline := make([]byte, size)
+	for i := 0; i < size; i += 4 {
+		baseline[i], baseline[i+1], baseline[i+2], baseline[i+3] = 128, 128, 128, 255
+	}
+
+	newResponse := func() []byte {
+		r := make([]byte, size)
+		copy(r, baseline)
+		return r
+	}
+
+	tests := []struct {
+		name    string
+		setup   func(response []byte)
+		want    string
+		notWant string // optional cardinal-rule guard
+	}{
+		{
+			// Large dark box (gray 0) covering ~30% of the screen → backdoor_likely.
+			// 548×548 pixels = ~30% of 1000×1000.  Fraction is in [0.04, 0.65].
+			name: "large dark box (~30%) → backdoor_likely",
+			setup: func(r []byte) {
+				paintBox(r, int(w), 0, 0, 548, 548, 0)
+			},
+			want:    "backdoor_likely",
+			notWant: "clean",
+		},
+		{
+			// Light dialog box (gray 200, small) → no new dark pixels → clean.
+			// Gray 200 >> darkBrightnessMax(60); delta ≈ 0 < 1%.
+			name: "light dialog box (gray 200, small) → clean",
+			setup: func(r []byte) {
+				paintBox(r, int(w), 430, 430, 570, 570, 200)
+			},
+			want: "clean",
+		},
+		{
+			// Tiny dark box (~2% area, gray 0) → below console band → indeterminate.
+			// 140×140 = 19600 pixels / 1000000 = 1.96% → in (1%, 4%) → indeterminate.
+			name: "tiny dark box (~2%) → indeterminate",
+			setup: func(r []byte) {
+				paintBox(r, int(w), 0, 0, 140, 140, 0)
+			},
+			want:    verdictIndeterminate,
+			notWant: "clean",
+		},
+		{
+			// Near-full-screen dark (>65%, gray 0) → above console band → indeterminate.
+			// 820×820 = 672400 / 1000000 = 67.24% > 65%.
+			name: "near-full-screen dark (>65%) → indeterminate",
+			setup: func(r []byte) {
+				paintBox(r, int(w), 0, 0, 820, 820, 0)
+			},
+			want:    verdictIndeterminate,
+			notWant: "clean",
+		},
+		{
+			// Themed/blue-ish dark console (RGB ≈ (1,36,86), brightness ≈ 41 < 60).
+			// Still registers as dark → ~30% area → backdoor_likely.
+			// brightness = (1 + 36 + 86) / 3 = 123/3 = 41 < darkBrightnessMax(60).
+			name: "blue-ish dark console (~30%) → backdoor_likely",
+			setup: func(r []byte) {
+				paintBoxRGB(r, int(w), 0, 0, 548, 548, 1, 36, 86)
+			},
+			want:    "backdoor_likely",
+			notWant: "clean",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			response := newResponse()
+			tc.setup(response)
+			got := darkDeltaVerdict(baseline, response, w, h)
+			assert.Equal(t, tc.want, got)
+			if tc.notWant != "" {
+				assert.NotEqual(t, tc.notWant, got,
+					"CARDINAL RULE: dark/ambiguous box must never yield %q", tc.notWant)
+			}
+		})
+	}
+
+	// CARDINAL SUB-ASSERT: for any dark box of console-band size, result is never "clean".
+	t.Run("cardinal_rule_dark_box_never_clean", func(t *testing.T) {
+		// Try several in-band sizes and confirm none yield "clean".
+		inBandSizes := []int{210, 300, 400, 500, 600, 700} // pixel edge lengths
+		for _, edge := range inBandSizes {
+			frac := float64(edge*edge) / float64(int(w)*int(h))
+			if frac < darkDeltaConsoleMinFrac || frac > darkDeltaConsoleMaxFrac {
+				continue // skip if this particular size fell outside the band
+			}
+			response := newResponse()
+			paintBox(response, int(w), 0, 0, edge, edge, 0)
+			got := darkDeltaVerdict(baseline, response, w, h)
+			assert.NotEqual(t, "clean", got,
+				"dark box of edge %d (frac %.3f) must not yield clean", edge, frac)
+		}
+	})
 }
 
 // ---------------------------------------------------------------------------
 // C1: structural guard — runStickyKeysAnalysis must have the vulnerable branch
 // ---------------------------------------------------------------------------
+
+// TestRunStickyKeysAnalysis_HasVulnerableBranch guards that runStickyKeysAnalysis
+// contains a symmetric `visionVerdict == "vulnerable"` branch matching the one
+// already present in runUtilmanAnalysis (analyze.go ~line 456).
+// The test reads analyze.go as source text and asserts the string
+// `visionVerdict == "vulnerable"` appears at least twice — once per analysis
+// function. Currently it appears only once (utilman only), so this test is RED
+// until the developer adds the symmetric branch to runStickyKeysAnalysis.
+func TestRunStickyKeysAnalysis_HasVulnerableBranch(t *testing.T) {
+	src, err := os.ReadFile("analyze.go")
+	require.NoError(t, err, "analyze.go must be readable")
+
+	const needle = `visionVerdict == "vulnerable"`
+	count := strings.Count(string(src), needle)
+	assert.GreaterOrEqual(t, count, 2,
+		"runStickyKeysAnalysis is missing the visionVerdict == \"vulnerable\" branch; "+
+			"found %d occurrence(s), need >= 2 (one per analysis function)", count)
+}
 
 // ---------------------------------------------------------------------------
 // A5: regionConfidenceAndNote — pure verdict×region → (confidence, note)
@@ -340,25 +496,25 @@ func TestRegionConfidenceAndNote(t *testing.T) {
 			region:         regionConsoleLike,
 			base:           base,
 			wantConfidence: confirmedConsoleConfidence,
-			wantNote:       "console-shaped + behaviorally confirmed",
+			wantNote:       "console-shaped + dark-region confirmed",
 		},
-		// backdoor_confirmed + dialog-shaped: echo beats geometry → base confidence unchanged
+		// backdoor_confirmed + dialog-shaped: dark-delta beats geometry → base confidence unchanged
 		{
-			name:           "confirmed + dialog → base confidence + echo-beats-geometry note",
+			name:           "confirmed + dialog → base confidence + dark-delta-beats-geometry note",
 			verdict:        "backdoor_confirmed",
 			region:         regionDialogLike,
 			base:           base,
 			wantConfidence: base,
-			wantNote:       "dialog-shaped but behaviorally confirmed (echo beats geometry)",
+			wantNote:       "dialog-shaped but dark-region confirmed (dark-delta beats geometry)",
 		},
-		// backdoor_confirmed + unknown region: echo beats geometry → base confidence unchanged
+		// backdoor_confirmed + unknown region: dark-delta beats geometry → base confidence unchanged
 		{
-			name:           "confirmed + unknown → base confidence + echo-beats-geometry note",
+			name:           "confirmed + unknown → base confidence + dark-delta-beats-geometry note",
 			verdict:        "backdoor_confirmed",
 			region:         regionUnknown,
 			base:           base,
 			wantConfidence: base,
-			wantNote:       "geometry inconclusive but behaviorally confirmed (echo beats geometry)",
+			wantNote:       "geometry inconclusive but dark-region confirmed (dark-delta beats geometry)",
 		},
 		// indeterminate + console: unconfirmed but console-shaped → rerun note
 		{
@@ -414,22 +570,4 @@ func TestRegionConfidenceAndNote(t *testing.T) {
 			assert.Equal(t, tc.wantNote, gotNote)
 		})
 	}
-}
-
-// TestRunStickyKeysAnalysis_HasVulnerableBranch guards that runStickyKeysAnalysis
-// contains a symmetric `visionVerdict == "vulnerable"` branch matching the one
-// already present in runUtilmanAnalysis (analyze.go ~line 456).
-// The test reads analyze.go as source text and asserts the string
-// `visionVerdict == "vulnerable"` appears at least twice — once per analysis
-// function. Currently it appears only once (utilman only), so this test is RED
-// until the developer adds the symmetric branch to runStickyKeysAnalysis.
-func TestRunStickyKeysAnalysis_HasVulnerableBranch(t *testing.T) {
-	src, err := os.ReadFile("analyze.go")
-	require.NoError(t, err, "analyze.go must be readable")
-
-	const needle = `visionVerdict == "vulnerable"`
-	count := strings.Count(string(src), needle)
-	assert.GreaterOrEqual(t, count, 2,
-		"runStickyKeysAnalysis is missing the visionVerdict == \"vulnerable\" branch; "+
-			"found %d occurrence(s), need >= 2 (one per analysis function)", count)
 }

--- a/internal/plugins/rdp/analyze_test.go
+++ b/internal/plugins/rdp/analyze_test.go
@@ -318,6 +318,104 @@ func TestVerifyEcho_Unconfirmed(t *testing.T) {
 // C1: structural guard — runStickyKeysAnalysis must have the vulnerable branch
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// A5: regionConfidenceAndNote — pure verdict×region → (confidence, note)
+// ---------------------------------------------------------------------------
+
+func TestRegionConfidenceAndNote(t *testing.T) {
+	const base = 0.75
+
+	tests := []struct {
+		name           string
+		verdict        string
+		region         regionSignal
+		base           float64
+		wantConfidence float64
+		wantNote       string
+	}{
+		// backdoor_confirmed + console-shaped: geometry corroborates → high confidence boost
+		{
+			name:           "confirmed + console → high confidence + console note",
+			verdict:        "backdoor_confirmed",
+			region:         regionConsoleLike,
+			base:           base,
+			wantConfidence: confirmedConsoleConfidence,
+			wantNote:       "console-shaped + behaviorally confirmed",
+		},
+		// backdoor_confirmed + dialog-shaped: echo beats geometry → base confidence unchanged
+		{
+			name:           "confirmed + dialog → base confidence + echo-beats-geometry note",
+			verdict:        "backdoor_confirmed",
+			region:         regionDialogLike,
+			base:           base,
+			wantConfidence: base,
+			wantNote:       "dialog-shaped but behaviorally confirmed (echo beats geometry)",
+		},
+		// backdoor_confirmed + unknown region: echo beats geometry → base confidence unchanged
+		{
+			name:           "confirmed + unknown → base confidence + echo-beats-geometry note",
+			verdict:        "backdoor_confirmed",
+			region:         regionUnknown,
+			base:           base,
+			wantConfidence: base,
+			wantNote:       "geometry inconclusive but behaviorally confirmed (echo beats geometry)",
+		},
+		// indeterminate + console: unconfirmed but console-shaped → rerun note
+		{
+			name:           "indeterminate + console → base confidence + rerun note",
+			verdict:        verdictIndeterminate,
+			region:         regionConsoleLike,
+			base:           base,
+			wantConfidence: base,
+			wantNote:       "console-shaped, unconfirmed — rerun",
+		},
+		// indeterminate + dialog: unconfirmed dialog-shaped → rerun note
+		{
+			name:           "indeterminate + dialog → base confidence + rerun note",
+			verdict:        verdictIndeterminate,
+			region:         regionDialogLike,
+			base:           base,
+			wantConfidence: base,
+			wantNote:       "dialog-shaped, unconfirmed — rerun",
+		},
+		// indeterminate + unknown: geometry inconclusive → rerun note
+		{
+			name:           "indeterminate + unknown → base confidence + rerun note",
+			verdict:        verdictIndeterminate,
+			region:         regionUnknown,
+			base:           base,
+			wantConfidence: base,
+			wantNote:       "geometry inconclusive, unconfirmed — rerun",
+		},
+		// clean verdict: no geometry enrichment, no note
+		{
+			name:           "clean → base confidence + empty note",
+			verdict:        "clean",
+			region:         regionConsoleLike,
+			base:           base,
+			wantConfidence: base,
+			wantNote:       "",
+		},
+		// other / arbitrary verdict: no spurious high confidence, no note
+		{
+			name:           "other verdict → base confidence + empty note",
+			verdict:        "some_other_verdict",
+			region:         regionConsoleLike,
+			base:           base,
+			wantConfidence: base,
+			wantNote:       "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotConf, gotNote := regionConfidenceAndNote(tc.verdict, tc.region, tc.base)
+			assert.Equal(t, tc.wantConfidence, gotConf)
+			assert.Equal(t, tc.wantNote, gotNote)
+		})
+	}
+}
+
 // TestRunStickyKeysAnalysis_HasVulnerableBranch guards that runStickyKeysAnalysis
 // contains a symmetric `visionVerdict == "vulnerable"` branch matching the one
 // already present in runUtilmanAnalysis (analyze.go ~line 456).

--- a/internal/plugins/rdp/analyze_test.go
+++ b/internal/plugins/rdp/analyze_test.go
@@ -144,7 +144,7 @@ func TestRunUtilmanAnalysis_Clean(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	result := runUtilmanAnalysis(ctx, baseline, response, w, h, "")
+	result := runUtilmanAnalysis(ctx, baseline, response, w, h, "", nonceSkipped)
 	assert.True(t, result.Performed)
 	assert.Equal(t, "clean", result.OverallVerdict)
 }
@@ -162,4 +162,123 @@ func TestRgbaToPNG(t *testing.T) {
 	// PNG magic bytes
 	assert.Equal(t, byte(0x89), pngData[0])
 	assert.Equal(t, byte(0x50), pngData[1])
+}
+
+// ---------------------------------------------------------------------------
+// A1: detectChangedRectangle returns bounding box
+// ---------------------------------------------------------------------------
+
+func TestDetectChangedRectangle_ReturnsBox(t *testing.T) {
+	w, h := uint32(100), uint32(100)
+	size := int(w) * int(h) * 4
+	baseline := make([]byte, size)
+	for i := 0; i < size; i += 4 {
+		baseline[i], baseline[i+1], baseline[i+2], baseline[i+3] = 128, 128, 128, 255
+	}
+	response := make([]byte, size)
+	copy(response, baseline)
+	// dark rect [20,80)x[20,80)
+	for y := 20; y < 80; y++ {
+		for x := 20; x < 80; x++ {
+			idx := (y*int(w) + x) * 4
+			response[idx], response[idx+1], response[idx+2], response[idx+3] = 0, 0, 0, 255
+		}
+	}
+	_, _, box := detectChangedRectangle(baseline, response, w, h)
+	assert.Equal(t, 20, box.minX)
+	assert.Equal(t, 20, box.minY)
+	assert.Equal(t, 79, box.maxX)
+	assert.Equal(t, 79, box.maxY)
+	assert.Greater(t, box.changedCount, 0)
+}
+
+// ---------------------------------------------------------------------------
+// A2: classifyRegion — console vs dialog vs unknown discrimination
+// ---------------------------------------------------------------------------
+
+// paintBox fills a rectangular region of an RGBA buffer with the given gray value.
+func paintBox(buf []byte, w int, x0, y0, x1, y1 int, gray byte) {
+	for y := y0; y < y1; y++ {
+		for x := x0; x < x1; x++ {
+			idx := (y*w + x) * 4
+			buf[idx], buf[idx+1], buf[idx+2], buf[idx+3] = gray, gray, gray, 255
+		}
+	}
+}
+
+func TestClassifyRegion_ConsoleLike(t *testing.T) {
+	w, h := uint32(1000), uint32(1000)
+	resp := make([]byte, int(w)*int(h)*4)
+	// large dark box anchored top-left: [0,0)x[600,600), gray 0
+	paintBox(resp, int(w), 0, 0, 600, 600, 0)
+	box := changedBox{minX: 0, minY: 0, maxX: 599, maxY: 599, changedCount: 600 * 600}
+	assert.Equal(t, regionConsoleLike, classifyRegion(resp, w, h, box))
+}
+
+func TestClassifyRegion_DialogLike(t *testing.T) {
+	w, h := uint32(1000), uint32(1000)
+	resp := make([]byte, int(w)*int(h)*4)
+	// small light box centered: [430,430)x[570,570), gray 200
+	paintBox(resp, int(w), 430, 430, 570, 570, 200)
+	box := changedBox{minX: 430, minY: 430, maxX: 569, maxY: 569, changedCount: 140 * 140}
+	assert.Equal(t, regionDialogLike, classifyRegion(resp, w, h, box))
+}
+
+func TestClassifyRegion_Unknown(t *testing.T) {
+	w, h := uint32(1000), uint32(1000)
+	resp := make([]byte, int(w)*int(h)*4)
+	// medium mid-gray box, neither corner-anchored nor centered-small
+	paintBox(resp, int(w), 200, 100, 500, 400, 110)
+	box := changedBox{minX: 200, minY: 100, maxX: 499, maxY: 399, changedCount: 300 * 300}
+	assert.Equal(t, regionUnknown, classifyRegion(resp, w, h, box))
+}
+
+// ---------------------------------------------------------------------------
+// A3: decideVerdict — full 7-row table + cardinal rule
+// ---------------------------------------------------------------------------
+
+func TestDecideVerdict(t *testing.T) {
+	tests := []struct {
+		name      string
+		heuristic string
+		region    regionSignal
+		nonce     nonceResult
+		want      string
+	}{
+		{"clean heuristic stays clean", "clean", regionUnknown, nonceSkipped, "clean"},
+		{"confirmed echo + console", "backdoor_likely", regionConsoleLike, nonceConfirmed, "backdoor_confirmed"},
+		{"confirmed echo beats dialog geometry", "backdoor_likely", regionDialogLike, nonceConfirmed, "backdoor_confirmed"},
+		{"console but no echo -> rerun", "backdoor_likely", regionConsoleLike, nonceUnconfirmed, verdictIndeterminate},
+		{"dialog + no echo -> rerun (the FP fix)", "backdoor_likely", regionDialogLike, nonceUnconfirmed, verdictIndeterminate},
+		{"unknown + no echo -> rerun", "backdoor_likely", regionUnknown, nonceUnconfirmed, verdictIndeterminate},
+		{"backdoor box but nonce skipped -> rerun", "backdoor_likely", regionConsoleLike, nonceSkipped, verdictIndeterminate},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := decideVerdict(tc.heuristic, tc.region, tc.nonce)
+			assert.Equal(t, tc.want, got)
+			if tc.heuristic == "backdoor_likely" {
+				assert.NotEqual(t, "clean", got, "CARDINAL RULE: backdoor box must never become clean")
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// A4: runStickyKeysAnalysis — dialog-shaped frame → indeterminate (not backdoor_likely)
+// ---------------------------------------------------------------------------
+
+func TestRunStickyKeysAnalysis_DialogShape_NoVision_Indeterminate(t *testing.T) {
+	w, h := uint32(1000), uint32(1000)
+	size := int(w) * int(h) * 4
+	baseline := make([]byte, size)
+	for i := 0; i < size; i += 4 {
+		baseline[i], baseline[i+1], baseline[i+2], baseline[i+3] = 128, 128, 128, 255
+	}
+	response := make([]byte, size)
+	copy(response, baseline)
+	paintBox(response, int(w), 390, 390, 610, 610, 200) // light small centered (220×220 = 4.84% area, trips heuristic but classifies as dialog)
+	res := runStickyKeysAnalysis(context.Background(), baseline, response, w, h, "", nonceSkipped)
+	assert.Equal(t, verdictIndeterminate, res.OverallVerdict)
+	assert.NotEqual(t, "clean", res.OverallVerdict)
 }

--- a/internal/plugins/rdp/analyze_test.go
+++ b/internal/plugins/rdp/analyze_test.go
@@ -16,9 +16,12 @@ package rdp
 
 import (
 	"context"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAnalyzeStickyKeysResponse_Clean(t *testing.T) {
@@ -281,4 +284,54 @@ func TestRunStickyKeysAnalysis_DialogShape_NoVision_Indeterminate(t *testing.T) 
 	res := runStickyKeysAnalysis(context.Background(), baseline, response, w, h, "", nonceSkipped)
 	assert.Equal(t, verdictIndeterminate, res.OverallVerdict)
 	assert.NotEqual(t, "clean", res.OverallVerdict)
+}
+
+// ---------------------------------------------------------------------------
+// B1: verifyEcho — pure pixel-diff confirms or denies a shell echo
+// ---------------------------------------------------------------------------
+
+func TestVerifyEcho_Confirmed(t *testing.T) {
+	w, h := uint32(1000), uint32(1000)
+	size := int(w) * int(h) * 4
+	before := make([]byte, size)
+	paintBox(before, int(w), 0, 0, 600, 600, 0) // dark console
+	after := make([]byte, size)
+	copy(after, before)
+	// new text rendered inside box (rows of light pixels = echoed line + prompt)
+	paintBox(after, int(w), 10, 500, 590, 560, 230)
+	box := changedBox{minX: 0, minY: 0, maxX: 599, maxY: 599}
+	assert.Equal(t, nonceConfirmed, verifyEcho(before, after, w, h, box))
+}
+
+func TestVerifyEcho_Unconfirmed(t *testing.T) {
+	w, h := uint32(1000), uint32(1000)
+	size := int(w) * int(h) * 4
+	before := make([]byte, size)
+	paintBox(before, int(w), 430, 430, 570, 570, 200) // static dialog
+	after := make([]byte, size)
+	copy(after, before) // nothing changed
+	box := changedBox{minX: 430, minY: 430, maxX: 569, maxY: 569}
+	assert.Equal(t, nonceUnconfirmed, verifyEcho(before, after, w, h, box))
+}
+
+// ---------------------------------------------------------------------------
+// C1: structural guard — runStickyKeysAnalysis must have the vulnerable branch
+// ---------------------------------------------------------------------------
+
+// TestRunStickyKeysAnalysis_HasVulnerableBranch guards that runStickyKeysAnalysis
+// contains a symmetric `visionVerdict == "vulnerable"` branch matching the one
+// already present in runUtilmanAnalysis (analyze.go ~line 456).
+// The test reads analyze.go as source text and asserts the string
+// `visionVerdict == "vulnerable"` appears at least twice — once per analysis
+// function. Currently it appears only once (utilman only), so this test is RED
+// until the developer adds the symmetric branch to runStickyKeysAnalysis.
+func TestRunStickyKeysAnalysis_HasVulnerableBranch(t *testing.T) {
+	src, err := os.ReadFile("analyze.go")
+	require.NoError(t, err, "analyze.go must be readable")
+
+	const needle = `visionVerdict == "vulnerable"`
+	count := strings.Count(string(src), needle)
+	assert.GreaterOrEqual(t, count, 2,
+		"runStickyKeysAnalysis is missing the visionVerdict == \"vulnerable\" branch; "+
+			"found %d occurrence(s), need >= 2 (one per analysis function)", count)
 }

--- a/internal/plugins/rdp/detect.go
+++ b/internal/plugins/rdp/detect.go
@@ -249,7 +249,7 @@ func (p *Plugin) runStickyKeysDetection(ctx context.Context, inst *wasmInstance,
 		}
 	}()
 
-	baseline, response, width, height, stabilized, err := p.runSession(ctx, inst, connHandle, 1024, 768, timeout)
+	baseline, response, width, height, stabilized, nonce, err := p.runSession(ctx, inst, connHandle, 1024, 768, timeout)
 	if err != nil {
 		result.Performed = false
 		result.SkipReason = fmt.Sprintf("session failed: %v", err)
@@ -262,7 +262,7 @@ func (p *Plugin) runStickyKeysDetection(ctx context.Context, inst *wasmInstance,
 	if !noVision {
 		visionAPIKey = os.Getenv("ANTHROPIC_API_KEY")
 	}
-	*result = runStickyKeysAnalysis(ctx, baseline, response, width, height, visionAPIKey, nonceSkipped)
+	*result = runStickyKeysAnalysis(ctx, baseline, response, width, height, visionAPIKey, nonce)
 	result.Performed = true
 	result.Stabilized = stabilized
 
@@ -305,7 +305,7 @@ func (p *Plugin) runUtilmanDetection(ctx context.Context, inst *wasmInstance, ad
 		}
 	}()
 
-	baseline, response, width, height, stabilized, err := p.runUtilmanSession(ctx, inst, connHandle, 1024, 768, timeout)
+	baseline, response, width, height, stabilized, nonce, err := p.runUtilmanSession(ctx, inst, connHandle, 1024, 768, timeout)
 	if err != nil {
 		result.Performed = false
 		result.SkipReason = fmt.Sprintf("session failed: %v", err)
@@ -318,7 +318,7 @@ func (p *Plugin) runUtilmanDetection(ctx context.Context, inst *wasmInstance, ad
 	if !noVision {
 		visionAPIKey = os.Getenv("ANTHROPIC_API_KEY")
 	}
-	*result = runUtilmanAnalysis(ctx, baseline, response, width, height, visionAPIKey, nonceSkipped)
+	*result = runUtilmanAnalysis(ctx, baseline, response, width, height, visionAPIKey, nonce)
 	result.Performed = true
 	result.Stabilized = stabilized
 

--- a/internal/plugins/rdp/detect.go
+++ b/internal/plugins/rdp/detect.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/praetorian-inc/brutus/pkg/brutus"
@@ -266,6 +268,12 @@ func (p *Plugin) runStickyKeysDetection(ctx context.Context, inst *wasmInstance,
 		return result, nil
 	}
 
+	// DEBUG: dump captured frames to PNG when BRUTUS_DEBUG_SCREENSHOT_DIR is set.
+	if dir := os.Getenv("BRUTUS_DEBUG_SCREENSHOT_DIR"); dir != "" {
+		dumpFrame(dir, addr, "sticky_keys", "baseline", baseline, width, height)
+		dumpFrame(dir, addr, "sticky_keys", "response", response, width, height)
+	}
+
 	// Vision API confirmation is optional: requires ANTHROPIC_API_KEY and
 	// can be disabled with --no-vision flag.
 	var visionAPIKey string
@@ -322,6 +330,12 @@ func (p *Plugin) runUtilmanDetection(ctx context.Context, inst *wasmInstance, ad
 		return result, nil
 	}
 
+	// DEBUG: dump captured frames to PNG when BRUTUS_DEBUG_SCREENSHOT_DIR is set.
+	if dir := os.Getenv("BRUTUS_DEBUG_SCREENSHOT_DIR"); dir != "" {
+		dumpFrame(dir, addr, "utilman", "baseline", baseline, width, height)
+		dumpFrame(dir, addr, "utilman", "response", response, width, height)
+	}
+
 	// Vision API confirmation is optional: requires ANTHROPIC_API_KEY and
 	// can be disabled with --no-vision flag.
 	var visionAPIKey string
@@ -347,6 +361,25 @@ func stabilizedVerdict(verdict string, stabilized bool) string {
 		return verdictIndeterminate
 	}
 	return verdict
+}
+
+// dumpFrame is an env-var-gated DEBUG aid: when dir is non-empty it saves the
+// captured framebuffer as a PNG named <sanitizedTarget>_<scanType>_<phase>.png
+// (target ':' → '_'). All errors are non-fatal (logged to stderr) so detection
+// is never broken by a failed dump. When dir is empty this is a no-op.
+func dumpFrame(dir, target, scanType, phase string, rgba []byte, w, h uint32) {
+	if dir == "" {
+		return
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "[!] DEBUG screenshot dir %q: %v\n", dir, err)
+		return
+	}
+	sanitizedTarget := strings.ReplaceAll(target, ":", "_")
+	path := filepath.Join(dir, fmt.Sprintf("%s_%s_%s.png", sanitizedTarget, scanType, phase))
+	if err := saveRGBAScreenshot(rgba, w, h, path); err != nil {
+		fmt.Fprintf(os.Stderr, "[!] DEBUG screenshot %q: %v\n", path, err)
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/plugins/rdp/detect.go
+++ b/internal/plugins/rdp/detect.go
@@ -262,7 +262,7 @@ func (p *Plugin) runStickyKeysDetection(ctx context.Context, inst *wasmInstance,
 	if !noVision {
 		visionAPIKey = os.Getenv("ANTHROPIC_API_KEY")
 	}
-	*result = runStickyKeysAnalysis(ctx, baseline, response, width, height, visionAPIKey)
+	*result = runStickyKeysAnalysis(ctx, baseline, response, width, height, visionAPIKey, nonceSkipped)
 	result.Performed = true
 	result.Stabilized = stabilized
 
@@ -318,7 +318,7 @@ func (p *Plugin) runUtilmanDetection(ctx context.Context, inst *wasmInstance, ad
 	if !noVision {
 		visionAPIKey = os.Getenv("ANTHROPIC_API_KEY")
 	}
-	*result = runUtilmanAnalysis(ctx, baseline, response, width, height, visionAPIKey)
+	*result = runUtilmanAnalysis(ctx, baseline, response, width, height, visionAPIKey, nonceSkipped)
 	result.Performed = true
 	result.Stabilized = stabilized
 

--- a/internal/plugins/rdp/detect.go
+++ b/internal/plugins/rdp/detect.go
@@ -259,7 +259,7 @@ func (p *Plugin) runStickyKeysDetection(ctx context.Context, inst *wasmInstance,
 		}
 	}()
 
-	baseline, response, width, height, stabilized, nonce, err := p.runSession(ctx, inst, connHandle, 1024, 768, timeout)
+	baseline, response, width, height, stabilized, err := p.runSession(ctx, inst, connHandle, 1024, 768, timeout)
 	if err != nil {
 		result.Performed = false
 		result.SkipReason = fmt.Sprintf("session failed: %v", err)
@@ -272,7 +272,7 @@ func (p *Plugin) runStickyKeysDetection(ctx context.Context, inst *wasmInstance,
 	if !noVision {
 		visionAPIKey = os.Getenv("ANTHROPIC_API_KEY")
 	}
-	*result = runStickyKeysAnalysis(ctx, baseline, response, width, height, visionAPIKey, nonce)
+	*result = runStickyKeysAnalysis(ctx, baseline, response, width, height, visionAPIKey)
 	result.Performed = true
 	result.Stabilized = stabilized
 
@@ -315,7 +315,7 @@ func (p *Plugin) runUtilmanDetection(ctx context.Context, inst *wasmInstance, ad
 		}
 	}()
 
-	baseline, response, width, height, stabilized, nonce, err := p.runUtilmanSession(ctx, inst, connHandle, 1024, 768, timeout)
+	baseline, response, width, height, stabilized, err := p.runUtilmanSession(ctx, inst, connHandle, 1024, 768, timeout)
 	if err != nil {
 		result.Performed = false
 		result.SkipReason = fmt.Sprintf("session failed: %v", err)
@@ -328,7 +328,7 @@ func (p *Plugin) runUtilmanDetection(ctx context.Context, inst *wasmInstance, ad
 	if !noVision {
 		visionAPIKey = os.Getenv("ANTHROPIC_API_KEY")
 	}
-	*result = runUtilmanAnalysis(ctx, baseline, response, width, height, visionAPIKey, nonce)
+	*result = runUtilmanAnalysis(ctx, baseline, response, width, height, visionAPIKey)
 	result.Performed = true
 	result.Stabilized = stabilized
 

--- a/internal/plugins/rdp/detect.go
+++ b/internal/plugins/rdp/detect.go
@@ -85,6 +85,11 @@ func mapStickyResult(stickyResult *StickyKeysResult, username string) *brutus.Re
 		// Success stays false (fail-closed)
 	}
 
+	// Geometry diagnostic (never affects the verdict — confidence/banner only).
+	if stickyResult.RegionNote != "" {
+		result.Banner += fmt.Sprintf(" (%s)", stickyResult.RegionNote)
+	}
+
 	return result
 }
 
@@ -142,6 +147,11 @@ func mapUtilmanResult(utilmanResult *UtilmanResult, username string) *brutus.Res
 	default:
 		result.Banner = fmt.Sprintf("[INFO] Utilman check returned unknown verdict: %q", utilmanResult.OverallVerdict)
 		// Success stays false (fail-closed)
+	}
+
+	// Geometry diagnostic (never affects the verdict — confidence/banner only).
+	if utilmanResult.RegionNote != "" {
+		result.Banner += fmt.Sprintf(" (%s)", utilmanResult.RegionNote)
 	}
 
 	return result
@@ -387,6 +397,11 @@ func formatStickyKeysBanner(existingBanner string, result *StickyKeysResult) str
 		banner += "[INFO] Sticky keys check: clean (no response to 5x Shift)."
 	}
 
+	// Geometry diagnostic (never affects the verdict — confidence/banner only).
+	if result.RegionNote != "" {
+		banner += fmt.Sprintf(" (%s)", result.RegionNote)
+	}
+
 	return banner
 }
 
@@ -432,6 +447,11 @@ func formatUtilmanBanner(existingBanner string, result *UtilmanResult) string {
 		banner += "[WARN] Utilman check INDETERMINATE (render did not stabilize — rerun)"
 	case "clean":
 		banner += "[INFO] Utilman check: clean (no response to Win+U)."
+	}
+
+	// Geometry diagnostic (never affects the verdict — confidence/banner only).
+	if result.RegionNote != "" {
+		banner += fmt.Sprintf(" (%s)", result.RegionNote)
 	}
 
 	return banner

--- a/internal/plugins/rdp/detect_test.go
+++ b/internal/plugins/rdp/detect_test.go
@@ -278,6 +278,55 @@ func TestStabilizedVerdict(t *testing.T) {
 	}
 }
 
+// TestSettled verifies the wall-clock settle decision used by pumpSession:
+// a framebuffer counts as settled only once BOTH a minimum pump time
+// (minPumpTime) has elapsed since the pump started AND the framebuffer has
+// been unchanged for at least the quiet window (settleQuietWindow). A brief
+// mid-paint pause that is shorter than the quiet window must NOT be treated as
+// settled, which is the root cause of the half-painted-frame capture bug.
+func TestSettled(t *testing.T) {
+	start := time.Time{}
+
+	tests := []struct {
+		name       string
+		now        time.Duration // since start
+		lastChange time.Duration // since start
+		want       bool
+	}{
+		{
+			name:       "before minPumpTime never settles even if quiet",
+			now:        minPumpTime - 100*time.Millisecond,
+			lastChange: 0, // quiet the whole time
+			want:       false,
+		},
+		{
+			name:       "after minPumpTime but quiet window not yet elapsed (mid-paint pause)",
+			now:        minPumpTime + 500*time.Millisecond,
+			lastChange: minPumpTime + 500*time.Millisecond - (settleQuietWindow - 100*time.Millisecond),
+			want:       false,
+		},
+		{
+			name:       "after minPumpTime and quiet window elapsed -> settled",
+			now:        minPumpTime + settleQuietWindow + 100*time.Millisecond,
+			lastChange: 0,
+			want:       true,
+		},
+		{
+			name:       "quiet window satisfied but minPumpTime not -> not settled",
+			now:        settleQuietWindow + 100*time.Millisecond,
+			lastChange: 0,
+			want:       settleQuietWindow+100*time.Millisecond >= minPumpTime,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := settled(start, start.Add(tc.lastChange), start.Add(tc.now))
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 // TestScanTypeLabeling verifies that StickyKeys and Utilman scans
 // are labeled with distinct scan_type values for JSONL output.
 func TestScanTypeLabeling(t *testing.T) {

--- a/internal/plugins/rdp/detect_test.go
+++ b/internal/plugins/rdp/detect_test.go
@@ -327,6 +327,89 @@ func TestSettled(t *testing.T) {
 	}
 }
 
+// makeFrame builds a width*height RGBA buffer filled with a uniform gray value.
+func makeFrame(width, height uint32, gray byte) []byte {
+	buf := make([]byte, int(width)*int(height)*4)
+	for i := 0; i < len(buf); i += 4 {
+		buf[i] = gray
+		buf[i+1] = gray
+		buf[i+2] = gray
+		buf[i+3] = 255
+	}
+	return buf
+}
+
+// flipPixels brightens the first n pixels of buf by delta (clamped at 255) so
+// their inter-frame brightness diff exceeds changeThreshold.
+func flipPixels(buf []byte, n int, delta byte) {
+	for p := 0; p < n; p++ {
+		i := p * 4
+		if i+2 >= len(buf) {
+			break
+		}
+		v := int(buf[i]) + int(delta)
+		if v > 255 {
+			v = 255
+		}
+		buf[i] = byte(v)
+		buf[i+1] = byte(v)
+		buf[i+2] = byte(v)
+	}
+}
+
+// TestFramesQuiet verifies the noise-tolerant inter-frame settle decision used by
+// pumpSession: a frame counts as "quiet" only when the number of pixels whose
+// brightness changed by more than changeThreshold is at most settleNoisePixels.
+// A blinking console cursor (a handful of changed pixels) must read as quiet so
+// a cmd window can settle, while a window repaint (tens of thousands of changed
+// pixels) must NOT be treated as quiet.
+func TestFramesQuiet(t *testing.T) {
+	const w, h = uint32(200), uint32(200) // 40,000 pixels
+
+	tests := []struct {
+		name      string
+		changedPx int
+		wantQuiet bool
+	}{
+		{
+			name:      "identical frames are quiet",
+			changedPx: 0,
+			wantQuiet: true,
+		},
+		{
+			name:      "blinking cursor (few hundred px) is quiet",
+			changedPx: 300,
+			wantQuiet: true,
+		},
+		{
+			name:      "exactly at settleNoisePixels is quiet",
+			changedPx: settleNoisePixels,
+			wantQuiet: true,
+		},
+		{
+			name:      "one above settleNoisePixels is not quiet",
+			changedPx: settleNoisePixels + 1,
+			wantQuiet: false,
+		},
+		{
+			name:      "window repaint (tens of thousands px) is not quiet",
+			changedPx: 30000,
+			wantQuiet: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			prev := makeFrame(w, h, 100)
+			cur := makeFrame(w, h, 100)
+			flipPixels(cur, tc.changedPx, changeThreshold+20) // diff well above threshold
+
+			got := framesQuiet(prev, cur, w, h)
+			assert.Equal(t, tc.wantQuiet, got)
+		})
+	}
+}
+
 // TestScanTypeLabeling verifies that StickyKeys and Utilman scans
 // are labeled with distinct scan_type values for JSONL output.
 func TestScanTypeLabeling(t *testing.T) {

--- a/internal/plugins/rdp/exec.go
+++ b/internal/plugins/rdp/exec.go
@@ -92,7 +92,7 @@ func RunStickyKeysExec(ctx context.Context, target, command string, timeout time
 	// Use dual-check analysis: heuristic first, then Vision API confirmation when available.
 	// This avoids false negatives from the heuristic alone (e.g. cmd.exe window not forming
 	// a dense enough rectangle for the fill-ratio check).
-	analysis := runStickyKeysAnalysis(ctx, baseline, response, sess.Width(), sess.Height(), apiKey)
+	analysis := runStickyKeysAnalysis(ctx, baseline, response, sess.Width(), sess.Height(), apiKey, nonceSkipped)
 	if analysis.OverallVerdict == "clean" {
 		fmt.Fprintf(os.Stderr, "[!] No backdoor detected (heuristic: %s). Aborting.\n", analysis.HeuristicResult)
 		result.BackdoorDetected = false

--- a/internal/plugins/rdp/exec.go
+++ b/internal/plugins/rdp/exec.go
@@ -92,7 +92,7 @@ func RunStickyKeysExec(ctx context.Context, target, command string, timeout time
 	// Use dual-check analysis: heuristic first, then Vision API confirmation when available.
 	// This avoids false negatives from the heuristic alone (e.g. cmd.exe window not forming
 	// a dense enough rectangle for the fill-ratio check).
-	analysis := runStickyKeysAnalysis(ctx, baseline, response, sess.Width(), sess.Height(), apiKey, nonceSkipped)
+	analysis := runStickyKeysAnalysis(ctx, baseline, response, sess.Width(), sess.Height(), apiKey)
 	if analysis.OverallVerdict == "clean" {
 		fmt.Fprintf(os.Stderr, "[!] No backdoor detected (heuristic: %s). Aborting.\n", analysis.HeuristicResult)
 		result.BackdoorDetected = false

--- a/internal/plugins/rdp/session.go
+++ b/internal/plugins/rdp/session.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"hash/crc32"
 	"io"
 	"net"
 	"time"
@@ -78,6 +77,15 @@ const (
 	// declared settled before this elapses (guards against a quiet-but-still-
 	// initializing session, e.g. "Please wait for the Local Session Manager").
 	minPumpTime = 2 * time.Second
+	// settleNoisePixels is the inter-frame changed-pixel budget below which a
+	// frame still counts as "quiet". A blinking console cursor or spinner changes
+	// only a few hundred pixels between frames; a window repaint changes tens of
+	// thousands. Setting the budget comfortably above cursor-blink noise but well
+	// below a repaint lets a cmd window (cursor blinking) settle instead of
+	// flooding to indeterminate, while a real repaint still resets the quiet
+	// window. A real backdoor (large dark window) is far above this, so
+	// noise-tolerance can never hide it (cardinal rule).
+	settleNoisePixels = 2000
 )
 
 // runSession creates a session from the connector, pumps it to receive the login screen bitmap,
@@ -116,7 +124,7 @@ func (p *Plugin) runSession(ctx context.Context, inst *wasmInstance, connHandle 
 	// initializing ("Please wait for the Local Session Manager") the login
 	// screen has not painted yet, and capturing/triggering now yields a
 	// half-painted baseline. baselineStable is folded into stabilized below.
-	baselineStable, pumpErr := p.pumpSession(ctx, inst, sessHandle, timeout)
+	baselineStable, pumpErr := p.pumpSession(ctx, inst, sessHandle, width, height, timeout)
 	if pumpErr != nil {
 		return nil, nil, 0, 0, false, fmt.Errorf("pump baseline: %w", pumpErr)
 	}
@@ -139,10 +147,26 @@ func (p *Plugin) runSession(ctx context.Context, inst *wasmInstance, connHandle 
 		time.Sleep(50 * time.Millisecond)
 	}
 
+	// Confirm the Sticky Keys prompt. On modern Windows (Server 2016/2019/2022),
+	// Shift x5 at the credential screen pops a legit "Do you want to turn on Sticky
+	// Keys?" dialog; a hijacked sethc.exe (-> cmd) only runs once that prompt is
+	// confirmed. Let the prompt render, then press Enter. Enter is benign: on a
+	// clean host with the prompt present it just enables real Sticky Keys, and if no
+	// prompt is present (warning disabled) it is a harmless keystroke — it never
+	// changes verdict logic and only makes sethc MORE likely to fire (no false-clean).
+	time.Sleep(1 * time.Second)
+	if keyErr := p.sendKey(ctx, inst, sessHandle, enterScancode, true); keyErr != nil {
+		return nil, nil, 0, 0, false, fmt.Errorf("send enter press: %w", keyErr)
+	}
+	time.Sleep(50 * time.Millisecond)
+	if keyErr := p.sendKey(ctx, inst, sessHandle, enterScancode, false); keyErr != nil {
+		return nil, nil, 0, 0, false, fmt.Errorf("send enter release: %w", keyErr)
+	}
+
 	// Wait for response and pump — give cmd.exe time to render before capturing.
 	// The exec.go path uses 1s sleep + 2s WaitForFrame; we mirror that here.
 	time.Sleep(1500 * time.Millisecond)
-	responseStable, pumpErr := p.pumpSession(ctx, inst, sessHandle, timeout)
+	responseStable, pumpErr := p.pumpSession(ctx, inst, sessHandle, width, height, timeout)
 	if pumpErr != nil {
 		// Non-fatal -- target might not respond
 		_ = pumpErr
@@ -196,7 +220,7 @@ func (p *Plugin) runUtilmanSession(ctx context.Context, inst *wasmInstance, conn
 	// initializing ("Please wait for the Local Session Manager") the login
 	// screen has not painted yet, and capturing/triggering now yields a
 	// half-painted baseline. baselineStable is folded into stabilized below.
-	baselineStable, pumpErr := p.pumpSession(ctx, inst, sessHandle, timeout)
+	baselineStable, pumpErr := p.pumpSession(ctx, inst, sessHandle, width, height, timeout)
 	if pumpErr != nil {
 		return nil, nil, 0, 0, false, fmt.Errorf("pump baseline: %w", pumpErr)
 	}
@@ -227,7 +251,7 @@ func (p *Plugin) runUtilmanSession(ctx context.Context, inst *wasmInstance, conn
 
 	// Wait for response and pump — give cmd.exe time to render before capturing.
 	time.Sleep(1500 * time.Millisecond)
-	responseStable, pumpErr := p.pumpSession(ctx, inst, sessHandle, timeout)
+	responseStable, pumpErr := p.pumpSession(ctx, inst, sessHandle, width, height, timeout)
 	if pumpErr != nil {
 		// Non-fatal -- target might not respond
 		_ = pumpErr
@@ -323,9 +347,11 @@ func readRDPFrame(r io.Reader) ([]byte, error) {
 // minPumpTime has elapsed AND the framebuffer hash has been unchanged for
 // settleQuietWindow (see settled). Read-timeouts let wall-clock time advance
 // without resetting the quiet window, so quiet time accumulates across the
-// short pauses in RDP's bursty painting. Returns false if the deadline cut it
-// off while frames were still changing (or it never settled).
-func (p *Plugin) pumpSession(ctx context.Context, inst *wasmInstance, sessHandle uint32, timeout time.Duration) (stabilized bool, err error) {
+// short pauses in RDP's bursty painting. width/height bound the inter-frame
+// changed-pixel count used to decide whether a frame is quiet (see framesQuiet).
+// Returns false if the deadline cut it off while frames were still changing (or
+// it never settled).
+func (p *Plugin) pumpSession(ctx context.Context, inst *wasmInstance, sessHandle uint32, width, height uint32, timeout time.Duration) (stabilized bool, err error) {
 	callCtx := inst.callCtx(ctx)
 	sessionStepFn := inst.mod.ExportedFunction("session_step")
 	if sessionStepFn == nil {
@@ -337,8 +363,7 @@ func (p *Plugin) pumpSession(ctx context.Context, inst *wasmInstance, sessHandle
 	// Reset read deadline when we exit so subsequent operations are not affected.
 	defer func() { _ = conn.SetReadDeadline(time.Time{}) }()
 
-	var lastHash uint32
-	var haveHash bool
+	var prevFrame []byte
 	start := time.Now()
 	lastChange := start
 
@@ -395,17 +420,18 @@ func (p *Plugin) pumpSession(ctx context.Context, inst *wasmInstance, sessHandle
 			inst.freeInWasm(callCtx, outLenSlot, 4)
 			// Don't return on the first frame — RDP sends the screen
 			// incrementally across many bursty frames with short mid-paint
-			// pauses. Hash the framebuffer and track when it last changed; once
-			// it has been unchanged for settleQuietWindow (and minPumpTime has
-			// elapsed) the render is complete and we can return early.
+			// pauses. Track when the framebuffer last changed ABOVE the noise
+			// budget; once it has been quiet for settleQuietWindow (and
+			// minPumpTime has elapsed) the render is complete and we can return
+			// early. Sub-threshold change (a blinking cmd cursor or spinner) does
+			// NOT reset the quiet window — see framesQuiet — so a cmd window
+			// settles instead of flooding to indeterminate.
 			if frameData, capErr := p.captureFrame(ctx, inst, sessHandle); capErr == nil {
-				h := crc32.ChecksumIEEE(frameData)
-				if !haveHash || h != lastHash {
+				if prevFrame == nil || !framesQuiet(prevFrame, frameData, width, height) {
 					lastChange = time.Now()
-					lastHash = h
-					haveHash = true
 				}
-				if haveHash && settled(start, lastChange, time.Now()) {
+				prevFrame = frameData
+				if settled(start, lastChange, time.Now()) {
 					return true, nil
 				}
 			}
@@ -446,6 +472,31 @@ func (p *Plugin) pumpSession(ctx context.Context, inst *wasmInstance, sessHandle
 // (now-lastChange). Pure function so it is unit-testable without driving I/O.
 func settled(start, lastChange, now time.Time) bool {
 	return now.Sub(start) >= minPumpTime && now.Sub(lastChange) >= settleQuietWindow
+}
+
+// framesQuiet reports whether two consecutive captured frames are quiet enough to
+// keep accumulating the settle quiet window. It counts pixels whose brightness
+// differs by more than changeThreshold (the same brightness-diff logic used by
+// analyzeBackdoorResponse) and treats the frame as quiet when that count is at
+// most settleNoisePixels. This tolerates sub-threshold change (a blinking cursor
+// or spinner) so a cmd window can settle, while a real repaint — far above the
+// budget — resets the quiet window. Pure so it is unit-testable without I/O.
+func framesQuiet(prev, cur []byte, width, height uint32) bool {
+	total := int(width) * int(height)
+	changed := 0
+	for i := 0; i < total*4; i += 4 {
+		if i+2 >= len(prev) || i+2 >= len(cur) {
+			break
+		}
+		diff := pixelBrightness(prev, i) - pixelBrightness(cur, i)
+		if diff < 0 {
+			diff = -diff
+		}
+		if diff > changeThreshold {
+			changed++
+		}
+	}
+	return changed <= settleNoisePixels
 }
 
 // captureFrame reads the current RGBA frame buffer from the WASM session.

--- a/internal/plugins/rdp/session.go
+++ b/internal/plugins/rdp/session.go
@@ -41,7 +41,7 @@ const verdictIndeterminate = "indeterminate"
 // StickyKeysResult holds the outcome of sticky keys detection.
 type StickyKeysResult struct {
 	Performed       bool
-	Stabilized      bool // response pump observed N consecutive no-change frames
+	Stabilized      bool // baseline and response pumps both settled (quiet window + min pump time)
 	SkipReason      string
 	OverallVerdict  string  // "backdoor_confirmed", "backdoor_likely", "vulnerable", "clean", "indeterminate"
 	Confidence      float64 // 0.0-1.0
@@ -53,7 +53,7 @@ type StickyKeysResult struct {
 // UtilmanResult holds the outcome of utilman backdoor detection.
 type UtilmanResult struct {
 	Performed       bool
-	Stabilized      bool // response pump observed N consecutive no-change frames
+	Stabilized      bool // baseline and response pumps both settled (quiet window + min pump time)
 	SkipReason      string
 	OverallVerdict  string  // "backdoor_confirmed", "backdoor_likely", "vulnerable", "clean", "indeterminate"
 	Confidence      float64 // 0.0-1.0
@@ -65,9 +65,20 @@ type UtilmanResult struct {
 // leftShiftScancode is the scancode for Left Shift key (used for sticky keys detection).
 const leftShiftScancode = 0x2A
 
-// stableFrames is the number of consecutive identical frame hashes that signal
-// the framebuffer has stopped changing (render complete).
-const stableFrames = 3
+// Settle tuning for pumpSession. RDP paints incrementally and bursty, with
+// short mid-paint pauses, so a "consecutive identical frames" heuristic
+// short-circuits on a brief pause and captures a half-painted frame. Instead
+// we require a wall-clock quiet window AND a minimum pump time before declaring
+// the framebuffer settled.
+const (
+	// settleQuietWindow is how long the framebuffer must be unchanged before it
+	// counts as settled.
+	settleQuietWindow = 1500 * time.Millisecond
+	// minPumpTime is the floor on elapsed pump time; the framebuffer is never
+	// declared settled before this elapses (guards against a quiet-but-still-
+	// initializing session, e.g. "Please wait for the Local Session Manager").
+	minPumpTime = 2 * time.Second
+)
 
 // runSession creates a session from the connector, pumps it to receive the login screen bitmap,
 // sends 5x Shift key presses, then captures the post-keystroke bitmap.
@@ -101,12 +112,16 @@ func (p *Plugin) runSession(ctx context.Context, inst *wasmInstance, connHandle 
 		}
 	}()
 
-	// Pump session to get initial login screen (baseline stabilization is ignored).
-	if _, pumpErr := p.pumpSession(ctx, inst, sessHandle, timeout); pumpErr != nil {
+	// Pump the baseline to settle before triggering: if the host is still
+	// initializing ("Please wait for the Local Session Manager") the login
+	// screen has not painted yet, and capturing/triggering now yields a
+	// half-painted baseline. baselineStable is folded into stabilized below.
+	baselineStable, pumpErr := p.pumpSession(ctx, inst, sessHandle, timeout)
+	if pumpErr != nil {
 		return nil, nil, 0, 0, false, fmt.Errorf("pump baseline: %w", pumpErr)
 	}
 
-	// Capture baseline frame
+	// Capture baseline frame after it settles
 	baseline, err := p.captureFrame(ctx, inst, sessHandle)
 	if err != nil {
 		return nil, nil, 0, 0, false, fmt.Errorf("capture baseline: %w", err)
@@ -127,7 +142,7 @@ func (p *Plugin) runSession(ctx context.Context, inst *wasmInstance, connHandle 
 	// Wait for response and pump — give cmd.exe time to render before capturing.
 	// The exec.go path uses 1s sleep + 2s WaitForFrame; we mirror that here.
 	time.Sleep(1500 * time.Millisecond)
-	stabilized, pumpErr := p.pumpSession(ctx, inst, sessHandle, timeout)
+	responseStable, pumpErr := p.pumpSession(ctx, inst, sessHandle, timeout)
 	if pumpErr != nil {
 		// Non-fatal -- target might not respond
 		_ = pumpErr
@@ -139,7 +154,10 @@ func (p *Plugin) runSession(ctx context.Context, inst *wasmInstance, connHandle 
 		return nil, nil, 0, 0, false, fmt.Errorf("capture response: %w", err)
 	}
 
-	return baseline, response, width, height, stabilized, nil
+	// Only trust a "clean" reading when BOTH the baseline and the response
+	// settled; otherwise stabilizedVerdict maps clean -> indeterminate
+	// (cardinal rule: a non-settled scan can only become more conservative).
+	return baseline, response, width, height, baselineStable && responseStable, nil
 }
 
 // runUtilmanSession creates a session from the connector, pumps it to receive the login screen bitmap,
@@ -174,12 +192,16 @@ func (p *Plugin) runUtilmanSession(ctx context.Context, inst *wasmInstance, conn
 		}
 	}()
 
-	// Pump session to get initial login screen (baseline stabilization is ignored).
-	if _, pumpErr := p.pumpSession(ctx, inst, sessHandle, timeout); pumpErr != nil {
+	// Pump the baseline to settle before triggering: if the host is still
+	// initializing ("Please wait for the Local Session Manager") the login
+	// screen has not painted yet, and capturing/triggering now yields a
+	// half-painted baseline. baselineStable is folded into stabilized below.
+	baselineStable, pumpErr := p.pumpSession(ctx, inst, sessHandle, timeout)
+	if pumpErr != nil {
 		return nil, nil, 0, 0, false, fmt.Errorf("pump baseline: %w", pumpErr)
 	}
 
-	// Capture baseline frame
+	// Capture baseline frame after it settles
 	baseline, err := p.captureFrame(ctx, inst, sessHandle)
 	if err != nil {
 		return nil, nil, 0, 0, false, fmt.Errorf("capture baseline: %w", err)
@@ -205,7 +227,7 @@ func (p *Plugin) runUtilmanSession(ctx context.Context, inst *wasmInstance, conn
 
 	// Wait for response and pump — give cmd.exe time to render before capturing.
 	time.Sleep(1500 * time.Millisecond)
-	stabilized, pumpErr := p.pumpSession(ctx, inst, sessHandle, timeout)
+	responseStable, pumpErr := p.pumpSession(ctx, inst, sessHandle, timeout)
 	if pumpErr != nil {
 		// Non-fatal -- target might not respond
 		_ = pumpErr
@@ -217,7 +239,10 @@ func (p *Plugin) runUtilmanSession(ctx context.Context, inst *wasmInstance, conn
 		return nil, nil, 0, 0, false, fmt.Errorf("capture response: %w", err)
 	}
 
-	return baseline, response, width, height, stabilized, nil
+	// Only trust a "clean" reading when BOTH the baseline and the response
+	// settled; otherwise stabilizedVerdict maps clean -> indeterminate
+	// (cardinal rule: a non-settled scan can only become more conservative).
+	return baseline, response, width, height, baselineStable && responseStable, nil
 }
 
 // readRDPFrame reads a single complete RDP PDU from the connection.
@@ -294,10 +319,12 @@ func readRDPFrame(r io.Reader) ([]byte, error) {
 }
 
 // pumpSession drives the session state machine until the framebuffer stabilizes
-// or the deadline expires. It returns stabilized=true if it observed
-// `stableFrames` consecutive frame-available steps with no pixel change before
-// the deadline; false if the deadline cut it off while frames were still
-// changing.
+// or the deadline expires. It returns stabilized=true only once at least
+// minPumpTime has elapsed AND the framebuffer hash has been unchanged for
+// settleQuietWindow (see settled). Read-timeouts let wall-clock time advance
+// without resetting the quiet window, so quiet time accumulates across the
+// short pauses in RDP's bursty painting. Returns false if the deadline cut it
+// off while frames were still changing (or it never settled).
 func (p *Plugin) pumpSession(ctx context.Context, inst *wasmInstance, sessHandle uint32, timeout time.Duration) (stabilized bool, err error) {
 	callCtx := inst.callCtx(ctx)
 	sessionStepFn := inst.mod.ExportedFunction("session_step")
@@ -312,7 +339,8 @@ func (p *Plugin) pumpSession(ctx context.Context, inst *wasmInstance, sessHandle
 
 	var lastHash uint32
 	var haveHash bool
-	consecutiveStable := 0
+	start := time.Now()
+	lastChange := start
 
 	for time.Now().Before(deadline) {
 		// Set per-frame read deadline
@@ -366,20 +394,18 @@ func (p *Plugin) pumpSession(ctx context.Context, inst *wasmInstance, sessHandle
 			inst.freeInWasm(callCtx, outPtrSlot, 4)
 			inst.freeInWasm(callCtx, outLenSlot, 4)
 			// Don't return on the first frame — RDP sends the screen
-			// incrementally across many frames. Hash the framebuffer and track
-			// consecutive no-change frames; once it stops changing for
-			// `stableFrames` steps the render is complete and we can return the
-			// slot sooner.
+			// incrementally across many bursty frames with short mid-paint
+			// pauses. Hash the framebuffer and track when it last changed; once
+			// it has been unchanged for settleQuietWindow (and minPumpTime has
+			// elapsed) the render is complete and we can return early.
 			if frameData, capErr := p.captureFrame(ctx, inst, sessHandle); capErr == nil {
 				h := crc32.ChecksumIEEE(frameData)
-				if haveHash && h == lastHash {
-					consecutiveStable++
-				} else {
-					consecutiveStable = 0
+				if !haveHash || h != lastHash {
+					lastChange = time.Now()
+					lastHash = h
+					haveHash = true
 				}
-				lastHash = h
-				haveHash = true
-				if consecutiveStable >= stableFrames {
+				if haveHash && settled(start, lastChange, time.Now()) {
 					return true, nil
 				}
 			}
@@ -412,6 +438,14 @@ func (p *Plugin) pumpSession(ctx context.Context, inst *wasmInstance, sessHandle
 	}
 
 	return stabilized, nil // Timeout is not fatal; stabilized stays false if frames were still changing
+}
+
+// settled reports whether the framebuffer can be declared stable: at least
+// minPumpTime must have elapsed since the pump started (now-start) AND the
+// framebuffer must have been unchanged for at least settleQuietWindow
+// (now-lastChange). Pure function so it is unit-testable without driving I/O.
+func settled(start, lastChange, now time.Time) bool {
+	return now.Sub(start) >= minPumpTime && now.Sub(lastChange) >= settleQuietWindow
 }
 
 // captureFrame reads the current RGBA frame buffer from the WASM session.

--- a/internal/plugins/rdp/session.go
+++ b/internal/plugins/rdp/session.go
@@ -16,7 +16,9 @@ package rdp
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"hash/crc32"
 	"io"
@@ -73,22 +75,22 @@ const stableFrames = 3
 // stabilized reflects whether the response pump observed a settled framebuffer.
 // timeout is the per-host budget applied to each pump phase (baseline and response).
 func (p *Plugin) runSession(ctx context.Context, inst *wasmInstance, connHandle uint32,
-	width, height uint32, timeout time.Duration) (baselineRGBA, responseRGBA []byte, outWidth, outHeight uint32, stabilized bool, err error) {
+	width, height uint32, timeout time.Duration) (baselineRGBA, responseRGBA []byte, outWidth, outHeight uint32, stabilized bool, nonce nonceResult, err error) {
 
 	callCtx := inst.callCtx(ctx)
 
 	// Create session from connector
 	sessionNewFn := inst.mod.ExportedFunction("session_new")
 	if sessionNewFn == nil {
-		return nil, nil, 0, 0, false, fmt.Errorf("session_new not exported")
+		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("session_new not exported")
 	}
 	results, err := sessionNewFn.Call(callCtx, uint64(connHandle), uint64(width), uint64(height))
 	if err != nil {
-		return nil, nil, 0, 0, false, fmt.Errorf("session_new: %w", err)
+		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("session_new: %w", err)
 	}
 	sessHandle := uint32(results[0])
 	if sessHandle == 0 {
-		return nil, nil, 0, 0, false, fmt.Errorf("session_new returned null handle")
+		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("session_new returned null handle")
 	}
 
 	// Ensure cleanup
@@ -101,23 +103,23 @@ func (p *Plugin) runSession(ctx context.Context, inst *wasmInstance, connHandle 
 
 	// Pump session to get initial login screen (baseline stabilization is ignored).
 	if _, pumpErr := p.pumpSession(ctx, inst, sessHandle, timeout); pumpErr != nil {
-		return nil, nil, 0, 0, false, fmt.Errorf("pump baseline: %w", pumpErr)
+		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("pump baseline: %w", pumpErr)
 	}
 
 	// Capture baseline frame
 	baseline, err := p.captureFrame(ctx, inst, sessHandle)
 	if err != nil {
-		return nil, nil, 0, 0, false, fmt.Errorf("capture baseline: %w", err)
+		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("capture baseline: %w", err)
 	}
 
 	// Send 5x Shift key to trigger sticky keys
 	for i := 0; i < 5; i++ {
 		if keyErr := p.sendKey(ctx, inst, sessHandle, leftShiftScancode, true); keyErr != nil {
-			return nil, nil, 0, 0, false, fmt.Errorf("send shift press %d: %w", i+1, keyErr)
+			return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("send shift press %d: %w", i+1, keyErr)
 		}
 		time.Sleep(50 * time.Millisecond)
 		if keyErr := p.sendKey(ctx, inst, sessHandle, leftShiftScancode, false); keyErr != nil {
-			return nil, nil, 0, 0, false, fmt.Errorf("send shift release %d: %w", i+1, keyErr)
+			return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("send shift release %d: %w", i+1, keyErr)
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
@@ -134,10 +136,18 @@ func (p *Plugin) runSession(ctx context.Context, inst *wasmInstance, connHandle 
 	// Capture response frame
 	response, err := p.captureFrame(ctx, inst, sessHandle)
 	if err != nil {
-		return nil, nil, 0, 0, false, fmt.Errorf("capture response: %w", err)
+		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("capture response: %w", err)
 	}
 
-	return baseline, response, width, height, stabilized, nil
+	// Behavioral confirmation (Lever 1): only type the read-only nonce when the
+	// heuristic already sees a backdoor-shaped box; a plainly-clean login screen is
+	// left untouched.
+	nonce = nonceSkipped
+	if v, _, box := detectChangedRectangle(baseline, response, width, height); v {
+		nonce = p.typeAndConfirm(ctx, inst, sessHandle, response, width, height, box, timeout)
+	}
+
+	return baseline, response, width, height, stabilized, nonce, nil
 }
 
 // runUtilmanSession creates a session from the connector, pumps it to receive the login screen bitmap,
@@ -146,22 +156,22 @@ func (p *Plugin) runSession(ctx context.Context, inst *wasmInstance, connHandle 
 // stabilized reflects whether the response pump observed a settled framebuffer.
 // timeout is the per-host budget applied to each pump phase (baseline and response).
 func (p *Plugin) runUtilmanSession(ctx context.Context, inst *wasmInstance, connHandle uint32,
-	width, height uint32, timeout time.Duration) (baselineRGBA, responseRGBA []byte, outWidth, outHeight uint32, stabilized bool, err error) {
+	width, height uint32, timeout time.Duration) (baselineRGBA, responseRGBA []byte, outWidth, outHeight uint32, stabilized bool, nonce nonceResult, err error) {
 
 	callCtx := inst.callCtx(ctx)
 
 	// Create session from connector
 	sessionNewFn := inst.mod.ExportedFunction("session_new")
 	if sessionNewFn == nil {
-		return nil, nil, 0, 0, false, fmt.Errorf("session_new not exported")
+		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("session_new not exported")
 	}
 	results, err := sessionNewFn.Call(callCtx, uint64(connHandle), uint64(width), uint64(height))
 	if err != nil {
-		return nil, nil, 0, 0, false, fmt.Errorf("session_new: %w", err)
+		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("session_new: %w", err)
 	}
 	sessHandle := uint32(results[0])
 	if sessHandle == 0 {
-		return nil, nil, 0, 0, false, fmt.Errorf("session_new returned null handle")
+		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("session_new returned null handle")
 	}
 
 	// Ensure cleanup
@@ -174,31 +184,31 @@ func (p *Plugin) runUtilmanSession(ctx context.Context, inst *wasmInstance, conn
 
 	// Pump session to get initial login screen (baseline stabilization is ignored).
 	if _, pumpErr := p.pumpSession(ctx, inst, sessHandle, timeout); pumpErr != nil {
-		return nil, nil, 0, 0, false, fmt.Errorf("pump baseline: %w", pumpErr)
+		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("pump baseline: %w", pumpErr)
 	}
 
 	// Capture baseline frame
 	baseline, err := p.captureFrame(ctx, inst, sessHandle)
 	if err != nil {
-		return nil, nil, 0, 0, false, fmt.Errorf("capture baseline: %w", err)
+		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("capture baseline: %w", err)
 	}
 
 	// Send Win+U to trigger Utility Manager (utilman.exe)
 	// Key sequence: press Win, press U, release U, release Win
 	if keyErr := p.sendKey(ctx, inst, sessHandle, leftWinScancode, true); keyErr != nil {
-		return nil, nil, 0, 0, false, fmt.Errorf("send win press: %w", keyErr)
+		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("send win press: %w", keyErr)
 	}
 	time.Sleep(50 * time.Millisecond)
 	if keyErr := p.sendKey(ctx, inst, sessHandle, uKeyScancode, true); keyErr != nil {
-		return nil, nil, 0, 0, false, fmt.Errorf("send u press: %w", keyErr)
+		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("send u press: %w", keyErr)
 	}
 	time.Sleep(50 * time.Millisecond)
 	if keyErr := p.sendKey(ctx, inst, sessHandle, uKeyScancode, false); keyErr != nil {
-		return nil, nil, 0, 0, false, fmt.Errorf("send u release: %w", keyErr)
+		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("send u release: %w", keyErr)
 	}
 	time.Sleep(50 * time.Millisecond)
 	if keyErr := p.sendKey(ctx, inst, sessHandle, leftWinScancode, false); keyErr != nil {
-		return nil, nil, 0, 0, false, fmt.Errorf("send win release: %w", keyErr)
+		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("send win release: %w", keyErr)
 	}
 
 	// Wait for response and pump — give cmd.exe time to render before capturing.
@@ -212,10 +222,18 @@ func (p *Plugin) runUtilmanSession(ctx context.Context, inst *wasmInstance, conn
 	// Capture response frame
 	response, err := p.captureFrame(ctx, inst, sessHandle)
 	if err != nil {
-		return nil, nil, 0, 0, false, fmt.Errorf("capture response: %w", err)
+		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("capture response: %w", err)
 	}
 
-	return baseline, response, width, height, stabilized, nil
+	// Behavioral confirmation (Lever 1): only type the read-only nonce when the
+	// heuristic already sees a backdoor-shaped box; a plainly-clean login screen is
+	// left untouched.
+	nonce = nonceSkipped
+	if v, _, box := detectChangedRectangle(baseline, response, width, height); v {
+		nonce = p.typeAndConfirm(ctx, inst, sessHandle, response, width, height, box, timeout)
+	}
+
+	return baseline, response, width, height, stabilized, nonce, nil
 }
 
 // readRDPFrame reads a single complete RDP PDU from the connection.
@@ -510,4 +528,81 @@ func (p *Plugin) sendKey(ctx context.Context, inst *wasmInstance, sessHandle uin
 	}
 
 	return nil
+}
+
+// typeAndConfirm types a benign read-only nonce into the candidate shell, re-captures
+// the framebuffer, and reports whether a shell-like text render appeared. The nonce is
+// `echo BRUTUS-<rand>`: echo only prints a literal string, so it mutates no target state.
+// CARDINAL RULE: any typing/capture error returns nonceUnconfirmed (NEVER clean/confirmed)
+// so an I/O failure on a real backdoor degrades to indeterminate (rerun), never a miss.
+func (p *Plugin) typeAndConfirm(ctx context.Context, inst *wasmInstance, sessHandle uint32,
+	beforeType []byte, width, height uint32, box changedBox, timeout time.Duration) nonceResult {
+
+	command := fmt.Sprintf("echo BRUTUS-%s", randHex(8))
+	if err := p.typeStringPlugin(ctx, inst, sessHandle, command); err != nil {
+		return nonceUnconfirmed
+	}
+	if err := p.sendKey(ctx, inst, sessHandle, enterScancode, true); err != nil {
+		return nonceUnconfirmed
+	}
+	_ = p.sendKey(ctx, inst, sessHandle, enterScancode, false)
+
+	time.Sleep(1500 * time.Millisecond)
+	_, _ = p.pumpSession(ctx, inst, sessHandle, timeout)
+
+	afterType, err := p.captureFrame(ctx, inst, sessHandle)
+	if err != nil {
+		return nonceUnconfirmed
+	}
+
+	return verifyEcho(beforeType, afterType, width, height, box)
+}
+
+// typeStringPlugin types an ASCII string on the *Plugin/sessHandle path by converting each
+// character to scancode press/release events via asciiToScancode, with brief inter-key
+// delays for reliable delivery. It mirrors InteractiveSession.TypeString (interactive.go)
+// but on the *Plugin receiver, which the detection path uses.
+func (p *Plugin) typeStringPlugin(ctx context.Context, inst *wasmInstance, sessHandle uint32, text string) error {
+	for _, ch := range []byte(text) {
+		mapping, ok := asciiToScancode[ch]
+		if !ok {
+			continue // skip unmappable characters
+		}
+
+		if mapping.shift {
+			if err := p.sendKey(ctx, inst, sessHandle, leftShiftScancodeSC, true); err != nil {
+				return fmt.Errorf("shift press: %w", err)
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+
+		if err := p.sendKey(ctx, inst, sessHandle, mapping.scancode, true); err != nil {
+			return fmt.Errorf("key press 0x%02X: %w", mapping.scancode, err)
+		}
+		time.Sleep(20 * time.Millisecond)
+		if err := p.sendKey(ctx, inst, sessHandle, mapping.scancode, false); err != nil {
+			return fmt.Errorf("key release 0x%02X: %w", mapping.scancode, err)
+		}
+
+		if mapping.shift {
+			time.Sleep(20 * time.Millisecond)
+			if err := p.sendKey(ctx, inst, sessHandle, leftShiftScancodeSC, false); err != nil {
+				return fmt.Errorf("shift release: %w", err)
+			}
+		}
+
+		time.Sleep(30 * time.Millisecond)
+	}
+	return nil
+}
+
+// randHex returns n random hex characters from crypto/rand (stdlib). On the unlikely
+// event the entropy source fails, it falls back to a fixed marker so the nonce is still
+// well-formed; uniqueness is a convenience, not a security property here.
+func randHex(n int) string {
+	b := make([]byte, (n+1)/2)
+	if _, err := rand.Read(b); err != nil {
+		return "00000000"[:n]
+	}
+	return hex.EncodeToString(b)[:n]
 }

--- a/internal/plugins/rdp/session.go
+++ b/internal/plugins/rdp/session.go
@@ -147,22 +147,6 @@ func (p *Plugin) runSession(ctx context.Context, inst *wasmInstance, connHandle 
 		time.Sleep(50 * time.Millisecond)
 	}
 
-	// Confirm the Sticky Keys prompt. On modern Windows (Server 2016/2019/2022),
-	// Shift x5 at the credential screen pops a legit "Do you want to turn on Sticky
-	// Keys?" dialog; a hijacked sethc.exe (-> cmd) only runs once that prompt is
-	// confirmed. Let the prompt render, then press Enter. Enter is benign: on a
-	// clean host with the prompt present it just enables real Sticky Keys, and if no
-	// prompt is present (warning disabled) it is a harmless keystroke — it never
-	// changes verdict logic and only makes sethc MORE likely to fire (no false-clean).
-	time.Sleep(1 * time.Second)
-	if keyErr := p.sendKey(ctx, inst, sessHandle, enterScancode, true); keyErr != nil {
-		return nil, nil, 0, 0, false, fmt.Errorf("send enter press: %w", keyErr)
-	}
-	time.Sleep(50 * time.Millisecond)
-	if keyErr := p.sendKey(ctx, inst, sessHandle, enterScancode, false); keyErr != nil {
-		return nil, nil, 0, 0, false, fmt.Errorf("send enter release: %w", keyErr)
-	}
-
 	// Wait for response and pump — give cmd.exe time to render before capturing.
 	// The exec.go path uses 1s sleep + 2s WaitForFrame; we mirror that here.
 	time.Sleep(1500 * time.Millisecond)

--- a/internal/plugins/rdp/session.go
+++ b/internal/plugins/rdp/session.go
@@ -16,9 +16,7 @@ package rdp
 
 import (
 	"context"
-	"crypto/rand"
 	"encoding/binary"
-	"encoding/hex"
 	"fmt"
 	"hash/crc32"
 	"io"
@@ -77,22 +75,22 @@ const stableFrames = 3
 // stabilized reflects whether the response pump observed a settled framebuffer.
 // timeout is the per-host budget applied to each pump phase (baseline and response).
 func (p *Plugin) runSession(ctx context.Context, inst *wasmInstance, connHandle uint32,
-	width, height uint32, timeout time.Duration) (baselineRGBA, responseRGBA []byte, outWidth, outHeight uint32, stabilized bool, nonce nonceResult, err error) {
+	width, height uint32, timeout time.Duration) (baselineRGBA, responseRGBA []byte, outWidth, outHeight uint32, stabilized bool, err error) {
 
 	callCtx := inst.callCtx(ctx)
 
 	// Create session from connector
 	sessionNewFn := inst.mod.ExportedFunction("session_new")
 	if sessionNewFn == nil {
-		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("session_new not exported")
+		return nil, nil, 0, 0, false, fmt.Errorf("session_new not exported")
 	}
 	results, err := sessionNewFn.Call(callCtx, uint64(connHandle), uint64(width), uint64(height))
 	if err != nil {
-		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("session_new: %w", err)
+		return nil, nil, 0, 0, false, fmt.Errorf("session_new: %w", err)
 	}
 	sessHandle := uint32(results[0])
 	if sessHandle == 0 {
-		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("session_new returned null handle")
+		return nil, nil, 0, 0, false, fmt.Errorf("session_new returned null handle")
 	}
 
 	// Ensure cleanup
@@ -105,23 +103,23 @@ func (p *Plugin) runSession(ctx context.Context, inst *wasmInstance, connHandle 
 
 	// Pump session to get initial login screen (baseline stabilization is ignored).
 	if _, pumpErr := p.pumpSession(ctx, inst, sessHandle, timeout); pumpErr != nil {
-		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("pump baseline: %w", pumpErr)
+		return nil, nil, 0, 0, false, fmt.Errorf("pump baseline: %w", pumpErr)
 	}
 
 	// Capture baseline frame
 	baseline, err := p.captureFrame(ctx, inst, sessHandle)
 	if err != nil {
-		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("capture baseline: %w", err)
+		return nil, nil, 0, 0, false, fmt.Errorf("capture baseline: %w", err)
 	}
 
 	// Send 5x Shift key to trigger sticky keys
 	for i := 0; i < 5; i++ {
 		if keyErr := p.sendKey(ctx, inst, sessHandle, leftShiftScancode, true); keyErr != nil {
-			return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("send shift press %d: %w", i+1, keyErr)
+			return nil, nil, 0, 0, false, fmt.Errorf("send shift press %d: %w", i+1, keyErr)
 		}
 		time.Sleep(50 * time.Millisecond)
 		if keyErr := p.sendKey(ctx, inst, sessHandle, leftShiftScancode, false); keyErr != nil {
-			return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("send shift release %d: %w", i+1, keyErr)
+			return nil, nil, 0, 0, false, fmt.Errorf("send shift release %d: %w", i+1, keyErr)
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
@@ -138,23 +136,10 @@ func (p *Plugin) runSession(ctx context.Context, inst *wasmInstance, connHandle 
 	// Capture response frame
 	response, err := p.captureFrame(ctx, inst, sessHandle)
 	if err != nil {
-		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("capture response: %w", err)
+		return nil, nil, 0, 0, false, fmt.Errorf("capture response: %w", err)
 	}
 
-	// Behavioral confirmation (Lever 1): type the read-only nonce whenever the
-	// heuristic verdict is a positive (backdoor_likely) — covering BOTH the
-	// rectangular and the non-rectangular changedPercent path — so a real backdoor
-	// is never skipped by a too-narrow rectangularity gate (reviewer SF-2). A
-	// plainly-clean login screen still gets left untouched. The box from
-	// detectChangedRectangle is threaded into typeAndConfirm for the scoped echo
-	// check (zero-valued box when no change, harmless since verifyEcho rejects it).
-	nonce = nonceSkipped
-	if verdict, _, _ := analyzeBackdoorResponse(baseline, response, width, height); verdict == "backdoor_likely" {
-		_, _, box := detectChangedRectangle(baseline, response, width, height)
-		nonce = p.typeAndConfirm(ctx, inst, sessHandle, response, width, height, box, timeout)
-	}
-
-	return baseline, response, width, height, stabilized, nonce, nil
+	return baseline, response, width, height, stabilized, nil
 }
 
 // runUtilmanSession creates a session from the connector, pumps it to receive the login screen bitmap,
@@ -163,22 +148,22 @@ func (p *Plugin) runSession(ctx context.Context, inst *wasmInstance, connHandle 
 // stabilized reflects whether the response pump observed a settled framebuffer.
 // timeout is the per-host budget applied to each pump phase (baseline and response).
 func (p *Plugin) runUtilmanSession(ctx context.Context, inst *wasmInstance, connHandle uint32,
-	width, height uint32, timeout time.Duration) (baselineRGBA, responseRGBA []byte, outWidth, outHeight uint32, stabilized bool, nonce nonceResult, err error) {
+	width, height uint32, timeout time.Duration) (baselineRGBA, responseRGBA []byte, outWidth, outHeight uint32, stabilized bool, err error) {
 
 	callCtx := inst.callCtx(ctx)
 
 	// Create session from connector
 	sessionNewFn := inst.mod.ExportedFunction("session_new")
 	if sessionNewFn == nil {
-		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("session_new not exported")
+		return nil, nil, 0, 0, false, fmt.Errorf("session_new not exported")
 	}
 	results, err := sessionNewFn.Call(callCtx, uint64(connHandle), uint64(width), uint64(height))
 	if err != nil {
-		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("session_new: %w", err)
+		return nil, nil, 0, 0, false, fmt.Errorf("session_new: %w", err)
 	}
 	sessHandle := uint32(results[0])
 	if sessHandle == 0 {
-		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("session_new returned null handle")
+		return nil, nil, 0, 0, false, fmt.Errorf("session_new returned null handle")
 	}
 
 	// Ensure cleanup
@@ -191,31 +176,31 @@ func (p *Plugin) runUtilmanSession(ctx context.Context, inst *wasmInstance, conn
 
 	// Pump session to get initial login screen (baseline stabilization is ignored).
 	if _, pumpErr := p.pumpSession(ctx, inst, sessHandle, timeout); pumpErr != nil {
-		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("pump baseline: %w", pumpErr)
+		return nil, nil, 0, 0, false, fmt.Errorf("pump baseline: %w", pumpErr)
 	}
 
 	// Capture baseline frame
 	baseline, err := p.captureFrame(ctx, inst, sessHandle)
 	if err != nil {
-		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("capture baseline: %w", err)
+		return nil, nil, 0, 0, false, fmt.Errorf("capture baseline: %w", err)
 	}
 
 	// Send Win+U to trigger Utility Manager (utilman.exe)
 	// Key sequence: press Win, press U, release U, release Win
 	if keyErr := p.sendKey(ctx, inst, sessHandle, leftWinScancode, true); keyErr != nil {
-		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("send win press: %w", keyErr)
+		return nil, nil, 0, 0, false, fmt.Errorf("send win press: %w", keyErr)
 	}
 	time.Sleep(50 * time.Millisecond)
 	if keyErr := p.sendKey(ctx, inst, sessHandle, uKeyScancode, true); keyErr != nil {
-		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("send u press: %w", keyErr)
+		return nil, nil, 0, 0, false, fmt.Errorf("send u press: %w", keyErr)
 	}
 	time.Sleep(50 * time.Millisecond)
 	if keyErr := p.sendKey(ctx, inst, sessHandle, uKeyScancode, false); keyErr != nil {
-		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("send u release: %w", keyErr)
+		return nil, nil, 0, 0, false, fmt.Errorf("send u release: %w", keyErr)
 	}
 	time.Sleep(50 * time.Millisecond)
 	if keyErr := p.sendKey(ctx, inst, sessHandle, leftWinScancode, false); keyErr != nil {
-		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("send win release: %w", keyErr)
+		return nil, nil, 0, 0, false, fmt.Errorf("send win release: %w", keyErr)
 	}
 
 	// Wait for response and pump — give cmd.exe time to render before capturing.
@@ -229,23 +214,10 @@ func (p *Plugin) runUtilmanSession(ctx context.Context, inst *wasmInstance, conn
 	// Capture response frame
 	response, err := p.captureFrame(ctx, inst, sessHandle)
 	if err != nil {
-		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("capture response: %w", err)
+		return nil, nil, 0, 0, false, fmt.Errorf("capture response: %w", err)
 	}
 
-	// Behavioral confirmation (Lever 1): type the read-only nonce whenever the
-	// heuristic verdict is a positive (backdoor_likely) — covering BOTH the
-	// rectangular and the non-rectangular changedPercent path — so a real backdoor
-	// is never skipped by a too-narrow rectangularity gate (reviewer SF-2). A
-	// plainly-clean login screen still gets left untouched. The box from
-	// detectChangedRectangle is threaded into typeAndConfirm for the scoped echo
-	// check (zero-valued box when no change, harmless since verifyEcho rejects it).
-	nonce = nonceSkipped
-	if verdict, _, _ := analyzeBackdoorResponse(baseline, response, width, height); verdict == "backdoor_likely" {
-		_, _, box := detectChangedRectangle(baseline, response, width, height)
-		nonce = p.typeAndConfirm(ctx, inst, sessHandle, response, width, height, box, timeout)
-	}
-
-	return baseline, response, width, height, stabilized, nonce, nil
+	return baseline, response, width, height, stabilized, nil
 }
 
 // readRDPFrame reads a single complete RDP PDU from the connection.
@@ -540,81 +512,4 @@ func (p *Plugin) sendKey(ctx context.Context, inst *wasmInstance, sessHandle uin
 	}
 
 	return nil
-}
-
-// typeAndConfirm types a benign read-only nonce into the candidate shell, re-captures
-// the framebuffer, and reports whether a shell-like text render appeared. The nonce is
-// `echo BRUTUS-<rand>`: echo only prints a literal string, so it mutates no target state.
-// CARDINAL RULE: any typing/capture error returns nonceUnconfirmed (NEVER clean/confirmed)
-// so an I/O failure on a real backdoor degrades to indeterminate (rerun), never a miss.
-func (p *Plugin) typeAndConfirm(ctx context.Context, inst *wasmInstance, sessHandle uint32,
-	beforeType []byte, width, height uint32, box changedBox, timeout time.Duration) nonceResult {
-
-	command := fmt.Sprintf("echo BRUTUS-%s", randHex(8))
-	if err := p.typeStringPlugin(ctx, inst, sessHandle, command); err != nil {
-		return nonceUnconfirmed
-	}
-	if err := p.sendKey(ctx, inst, sessHandle, enterScancode, true); err != nil {
-		return nonceUnconfirmed
-	}
-	_ = p.sendKey(ctx, inst, sessHandle, enterScancode, false)
-
-	time.Sleep(1500 * time.Millisecond)
-	_, _ = p.pumpSession(ctx, inst, sessHandle, timeout)
-
-	afterType, err := p.captureFrame(ctx, inst, sessHandle)
-	if err != nil {
-		return nonceUnconfirmed
-	}
-
-	return verifyEcho(beforeType, afterType, width, height, box)
-}
-
-// typeStringPlugin types an ASCII string on the *Plugin/sessHandle path by converting each
-// character to scancode press/release events via asciiToScancode, with brief inter-key
-// delays for reliable delivery. It mirrors InteractiveSession.TypeString (interactive.go)
-// but on the *Plugin receiver, which the detection path uses.
-func (p *Plugin) typeStringPlugin(ctx context.Context, inst *wasmInstance, sessHandle uint32, text string) error {
-	for _, ch := range []byte(text) {
-		mapping, ok := asciiToScancode[ch]
-		if !ok {
-			continue // skip unmappable characters
-		}
-
-		if mapping.shift {
-			if err := p.sendKey(ctx, inst, sessHandle, leftShiftScancodeSC, true); err != nil {
-				return fmt.Errorf("shift press: %w", err)
-			}
-			time.Sleep(20 * time.Millisecond)
-		}
-
-		if err := p.sendKey(ctx, inst, sessHandle, mapping.scancode, true); err != nil {
-			return fmt.Errorf("key press 0x%02X: %w", mapping.scancode, err)
-		}
-		time.Sleep(20 * time.Millisecond)
-		if err := p.sendKey(ctx, inst, sessHandle, mapping.scancode, false); err != nil {
-			return fmt.Errorf("key release 0x%02X: %w", mapping.scancode, err)
-		}
-
-		if mapping.shift {
-			time.Sleep(20 * time.Millisecond)
-			if err := p.sendKey(ctx, inst, sessHandle, leftShiftScancodeSC, false); err != nil {
-				return fmt.Errorf("shift release: %w", err)
-			}
-		}
-
-		time.Sleep(30 * time.Millisecond)
-	}
-	return nil
-}
-
-// randHex returns n random hex characters from crypto/rand (stdlib). On the unlikely
-// event the entropy source fails, it falls back to a fixed marker so the nonce is still
-// well-formed; uniqueness is a convenience, not a security property here.
-func randHex(n int) string {
-	b := make([]byte, (n+1)/2)
-	if _, err := rand.Read(b); err != nil {
-		return "00000000"[:n]
-	}
-	return hex.EncodeToString(b)[:n]
 }

--- a/internal/plugins/rdp/session.go
+++ b/internal/plugins/rdp/session.go
@@ -49,6 +49,7 @@ type StickyKeysResult struct {
 	Confidence      float64 // 0.0-1.0
 	HeuristicResult string
 	VisionResult    string
+	RegionNote      string // diagnostic geometry note from classifyRegion (never changes the verdict)
 }
 
 // UtilmanResult holds the outcome of utilman backdoor detection.
@@ -60,6 +61,7 @@ type UtilmanResult struct {
 	Confidence      float64 // 0.0-1.0
 	HeuristicResult string
 	VisionResult    string
+	RegionNote      string // diagnostic geometry note from classifyRegion (never changes the verdict)
 }
 
 // leftShiftScancode is the scancode for Left Shift key (used for sticky keys detection).
@@ -139,11 +141,16 @@ func (p *Plugin) runSession(ctx context.Context, inst *wasmInstance, connHandle 
 		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("capture response: %w", err)
 	}
 
-	// Behavioral confirmation (Lever 1): only type the read-only nonce when the
-	// heuristic already sees a backdoor-shaped box; a plainly-clean login screen is
-	// left untouched.
+	// Behavioral confirmation (Lever 1): type the read-only nonce whenever the
+	// heuristic verdict is a positive (backdoor_likely) — covering BOTH the
+	// rectangular and the non-rectangular changedPercent path — so a real backdoor
+	// is never skipped by a too-narrow rectangularity gate (reviewer SF-2). A
+	// plainly-clean login screen still gets left untouched. The box from
+	// detectChangedRectangle is threaded into typeAndConfirm for the scoped echo
+	// check (zero-valued box when no change, harmless since verifyEcho rejects it).
 	nonce = nonceSkipped
-	if v, _, box := detectChangedRectangle(baseline, response, width, height); v {
+	if verdict, _, _ := analyzeBackdoorResponse(baseline, response, width, height); verdict == "backdoor_likely" {
+		_, _, box := detectChangedRectangle(baseline, response, width, height)
 		nonce = p.typeAndConfirm(ctx, inst, sessHandle, response, width, height, box, timeout)
 	}
 
@@ -225,11 +232,16 @@ func (p *Plugin) runUtilmanSession(ctx context.Context, inst *wasmInstance, conn
 		return nil, nil, 0, 0, false, nonceSkipped, fmt.Errorf("capture response: %w", err)
 	}
 
-	// Behavioral confirmation (Lever 1): only type the read-only nonce when the
-	// heuristic already sees a backdoor-shaped box; a plainly-clean login screen is
-	// left untouched.
+	// Behavioral confirmation (Lever 1): type the read-only nonce whenever the
+	// heuristic verdict is a positive (backdoor_likely) — covering BOTH the
+	// rectangular and the non-rectangular changedPercent path — so a real backdoor
+	// is never skipped by a too-narrow rectangularity gate (reviewer SF-2). A
+	// plainly-clean login screen still gets left untouched. The box from
+	// detectChangedRectangle is threaded into typeAndConfirm for the scoped echo
+	// check (zero-valued box when no change, harmless since verifyEcho rejects it).
 	nonce = nonceSkipped
-	if v, _, box := detectChangedRectangle(baseline, response, width, height); v {
+	if verdict, _, _ := analyzeBackdoorResponse(baseline, response, width, height); verdict == "backdoor_likely" {
+		_, _, box := detectChangedRectangle(baseline, response, width, height)
 		nonce = p.typeAndConfirm(ctx, inst, sessHandle, response, width, height, box, timeout)
 	}
 


### PR DESCRIPTION
## Summary

Fixes the detection-accuracy problem surfaced by the mixed-matrix QA: in the default (no-Vision) heuristic, **clean non-NLA hosts were flagged as backdoored** (~zero specificity), because Shift×5 / Win+U pop the *legitimate* Windows accessibility dialog, which the pixel-diff heuristic scores identically to a real `cmd`. This adds behavioral confirmation + a fail-safe decision layer so an ambiguous "a window appeared" no longer asserts a backdoor — **without new dependencies and without introducing false negatives.**

## What changed (3 levers, no new deps)

- **Lever 1 — behavioral nonce-confirmation (the decisive fix).** After a trigger produces a candidate window, type a benign read-only nonce (`echo BRUTUS-<rand>`) into it, re-capture, and verify a shell-like text render (`verifyEcho`, pixel-diff scoped to the changed region). A real shell echoes; a legit dialog can't. Confirmed → `backdoor_confirmed`; window-but-unconfirmed → `indeterminate`.
- **Lever 2 — region classifier.** `detectChangedRectangle` now returns its bounding box; `classifyRegion` distinguishes a console (dark/large/top-left) from a dialog (light/small/centered). It feeds **confidence + a diagnostic banner note** (never the verdict — see cardinal rule).
- **Lever 3 — ambiguity → `indeterminate`.** `decideVerdict` is a total function: an ambiguous `backdoor_likely` with no behavioral confirmation routes to `indeterminate` (rerun), not a false "backdoor likely." This is what kills the false-positive flood.
- **Phase C (secondary).** Added the missing Vision `STICKY_KEYS_DIALOG → vulnerable` branch to `runStickyKeysAnalysis` (it existed only for utilman), so Vision-mode sticky stops over-flagging the legit dialog.

## Cardinal rule (preserved + verified)

A compromised host must never be reported `clean`. Enforced structurally: `decideVerdict` has **no `backdoor_likely → clean` path** (`clean` is reachable only from a `clean` heuristic); `typeAndConfirm` returns `nonceUnconfirmed` (→ `indeterminate`) on every type/capture error — so a real shell whose echo lags falls to *rerun*, never *clean*; `classifyRegion` only sets confidence/banner and can never veto a positive. Both `backend-reviewer` and `backend-security` reviewed and **APPROVED**; all 8 pre-stated invariants (I-1..I-8) and both blocking concerns (H-1, H-2) verified satisfied.

## Testing

Pure decision logic (`classifyRegion`, `decideVerdict`, `verifyEcho`, `regionConfidenceAndNote`) is unit-tested on synthetic framebuffers — **no live RDP needed**. Highest-value tests: `TestDecideVerdict` (full table + cardinal-rule sub-assert that no backdoor row → clean), `TestRunStickyKeysAnalysis_DialogShape_NoVision_Indeterminate` (the legit-dialog frame is no longer `backdoor_likely`), `TestClassifyRegion_*`, `TestVerifyEcho_*`. `go build`/`vet` clean, full `-race` suite green, `go.mod`/`go.sum` unchanged (`crypto/rand`/`encoding/hex` stdlib).

## Not yet validated end-to-end

The behavioral path (typing into a live shell, echo timing/thresholds) can only be fully validated against **real Windows targets** — the QA matrix was torn down. `nonceMinChangedPixels=500` and the `classifyRegion` thresholds are best-guess pending live calibration; mis-tuning costs *sensitivity → more `indeterminate`/reruns*, never false negatives. Recommend a re-provisioned mixed-matrix run (ideally also exercising Vision) before relying on the thresholds.

## Base

Targets `dev`, branched off current `dev` (#170 + #171 merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
