### PR TITLE
docs(examples): enum-custom demo — vulnerable app + oracle specs

### DIFF
--- a/examples/enum-custom-demo/README.md
+++ b/examples/enum-custom-demo/README.md
@@ -1,0 +1,192 @@
+# enum custom demo
+
+A self-contained demo of Brutus's `enum custom` declarative oracle, run against
+an **intentionally account-enumeration-vulnerable** web app.
+
+It has three parts, all in this directory:
+
+| File                          | What it is                                                        |
+| ----------------------------- | ----------------------------------------------------------------- |
+| `main.go`                     | A deliberately vulnerable HTTP server (the target).               |
+| `forgot-password-oracle.yaml` | A custom oracle spec for the password-reset enumeration vector.   |
+| `login-oracle.yaml`           | A second spec for the login enumeration vector.                   |
+
+> ⚠️ **Safety note.** `main.go` is intentionally vulnerable teaching code. It
+> leaks whether an account exists. It binds to localhost by default. **Do not
+> deploy it.** Use it only on your own machine.
+
+---
+
+## The vulnerability
+
+Account enumeration happens when an app's response *differs* between accounts
+that exist and accounts that don't. An attacker who can tell the difference can
+harvest a list of valid users (for phishing, password spraying, etc.) without
+ever logging in.
+
+This demo app leaks existence two ways:
+
+**`POST /api/forgot-password`** with `{"email":"..."}`:
+
+| Email                | Status | Body                                                                  |
+| -------------------- | ------ | --------------------------------------------------------------------- |
+| valid (e.g. alice)   | `200`  | `{"status":"ok","message":"Password reset link sent to your email"}`  |
+| invalid (e.g. nobody)| `404`  | `{"status":"error","message":"No account found for that email address"}` |
+
+**`POST /api/login`** with `{"email":"...","password":"..."}`:
+
+| Email                | Status | Body                                   |
+| -------------------- | ------ | -------------------------------------- |
+| valid (any password) | `401`  | `{"message":"Incorrect password"}`     |
+| invalid              | `404`  | `{"message":"No account with that email"}` |
+
+The four demo accounts are: `alice@demo.local`, `bob@demo.local`,
+`carol@demo.local`, `admin@demo.local`.
+
+---
+
+## 1. Run the target
+
+```bash
+go run ./examples/enum-custom-demo
+```
+
+It listens on `:8080` by default (override with `-addr :9000` or the `PORT`
+env var) and logs each request to stderr so you can watch Brutus probe it. You
+should see the banner:
+
+```
+⚠ INTENTIONALLY VULNERABLE demo target — do not deploy.
+Valid demo accounts: alice@demo.local, bob@demo.local, carol@demo.local, admin@demo.local
+Listening on :8080 (POST /api/forgot-password, POST /api/login, GET /)
+```
+
+Leave it running in one terminal.
+
+> If your environment pins a specific Go toolchain (see the repo `Makefile`),
+> use that wrapper for `go run`/`go build`. The demo is plain `net/http` with no
+> external dependencies, so any recent Go works.
+
+## 2. Build brutus
+
+In a second terminal:
+
+```bash
+go build -o brutus ./cmd/brutus
+```
+
+## 3. Run the oracle
+
+```bash
+./brutus enum custom \
+  -f examples/enum-custom-demo/forgot-password-oracle.yaml \
+  -e alice@demo.local,nobody@demo.local
+```
+
+Expected: `alice@demo.local` resolves to **exists** (the app returned 200 +
+"reset link sent"), `nobody@demo.local` resolves to **absent** (404 + "No
+account found"). In the target's terminal you'll see the matching request log
+lines.
+
+The login vector works the same way:
+
+```bash
+./brutus enum custom \
+  -f examples/enum-custom-demo/login-oracle.yaml \
+  -e alice@demo.local,nobody@demo.local
+```
+
+### Other ways to supply subjects
+
+`enum custom` takes subjects from `-e` (inline), `-E` (a file, or `-` for
+stdin), or `--generate`:
+
+```bash
+# From a file (one subject per line)
+printf 'alice@demo.local\nbob@demo.local\nnobody@demo.local\n' > /tmp/subjects.txt
+./brutus enum custom -f examples/enum-custom-demo/forgot-password-oracle.yaml -E /tmp/subjects.txt
+
+# From stdin
+printf 'alice@demo.local\nnobody@demo.local\n' \
+  | ./brutus enum custom -f examples/enum-custom-demo/forgot-password-oracle.yaml -E -
+
+# Generate candidate emails from embedded name lists
+./brutus enum custom -f examples/enum-custom-demo/forgot-password-oracle.yaml \
+  --generate --domain demo.local --format first
+```
+
+---
+
+## How the spec works
+
+The spec maps the app's observable behaviour to a verdict. Walking through
+`forgot-password-oracle.yaml`:
+
+```yaml
+version: "1"                       # schema version (must be "1")
+oracle:
+  name: demo-forgot-password       # label for the oracle
+  request:                         # the HTTP request sent once per subject
+    method: POST
+    url: "http://localhost:8080/api/forgot-password"
+    headers:
+      Content-Type: application/json
+    body: '{"email":"{{email}}"}'  # {{email}} is substituted per subject
+    body_encoding: json            # placeholders are JSON-escaped
+  match:
+    rules:                         # ordered; FIRST matching rule wins
+      - when:                      # conditions are AND-ed
+          status: 200
+          body_contains: "reset link sent"
+        verdict: exists            # both conditions hold -> account exists
+        confidence: high
+      - when:
+          status: 404
+          body_contains: "No account found"
+        verdict: absent            # 404 + this message -> no account
+        confidence: high
+    default: error                 # no rule matched -> error (ambiguous)
+```
+
+### Request template + placeholders
+
+For each subject Brutus sends the templated request. Placeholders are
+substituted per subject and escaped according to `body_encoding`:
+
+| Placeholder      | Meaning                                            |
+| ---------------- | -------------------------------------------------- |
+| `{{email}}`      | the full subject value                             |
+| `{{username}}`   | the subject value                                  |
+| `{{localpart}}`  | part before `@` (for `alice@demo.local` -> `alice`)|
+| `{{domain}}`     | part after `@` (-> `demo.local`)                   |
+
+URL placeholders are URL-escaped; body placeholders are escaped per
+`body_encoding` (`json`, `form`, or `raw`). Only `http`/`https` URLs are allowed.
+
+### Match rules → verdict
+
+Rules are evaluated top to bottom and the **first** one whose conditions all
+hold decides the verdict. Each `when` condition is optional — only the ones you
+set are active, and active conditions are AND-ed:
+
+| `when` field      | Matches when…                                        |
+| ----------------- | ---------------------------------------------------- |
+| `status`          | response status equals the int (or is in the list)   |
+| `body_contains`   | response body contains the substring                 |
+| `body_regex`      | response body matches the RE2 regex                  |
+| `json_field`      | a dot-path value `equals` / is `in` a set            |
+| `header`          | a response header is `present` / `equals` a value    |
+
+A rule's `verdict` is `exists`, `absent`, or `error`. If no rule matches, the
+`default` verdict applies.
+
+**The critical coordination:** the `body_contains` substrings in the spec must
+be exact substrings of what the app returns. Here, `"reset link sent"` is a
+substring of `Password reset link sent to your email`, and `"No account found"`
+is a substring of `No account found for that email address`. Change one without
+the other and the oracle breaks — which is the whole point of the exercise: the
+oracle keys off the app's distinguishable responses.
+
+`login-oracle.yaml` follows the same shape against `/api/login`, keying off the
+`401 "Incorrect password"` (exists) vs `404 "No account with that email"`
+(absent) split.

--- a/examples/enum-custom-demo/forgot-password-oracle.yaml
+++ b/examples/enum-custom-demo/forgot-password-oracle.yaml
@@ -1,0 +1,33 @@
+# Brutus custom oracle spec (schema v1) for the enum-custom-demo target.
+#
+# Targets the demo app's password-reset endpoint. A valid email yields HTTP 200
+# with a "reset link sent" message; an invalid one yields HTTP 404 with a
+# "No account found" message. The body_contains substrings below are exact
+# substrings of those responses (see examples/enum-custom-demo/main.go).
+#
+# Run (with the demo server running on :8080):
+#   ./brutus enum custom -f examples/enum-custom-demo/forgot-password-oracle.yaml \
+#       -e alice@demo.local,nobody@demo.local
+version: "1"
+oracle:
+  name: demo-forgot-password
+  request:
+    method: POST
+    url: "http://localhost:8080/api/forgot-password"
+    headers:
+      Content-Type: application/json
+    body: '{"email":"{{email}}"}'
+    body_encoding: json
+  match:
+    rules:
+      - when:
+          status: 200
+          body_contains: "reset link sent"
+        verdict: exists
+        confidence: high
+      - when:
+          status: 404
+          body_contains: "No account found"
+        verdict: absent
+        confidence: high
+    default: error

--- a/examples/enum-custom-demo/login-oracle.yaml
+++ b/examples/enum-custom-demo/login-oracle.yaml
@@ -1,0 +1,34 @@
+# Brutus custom oracle spec (schema v1) for the enum-custom-demo target.
+#
+# A second enumeration vector: the login endpoint. A valid email (with any
+# password) yields HTTP 401 "Incorrect password"; an invalid email yields HTTP
+# 404 "No account with that email". The 401-vs-404 split leaks account existence
+# without ever guessing a real password. The body_contains substrings below are
+# exact substrings of those responses (see examples/enum-custom-demo/main.go).
+#
+# Run (with the demo server running on :8080):
+#   ./brutus enum custom -f examples/enum-custom-demo/login-oracle.yaml \
+#       -e alice@demo.local,nobody@demo.local
+version: "1"
+oracle:
+  name: demo-login
+  request:
+    method: POST
+    url: "http://localhost:8080/api/login"
+    headers:
+      Content-Type: application/json
+    body: '{"email":"{{email}}","password":"x"}'
+    body_encoding: json
+  match:
+    rules:
+      - when:
+          status: 401
+          body_contains: "Incorrect password"
+        verdict: exists
+        confidence: high
+      - when:
+          status: 404
+          body_contains: "No account with that email"
+        verdict: absent
+        confidence: high
+    default: error

--- a/examples/enum-custom-demo/main.go
+++ b/examples/enum-custom-demo/main.go
@@ -1,0 +1,203 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command enum-custom-demo is an INTENTIONALLY account-enumeration-VULNERABLE
+// HTTP server used as a teaching target for Brutus's "enum custom" declarative
+// oracle. Two endpoints leak whether an account exists: the responses for valid
+// vs. invalid accounts differ in both HTTP status and message body — exactly the
+// signal a custom oracle spec keys off of.
+//
+// This is demo/teaching code. Do NOT deploy it. It listens on localhost by
+// default and holds a tiny hardcoded set of fake accounts.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+)
+
+// validAccounts is the hardcoded set of "real" demo accounts. A leak that lets
+// an attacker tell these apart from non-accounts is the enumeration vulnerability
+// this server demonstrates. Keys are lowercased so matching is case-insensitive.
+var validAccounts = map[string]bool{
+	"alice@demo.local": true,
+	"bob@demo.local":   true,
+	"carol@demo.local": true,
+	"admin@demo.local": true,
+}
+
+func main() {
+	addr := flag.String("addr", ":8080", "listen address (host:port)")
+	flag.Parse()
+
+	// PORT env overrides the default port when -addr was not customised, so the
+	// demo runs unchanged on platforms that inject a PORT.
+	if port := os.Getenv("PORT"); port != "" && *addr == ":8080" {
+		*addr = ":" + port
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", handleIndex)
+	mux.HandleFunc("/api/forgot-password", handleForgotPassword)
+	mux.HandleFunc("/api/login", handleLogin)
+
+	printBanner(*addr)
+
+	if err := http.ListenAndServe(*addr, mux); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
+}
+
+// =============================================================================
+// HANDLERS
+// =============================================================================
+
+// handleForgotPassword is the primary enumeration oracle. A valid email returns
+// HTTP 200 with a "reset link sent" message; an invalid one returns HTTP 404
+// with a "No account found" message. The status + message difference is the leak.
+func handleForgotPassword(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSON(w, http.StatusMethodNotAllowed, response{Status: "error", Message: "method not allowed"})
+		return
+	}
+
+	var req struct {
+		Email string `json:"email"`
+	}
+	if err := decodeJSON(r, &req); err != nil {
+		writeJSON(w, http.StatusBadRequest, response{Status: "error", Message: "invalid JSON body"})
+		logRequest(r, req.Email, "bad-request")
+		return
+	}
+
+	if accountExists(req.Email) {
+		logRequest(r, req.Email, "exists")
+		writeJSON(w, http.StatusOK, response{Status: "ok", Message: "Password reset link sent to your email"})
+		return
+	}
+
+	logRequest(r, req.Email, "absent")
+	writeJSON(w, http.StatusNotFound, response{Status: "error", Message: "No account found for that email address"})
+}
+
+// handleLogin is a second enumeration vector. A valid email (any password)
+// returns HTTP 401 "Incorrect password"; an invalid email returns HTTP 404
+// "No account with that email". The 401-vs-404 split leaks account existence.
+func handleLogin(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSON(w, http.StatusMethodNotAllowed, response{Message: "method not allowed"})
+		return
+	}
+
+	var req struct {
+		Email    string `json:"email"`
+		Password string `json:"password"`
+	}
+	if err := decodeJSON(r, &req); err != nil {
+		writeJSON(w, http.StatusBadRequest, response{Message: "invalid JSON body"})
+		logRequest(r, req.Email, "bad-request")
+		return
+	}
+
+	if accountExists(req.Email) {
+		// Real account: we never reveal "wrong password" only for real accounts in
+		// a secure design — but this demo does exactly that, which is the bug.
+		logRequest(r, req.Email, "exists")
+		writeJSON(w, http.StatusUnauthorized, response{Message: "Incorrect password"})
+		return
+	}
+
+	logRequest(r, req.Email, "absent")
+	writeJSON(w, http.StatusNotFound, response{Message: "No account with that email"})
+}
+
+// handleIndex serves a short human-readable description of the demo target.
+func handleIndex(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	fmt.Fprint(w, indexText)
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+// response is the JSON envelope returned by both API endpoints. Status is
+// omitted from the login responses (which only carry a message).
+type response struct {
+	Status  string `json:"status,omitempty"`
+	Message string `json:"message"`
+}
+
+// accountExists reports whether email is one of the hardcoded demo accounts,
+// matching case-insensitively after trimming surrounding whitespace.
+func accountExists(email string) bool {
+	return validAccounts[strings.ToLower(strings.TrimSpace(email))]
+}
+
+// decodeJSON decodes the request body into v, rejecting unknown fields so a
+// malformed body produces a clean 400.
+func decodeJSON(r *http.Request, v any) error {
+	dec := json.NewDecoder(r.Body)
+	return dec.Decode(v)
+}
+
+// writeJSON writes status and the JSON-encoded body.
+func writeJSON(w http.ResponseWriter, status int, body response) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+// logRequest emits one request line to stderr so the demo is visible as Brutus
+// probes the target.
+func logRequest(r *http.Request, email, verdict string) {
+	log.Printf("%s %s email=%q -> %s", r.Method, r.URL.Path, email, verdict)
+}
+
+// printBanner prints the startup banner, including the loud "do not deploy"
+// warning and the list of valid demo accounts.
+func printBanner(addr string) {
+	log.Printf("⚠ INTENTIONALLY VULNERABLE demo target — do not deploy.")
+	log.Printf("Valid demo accounts: alice@demo.local, bob@demo.local, carol@demo.local, admin@demo.local")
+	log.Printf("Listening on %s (POST /api/forgot-password, POST /api/login, GET /)", addr)
+}
+
+// indexText is the GET / landing page explaining the demo.
+const indexText = `enum-custom-demo — INTENTIONALLY account-enumeration-vulnerable target
+
+This server exists to demonstrate Brutus's "enum custom" declarative oracle.
+Do NOT deploy it. It leaks whether an account exists.
+
+Endpoints:
+  POST /api/forgot-password  {"email":"..."}
+      valid email   -> 200 {"status":"ok","message":"Password reset link sent to your email"}
+      invalid email -> 404 {"status":"error","message":"No account found for that email address"}
+
+  POST /api/login            {"email":"...","password":"..."}
+      valid email   -> 401 {"message":"Incorrect password"}
+      invalid email -> 404 {"message":"No account with that email"}
+
+  GET  /                     this page
+
+There are 4 demo accounts: alice@demo.local, bob@demo.local, carol@demo.local, admin@demo.local
+`


### PR DESCRIPTION
## Summary
Adds `examples/enum-custom-demo/` — a self-contained, intentionally account-enumeration-vulnerable web app plus matching Brutus `enum custom` oracle specs, to **teach/demo the declarative oracle spec format** (schema v1).

## Contents
- **`main.go`** — zero-dependency `net/http` target (mirrors `examples/basic`):
  - `POST /api/forgot-password` leaks account existence: valid email → `200 "…reset link sent…"`, invalid → `404 "No account found…"`.
  - `POST /api/login` leaks via distinct messages: valid → `401 "Incorrect password"`, invalid → `404 "No account with that email"`.
  - 4 hardcoded demo accounts (`alice/bob/carol/admin@demo.local`), `--addr` flag, request logging, and a loud "INTENTIONALLY VULNERABLE — do not deploy" banner.
- **`forgot-password-oracle.yaml` / `login-oracle.yaml`** — schema-v1 custom specs whose `match.rules` map those responses to `exists`/`absent` verdicts (`body_contains` substrings aligned to the app's actual messages).
- **`README.md`** — walkthrough (run target → build brutus → `enum custom -f … -e …`), expected output, a "How the spec works" section mapping each YAML field (request template + `{{email}}` placeholders, match rules → verdict) to the app's behavior, and a safety note.

## Demo / verification (run end-to-end)
```
$ go run ./examples/enum-custom-demo            # starts the vulnerable target on :8080
$ go build -o brutus ./cmd/brutus
$ ./brutus enum custom -f examples/enum-custom-demo/forgot-password-oracle.yaml \
    -e alice@demo.local,nobody@demo.local
  [+] EXISTS    alice@demo.local    demo-forgot-password (high)
  [ ] NOT FOUND nobody@demo.local   demo-forgot-password
```
Confirmed working for both specs (login oracle: `bob` → EXISTS, `ghost` → NOT FOUND).

## Notes
- Purely additive under `examples/` — no changes to `pkg/`/`cmd/`/`internal/`.
- The target is localhost-only and clearly marked intentionally vulnerable; it exists solely to demonstrate `enum custom`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)