### PR TITLE
feat(enum): add Apollo.io + Lusha HUMINT enum subcommands

### DIFF
--- a/.feature-development/MANIFEST.yaml
+++ b/.feature-development/MANIFEST.yaml
@@ -1,0 +1,160 @@
+feature_name: "Apollo + Lusha HUMINT enum integrations (brutus enum apollo / lusha)"
+feature_slug: "apollo-lusha-enum"
+orchestration_skill: "orchestrating-feature-development"
+created_at: "2026-06-25T00:00:00Z"
+description: |
+  Add two API-key Human Intelligence Source enum subcommands, mirroring the
+  verified Hunter.io pattern (pkg/enum/<svc> client + cmd_enum_<svc> subcommand):
+    - `brutus enum apollo`  : sales-intelligence org/people discovery + enrichment
+    - `brutus enum lusha`   : individual contact enrichment (email/phone)
+  Hunter.io already shipped (PR #160) — out of scope. ZoomInfo (blocked worktree)
+  out of scope; its architecture.md used only as a design template.
+
+status: "in-progress"
+current_phase: 7
+current_phase_name: "architecture_plan"
+work_type: "LARGE"
+
+triage:
+  work_type: "LARGE"
+  design_review: false
+  classification_method: "user_clarification"
+  feature_type: "backend"   # Go CLI; no frontend → Phase 17 Visual QA skipped
+  phases_to_execute: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18]
+  phases_to_skip: [17]
+  checkpoints:
+    - phase: 7
+      type: "human_approval"
+      description: "Architecture plan + scope review"
+    - phase: 8
+      type: "human_approval"
+      description: "Implementation review"
+    - phase: 18
+      type: "human_approval"
+      description: "Completion / PR"
+
+phases:
+  1_setup: { status: "complete" }
+  2_triage: { status: "complete" }
+  3_codebase_discovery: { status: "complete" }
+  4_skill_discovery: { status: "complete" }
+  5_complexity: { status: "complete" }
+  6_brainstorming: { status: "complete", conditional: true }
+  7_architecture_plan: { status: "complete", conditional: true }
+  8_implementation: { status: "pending" }
+  9_design_verification: { status: "pending", conditional: true }
+  10_domain_compliance: { status: "pending" }
+  11_code_quality: { status: "pending", retry_count: 0 }
+  12_architectural_review: { status: "pending", conditional: true }
+  13_test_planning: { status: "pending", conditional: true }
+  14_testing: { status: "pending" }
+  15_coverage_verification: { status: "pending" }
+  16_test_quality: { status: "pending", retry_count: 0 }
+  17_visual_qa: { status: "skipped", reason: "backend-only, no .tsx" }
+  18_completion: { status: "pending" }
+
+feature_type: "backend"
+technologies_detected: ["go", "cobra", "net/http", "testify", "httptest"]
+scope_decisions:
+  hunter: "out_of_scope (already merged PR #160)"
+  zoominfo: "out_of_scope (template only)"
+  apollo: "in_scope"
+  lusha: "in_scope"
+
+worktree:
+  path: ".worktrees/apollo-lusha-enum"
+  branch: "feat/enum-apollo-lusha"
+  base: "main (7d7a28d)"
+  pre_feature_commit: "7d7a28d6338d1aa0dbf0327d95f06ac9494bf419"
+
+agents_contributed:
+  - agent: "security-lead"
+    artifact: "security-assessment.md"
+    timestamp: "2026-06-25T00:00:00Z"
+    status: "complete"
+  - agent: "capability-lead"
+    artifact: "architecture.md"
+    timestamp: "2026-06-25T00:00:00Z"
+    status: "complete"
+  - agent: "capability-lead"
+    artifact: "plan.md"
+    timestamp: "2026-06-25T00:00:00Z"
+    status: "complete"
+  - agent: "integration-developer"
+    artifact: "(none — blocked before any file write)"
+    timestamp: "2026-06-26T00:00:00Z"
+    status: "blocked"
+    blocked_reason: "out_of_scope"
+    note: |
+      Track A (Apollo) implementation could not proceed. The agent-first-enforcement
+      PreToolUse hook (core plugin) denies Edit/Write/Bash file writes from the
+      integration-developer agent_type for the target paths:
+        - pkg/enum/apollo/apollo.go        -> requires backend-developer
+        - pkg/enum/apollo/apollo_test.go   -> requires backend-tester
+        - cmd/brutus/cmd_enum_apollo*.go    -> requires backend-developer/backend-tester
+      These paths route to the BACKEND domain (pkg/, cmd/), not /integrations/, so the
+      hook requires backend-developer / backend-tester rather than integration-developer.
+      This agent has no Agent/Task tool available to delegate to those agents, so it can
+      neither write the files directly nor spawn the required agents. Needs orchestrator
+      to either (a) dispatch backend-developer + backend-tester for these paths, or
+      (b) grant integration-developer write access for this feature's pkg/cmd paths.
+  - agent: "backend-developer"
+    artifact: "Track A (Apollo) production code"
+    timestamp: "2026-06-26T00:00:00Z"
+    status: "complete"
+    note: |
+      Phase 8 Track A production .go files written to the exact signatures/consts
+      required by the T001-T004 test specs (tester implements tests in Phase 14):
+        - pkg/enum/apollo/apollo.go            (Client, NewClient, do, searchPage,
+          matchPerson, SearchPeople, RevealEmails, APIError+Unwrap, sentinels,
+          Person/DomainResult, toPerson, consts)
+        - cmd/brutus/cmd_enum_apollo.go        (flags, enumApolloCmd, runEnumApollo,
+          resolveApolloAPIKey, classifyApolloError, pageSizeForLimit)
+        - cmd/brutus/cmd_enum_apollo_output.go (outputApolloHuman, outputApolloJSONL)
+      --limit default = 100 (ORCHESTRATION DELTA #1). Output formatters in a
+      per-service file, not appended to cmd_enum_output.go (DELTA #2). cmd_enum.go
+      registration left to orchestrator (DELTA #3); no test files written (Phase 14).
+      Verified: go build ./pkg/enum/apollo/ exit 0; go vet ./pkg/enum/apollo/ exit 0;
+      cmd/brutus build+vet clean with Track-B's in-progress cmd_enum_lusha.go isolated;
+      no httputil.Dump*, no raw io.ReadAll, apiKey unexported/no-tag.
+  - agent: "backend-reviewer"
+    artifact: "agents/backend-reviewer.md"
+    timestamp: "2026-06-26T00:00:00Z"
+    status: "complete"
+    verdict: "NEEDS_CHANGES"
+    note: |
+      Phase 11 code-quality review of both tracks (Apollo + Lusha) against
+      architecture.md + plan.md (ORCHESTRATION DELTAS applied). Verified
+      go build/vet/test (incl. -race). Package client tests (52 cases) pass and
+      match T001-T003/T101-T102 specs. cmd/brutus suite is RED:
+        - P0 (real leak): classifyLushaError default branch (cmd_enum_lusha.go:228-230)
+          %w-wraps *lusha.APIError, surfacing vendor-echoed Details (possible api_key)
+          on any unmapped status. Fix = mirror Apollo's errors.As/status-only default.
+        - P1 (buggy test): TestClassifyApolloError_NoKeyLeak asserts NotContains
+          "api-key", forbidding the intended actionable --api-key hint. Fix the test.
+        - P2: apollo help example shows --limit 25 (default now 100);
+          lusha_test request-body capture uses single r.Body.Read.
+      Route P0+P2-help to backend-developer; P1 test fix to backend-tester.
+
+artifacts:
+  - path: "agents/backend-reviewer.md"
+    type: "code-review"
+    agent: "backend-reviewer"
+  - path: "security-assessment.md"
+    type: "security-architecture"
+    agent: "security-lead"
+  - path: "architecture.md"
+    type: "integration-architecture"
+    agent: "capability-lead"
+  - path: "plan.md"
+    type: "integration-architecture"
+    agent: "capability-lead"
+  - path: "pkg/enum/apollo/apollo.go"
+    type: "implementation"
+    agent: "backend-developer"
+  - path: "cmd/brutus/cmd_enum_apollo.go"
+    type: "implementation"
+    agent: "backend-developer"
+  - path: "cmd/brutus/cmd_enum_apollo_output.go"
+    type: "implementation"
+    agent: "backend-developer"

--- a/.feature-development/agents/backend-reviewer.md
+++ b/.feature-development/agents/backend-reviewer.md
@@ -1,0 +1,261 @@
+# Backend Review: Apollo + Lusha enum integrations
+
+**Reviewer:** backend-reviewer
+**Date:** 2026-06-26
+**Scope:** `pkg/enum/apollo/apollo.go`, `pkg/enum/lusha/lusha.go`, `cmd/brutus/cmd_enum_apollo.go`,
+`cmd/brutus/cmd_enum_apollo_output.go`, `cmd/brutus/cmd_enum_lusha.go`,
+`cmd/brutus/cmd_enum_lusha_output.go`, `cmd/brutus/cmd_enum.go` registration, plus
+`pkg/enum/{apollo,lusha}/*_test.go` and `cmd/brutus/cmd_enum_{apollo,lusha}_test.go`.
+**Contract:** `.feature-development/architecture.md` + `plan.md` (ORCHESTRATION DELTAS applied:
+`--limit` default 100, per-service output files, orchestrator registration).
+
+---
+
+## Verification Results
+
+| Command | Result |
+| ------- | ------ |
+| `go build ./...` | PASS (exit 0) |
+| `go vet ./pkg/enum/apollo/ ./pkg/enum/lusha/ ./cmd/brutus/` | PASS (exit 0) |
+| `go test ./pkg/enum/apollo/ ./pkg/enum/lusha/` | PASS (52 cases) |
+| `go test -race ./pkg/enum/apollo/ ./pkg/enum/lusha/` | PASS |
+| `go test ./cmd/brutus/` | **FAIL** — `TestClassifyLushaError_NoKeyLeak/wrapped_500_with_sentinel_in_Details` and `TestClassifyApolloError_NoKeyLeak/401_with_sentinel_in_Details` |
+| `golangci-lint run` | NOT RUN — installed binary built with go1.25 < repo's go1.26; `go vet` used as substitute |
+| help smoke (`enum apollo --help`, `enum lusha --help`) | PASS — all flags + credit warnings present |
+| DRY grep `func sanitizeTerminal` / `func truncate` in `cmd/brutus/*.go` | 1 each (PASS) |
+| P0-1c grep `httputil.Dump` in new packages | none (only a comment) (PASS) |
+| P0-3 grep raw `io.ReadAll(resp.Body)` in new packages | none (PASS) |
+
+`go test ./cmd/brutus/` is **RED**. Two failing subtests — one is a real production bug, one is a buggy test assertion. Details below.
+
+---
+
+## Findings
+
+### P0-1 — `classifyLushaError` default branch leaks vendor `APIError.Details` (real credential-leak bug)
+**Severity: P0 blocker**
+**File:** `cmd/brutus/cmd_enum_lusha.go:228-230`
+
+```go
+default:
+    return fmt.Errorf("lusha enrichment failed: %w", err)
+```
+
+`%w`-wrapping the underlying error embeds `(*lusha.APIError).Error()`, which formats
+`Details`. `Details` is populated from the vendor response envelope in `lusha.go:197-201`,
+so any non-2xx status that is NOT one of the mapped sentinels (e.g. 500/502/400/409) surfaces
+the raw server body — which can echo the submitted `api_key` back to the operator's terminal /
+output file. This is the exact P0-1 failure the plan's `TestClassifyLushaError_NoKeyLeak`
+(security-assessment §2.1) was written to catch, and it fails:
+
+```
+"lusha enrichment failed: wrapped: lusha API error (HTTP 500): SECRETKEY-DO-NOT-LEAK-abc123"
+  should not contain "SECRETKEY-DO-NOT-LEAK-abc123"
+```
+
+**Recommended fix:** mirror the already-correct Apollo classifier (`cmd_enum_apollo.go:166-171`) —
+in the default branch use `errors.As` to extract `*lusha.APIError` and report only its
+`StatusCode`, never `%w`-wrap:
+
+```go
+default:
+    var apiErr *lusha.APIError
+    if errors.As(err, &apiErr) {
+        return fmt.Errorf("lusha enrichment failed (HTTP %d)", apiErr.StatusCode)
+    }
+    return fmt.Errorf("lusha enrichment failed")
+}
+```
+
+> Note: Hunter (`cmd_enum_hunter.go:137`) has the same `%w` default and the same latent leak, but
+> Hunter is out of scope for this review and its key is query-string (different threat surface).
+> The Apollo classifier in this PR is the correct pattern of record; Lusha must match it.
+
+---
+
+### P1 — `TestClassifyApolloError_NoKeyLeak` asserts `NotContains(out, "api-key")`, contradicting the intended actionable message (buggy test)
+**Severity: P1 should-fix**
+**File:** `cmd/brutus/cmd_enum_apollo_test.go:121` (and the analogous Lusha assertion at `cmd_enum_lusha_test.go` only checks `"api_key"`, so it does not collide)
+
+The Apollo 401 case fails:
+
+```
+"apollo: invalid or missing API key (check APOLLO_API_KEY / --api-key)"
+  should not contain "api-key"
+```
+
+The production message at `cmd_enum_apollo.go:157` is **correct and intended** — the plan (T004)
+requires an actionable message that points the user at `APOLLO_API_KEY` / `--api-key`. The test's
+`assert.NotContains(out, "api-key")` is over-broad: it forbids the very flag name the message is
+supposed to surface. The P0-1 intent is "never leak the key *value* or the *header name*
+(`X-Api-Key`)", not "never mention the `--api-key` flag".
+
+**Recommended fix (test, not production):** drop the `NotContains(out, "api-key")` assertion (the
+flag name is safe and desirable) and keep `NotContains(out, sentinelKey)` + `NotContains(out,
+"X-Api-Key")`. Do NOT change the production message — weakening it to satisfy a wrong assertion
+would regress UX. (The Apollo *production* classifier is correct; only this test assertion is wrong.)
+
+---
+
+### P1 — CLI-layer tests violate the plan's TDD contract by being inconsistent with the code they guard
+**Severity: P1 should-fix (process / gate integrity)**
+
+The package-level client tests (`apollo_test.go`, `lusha_test.go`, 52 cases) are thorough,
+correctly httptest-driven, and match the T001-T003 / T101-T102 specs (pagination incl. `--limit`
+truncation + mid-pagination 429; reveal merge / skip-empty-id / serial-count; context cancellation;
+empty-200; malformed JSON; auth-header-not-in-URL; DNC round-trip). Good.
+
+But the suite as delivered is **RED**, which means the GREEN gate the plan mandates (Phase 14
+"reruns (PASS)") was not actually reached before handoff. One failure is a real bug (P0 above), one
+is a wrong assertion (P1 above). Either way the developer/tester loop must close to GREEN before
+this is approvable. Re-run `go test ./cmd/brutus/` and confirm 0 failures.
+
+---
+
+### P2 — Apollo `--reveal` example in help still shows `--limit 25`; default is now 100
+**Severity: P2 nit**
+**File:** `cmd/brutus/cmd_enum_apollo.go:61`
+
+```
+brutus enum apollo -d example.com --reveal --limit 25
+```
+
+The ORCHESTRATION DELTA raised the default `--limit` to 100 (flag registered correctly at
+`cmd_enum_apollo.go:73`). The example showing `25` is harmless but slightly inconsistent with the
+new cost-rail default. Consider aligning the example to `--limit 100` or leaving an explicit
+smaller value with a "lower to cap spend" note. Cosmetic only.
+
+---
+
+### P2 — Lusha `TestEnrich_Success` captures the request body via a single `r.Body.Read(buf)` (fragile, can under-read)
+**Severity: P2 nit**
+**File:** `cmd/brutus/.../lusha_test.go` → actually `pkg/enum/lusha/lusha_test.go:122-126`
+
+```go
+buf := make([]byte, r.ContentLength)
+_, err = r.Body.Read(buf)
+_ = err
+capturedReqBody = buf
+```
+
+A single `Read` is not guaranteed to fill `buf`; it may return a short read, and the error is
+discarded. The assertion `Contains(string(capturedReqBody), "Ada")` happens to pass for this small
+body, but the pattern is brittle. Prefer `io.ReadAll(r.Body)`. Test-only; no production impact.
+
+---
+
+## Plan Adherence
+
+| Plan Requirement | Status | Notes |
+| ---------------- | ------ | ----- |
+| Apollo `Client` shape mirrors Hunter (apiKey/httpClient/baseURL/pageSize) | PASS | `apollo.go:114-133` |
+| Lusha minimal `Client` (no pageSize) | PASS | `lusha.go:127-141` |
+| Pagination termination order (empty → limit → short → total → maxPages → ctx) | PASS | `apollo.go:142-174` matches §2.4 exactly |
+| `RevealEmails` partial-honesty `Revealed=true` even on empty email | PASS | `apollo.go:184-203`; verified by `TestRevealEmails_Merge` |
+| `RevealEmails` skips empty ID | PASS | `apollo.go:187-189`; `TestRevealEmails_SkipsEmptyID` |
+| Lusha empty-200 → empty `*Contact`, not error | PASS | `lusha.go:145-157`; `TestEnrich_EmptyMatch` |
+| Sentinels + `APIError.Unwrap` per service (Apollo 401/403/422/429; Lusha 401/402/403/404/429) | PASS | `apollo.go:95-107`, `lusha.go:106-120` |
+| `do` is single P0-1/P0-3 choke point (header auth, bounded read, no key/body/URL log) | PASS | `apollo.go:255-291`, `lusha.go:168-206` |
+| Per-service output files (DELTA, not appended to `cmd_enum_output.go`) | PASS | `cmd_enum_apollo_output.go`, `cmd_enum_lusha_output.go` |
+| `sanitizeTerminal`/`truncate` reused, not duplicated | PASS | grep = 1 each |
+| Apollo `--limit` default 100 (DELTA) | PASS | `cmd_enum_apollo.go:73` |
+| `pageSizeForLimit` = min(limit,100), 100 when 0 | PASS | `cmd_enum_apollo.go:178-186` |
+| Lusha identity mutual-exclusion validation | PASS | `validateLushaIdentity` `cmd_enum_lusha.go:157-199`; `TestValidateLushaIdentity` (9 cases) |
+| `--phone` / `--email-only` mutual exclusion | PASS | `cmd_enum_lusha.go:158-160` |
+| Cost notices to stderr (Apollo opt-in N people; Lusha unconditional) | PASS | `cmd_enum_apollo.go:116-119`, `cmd_enum_lusha.go:117-120` |
+| `omitempty` on PII (Apollo email/email_status preview) | PASS | `cmd_enum_apollo_output.go:100-101`; `TestOutputApolloJSONL` preview omits email |
+| DNC surfaced (human marker + JSON `do_not_call` always emitted) | PASS | `cmd_enum_lusha_output.go:72-79,97` |
+| Registration by orchestrator in `cmd_enum.go` (developers don't edit) | PASS | both `AddCommand` lines + help present `cmd_enum.go:122-123` |
+| No premature shared HUMINT interface (Rule of Three intentionally not met) | PASS | two independent packages, as designed |
+| Apollo/Lusha paths/fields/headers isolated in consts + unexported structs (UNVERIFIED-safe) | PASS | `apollo.go:41-49,322-379`, `lusha.go:41-47,260-299` |
+| `classifyApolloError` default = status-code only, no `%w` | PASS | `cmd_enum_apollo.go:166-171` |
+| `classifyLushaError` default = status-code only, no `%w` | **FAIL (P0 above)** | `cmd_enum_lusha.go:228-230` leaks via `%w` |
+
+## Go Idioms / Quality
+
+- Error wrapping: correct `%w` use for internal/decoding errors; the ONLY misuse is the Lusha
+  classifier default (P0). Sentinels via `errors.New`, `Unwrap` for `errors.Is`, `errors.As` for
+  the typed error — idiomatic and consistent with Hunter.
+- Context: `http.NewRequestWithContext` in both `do` helpers; `ctx.Err()` checked between pages
+  (Apollo) and per reveal iteration; matches Hunter.
+- `defer resp.Body.Close()` present in both `do` helpers (with `_ =` to satisfy errcheck).
+- No goroutines (serial by design, §6) → no leak surface; race detector clean.
+- Function organization: exported/public-API-first, helpers last, early returns, nesting ≤2 —
+  conforms to `go-best-practices`. File sizes: apollo.go ~380 lines, lusha.go ~300, both under the
+  400/500 limits (no `apollo_types.go` split needed, as the plan permitted).
+- Exported surface is minimal and matches the architecture's §2.3/§3.3 public types. `apiKey` is
+  unexported, no JSON tag, no getter (P0-1b) in both clients.
+- YAGNI/KISS: no errgroup/limiter/retry (correctly deferred per §6/§12); no dead code observed;
+  `pageSizeForLimit` is a justified small helper (used once but it isolates a non-obvious clamp).
+
+## Security (P0 mapping)
+
+- P0-1 key-never-logged: clients PASS (header set inline, never logged; `--verbose` logs counts
+  only). **CLI classifier: Lusha FAILS (P0 above); Apollo PASSES.**
+- P0-1b unexported apiKey field: PASS both.
+- P0-1c no `httputil.Dump*`: PASS (grep clean).
+- P0-1d `--api-key` process-list/history warning + prefer env: PASS both help strings.
+- P0-3 bounded read via `enum.ReadResponseBody(resp, 0)`: PASS both; no raw `io.ReadAll(resp.Body)`.
+- P0-4 terminal sanitization on every API string in human output: PASS both; JSONL relies on
+  `encoding/json` escaping (documented).
+- P0-5 no silent 429 retry: PASS (mapped to `ErrRateLimited`, surfaced).
+- P0-6/P0-7 cost rails: PASS.
+
+---
+
+## Review Result
+REVIEW_REJECTED
+
+### Issues
+- **P0:** `classifyLushaError` default branch (`cmd_enum_lusha.go:228-230`) `%w`-wraps `*lusha.APIError`, leaking vendor-echoed `Details` (possible API key) for any unmapped status. Real P0-1 credential leak; `TestClassifyLushaError_NoKeyLeak/wrapped_500` fails. Fix: mirror the Apollo default branch (extract `*APIError` via `errors.As`, report `StatusCode` only, no `%w`).
+- **P1:** `TestClassifyApolloError_NoKeyLeak` asserts `NotContains(out, "api-key")` (`cmd_enum_apollo_test.go:121`), which wrongly forbids the intended actionable `--api-key` hint. Fix the *test* (drop that assertion), not the production message.
+- **P1:** `go test ./cmd/brutus/` is RED on handoff — the mandated GREEN gate was not reached. Close the loop to 0 failures.
+- **P2:** Apollo `--reveal` help example shows `--limit 25` but default is now 100 (`cmd_enum_apollo.go:61`).
+- **P2:** `pkg/enum/lusha/lusha_test.go:122-126` captures the request body with a single `r.Body.Read` (can under-read; error discarded) — prefer `io.ReadAll`.
+
+**Verdict: NEEDS_CHANGES.** The package clients, pagination, reveal honesty, identity validation,
+DNC handling, DRY, and P0-3/P0-4 controls are all correctly implemented and well-tested. One real
+P0 credential-leak in the Lusha error classifier and one buggy Apollo test assertion leave the
+`cmd/brutus` suite RED. Both are small, localized fixes (Apollo already shows the correct
+classifier pattern to copy). Route to `backend-developer` for the P0 + P2-help, and to
+`backend-tester` for the P1 test-assertion fix; re-run `go test ./cmd/brutus/` to GREEN before
+re-review.
+
+---
+
+## Metadata
+
+```json
+{
+  "agent": "backend-reviewer",
+  "output_type": "code-review",
+  "timestamp": "2026-06-26",
+  "feature_directory": "/Users/engineer/github/brutus/.worktrees/apollo-lusha-enum/.feature-development",
+  "skills_invoked": ["using-skills", "focusing-on-the-goal", "enforcing-evidence-based-analysis", "discovering-reusable-code", "gateway-backend", "persisting-agent-outputs", "verifying-before-completion", "analyzing-with-adversarial-pov", "calibrating-time-estimates", "preferring-simple-solutions", "adhering-to-dry", "adhering-to-yagni"],
+  "library_skills_read": [
+    "/Users/engineer/.claude/plugins/cache/praetorian-ai-marketplace/engineering/1.38.17/skill-library/development/backend/reviewing-backend-implementations/SKILL.md",
+    "/Users/engineer/.claude/plugins/cache/praetorian-ai-marketplace/engineering/1.38.17/skill-library/development/backend/go-best-practices/SKILL.md",
+    "/Users/engineer/.claude/plugins/cache/praetorian-ai-marketplace/engineering/1.38.17/skill-library/development/error-handling-patterns/SKILL.md"
+  ],
+  "source_files_verified": [
+    "pkg/enum/apollo/apollo.go:1-380",
+    "pkg/enum/apollo/apollo_test.go:1-547",
+    "pkg/enum/lusha/lusha.go:1-300",
+    "pkg/enum/lusha/lusha_test.go:1-327",
+    "cmd/brutus/cmd_enum_apollo.go:1-187",
+    "cmd/brutus/cmd_enum_apollo_output.go:1-136",
+    "cmd/brutus/cmd_enum_apollo_test.go:84-125",
+    "cmd/brutus/cmd_enum_lusha.go:1-232",
+    "cmd/brutus/cmd_enum_lusha_output.go:1-144",
+    "cmd/brutus/cmd_enum_lusha_test.go:320-365",
+    "cmd/brutus/cmd_enum.go:30-124",
+    "cmd/brutus/cmd_enum_hunter.go:1-140"
+  ],
+  "status": "complete",
+  "verdict": "NEEDS_CHANGES",
+  "handoff": {
+    "next_agent": "backend-developer",
+    "context": "Fix P0 classifyLushaError default branch (cmd_enum_lusha.go:228-230) to mirror Apollo's errors.As/status-code-only pattern (no %w). Fix P2 apollo help example --limit. backend-tester: drop the NotContains(out, 'api-key') assertion in TestClassifyApolloError_NoKeyLeak (flag name is safe). Re-run go test ./cmd/brutus/ to GREEN."
+  }
+}
+```

--- a/.feature-development/agents/backend-security.md
+++ b/.feature-development/agents/backend-security.md
@@ -1,0 +1,112 @@
+# Security Review: Apollo.io + Lusha enum subcommands (Phase-7 P0 audit)
+
+**Reviewer:** backend-security
+**Date:** 2026-06-26
+**Scope:** `pkg/enum/apollo/apollo.go`, `pkg/enum/lusha/lusha.go`, `cmd/brutus/cmd_enum_apollo.go`, `cmd/brutus/cmd_enum_apollo_output.go`, `cmd/brutus/cmd_enum_lusha.go`, `cmd/brutus/cmd_enum_lusha_output.go`, package tests.
+**Contract:** `.feature-development/security-assessment.md` (security-lead, P0-1 family / P0-3 / P0-4 / P0-5 / P0-6/7/8 / P0-DNC / P0-ToS).
+**Methodology:** Evidence-based — every claim below is anchored to a file:line read this session. Reference: Hunter implementation (`cmd_enum_hunter.go:128-139`), bounded-read primitive (`httpclient.go:58-65`), output writer perms (`flags.go:308-312`).
+
+## Summary
+
+Implementation closely follows the Hunter template and the security-lead's P0 contract. The `do()` choke point in both client packages is correct: bounded read on every call, header-based auth, no request dumping. Output formatting sanitizes every human field. The Apollo error classifier is exemplary (reports status code only, never `%w`-wraps). **One real P0 credential-leak path exists in the Lusha error classifier**, and **the entire command-layer test contract (§4) is missing** (no `cmd_enum_apollo_test.go` / `cmd_enum_lusha_test.go`), so the mandatory P0-1 no-key-leak negative test does not exist for either service.
+
+## Security Findings
+
+### Critical Issues
+
+| Severity | Issue | Location | Remediation |
+| -------- | ----- | -------- | ----------- |
+| P0 | **P0-1 credential-leak path: `classifyLushaError` default branch `%w`-wraps the `*lusha.APIError`, whose `Error()` embeds vendor `Details`.** If Lusha echoes the API key (or any sensitive request content) into its error envelope `message`, it is mapped to `APIError.Details` (`lusha.go:197-202`) and surfaced verbatim through `err.Error()` to the user/CLI. This is exactly the "vendor-echoes-key-in-body" case the contract forbids (assessment §2.1 P0-1, §3 AVOID: "Do NOT pass the vendor's error Details body straight into a user-facing error"). | `cmd/brutus/cmd_enum_lusha.go:228-230` (`default: return fmt.Errorf("lusha enrichment failed: %w", err)`); leak surface created at `lusha.go:99-101` (`Error()` includes `e.Details`) + `lusha.go:197-202` (`Details = env.Message`). | Mirror the Apollo classifier (`cmd_enum_apollo.go:165-171`): in the default branch, `errors.As` into `*lusha.APIError` and return only the status code — `return fmt.Errorf("lusha enrichment failed (HTTP %d)", apiErr.StatusCode)` — falling back to a generic static message otherwise. Never `%w`-wrap an error whose `Error()` embeds `Details`. |
+
+### High Severity Issues
+
+| Severity | Issue | Location | Remediation |
+| -------- | ----- | -------- | ----------- |
+| P0 | **Mandatory §4 test contract is entirely absent at the command layer.** No `cmd_enum_apollo_test.go` or `cmd_enum_lusha_test.go` exists (verified via Glob: "No files found"). The contract's enforcement tests are therefore not present: `TestClassifyXError_NoKeyLeak` incl. the vendor-echoes-key-in-body case (§2.1, the canonical P0-1 control), verbose-path no-leak, `TestOutputXHuman` ANSI injection (P0-4), `TestOutputXJSONL`, Apollo default-path-no-spend (P0-6), cost-notice-emitted/suppressed (P0-7), `--limit` spend cap (P0-8), and DNC-surfaced (P0-DNC). The classifier in Finding 1 would have been caught by the required `NoKeyLeak` test. The only no-leak assertion in the repo is Hunter's (`cmd_enum_hunter_test.go:110`). | absent: `cmd/brutus/cmd_enum_apollo_test.go`, `cmd/brutus/cmd_enum_lusha_test.go` | Add both command-layer test files implementing the §4 matrix. The `TestClassifyLushaError_NoKeyLeak` case MUST feed `&lusha.APIError{StatusCode: 500, Details: sentinelKey}` (and a `%w`-wrapped variant) through `classifyLushaError` and `assert.NotContains(out, sentinelKey)` — this is the regression test for Finding 1. Same for Apollo's classifier and the verbose-stderr path. |
+
+### Medium/Low Severity Issues
+
+| Severity | Issue | Location | Remediation |
+| -------- | ----- | -------- | ----------- |
+| P2 | **Apollo `--reveal` cost notice prints the count but is not a hard pre-spend gate per the P0-7 "before any spend" wording — it is fine, but the notice fires unconditionally inside the `--reveal` branch even when `len(result.People)==0` (no spend will occur).** Minor: emits "will consume Apollo credits for 0 people". Not a security risk; cosmetic accuracy. | `cmd/brutus/cmd_enum_apollo.go:115-119` | Optional: skip the notice when `len(result.People)==0`. Non-blocking. |
+| P2 | **Apollo `--limit` default is 100, not the contract's recommended 25 (P0-8 "default 25").** The contract said "conservative default 25"; 100 still bounds spend (no blowout) and is documented, but is 4x the recommended conservative cap. | `cmd/brutus/cmd_enum_apollo.go:73` | Confirm with security-lead whether 100 is an accepted deviation; if the conservative-default intent stands, lower to 25. Non-blocking (a cap exists; this is a tuning choice). |
+
+## P0 Verification Matrix (evidence)
+
+| P0 | Verdict | Evidence |
+| -- | ------- | -------- |
+| P0-1 (key never in log/print/error sink) | **FAIL (Lusha)** / PASS (Apollo) | Apollo classifier reports status code only, no `%w` (`cmd_enum_apollo.go:165-171`); verbose logs counts only (`apollo.go cmd:126-127`, `lusha.go cmd:142-143`). **Lusha default branch `%w`-wraps `*APIError` whose `Error()` embeds `Details` (`cmd_enum_lusha.go:229`) — see Finding 1.** Key never in URL: header-set inline (`apollo.go:265`, `lusha.go:178`), asserted in pkg tests (`apollo_test.go:272`, `lusha_test.go:119`). |
+| P0-1b (unexported field, no tag/getter) | PASS | `apiKey string` unexported, no JSON tag, no getter (`apollo.go:115`, `lusha.go:128`). |
+| P0-1c (no httputil.Dump*) | PASS | Grep over all 6 files: only a comment mention at `apollo.go:254`; zero `DumpRequest`/`DumpResponse` calls. |
+| P0-3 (bounded read every call) | PASS | `enum.ReadResponseBody(resp, 0)` is the sole read path in both `do()` (`apollo.go:275`, `lusha.go:188`); 1 MB cap at `httpclient.go:60-64`. Grep for `io.ReadAll`/`ioutil.ReadAll` in scope: no matches. |
+| P0-4 (sanitize+truncate every human field) | PASS | Apollo: every field `sanitizeTerminal`+`truncate` incl. Email/EmailStatus (`cmd_enum_apollo_output.go:62-78`, name via `personName` :130-135). Lusha: Title/Company/Email/Type/Confidence/Phone/Type sanitized (`cmd_enum_lusha_output.go:37-79`). |
+| P0-4b (JSONL not sanitized) | PASS | Both JSONL emitters use `encoding/json` only (`cmd_enum_apollo_output.go:104`, `cmd_enum_lusha_output.go:131`). |
+| P0-5 (429 → sentinel, no auto-retry) | PASS | 429→`ErrRateLimited` (`apollo.go:103-104`, `lusha.go:116-117`); no retry loop in `do()`/`SearchPeople`/`Enrich`; classifiers return actionable text (`cmd_enum_apollo.go:162-163`, `cmd_enum_lusha.go:226-227`). pkg tests confirm mid-pagination 429 surfaces (`apollo_test.go:385-395`). |
+| P0-6 (Apollo --reveal opt-in, distinct methods) | PASS | `--reveal` default false (`cmd_enum_apollo.go:72`); `SearchPeople` (free) and `RevealEmails` (paid) are distinct methods; reveal only runs in the `if flagApolloReveal` branch (`cmd_enum_apollo.go:115-123`). |
+| P0-7 (stderr cost notice before spend) | PASS | Apollo: notice gated by `--reveal` + `!flagQuiet && !flagJSON`, states count, before `RevealEmails` (`cmd_enum_apollo.go:116-119`). Lusha: unconditional notice, same gating, before `Enrich` (`cmd_enum_lusha.go:117-120`). |
+| P0-8 (bounded --limit spend cap) | PASS (with P2 note) | Apollo `--limit` truncates accumulated people (`apollo.go:157-160`) and bounds reveals; default 100 (contract suggested 25 — see P2). |
+| P0-DNC (surface Lusha DNC) | PASS | `PhoneEntry.DoNotCall` preserved (`lusha.go:240-245`); human DNC marker (`cmd_enum_lusha_output.go:72-79`); JSONL `do_not_call` bool NOT omitempty (`cmd_enum_lusha_output.go:97`). pkg test asserts preservation (`lusha_test.go:74`). |
+| P0-ToS (authorized-use note in Long) | PASS | Apollo Long (`cmd_enum_apollo.go:49-50`); Lusha Long incl. DNC warning + ToS line (`cmd_enum_lusha.go:53-56`). |
+| Apollo phone correctly NOT implemented | PASS | No `webhook_url`, no `reveal_phone_number`, no inbound listener anywhere in apollo package; match request is `{id, reveal_personal_emails}` only (`apollo.go:341-344`). No SSRF/callback surface. |
+| P1-PII (output file perms) | PASS | `setupOutputWriter` opens `0o600` (`flags.go:312`). |
+| P1-1 (no credential zeroing) | PASS | No `Zero()` routine — correct per contract (KISS). |
+
+## Verification (automated checks)
+
+Not run (review is read-only; no build/test execution requested). Recommended before merge: `go test ./cmd/brutus/... ./pkg/enum/apollo/... ./pkg/enum/lusha/...` after the §4 command-layer tests are added; `go vet`. The package-level tests (`apollo_test.go`, `lusha_test.go`) exist and cover client behavior, pagination, error mapping, and DNC preservation, but do NOT cover the command-layer classifiers/output (where Finding 1 lives).
+
+## Verdict
+
+**NEEDS_CHANGES**
+
+The client packages and output formatters are well-built and satisfy the bulk of the P0 contract. However, two P0-level items block approval: (1) the `classifyLushaError` default branch creates a real credential-leak path that the contract explicitly forbids, and (2) the mandatory P0-1/P0-4/P0-6/P0-7/P0-8/P0-DNC enforcement tests at the command layer are entirely absent — including the very test that would catch Finding 1. Both are mechanical fixes mirroring the already-correct Apollo classifier and the §4 test matrix.
+
+## Recommendations (priority order for backend-developer)
+
+1. Fix `classifyLushaError` default branch to mirror `classifyApolloError` (status-code-only, no `%w` of `*APIError`). (Finding 1)
+2. Add `cmd_enum_lusha_test.go` + `cmd_enum_apollo_test.go` implementing the §4 matrix, with `TestClassifyXError_NoKeyLeak` (including the `Details: sentinelKey` vendor-echo case and the `%w`-wrapped variant) as the regression test for Finding 1, plus the verbose-stderr no-leak, ANSI-injection (P0-4), default-no-spend (P0-6), cost-notice (P0-7), `--limit` cap (P0-8), and DNC-surfaced (P0-DNC) tests.
+3. Confirm `--limit` default (100 vs contract's 25) with security-lead; lower if the conservative-default intent stands. (P2)
+4. Optional: suppress the Apollo cost notice when 0 people discovered. (P2)
+
+---
+
+## Metadata
+
+```json
+{
+  "agent": "backend-security",
+  "output_type": "security-review",
+  "timestamp": "2026-06-26T00:00:00Z",
+  "feature_directory": "/Users/engineer/github/brutus/.worktrees/apollo-lusha-enum/.feature-development/agents",
+  "skills_invoked": [
+    "using-skills",
+    "enforcing-evidence-based-analysis",
+    "gateway-security",
+    "persisting-agent-outputs",
+    "verifying-before-completion",
+    "using-todowrite"
+  ],
+  "library_skills_read": [
+    "/Users/engineer/.claude/plugins/cache/praetorian-ai-marketplace/engineering/1.38.17/skill-library/security/reviewing-backend-security/SKILL.md"
+  ],
+  "source_files_verified": [
+    "pkg/enum/apollo/apollo.go:1-380",
+    "pkg/enum/lusha/lusha.go:1-300",
+    "cmd/brutus/cmd_enum_apollo.go:1-187",
+    "cmd/brutus/cmd_enum_apollo_output.go:1-136",
+    "cmd/brutus/cmd_enum_lusha.go:1-232",
+    "cmd/brutus/cmd_enum_lusha_output.go:1-144",
+    "cmd/brutus/cmd_enum_hunter.go:125-139",
+    "pkg/enum/httpclient.go:55-65",
+    "pkg/enum/apollo/apollo_test.go:1-547",
+    "pkg/enum/lusha/lusha_test.go:1-327",
+    "cmd/brutus/flags.go:308-312"
+  ],
+  "status": "complete",
+  "verdict": "NEEDS_CHANGES",
+  "handoff": {
+    "next_agent": "backend-developer",
+    "context": "Two P0 fixes: (1) classifyLushaError default branch %w-wraps *lusha.APIError whose Error() embeds vendor Details — credential leak path (cmd_enum_lusha.go:229); fix to status-code-only like classifyApolloError. (2) No command-layer test files exist — add the §4 matrix incl. TestClassifyXError_NoKeyLeak (vendor-echoes-key-in-body + %w variant). P2: --limit default 100 vs contract 25; cosmetic cost-notice on 0 people."
+  }
+}
+```

--- a/.feature-development/architecture.md
+++ b/.feature-development/architecture.md
@@ -1,0 +1,751 @@
+# Apollo + Lusha HUMINT enum integrations — Technical Architecture
+
+**Feature:** Two new standalone enum subcommands:
+- `brutus enum apollo` — domain → people *discovery* (free) + opt-in `--reveal` email *enrichment* (credits).
+- `brutus enum lusha` — single-identity contact *enrichment* (email + phone, credits) via Lusha v3.
+
+**Goal:** Add two independent enum subcommands that mirror the verified Hunter.io pattern
+(`pkg/enum/hunter/`, `cmd/brutus/cmd_enum_hunter*.go`). Apollo discovers people for a company
+domain and optionally reveals emails for a bounded set. Lusha enriches one person identity.
+
+**Status:** Architecture plan (no code written). Implements the Hunter pattern; ZoomInfo
+(`.worktrees/zoominfo-enum/`) is a structural sibling consulted only for detail-level — none of
+its content is copied (different APIs, different shapes).
+
+**Scope lock (from task):** Apollo + Lusha only. Hunter shipped (out of scope). ZoomInfo out of
+scope. Apollo = emails only (phone requires an async `webhook_url`, impossible for a CLI). Lusha =
+v3 only (v2 sunsets 2026-11-18). Single API key per service (no YAML creds file).
+
+---
+
+## 0. Evidence Base (Verified internal APIs)
+
+All design below references code READ in this worktree. No assumptions about internal APIs.
+External Apollo/Lusha facts are from `discovery.md` (live vendor docs, June 2026); fields not
+confirmable without a live key are isolated and flagged in the Assumptions tables (§7, §11).
+
+### Reference: Hunter client structure
+**Source:** `pkg/enum/hunter/hunter.go:98-118`
+```go
+type Client struct {
+    apiKey     string
+    httpClient *http.Client
+    baseURL    string
+    pageSize   int
+}
+func NewClient(apiKey string, timeout time.Duration, pageSize int) *Client {
+    if pageSize <= 0 { pageSize = defaultPageSize }
+    return &Client{
+        apiKey:     apiKey,
+        httpClient: enum.NewEnumHTTPClient(timeout),
+        baseURL:    defaultBaseURL,
+        pageSize:   pageSize,
+    }
+}
+```
+
+### Reference: Sentinel errors + APIError.Unwrap (status → sentinel)
+**Source:** `pkg/enum/hunter/hunter.go:33-37, 70-92`
+```go
+var (
+    ErrUnauthorized = errors.New("invalid or missing API key")
+    ErrRateLimited  = errors.New("rate limit exceeded")
+    ErrLegalReasons = errors.New("unavailable for legal reasons")
+)
+type APIError struct { StatusCode int; Details string }
+func (e *APIError) Error() string { return fmt.Sprintf("hunter API error (HTTP %d): %s", ...) }
+func (e *APIError) Unwrap() error {
+    switch e.StatusCode {
+    case http.StatusUnauthorized:    return ErrUnauthorized
+    case http.StatusTooManyRequests: return ErrRateLimited
+    case http.StatusUnavailableForLegalReasons: return ErrLegalReasons
+    }
+    return nil
+}
+```
+**Contract note:** `Unwrap()` maps status → sentinel; the `*APIError` itself is still retrievable
+via `errors.As`. I mirror this per service (Apollo: 401/403/422/429; Lusha: 401/403/402/429).
+
+### Reference: Paginated Search loop (accumulate, advance, terminate, honor ctx)
+**Source:** `pkg/enum/hunter/hunter.go:122-162` — loop fetches a page, accumulates, advances the
+offset by the returned count, terminates on empty page / short final page / reached known total,
+and checks `ctx.Err()` between requests. Apollo mirrors this (paging by `page`/`per_page` instead
+of `offset`/`limit`; same termination logic).
+
+### Reference: GET + query-string request + bounded read + error mapping
+**Source:** `pkg/enum/hunter/hunter.go:171-213` — `fetchPage` builds the request, calls
+`c.httpClient.Do`, `defer resp.Body.Close()`, reads via `enum.ReadResponseBody(resp, 0)` (P0-3),
+maps non-200 → `*APIError` (extracting details from the error envelope if present, else
+`resp.Status`), then `json.Unmarshal`. Apollo/Lusha use **POST with a JSON body + header auth**
+instead of GET + query-string key, but the body-read / error-map / decode sequence is identical.
+
+### Reference: Shared HTTP utilities (verified — reuse, no new client)
+**Source:** `pkg/enum/httpclient.go:44-65`
+```go
+func NewEnumHTTPClient(timeout time.Duration) *http.Client { ... } // no-redirect, default UA
+func ReadResponseBody(resp *http.Response, limit int64) ([]byte, error) { // 0 => 1 MB cap
+    if limit <= 0 { limit = maxResponseBody } // maxResponseBody = 1<<20
+    return io.ReadAll(io.LimitReader(resp.Body, limit))
+}
+```
+
+### Reference: CLI subcommand wiring
+**Source:** `cmd/brutus/cmd_enum_hunter.go:30-139` and `cmd/brutus/cmd_enum.go:99-112`
+- Subcommand registered via `enumCmd.AddCommand(enumHunterCmd)` inside `cmd_enum.go`'s `init()`
+  (the call list is at `cmd_enum.go:106-111`).
+- File-local flag vars (`flagHunterDomain` etc.) declared in the command file to avoid
+  cross-command state bleed (`cmd_enum_hunter.go:32-36`).
+- Run flow (`cmd_enum_hunter.go:68-113`): validate → `resolveHunterAPIKey` → `setupOutputWriter`
+  (set `flagJSON=true` if `forceJSON`) → `signal.NotifyContext(... os.Interrupt, SIGTERM)` →
+  stderr progress if `!quiet && !json` → `NewClient` → `client.Search` → `classifyHunterError` on
+  error → `outputHunterJSONL`/`outputHunterHuman`.
+- `resolveHunterAPIKey(flagValue)` returns flag value, else `os.Getenv("HUNTER_API_KEY")`, else
+  error (`cmd_enum_hunter.go:117-125`). `classifyHunterError` maps sentinels → key-free actionable
+  messages (`cmd_enum_hunter.go:128-139`).
+
+### Reference: Output helpers + shared sanitizers (reuse as-is — DRY)
+**Source:** `cmd/brutus/cmd_enum_output.go:294-356` (`outputHunterHuman`/`outputHunterJSONL`),
+and shared `sanitizeTerminal`/`truncate` used there (same file, package-level). JSONL uses a local
+anonymous struct with `omitempty` and `encoding/json` for control-char escaping (no manual
+sanitize). Human output wraps every API string in `sanitizeTerminal(...)` then `truncate(...)`.
+
+### Reference: Shared CLI globals + helpers (all verified present)
+**Source:** `cmd/brutus/flags.go:307-317, 360-363` and `cmd/brutus/cmd_enum_hunter.go:69,80-95,104`
+- Globals: `flagTimeout time.Duration`, `flagJSON bool`, `flagOutputFile string`,
+  `flagNoColor bool`, `flagQuiet bool`, `flagVerbose bool`.
+- Helpers: `setupOutputWriter(string) (io.Writer, bool, func(), error)` (`flags.go:308`),
+  `isColorEnabled(bool) bool` (`flags.go:361`), `logVerbose(verbose bool, format string, ...any)`,
+  `dim`, `heading`, `colorIf`, `SymbolInfo`, plus `sanitizeTerminal`/`truncate`
+  (`cmd_enum_output.go`). All reused as-is.
+
+### Reference: go.mod
+**Source:** `go.mod:1-3, 29-31` — `module github.com/praetorian-inc/brutus`, `go 1.26`.
+`golang.org/x/sync` (errgroup) and `golang.org/x/time` (rate) are already present (lines 29-30)
+but **not needed** (serial requests — see §6). `gopkg.in/yaml.v3` present but **not used** (single
+API key each, no creds file). Test deps: `testify` (assert/require) + stdlib `net/http/httptest`.
+
+---
+
+## 1. Design philosophy — two independent commands, no shared abstraction
+
+**Decision: build Apollo and Lusha as two fully independent packages + commands, reusing only the
+existing shared helpers. Do NOT introduce a "HUMINT provider" interface.**
+
+Chain-of-thought (KISS / DRY Rule-of-Three):
+- We now have three HUMINT-ish integrations (Hunter, Apollo, Lusha). Rule of Three *appears* met —
+  but DRY's "coincidental similarity" caveat applies: they differ in **shape**, not just values.
+  - Hunter: GET, query-string key, domain→emails, single phase.
+  - Apollo: POST + `X-Api-Key` header, domain→people discovery (free) then per-person email
+    reveal (credits) — **two phases**.
+  - Lusha: POST + `api_key` header, **single identity in → one enriched contact out** — no
+    pagination, no domain, mutually-exclusive identity inputs.
+- A shared `Provider` interface would have to be the union of "paginated domain search",
+  "per-id enrich", and "single-identity enrich" — a leaky abstraction that every implementer
+  partially ignores. That is premature abstraction (the exact anti-pattern in
+  `preferring-simple-solutions` §1).
+- What they genuinely share is already extracted: `enum.NewEnumHTTPClient`, `enum.ReadResponseBody`,
+  `sanitizeTerminal`, `truncate`, the CLI globals/helpers, and the `APIError`+`Unwrap` *pattern*
+  (a pattern to copy, not a type to share). Each package gets its own sentinels + `APIError`
+  (different status sets) — copying ~20 lines is cheaper and clearer than a shared error type that
+  must enumerate every service's statuses.
+
+**Self-consistency check:** would I extract a shared client if a 4th identical-shape provider
+arrived? Yes — but only when a real third *same-shape* case exists. Today they diverge. Holds.
+
+---
+
+## 2. Apollo — package `pkg/enum/apollo/apollo.go`
+
+### 2.1 Client struct
+Mirror Hunter's struct. `pageSize` is a real tuning knob (people-search `per_page`, ≤100), so it
+stays in the struct exactly as Hunter does (`hunter.go:98-104`).
+
+```go
+type Client struct {
+    apiKey     string        // X-Api-Key — NEVER logged (P0-1)
+    httpClient *http.Client
+    baseURL    string        // default "https://api.apollo.io" (UNVERIFIED-safe: host only)
+    pageSize   int           // people-search per_page; <=0 => defaultPageSize (100)
+}
+
+func NewClient(apiKey string, timeout time.Duration, pageSize int) *Client {
+    if pageSize <= 0 { pageSize = defaultPageSize }
+    return &Client{
+        apiKey:     apiKey,
+        httpClient: enum.NewEnumHTTPClient(timeout),
+        baseURL:    defaultBaseURL,
+        pageSize:   pageSize,
+    }
+}
+```
+
+### 2.2 Public API surface (two phases, single command)
+```go
+// Phase 1 (FREE, no PII): paginate people-search for a domain. Emails are masked/absent here.
+func (c *Client) SearchPeople(ctx context.Context, domain string, titles []string, limit int) (*DomainResult, error)
+
+// Phase 2 (CREDITS): reveal emails for the already-discovered people, in place, by id.
+// Called only when --reveal is set. Operates on result.People from SearchPeople.
+func (c *Client) RevealEmails(ctx context.Context, result *DomainResult) error
+```
+
+`RevealEmails` mutates `result.People` (sets `Email`, `EmailStatus`, `Revealed=true`) and sets
+`result.Revealed=true` if any reveal ran — mirroring ZoomInfo's two-tier `Contact.Enriched`
+correctness rail so a consumer never misreads an un-revealed blank email as "no email on file".
+
+### 2.3 Public types
+```go
+type Person struct {
+    // --- From /mixed_people/api_search (FREE, no PII) ---
+    ID         string   // Apollo person id — required for reveal
+    FirstName  string
+    LastName   string
+    Name       string   // full name as Apollo returns it
+    Title      string
+    Seniority  string
+    Department string   // first of departments[] (see §7 assumption)
+    Organization string // organization.name
+
+    // --- From /people/match (CREDITS, PII) — empty unless --reveal ---
+    Email       string
+    EmailStatus string  // e.g. "verified" / "guessed" (UNVERIFIED field name; §7)
+    Revealed    bool    // true if this person went through reveal
+}
+
+type DomainResult struct {
+    Domain   string
+    People   []Person
+    Total    int   // pagination.total_entries
+    Revealed bool  // true if RevealEmails ran (any credits spent)
+}
+```
+
+### 2.4 SearchPeople pagination (mirror Hunter loop, page-based)
+**Decision: mirror `hunter.go:122-162` exactly, paging by `page`/`per_page` and bounding total by
+`--limit` (the credit-relevant number for a subsequent reveal).**
+
+```go
+func (c *Client) SearchPeople(ctx context.Context, domain string, titles []string, limit int) (*DomainResult, error) {
+    result := &DomainResult{Domain: domain}
+    page := 1
+    for {
+        people, total, err := c.searchPage(ctx, domain, titles, page)
+        if err != nil { return nil, err }
+        if page == 1 { result.Total = total }
+
+        result.People = append(result.People, people...)
+
+        fetched := len(people)
+        if fetched == 0 { break }                                    // empty page
+        if limit > 0 && len(result.People) >= limit {                // user cap (truncate)
+            result.People = result.People[:limit]
+            break
+        }
+        if fetched < c.pageSize { break }                            // short final page
+        if result.Total > 0 && len(result.People) >= result.Total { break } // known total
+        if page >= maxPages { break }                                // hard safety cap
+        if err := ctx.Err(); err != nil { return nil, err }          // cancellation
+        page++
+    }
+    return result, nil
+}
+```
+`maxPages` is a hard safety cap (const `maxPages = 500`; Apollo's free people-search documents a
+100/page × 500-page = 50k ceiling — see discovery §2). The `limit > 0` truncation is the normal
+bound; `maxPages` is belt-and-suspenders against an API that never returns a short page.
+
+### 2.5 RevealEmails (per-person, serial, bounded by --limit)
+**Decision: `/people/match` is one call per person (it matches a single identity). Loop the
+discovered people serially, calling match with `id` + `reveal_personal_emails: true`, merge the
+returned email back by id. NO phone (`reveal_phone_number` needs a `webhook_url` — out of scope,
+documented in §11). Spend is bounded because we only reveal `result.People`, which `SearchPeople`
+already capped at `--limit`.**
+
+```go
+func (c *Client) RevealEmails(ctx context.Context, result *DomainResult) error {
+    for i := range result.People {
+        p := &result.People[i]
+        if p.ID == "" { continue } // can't match without an id
+        email, status, err := c.matchPerson(ctx, p.ID)
+        if err != nil { return err } // surface first error (mirrors Hunter: no partial swallow)
+        p.Email, p.EmailStatus, p.Revealed = email, status, true
+        if err := ctx.Err(); err != nil { return err }
+    }
+    if len(result.People) > 0 { result.Revealed = true }
+    return nil
+}
+```
+Serial (no goroutines) — see §6. `matchPerson` returns empty email + `Revealed=true` when Apollo
+has no email for that id (requested, none returned) — same partial-result honesty as ZoomInfo.
+
+### 2.6 Sentinels + error mapping (Apollo)
+```go
+var (
+    ErrUnauthorized = errors.New("invalid or missing Apollo API key") // 401
+    ErrForbidden    = errors.New("access forbidden (plan or permissions)") // 403
+    ErrBadRequest   = errors.New("invalid request parameters")        // 422
+    ErrRateLimited  = errors.New("rate limit exceeded")               // 429
+)
+// APIError.Unwrap: 401→Unauthorized, 403→Forbidden, 422→BadRequest, 429→RateLimited, else nil.
+```
+
+---
+
+## 3. Lusha — package `pkg/enum/lusha/lusha.go`
+
+### 3.1 Client struct (simplest — no pagination, no page size)
+**Decision: minimal struct. No `pageSize` (single identity → single contact, no pagination). This
+is the `preferring-simple-solutions` ladder applied: Lusha needs state (apiKey + http client +
+baseURL) → struct (level 4), but nothing more.**
+
+```go
+type Client struct {
+    apiKey     string        // api_key header — NEVER logged (P0-1)
+    httpClient *http.Client
+    baseURL    string        // default "https://api.lusha.com"
+}
+
+func NewClient(apiKey string, timeout time.Duration) *Client {
+    return &Client{
+        apiKey:     apiKey,
+        httpClient: enum.NewEnumHTTPClient(timeout),
+        baseURL:    defaultBaseURL,
+    }
+}
+```
+
+### 3.2 Public API surface (single call)
+```go
+// Enrich resolves one identity to an enriched contact via v3 search-and-enrich (CREDITS).
+// query carries exactly one identity (validated by the caller — see §3.4).
+func (c *Client) Enrich(ctx context.Context, query ContactQuery, reveal RevealOptions) (*Contact, error)
+```
+
+### 3.3 Public types
+```go
+type ContactQuery struct {
+    // Exactly one identity set is used (mutually exclusive — validated at the CLI layer).
+    FirstName   string
+    LastName    string
+    CompanyName string // pairs with FirstName+LastName
+    CompanyDomain string // alternative to CompanyName
+    Email       string
+    LinkedinURL string
+}
+
+type RevealOptions struct {
+    Email bool // request email datapoints
+    Phone bool // request phone datapoints
+}
+
+type EmailEntry struct {
+    Address    string // UNVERIFIED: "email" vs "address" (§11)
+    Type       string // personal | business
+    Confidence string // UNVERIFIED shape
+}
+type PhoneEntry struct {
+    Number    string
+    Type      string
+    DoNotCall bool   // DNC flag — surface in output (compliance signal)
+}
+type Contact struct {
+    Name     string
+    JobTitle string
+    Company  string
+    Emails   []EmailEntry
+    Phones   []PhoneEntry
+}
+```
+
+### 3.4 Enrich flow (single POST, v3)
+```go
+func (c *Client) Enrich(ctx context.Context, q ContactQuery, r RevealOptions) (*Contact, error) {
+    body := buildEnrichRequest(q, r) // maps identity + reveal flags to the v3 request shape (§11)
+    raw, err := c.do(ctx, http.MethodPost, enrichPath, body) // enrichPath = "/v3/contacts/search-and-enrich"
+    if err != nil { return nil, err }
+    var resp enrichResponse
+    if err := json.Unmarshal(raw, &resp); err != nil {
+        return nil, fmt.Errorf("decoding lusha response: %w", err)
+    }
+    return toContact(&resp), nil
+}
+```
+`do` is the single P0-1/P0-3 choke point: sets `api_key` header, JSON-encodes body, reads via
+`enum.ReadResponseBody(resp, 0)`, maps non-2xx → `*APIError`, never logs the key or body.
+
+**Empty-match handling:** if v3 returns 200 with no contact / no datapoints, `Enrich` returns a
+`*Contact` with empty slices (not an error) — the CLI prints "no contact data returned". A 404 (if
+Lusha uses it for no-match) maps to a `ErrNotFound` sentinel; flagged UNVERIFIED in §11.
+
+### 3.5 Sentinels + error mapping (Lusha)
+```go
+var (
+    ErrUnauthorized = errors.New("invalid or missing Lusha API key") // 401
+    ErrForbidden    = errors.New("access forbidden")                 // 403
+    ErrNoCredits    = errors.New("insufficient Lusha credits")       // 402 / quota code (§11)
+    ErrRateLimited  = errors.New("rate limit exceeded")              // 429
+)
+// APIError.Unwrap: 401→Unauthorized, 403→Forbidden, 402→NoCredits, 429→RateLimited, else nil.
+```
+
+---
+
+## 4. Auth flow (both services)
+
+| | Apollo | Lusha |
+|---|---|---|
+| Pattern | API key in request **header** | API key in request **header** |
+| Header name | `X-Api-Key: <key>` (isolate in one const) | `api_key: <key>` (isolate in one const) |
+| Env var | `APOLLO_API_KEY` | `LUSHA_API_KEY` |
+| Flag | `--api-key` (warning: visible in process list/history) | `--api-key` (same warning) |
+| Resolution | `resolveApolloAPIKey(flag)` → flag, else env, else error | `resolveLushaAPIKey(flag)` → flag, else env, else error |
+| ValidateCredentials | No separate ping — first real API call surfaces 401 → `ErrUnauthorized` via `classifyXError`. Matches Hunter (no validate endpoint). | Same. |
+
+Both resolvers mirror `resolveHunterAPIKey` (`cmd_enum_hunter.go:117-125`) exactly. **No YAML creds
+file** — single secret each (the task locks this; ZoomInfo's `--credentials-file` was for its
+two-secret PKI, which does not apply).
+
+**Decision — no auth-only validate endpoint.** Apollo/Lusha have no documented lightweight
+"whoami". Adding a probe call would spend a request (and possibly a credit) for no benefit; the
+first real call returns 401 just as fast. Matches Hunter. (YAGNI.)
+
+---
+
+## 5. Pagination strategy
+
+| Service | Strategy | maxPages | Parallel fetch |
+|---|---|---|---|
+| Apollo | **Page-based** (`page`/`per_page`, 1-based), mirror Hunter loop | `500` (const; API's documented 50k/100 ceiling) | **No** (serial — §6) |
+| Lusha | **None** — single identity → single contact | n/a | n/a |
+
+Apollo termination order (matches Hunter `hunter.go:144-158`): empty page → `--limit` truncation →
+short final page → known `total_entries` → `maxPages` cap → `ctx.Err()`.
+
+---
+
+## 6. Concurrency / rate-limiting strategy
+
+**Decision: serial requests for both. No errgroup, no `golang.org/x/time/rate` limiter, no
+auto-retry on 429.**
+
+Chain-of-thought:
+- Apollo's reveal loop is the only place concurrency could apply (N independent `/people/match`
+  calls). But: (1) Hunter and the ZoomInfo sibling are both serial — consistency; (2) the loop is
+  bounded by `--limit` (default 25), so wall-clock cost is small; (3) Apollo rate-limits per
+  minute/hour/day — firing 25 concurrent matches is the *fastest* way to trip a 429. Serial issue
+  is self-throttling and predictable. Adding `errgroup` + a `rate.Limiter` is unrequested
+  complexity (YAGNI) for a 25-item loop.
+- Lusha is a single call — nothing to parallelize.
+- **429 handling:** map to `ErrRateLimited` via `APIError.Unwrap`, surface via `classifyXError`
+  with an actionable message ("wait and retry, or lower --limit"). **No automatic retry/backoff** —
+  Hunter doesn't retry (the task's pattern of record), and silent multi-second hangs would surprise
+  a CLI user. Documented as a future extension.
+- **Rate-limit headers** (`x-rate-limit-daily` / `x-daily-requests-left` for Lusha; Apollo's
+  `x-rate-limit-*`): read opportunistically for the `--verbose` log line only, never for flow
+  control. (YAGNI — header-driven throttling is a real but unrequested feature.)
+
+**Self-consistency check:** would I add a limiter if the reveal cap were 10k? Yes — but the cap is
+25 by design (the cost rail, §8). At 25 serial calls a limiter is pure overhead. Holds.
+
+---
+
+## 7. Apollo data-model mapping + Assumptions
+
+| Apollo entity (external) | Tabularium-equivalent role | brutus type | Key fields |
+|---|---|---|---|
+| `people[]` (search) | person/contact discovery | `apollo.Person` (free tier) | `id, first_name, last_name, name, title, seniority, departments[], organization.name` |
+| `person` (match) | enriched contact (PII) | `apollo.Person` (reveal tier) | `email, email_status` |
+
+> This is a standalone enum CLI (people/email discovery), **not** the Chariot asset/risk ingestion
+> pipeline. There is no `Job.Send`, no `VMFilter`, no `CheckAffiliation` — those P0s belong to
+> Chariot *integrations*, not `brutus enum` subcommands (confirmed: Hunter, the pattern of record,
+> has none of them). The applicable P0s here are the enum-CLI security P0s (P0-1/P0-3/P0-4, §10).
+
+### Apollo Assumptions (NOT verified against a live key — isolate, flag for developer)
+| Assumption | Why unverified | Risk if wrong | Isolation |
+|---|---|---|---|
+| Search path `POST /api/v1/mixed_people/api_search`; match path `POST /api/v1/people/match` | No live Apollo key in repo (docs-derived, discovery §2) | 404 / wrong endpoint | `const searchPath`, `const matchPath` — one edit each |
+| Request fields `q_organization_domains_list[]`, `person_titles[]`, `page`, `per_page`, `reveal_personal_emails` | docs-derived | Bad params → 422 | unexported request structs in `apollo_types.go` |
+| Response: `people[]`, `pagination.{total_entries,total_pages,page,per_page}`, `person.email`, `person.email_status`, `organization.name`, `departments[]` (array; take first) | docs-derived | Decode yields zero values / wrong pagination | unexported response structs; `toPerson` mapper |
+| Auth header literal `X-Api-Key` | docs-derived | 401 | `const headerAPIKey = "X-Api-Key"` |
+| `email_status` field name + values | docs-derived | Cosmetic (status label blank) | field in `apolloPerson` struct |
+
+**These are intentionally isolated** behind unexported consts + JSON structs so the developer
+corrects each against the live API/docs with a single edit, without touching control flow (the
+ZoomInfo mitigation). `httptest`-based tests use controlled payloads and pass regardless.
+
+---
+
+## 8. Apollo `--reveal` cost rail (resolves open question §5.1)
+
+**Decision: `--reveal` enriches ONLY the people the command returns, and that set is bounded by
+`--limit` (default 25). `--limit` IS the reveal-spend cap.**
+
+Chain-of-thought (the documented cost footgun):
+- `/people/match` consumes credits per call. Domain search can yield up to 50k people. Revealing
+  all of them on a single flag would drain an account on one typo.
+- **Option A — reveal all discovered.** Maximally useful, catastrophic spend. Rejected.
+- **Option B (CHOSEN) — reveal only `result.People`, capped by `--limit` (default 25).** A single
+  accidental `--reveal` costs at most 25 credits. The user raises `--limit` deliberately to reveal
+  more — explicit consent scales with spend. Mirrors ZoomInfo's `--enrich` + `--limit` rail.
+- **Cost notice:** when `--reveal` is set and `!quiet && !json`, print to **stderr** before
+  spending: `[*] --reveal will consume Apollo credits for N people` (N = `len(result.People)`).
+  No interactive prompt (would break scripting/`--json`); the explicit `--reveal` flag is consent.
+  Mirrors Hunter's stderr progress line (`cmd_enum_hunter.go:92-95`).
+
+**Self-consistency check:** is default 25 right? Hunter's `--limit` default is 100 (page size,
+free). ZoomInfo's is 100 (contacts cap). Apollo's `--limit` here bounds *credit-spending* reveals,
+so a smaller, safer default (25) is correct — large enough to be useful, small enough that an
+accidental reveal is cheap. Holds. (Without `--reveal`, `--limit` still caps the free people list;
+25 free results is a fine default and a one-flag bump raises it.)
+
+---
+
+## 9. CLI design
+
+### Apollo — `brutus enum apollo`
+File-local flags in `cmd/brutus/cmd_enum_apollo.go` (mirror `cmd_enum_hunter.go:32-65`). Reuses
+globals `--timeout`, `--json`, `--output/-o`, `--no-color`, `--quiet/-q`, `--verbose/-v`.
+
+| Flag | Type | Default | Notes |
+|---|---|---|---|
+| `--domain` / `-d` | string | "" | Company domain to discover people for (required). |
+| `--titles` | []string | nil | Optional `person_titles[]` filter (repeatable / comma-sep via `StringSliceVar`). |
+| `--reveal` | bool | false | Opt-in email enrichment via `/people/match`. **Consumes credits.** |
+| `--limit` | int | 25 | Max people to return AND max to reveal. Bounds credit spend. 0 = no cap (free list only; with `--reveal` 0 is treated as unbounded — guard with cost notice). |
+| `--api-key` | string | "" | Overrides `APOLLO_API_KEY`. WARNING in help: visible in process list/shell history; prefer the env var. |
+
+`runEnumApollo` (mirror `cmd_enum_hunter.go:68-113`): require `--domain` → `resolveApolloAPIKey` →
+`setupOutputWriter` (set `flagJSON=true` if forceJSON) → `signal.NotifyContext` → stderr progress
+if `!quiet && !json` → `NewClient(key, flagTimeout, perPageFromLimit)` → `SearchPeople(ctx, domain,
+titles, limit)` → if `--reveal`: stderr cost notice then `RevealEmails(ctx, result)` →
+`classifyApolloError` on any error → `outputApolloJSONL`/`outputApolloHuman`.
+
+> Note on `--limit` vs page size: pass `min(limit, 100)` (or `defaultPageSize` when `limit==0`) as
+> the `NewClient` pageSize so we never request a `per_page` above Apollo's 100 max; `--limit`
+> separately bounds the accumulated total inside `SearchPeople`. (Distinct knobs, like ZoomInfo §1.)
+
+### Lusha — `brutus enum lusha`
+File-local flags in `cmd/brutus/cmd_enum_lusha.go`. Reuses the same globals.
+
+| Flag | Type | Default | Notes |
+|---|---|---|---|
+| `--first-name` | string | "" | With `--last-name` + (`--company` or `--domain`). |
+| `--last-name` | string | "" | Pairs with `--first-name`. |
+| `--company` | string | "" | Company name (with name pair). |
+| `--domain` | string | "" | Company domain (alternative to `--company`). |
+| `--email` | string | "" | Enrich by email (mutually exclusive identity). |
+| `--linkedin` | string | "" | Enrich by LinkedIn URL (mutually exclusive identity). |
+| `--phone` | bool | false | Request phone datapoints (in addition to email). |
+| `--email-only` | bool | false | Request only email (suppress phone). Mutually exclusive with `--phone`. |
+| `--api-key` | string | "" | Overrides `LUSHA_API_KEY`. Same process-list/history WARNING. |
+
+**Identity validation (`runEnumLusha`)** — exactly one identity group must be set:
+1. name group: `--first-name` + `--last-name` + exactly one of (`--company` | `--domain`), OR
+2. `--email`, OR
+3. `--linkedin`.
+
+Setting more than one group, or an incomplete name group (e.g. `--first-name` without
+`--last-name`, or name without company/domain), is an error with an actionable message. **No
+default reveal both** — default requests email; `--phone` adds phone; `--email-only` is the
+explicit email-only form (and conflicts with `--phone`). Enrichment **always** costs credits
+(that's the command's purpose) → unconditional stderr cost notice when `!quiet && !json`
+(`[*] lusha enrichment consumes credits`), no separate gate flag (matches discovery §4.3).
+
+Run flow mirrors Hunter: validate identity → `resolveLushaAPIKey` → `setupOutputWriter` →
+`signal.NotifyContext` → cost notice → `NewClient(key, flagTimeout)` → `Enrich(ctx, query, reveal)`
+→ `classifyLushaError` → `outputLushaJSONL`/`outputLushaHuman`.
+
+### Output (both — mirror Hunter, reuse sanitizers)
+Two functions per service appended to `cmd/brutus/cmd_enum_output.go`, mirroring
+`outputHunterHuman`/`outputHunterJSONL` (`cmd_enum_output.go:294-356`). **Reuse `sanitizeTerminal`
+and `truncate` as-is** (package-level, same file — DRY, no new copies; a test asserts
+`grep -c 'func sanitizeTerminal'` stays 1).
+
+- **`outputApolloHuman`:** header `Apollo: <sanitized domain>`, `People found: N (total: M)`; dim
+  preview note when `!result.Revealed` (`(preview — run with --reveal for emails; consumes
+  credits)`); columns adapt: preview `Name | Title | Dept | Org`, revealed `+ Email | Status`;
+  every API string `sanitizeTerminal`+`truncate` (P0-4); empty → `No people found for this domain`.
+- **`outputApolloJSONL`:** local struct, `type:"apollo"`, always `domain`+`revealed`+`id`;
+  `omitempty` on name/title/dept/org/email/email_status so preview JSONL never emits a misleading
+  `"email":""`.
+- **`outputLushaHuman`:** header `Lusha: <sanitized identity summary>`; rows for each email
+  (`address | type | confidence`) and phone (`number | type | DNC`); DNC flag rendered explicitly
+  (`DNC` marker) so the operator sees do-not-call compliance status; empty → `No contact data
+  returned`. All strings `sanitizeTerminal`+`truncate` (P0-4).
+- **`outputLushaJSONL`:** local struct, `type:"lusha"`, `name/job_title/company` (`omitempty`),
+  `emails[]` and `phones[]` arrays (each with `do_not_call` bool for phones), `omitempty` on the
+  arrays.
+
+---
+
+## 10. P0 security mapping
+
+| Constraint | Apollo | Lusha |
+|---|---|---|
+| **P0-1** API key NEVER logged | `resolveApolloAPIKey` + `classifyApolloError` return only status-derived, key-free text; `searchPage`/`matchPerson` never log the key, header, or body; `--verbose` logs counts + non-secret rate headers only (mirror `cmd_enum_hunter.go:103-105`). Unit test asserts the key never appears in any classified error string (mirror `cmd_enum_hunter_test.go:109-111`). | `resolveLushaAPIKey` + `classifyLushaError` same; `do` never logs the `api_key` header or body. Same no-leak unit test. |
+| **P0-3** bounded body read (1 MB) | every HTTP body via `enum.ReadResponseBody(resp, 0)` before decode (search, match), exactly like `hunter.go:193`. No raw `io.ReadAll(resp.Body)`. | `do` reads via `enum.ReadResponseBody(resp, 0)` before decode. |
+| **P0-4** terminal sanitization | `outputApolloHuman` wraps every API string (name/title/dept/org/email/status) in `sanitizeTerminal`+`truncate`; JSONL relies on `encoding/json` escaping (documented). | `outputLushaHuman` wraps name/title/company/email/phone/type; JSONL relies on `encoding/json`. |
+| Sentinels never expose secrets | sentinels are static strings; `*APIError.Details` carries only `resp.Status`/server error-envelope text, never the request body or key. | same |
+
+(P0-2 / P0-5+ Chariot-integration P0s — VMFilter, CheckAffiliation, ValidateCredentials, errgroup
+limits — **do not apply**: this is a `brutus enum` CLI, not a Chariot integration. Confirmed by the
+Hunter precedent, which has none of them.)
+
+---
+
+## 11. Lusha v3 Assumptions (resolves open questions §5.2, §5.3)
+
+**v3 confirmed over v2 (§5.3):** v2 (`GET /v2/person`) sunsets 2026-11-18 and already emits a
+`Sunset` header (active since 2026-05-18). Today is 2026-06-25 — v2 would ship with <5 months of
+life and a deprecation header. v3 (`POST /v3/contacts/search-and-enrich`) is the documented
+recommendation for new integrations. **Target v3.** Exact v3 schema needs live-key verification →
+isolate + flag below.
+
+**Batch scope (§5.2):** single-identity per invocation. Bulk/stdin identity lists are explicitly
+out of scope (YAGNI); noted as a future extension (§12). The command takes one identity group.
+
+### Lusha Assumptions (NOT verified against a live key — isolate, flag for developer)
+| Assumption | Why unverified | Risk if wrong | Isolation |
+|---|---|---|---|
+| Endpoint `POST /v3/contacts/search-and-enrich` | docs-derived (discovery §3) | 404 | `const enrichPath` |
+| Auth header literal `api_key` | docs-derived | 401 | `const headerAPIKey = "api_key"` |
+| Request identity field names (`firstName`,`lastName`,`companyName`,`companyDomain`,`email`,`linkedinUrl`) + reveal control shape | docs-derived | 422 / unmatched | `buildEnrichRequest` + unexported request struct in `lusha_types.go` |
+| Response: `emailAddresses[]`{email/address,type,confidence}, `phoneNumbers[]`{number,type,doNotCall}, name, jobTitle, company | docs-derived; "email" vs "address" key uncertain | Decode yields empty contact | unexported response structs; `toContact` mapper |
+| No-match signal (200 + empty vs 404) | docs-derived | Wrong empty/error branch | `do` maps 404→`ErrNotFound` (add sentinel) AND `Enrich` treats empty 200 as empty contact; developer keeps whichever the live API uses |
+| 402 / quota code for "out of credits" | docs-derived | NoCredits not surfaced | `APIError.Unwrap` 402→`ErrNoCredits`; widen if live API uses a different code |
+
+Same isolation discipline as Apollo (§7): one edit per const/struct corrects any mismatch without
+touching control flow. `httptest` tests pass regardless of live-schema correctness.
+
+---
+
+## 12. Out of scope (YAGNI — documented future extensions)
+
+- **Apollo phone reveal** — `reveal_phone_number` requires a `webhook_url` for async delivery; a
+  CLI cannot receive webhooks. Emails only. (Hard constraint, discovery §2.)
+- **Apollo org-enrich endpoint** — not requested.
+- **Lusha bulk / stdin identity list** — single identity per invocation in v1.
+- **Auto-retry / exponential backoff on 429** — surface as a sentinel; no silent retry.
+- **Header-driven client-side throttling** (`x-rate-limit-*`) — read for `--verbose` only.
+- **A shared "HUMINT provider" interface** — Rule of Three not met (different shapes); see §1.
+
+---
+
+## 13. File-by-File summary
+
+**Create:**
+1. `pkg/enum/apollo/apollo.go` — `Client`, `NewClient`, `SearchPeople`, `searchPage`,
+   `RevealEmails`, `matchPerson`, `do` helper, `APIError`+`Unwrap`, sentinels, request/response
+   structs, consts, `toPerson`. (Split `apollo_types.go` only if the file exceeds ~400 lines — see
+   note below.)
+2. `pkg/enum/apollo/apollo_test.go` — httptest-driven: `toPerson`, `APIError.Unwrap`,
+   `searchPage` decode + error mapping, `SearchPeople` pagination (incl. `--limit` truncation,
+   mid-pagination 429), `RevealEmails` merge + partial + serial-count, context cancellation.
+3. `pkg/enum/lusha/lusha.go` — `Client`, `NewClient`, `Enrich`, `do`, `buildEnrichRequest`,
+   `APIError`+`Unwrap`, sentinels, request/response structs, consts, `toContact`.
+4. `pkg/enum/lusha/lusha_test.go` — httptest-driven: `toContact`, `APIError.Unwrap`, `Enrich`
+   success (email+phone), `buildEnrichRequest` per identity group, error mapping
+   (401/402/403/429/404), empty-match, context cancellation, key-not-in-request-log assertion.
+5. `cmd/brutus/cmd_enum_apollo.go` — flags, `enumApolloCmd`, `runEnumApollo`, `resolveApolloAPIKey`,
+   `classifyApolloError`.
+6. `cmd/brutus/cmd_enum_apollo_test.go` — `resolveApolloAPIKey`, `classifyApolloError` (no-leak),
+   registration, output (`outputApolloHuman`/`outputApolloJSONL`).
+7. `cmd/brutus/cmd_enum_lusha.go` — flags, `enumLushaCmd`, `runEnumLusha`, `resolveLushaAPIKey`,
+   `classifyLushaError`, identity-validation helper.
+8. `cmd/brutus/cmd_enum_lusha_test.go` — `resolveLushaAPIKey`, `classifyLushaError` (no-leak),
+   identity validation (mutual exclusion), registration, output.
+
+**Modify (BOTH commands touch these two — conflict-management in plan.md §ordering):**
+9. `cmd/brutus/cmd_enum.go` — two `enumCmd.AddCommand(...)` lines in `init()` (after line 111) + two
+   `Long`/`Example` lines. **Distinct insertion points per command** (separate lines) so the two
+   developers' edits don't collide; serialize if both land simultaneously.
+10. `cmd/brutus/cmd_enum_output.go` — append `outputApolloHuman/JSONL` and `outputLushaHuman/JSONL`
+    at the bottom (each block independent; append-only avoids line-overlap conflicts).
+
+**File-size note (P0 file-size discipline):** Apollo's client (two phases + structs) may approach
+~400 lines. If it exceeds 400, split request/response structs into `apollo_types.go` (the plan's
+T-tasks instruct this). Lusha is smaller (single call) — one file. No splitting expected for Lusha.
+
+---
+
+## 14. Adversarial Review (blind-spot pass — `analyzing-with-adversarial-pov`)
+
+**Reality / data-contract risk (Dim 1, 2):** Apollo endpoint paths/fields and Lusha v3 schema are
+*unverified* (no live keys). Mitigation: every path/field/header isolated in consts + unexported
+structs (§7, §11); a single edit fixes a mismatch without touching control flow. `httptest` tests
+use controlled payloads → pass regardless of live correctness. Flagged for the developer to verify
+against live docs/key before relying on live calls.
+
+**Negative space — Apollo partial reveal (Dim 5):** `/people/match` may return no email for some
+ids. `Person.Revealed=true` + `omitempty` `email` correctly distinguish "requested, none returned"
+from "not requested". Without the flag, a consumer misreads a blank as confirmed-absent. Addressed
+in §2.5/§2.3.
+
+**Negative space — Apollo person with no `id` (Dim 5):** free search could return a person without
+a usable id (e.g. masked record). `RevealEmails` skips ids that are empty (`if p.ID == ""
+continue`) rather than firing a match call that 422s. Addressed in §2.5.
+
+**Cost footgun (Dim 5):** `--reveal` on a large domain. Mitigation: `--limit` default 25 bounds
+reveal spend; stderr cost notice prints N before spending. The `--limit 0` (uncapped) + `--reveal`
+combination is the sharp edge — guarded by the cost notice still printing the (large) N so the user
+sees the spend before it happens. Addressed in §8/§9.
+
+**Data contract — Lusha identity mutual-exclusion (Dim 2, 7):** ambiguous/partial identity (name
+without company, two groups set) would otherwise produce a 422 or, worse, a silently-wrong match.
+Validated at the CLI layer with explicit errors before any spend. Addressed in §9.
+
+**Negative space — Lusha DNC phones (Dim 5):** a returned phone may carry `doNotCall=true`
+(compliance-relevant). Output renders the DNC flag explicitly (human marker + JSON `do_not_call`)
+so an operator doesn't dial a DNC number. Addressed in §3.3/§9.
+
+**Dependency / sequencing (Dim 6):** Apollo `RevealEmails` strictly depends on `SearchPeople`
+output (ids); it takes `*DomainResult`, so it cannot run before a completed search. Single command
+guarantees ordering. The two *subcommands* are independent (no cross-package import) → two
+developers can build Apollo and Lusha fully in parallel; the only shared files are `cmd_enum.go`
+and `cmd_enum_output.go` (append-only, distinct insertion points — see plan.md).
+
+**Architecture justification (Dim 3):** rejected the shared-provider interface (§1) — deleting it
+costs nothing because it never existed; the shared helpers already carry the real reuse. Rejected
+errgroup/limiter (§6) — a 25-item serial loop doesn't need them.
+
+**Implementability (Dim 7):** every referenced internal helper (`enum.NewEnumHTTPClient`,
+`enum.ReadResponseBody`, `setupOutputWriter`, `isColorEnabled`, `logVerbose`, `sanitizeTerminal`,
+`truncate`, `dim`, `heading`, `colorIf`, `SymbolInfo`, the six CLI globals) was READ and exists at
+the cited lines. A developer can build against them without clarification. The only unknowns are
+the external API schemas — explicitly isolated and flagged.
+
+---
+
+## Metadata
+
+```json
+{
+  "agent": "capability-lead",
+  "output_type": "integration-architecture",
+  "timestamp": "2026-06-25",
+  "feature_directory": "/Users/engineer/github/brutus/.worktrees/apollo-lusha-enum/.feature-development",
+  "skills_invoked": ["using-skills", "focusing-on-the-goal", "enforcing-evidence-based-analysis", "preferring-simple-solutions", "adhering-to-dry", "adhering-to-yagni", "analyzing-with-adversarial-pov", "plan-write", "persisting-agent-outputs", "using-todowrite", "verifying-before-completion", "gateway-backend", "gateway-integrations"],
+  "library_skills_read": [
+    "/Users/engineer/.claude/plugins/cache/praetorian-ai-marketplace/engineering/1.38.17/skill-library/development/error-handling-patterns/SKILL.md"
+  ],
+  "source_files_verified": [
+    "pkg/enum/hunter/hunter.go:33-282",
+    "pkg/enum/hunter/hunter_test.go:1-368",
+    "cmd/brutus/cmd_enum_hunter.go:30-139",
+    "cmd/brutus/cmd_enum_hunter_test.go:1-353",
+    "cmd/brutus/cmd_enum_output.go:290-449",
+    "cmd/brutus/cmd_enum.go:30-112",
+    "cmd/brutus/flags.go:300-368",
+    "pkg/enum/httpclient.go:1-65",
+    "go.mod:1-32",
+    ".worktrees/zoominfo-enum/.feature-development/architecture.md (structural template only)",
+    ".worktrees/zoominfo-enum/.feature-development/plan.md (structural template only)"
+  ],
+  "status": "complete",
+  "handoff": {
+    "next_agent": "integration-developer",
+    "context": "Implement per plan.md. Two independent commands buildable in parallel; only cmd_enum.go + cmd_enum_output.go are shared (append-only, distinct insertion points). VERIFY Apollo paths/fields (§7) and Lusha v3 schema (§11) against live docs/key — isolated in consts/structs; httptest tests pass regardless."
+  }
+}
+```

--- a/.feature-development/discovery.md
+++ b/.feature-development/discovery.md
@@ -1,0 +1,131 @@
+# Discovery — Apollo + Lusha HUMINT enum integrations
+
+Phase 3–5 output. All internal references READ in this repo; all external API facts
+sourced from live vendor docs (June 2026). Unverified API details are flagged so the
+developer corrects them against a live key — they are isolated in consts/structs so a
+single edit fixes a mismatch without touching control flow (the ZoomInfo mitigation).
+
+## 1. Verified internal pattern (the template to mirror)
+
+The repo already ships the **Hunter.io** integration (PR #160). Apollo/Lusha mirror it
+exactly. Pattern = standalone client package + cobra subcommand + output helpers + tests.
+This is NOT the `enum.Plugin` (email-exists oracle) interface used by microsoft365/google.
+
+| Concern | Reference (verified) |
+|---|---|
+| Client struct + `NewClient(apiKey, timeout, …)` | `pkg/enum/hunter/hunter.go:99-118` |
+| Sentinel errors + `APIError` + `Unwrap()` (status→sentinel) | `pkg/enum/hunter/hunter.go:33-37, 71-92` |
+| Paginated `Search` loop (accumulate, advance, terminate empty/short/total, honor ctx) | `pkg/enum/hunter/hunter.go:122-162` |
+| JSON structs unexported, map exactly to API; `toPerson` mapper | `pkg/enum/hunter/hunter.go:215-281` |
+| Shared HTTP client (no-redirect, UA) + `ReadResponseBody` 1MB cap | `pkg/enum/httpclient.go:44-65` |
+| Subcommand: flags, cobra cmd, `runEnumX`, `resolveXAPIKey`, `classifyXError` | `cmd/brutus/cmd_enum_hunter.go:30-139` |
+| Command registration (`enumCmd.AddCommand`) + Long/Example text | `cmd/brutus/cmd_enum.go:107-121` |
+| Output: `outputXHuman` (table, sanitized) + `outputXJSONL` (omitempty) | `cmd/brutus/cmd_enum_output.go:385-460` |
+| Shared output helpers `sanitizeTerminal`, `truncate` (reuse as-is) | `cmd/brutus/cmd_enum_output.go:306-381` |
+| CLI globals: `flagTimeout, flagJSON, flagOutputFile, flagNoColor, flagQuiet, flagVerbose` | `cmd/brutus/flags.go` |
+| Helpers: `setupOutputWriter`, `isColorEnabled`, `logVerbose`, `dim`, `heading`, `colorIf`, `SymbolInfo` | `flags.go:308,361`; `output.go:114` |
+| Test style: `httptest.NewServer` + testify, table-driven pagination, error-mapping, no-key-leak assertions | `pkg/enum/hunter/hunter_test.go`; `cmd/brutus/cmd_enum_hunter_test.go` |
+
+### P0 security constraints (mandatory, from Hunter + ZoomInfo precedent)
+- **P0-1** API key / token NEVER logged. `resolveXAPIKey` + `classifyXError` return only
+  status-derived, key-free text. Verbose logs counts only. Unit test asserts the key never
+  appears in any error string.
+- **P0-3** Every HTTP body read via `enum.ReadResponseBody(resp, 0)` (1 MB cap) before decode.
+- **P0-4** Every API-sourced string in human output wrapped in `sanitizeTerminal()` + `truncate()`.
+  JSONL relies on `encoding/json` control-char escaping (no manual sanitize).
+
+### go.mod / deps
+`module github.com/praetorian-inc/brutus`, `go 1.26`. Tests: `testify` (assert/require) +
+stdlib `net/http/httptest`. No new deps required (single API key each → no YAML creds file,
+unlike ZoomInfo's two-secret PKI).
+
+---
+
+## 2. Apollo API contract (verified against docs.apollo.io, June 2026)
+
+**Role:** sales-intelligence → org/domain people *discovery* + optional email *enrichment*.
+Maps to the ZoomInfo free-search / paid-enrich gate.
+
+### Auth
+- Header `X-Api-Key: <master key>` (direct API-key method). `Authorization: Bearer` is
+  ONLY for OAuth partner flows — not us. Isolate header name in one const.
+- Env `APOLLO_API_KEY` + `--api-key` flag (warning: visible in process list/history).
+
+### Discovery — People Search (FREE, no PII)
+- `POST https://api.apollo.io/api/v1/mixed_people/api_search`
+- Body: `q_organization_domains_list[]` (array of domains, ≤1000), optional `person_titles[]`,
+  `page`, `per_page` (≤100). **Does NOT consume credits. Does NOT return email/phone.**
+- Pagination: `page`/`per_page`, max 100/page × 500 pages = 50k cap; response has
+  `pagination: {page, per_page, total_entries, total_pages}` and a `people[]` array.
+- Person fields (free): `id, first_name, last_name, name, title, seniority, departments[],
+  organization{name,…}`. Email field present but masked/absent at this tier.
+
+### Enrichment — People Match (CREDITS, PII) — opt-in via `--reveal`
+- `POST https://api.apollo.io/api/v1/people/match`
+- Body: `id` (from search) OR `first_name`+`last_name`+`domain`/`organization_name`,
+  plus `reveal_personal_emails: true`. Returns synchronously: `person{email, email_status,
+  name, title, organization, …}`.
+- **⚠ `reveal_phone_number` requires a `webhook_url`** — phones are delivered ASYNC via
+  webhook, NOT in the response. A CLI cannot receive webhooks. → **Apollo v1 reveals EMAILS
+  ONLY** (`reveal_personal_emails`). Phone is explicitly out of scope (documented). 
+
+### Errors: 401 (unauth), 403 (forbidden/plan), 422 (bad params), 429 (rate limit). Map
+401→ErrUnauthorized, 429→ErrRateLimited, 403→ErrForbidden, 422→ErrBadRequest.
+
+---
+
+## 3. Lusha API contract (verified against docs.lusha.com, June 2026)
+
+**Role:** contact enrichment (email + phone) for *individuals*. Input = a person identity.
+
+### ⚠ Version decision: TARGET v3, NOT v2
+- v2 (`GET /v2/person`) is **sunsetting 2026-11-18**; emits `Sunset` header since 2026-05-18
+  (already active). Docs explicitly recommend **v3 for new integrations** (cheaper search,
+  stable IDs). Building on v2 would ship deprecated-on-arrival.
+- v3 contact enrich: `POST https://api.lusha.com/v3/contacts/search-and-enrich`
+  (single call: provide identifiers → enriched contact). Also `POST /v3/contacts/enrich`
+  (by `contactId` from a prior search).
+
+### Auth
+- Header `api_key: <key>`. Env `LUSHA_API_KEY` + `--api-key` flag (warning).
+
+### Request identifiers (mutually-exclusive identity, choose one)
+- `firstName`+`lastName`+(`companyName` OR `companyDomain`), OR `email`, OR `linkedinUrl`.
+- A `reveal` control selects email vs phone vs company data (charged per revealed field).
+
+### Response (field names UNVERIFIED — isolate in structs, flag for live check)
+- `emailAddresses[]` {email/address, type (personal|business), confidence}
+- `phoneNumbers[]` {number, type, doNotCall (DNC) flag}
+- name, jobTitle, company.
+- Billing: charged per revealed datapoint. Rate-limit headers: `x-rate-limit-daily`,
+  `x-daily-requests-left` (read for `--verbose` only, not flow control).
+
+### Errors: 401, 403, 429, plus per-datapoint billing/quota → map to
+ErrUnauthorized / ErrForbidden / ErrRateLimited (+ ErrNoCredits if a 402/quota code appears).
+
+---
+
+## 4. Recommended design decisions (for lead review)
+
+1. **Two independent subcommands**, no shared abstraction beyond existing helpers
+   (Rule of Three not met — Hunter+Apollo+Lusha differ in shape; do NOT prematurely extract
+   a "HUMINT provider" interface). KISS.
+2. **Apollo = `brutus enum apollo --domain <d> [--titles ...] [--reveal] [--limit N]`** —
+   single command, `--reveal` is the credit gate (mirrors ZoomInfo `--enrich`): default lists
+   people (name/title/dept, masked email); `--reveal` calls people/match per discovered id to
+   unlock emails (credits). Emails only (no phone webhook). Stderr cost notice when `--reveal`.
+3. **Lusha = `brutus enum lusha`** with mutually-exclusive identity flags
+   (`--first-name/--last-name`+`--company`/`--domain`, OR `--email`, OR `--linkedin`).
+   v3 `search-and-enrich`. Enrichment always costs credits (that's the command's purpose) →
+   stderr cost notice, no separate gate flag. Optional `--phone`/`--email-only` reveal toggles.
+4. **Single API key each** → mirror Hunter's `resolveXAPIKey(flag) → env`. No creds file.
+5. **Sentinels + APIError.Unwrap** per service; `classifyXError` produces key-free messages;
+   no auto-retry on 429 (matches Hunter).
+6. **Out of scope (YAGNI):** Apollo phone (webhook), Lusha bulk file/stdin enrichment,
+   Apollo org-enrich endpoint, ToS-gated auto-throttling. Note as future extensions.
+
+## 5. Open questions deferred to leads / Phase 7 checkpoint
+- Apollo `--reveal`: enrich ALL discovered people or only first N (`--limit`/`--reveal-limit`)?
+  (cost footgun — recommend `--limit` default 25, cap reveal spend.)
+- Lusha batch: confirm v1 is single-identity only (recommended) vs. stdin identity list.
+- Confirm v3 over v2 is acceptable given exact v3 schema needs live-key verification.

--- a/.feature-development/plan.md
+++ b/.feature-development/plan.md
@@ -1,0 +1,609 @@
+# Apollo + Lusha enum integrations — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use plan-execute (or developing-with-subagents) to implement
+> this plan task-by-task.
+
+**Goal:** Add `brutus enum apollo` (domain → people discovery + opt-in `--reveal` email enrichment)
+and `brutus enum lusha` (single-identity contact enrichment via Lusha v3), mirroring the verified
+Hunter.io pattern.
+
+> **ORCHESTRATION DELTAS (2026-06-26, applied for safe parallel execution — intentional, NOT drift):**
+> 1. **Apollo `--limit` default = 100** (user decision at Phase 7 checkpoint), not 25. Aligns with
+>    Hunter's default page size. Cost notice + tests reflect 100.
+> 2. **Output formatters live in per-service files, NOT appended to `cmd_enum_output.go`:** Apollo →
+>    `cmd/brutus/cmd_enum_apollo_output.go`, Lusha → `cmd/brutus/cmd_enum_lusha_output.go`. This
+>    removes the shared-file (`cmd_enum_output.go`) write contention between the two parallel tracks.
+>    They still reuse `sanitizeTerminal`/`truncate` from `cmd_enum_output.go` (DRY preserved).
+> 3. **Command registration (`cmd_enum.go`, T006/T105) is performed by the ORCHESTRATOR** as a single
+>    serialized step after both tracks land — developers do NOT edit `cmd_enum.go`. This leaves ZERO
+>    files shared between the two parallel developer tracks.
+> 4. **Dev/test agent split (forced by the `agent-first-enforcement` hook):** the hook routes
+>    production `.go` under `pkg/`/`cmd/` to `backend-developer` and `_test.go` to `backend-tester`,
+>    and denies all other writers (incl. the orchestrator and `integration-developer`). Therefore the
+>    per-task RED/GREEN is realized across phases, NOT in one agent: **Phase 8** `backend-developer`
+>    writes production code (apollo.go, lusha.go, cmd_enum_{apollo,lusha}.go, cmd_enum_{apollo,lusha}_output.go)
+>    to the EXACT signatures/consts the task specs require; **Phase 14** `backend-tester` writes the
+>    full per-task test matrix (T001/T002/T003/T004 + T101/T102/T103/T104 test blocks) and runs it;
+>    failures route back to `backend-developer` via the tight-feedback loop. The test SPECS in each
+>    task below are the contract the tester implements and the developer must satisfy. The
+>    `enum{Apollo,Lusha}Cmd` registration test moves to after orchestrator registration.
+
+**Architecture:** See `architecture.md` in this directory. Two independent client packages +
+cobra subcommands + output formatters + tests. No shared abstraction beyond existing helpers
+(`enum.NewEnumHTTPClient`, `enum.ReadResponseBody`, `sanitizeTerminal`, `truncate`, CLI globals).
+
+**Security:** See `security-assessment.md` (security-lead, Phase 7). P0 controls below are derived
+from it: P0-1/P0-1b/P0-1c/P0-1d (credential handling), P0-3 (bounded read), P0-4 (terminal
+sanitization), P0-5 (no silent 429 retry), P0-6/P0-7 (cost rails). P1-PII output-file perms are
+already satisfied by `setupOutputWriter` (`flags.go:312`, `0o600`).
+
+**Tech Stack:** Go 1.26, `github.com/spf13/cobra` v1.10.2, `github.com/stretchr/testify` v1.11.1
+(assert/require), stdlib `net/http`/`net/http/httptest`/`context`/`encoding/json`. No new deps.
+
+**TDD throughout:** every task writes the failing test first, runs it (RED), implements minimal
+code (GREEN), reruns (PASS), commits. DRY/YAGNI/KISS per architecture.
+
+> **CRITICAL for developer:** Apollo endpoint paths/fields (architecture §7) and Lusha v3 schema
+> (architecture §11) are research-derived, NOT verified against a live API. Keep them isolated in
+> unexported consts + request/response structs (the tasks enforce this) and verify against live
+> docs/a key. `httptest` tests use controlled payloads, so they pass regardless — but live calls
+> require correct paths/fields/headers.
+
+---
+
+## Parallelization & shared-file conflict management
+
+**Apollo (Track A: T001–T006) and Lusha (Track B: T101–T105) are fully independent** — separate
+packages (`pkg/enum/apollo/`, `pkg/enum/lusha/`) and separate command files
+(`cmd/brutus/cmd_enum_apollo*.go`, `cmd/brutus/cmd_enum_lusha*.go`). Two developers can run Track A
+and Track B in parallel with **zero file conflicts** for T001–T005 and T101–T104.
+
+**Only two files are shared by both tracks:**
+- `cmd/brutus/cmd_enum.go` (registration + help text) — touched by **T006** (Apollo) and **T105**
+  (Lusha).
+- `cmd/brutus/cmd_enum_output.go` (output formatters) — touched by **T003** (Apollo) and **T103**
+  (Lusha).
+
+**Conflict-avoidance rules (mandatory):**
+1. **`cmd_enum_output.go` is APPEND-ONLY.** Each track appends its two `output*` functions at the
+   end of the file. Appends to different ends never overlap line-wise; if both land at once, the
+   merge is trivial (two independent function blocks). Do NOT reorder or edit existing functions.
+2. **`cmd_enum.go` edits use distinct insertion points.** Apollo adds its `AddCommand` +
+   help lines for `apollo`; Lusha adds separate lines for `lusha`. Add each on its **own line**
+   (do not combine). If both developers edit simultaneously, **serialize**: whoever lands second
+   rebases their two-line addition onto the other's (no semantic conflict — independent lines).
+3. **Recommended serialization:** land **T006 before T105** (or vice-versa) rather than merging
+   `cmd_enum.go` concurrently. The registration tasks are tiny (~4 lines each); doing them
+   back-to-back is faster than resolving a merge.
+
+```
+Track A (Apollo):  T001 → T002 → T003 → T004 → T006(reg) ─┐
+Track B (Lusha):   T101 → T102 → T103 → T104 → T105(reg) ─┤
+                                                          └→ T200 (final gate, both)
+```
+
+---
+
+# TRACK A — Apollo (`pkg/enum/apollo/` + `cmd/brutus/cmd_enum_apollo*.go`)
+
+---
+
+## T001: Apollo types, sentinels, APIError+Unwrap, toPerson
+
+**Files:**
+- Create: `pkg/enum/apollo/apollo.go`
+- Test: `pkg/enum/apollo/apollo_test.go`
+
+**Implementation notes:**
+- Package doc comment + Apache license header (copy header from `pkg/enum/hunter/hunter.go:1-13`).
+- Sentinels: `ErrUnauthorized` (401), `ErrForbidden` (403), `ErrBadRequest` (422), `ErrRateLimited`
+  (429) — architecture §2.6.
+- `APIError{StatusCode int; Details string}` with `Error()` and `Unwrap()` (401→Unauthorized,
+  403→Forbidden, 422→BadRequest, 429→RateLimited, else nil). Mirror `hunter.go:70-92`.
+- Public types `Person`, `DomainResult` (architecture §2.3).
+- Unexported request/response structs (architecture §7 isolation): `apolloSearchRequest`,
+  `apolloSearchResponse{People []apolloPerson; Pagination apolloPagination}`, `apolloPerson`,
+  `apolloPagination`, `apolloMatchRequest`, `apolloMatchResponse{Person apolloPerson}`.
+- `toPerson(*apolloPerson) Person` mapper (search fields; PII empty, `Revealed=false`). Mirror
+  `toPerson` at `hunter.go:216-236`.
+- Consts: `defaultBaseURL = "https://api.apollo.io"`, `searchPath = "/api/v1/mixed_people/api_search"`,
+  `matchPath = "/api/v1/people/match"`, `headerAPIKey = "X-Api-Key"`, `defaultPageSize = 100`,
+  `maxPages = 500`.
+- **P0-1b:** `apiKey` field is unexported, no JSON tag, no getter.
+
+**Step 1 — failing test** (`apollo_test.go`): `TestToPerson` (search fields map; `Email` empty,
+`Revealed=false`); `TestAPIError_Unwrap` (table: 401→ErrUnauthorized, 403→ErrForbidden,
+422→ErrBadRequest, 429→ErrRateLimited, 500→nil for each); `TestAPIError_Error` (contains status +
+details). Pattern: `hunter_test.go:37-91`.
+**Step 2 — run, expect FAIL:** `go test ./pkg/enum/apollo/ -run 'TestToPerson|TestAPIError'` (undefined symbols).
+**Step 3 — implement** types/errors/converter/consts (no network code).
+**Step 4 — run, expect PASS.**
+**Step 5 — commit:** `feat(enum): add apollo client types and sentinel errors`
+
+**Exit Criteria:**
+- [ ] 3 test functions pass (verify: `go test ./pkg/enum/apollo/ -run 'TestToPerson|TestAPIError' -v`)
+- [ ] `go vet ./pkg/enum/apollo/` exit 0
+- [ ] `errors.Is(&APIError{StatusCode:422}, ErrBadRequest)` true (asserted)
+
+**Dependencies:** none.
+
+---
+
+## T002: Apollo Client, NewClient, do helper, searchPage, matchPerson (single calls)
+
+**Files:**
+- Modify: `pkg/enum/apollo/apollo.go`
+- Test: `pkg/enum/apollo/apollo_test.go`
+
+**Implementation notes:**
+- `Client` struct + `NewClient(apiKey string, timeout time.Duration, pageSize int) *Client`
+  (architecture §2.1; `httpClient: enum.NewEnumHTTPClient(timeout)`, `pageSize<=0 → defaultPageSize`).
+- `do(ctx, method, path string, body any) ([]byte, error)`: JSON-encode body, build request with
+  `req.Header.Set(headerAPIKey, c.apiKey)` + `Content-Type: application/json`, `c.httpClient.Do`,
+  `defer resp.Body.Close()`, read via `enum.ReadResponseBody(resp, 0)` (P0-3), map non-2xx →
+  `*APIError` (extract details from error envelope if decodable, else `resp.Status` — mirror
+  `hunter.go:198-206`). **P0-1: never log the key, header, body, or URL. P0-1c: NEVER use
+  `httputil.DumpRequest`/`DumpResponse` (would capture the `X-Api-Key` header).** Single
+  P0-1/P0-3 choke point.
+- `searchPage(ctx, domain string, titles []string, page int) (people []Person, total int, err error)`:
+  build `apolloSearchRequest{Domains:[]string{domain}, Titles:titles, Page:page, PerPage:c.pageSize}`,
+  POST `searchPath`, decode `apolloSearchResponse`, map each via `toPerson`, return
+  `pagination.total_entries`.
+- `matchPerson(ctx, id string) (email, status string, err error)`: POST `matchPath` with
+  `apolloMatchRequest{ID:id, RevealPersonalEmails:true}`, decode `apolloMatchResponse`, return
+  `person.email` + `person.email_status`.
+- Add `newTestClient(baseURL string) *Client` test helper overriding `c.baseURL` (mirror
+  `hunter_test.go:122-126`).
+
+**Step 1 — failing test:** `TestSearchPage_Decode` (httptest returns 2 people + pagination → assert
+fields incl. `ID`, `Title`, `Organization`; `Email` empty; total returned). `TestSearchPage_401`
+(server 401 → `errors.Is(err, ErrUnauthorized)` + `errors.As` to `*APIError` with 401).
+`TestSearchPage_422` (→ `ErrBadRequest`). `TestMatchPerson_Decode` (server returns
+`person.email`+`email_status` → returned). `TestDo_MalformedJSON` (200 + `not-json{{{` → decode
+error). `TestDo_SetsAuthHeader` (capture request, assert `X-Api-Key` header == test key, assert key
+NOT in URL). Pattern: `hunter_test.go:128-229`.
+**Step 2 — run, expect FAIL.**
+**Step 3 — implement** `Client`, `NewClient`, `do`, `searchPage`, `matchPerson`.
+**Step 4 — run, expect PASS.**
+**Step 5 — commit:** `feat(enum): add apollo HTTP client, people search and match`
+
+**Exit Criteria:**
+- [ ] 6 test functions pass (verify: `go test ./pkg/enum/apollo/ -run 'TestSearchPage|TestMatchPerson|TestDo' -v`)
+- [ ] `X-Api-Key` set as a header and absent from the request URL (asserted in `TestDo_SetsAuthHeader`)
+- [ ] body read via `enum.ReadResponseBody` (verify by code read: no raw `io.ReadAll(resp.Body)` in package)
+- [ ] no `httputil.Dump*` in package (verify: `grep -rn 'httputil.Dump' pkg/enum/apollo/` returns nothing) (P0-1c)
+
+**Dependencies:** T001.
+
+---
+
+## T003: Apollo SearchPeople pagination + RevealEmails + output formatters
+
+**Files:**
+- Modify: `pkg/enum/apollo/apollo.go`
+- Modify: `cmd/brutus/cmd_enum_output.go` (APPEND `outputApolloHuman` + `outputApolloJSONL` at end)
+- Test: `pkg/enum/apollo/apollo_test.go`
+- Test: `cmd/brutus/cmd_enum_apollo_test.go` (create)
+
+**Implementation notes:**
+- `SearchPeople(ctx, domain string, titles []string, limit int) (*DomainResult, error)` — loop from
+  architecture §2.4. Termination order: empty page → `--limit` truncation → short page → known
+  total → `maxPages` → `ctx.Err()`. Page is 1-based.
+- `RevealEmails(ctx, result *DomainResult) error` — architecture §2.5: serial loop over
+  `result.People`, skip empty `ID`, `matchPerson` per id, set `Email`/`EmailStatus`/`Revealed=true`
+  (true even when returned email is empty — partial honesty), set `result.Revealed=true` if
+  `len(People)>0`. Return first error (no swallow).
+- Output (`cmd_enum_output.go`, append — DRY: reuse `sanitizeTerminal`/`truncate`, do NOT redefine):
+  - `outputApolloHuman(w io.Writer, result *apollo.DomainResult, useColor bool)` — architecture §9:
+    header (`Apollo: <sanitized domain>`, `People found: N (total: M)`); dim preview note when
+    `!result.Revealed`; columns `Name|Title|Dept|Org` (preview) or `+Email|Status` (revealed);
+    every API string `sanitizeTerminal`+`truncate` (P0-4); empty → `No people found for this domain`.
+  - `outputApolloJSONL(w io.Writer, result *apollo.DomainResult)` — local struct, `type:"apollo"`,
+    always `domain`+`revealed`+`id`, `omitempty` on name/title/dept/org/email/email_status.
+
+**Step 1 — failing test:**
+- In `apollo_test.go`: `TestSearchPeople_Pagination` table (mirror `hunter_test.go:264-345`, paged
+  httptest keyed on `page`, `atomic.Int32` counter): single page; two full pages + short final;
+  empty domain (0 people, 1 request); `--limit=2` over 5 people → 2 returned; mid-pagination 429 →
+  `errors.Is(err, ErrRateLimited)`. `TestSearchPeople_ContextCancellation` (slow server + short ctx
+  → error, mirror `hunter_test.go:347-367`). `TestRevealEmails_Merge` (3 people, server returns
+  email for 2, none for 3rd → those 2 have email + `Revealed=true`; 3rd empty email + `Revealed=true`;
+  `result.Revealed=true`). `TestRevealEmails_SkipsEmptyID` (person with `ID==""` → no match call;
+  assert request counter). `TestRevealEmails_SerialCount` (5 ids → exactly 5 match requests).
+- In `cmd_enum_apollo_test.go`: `TestOutputApolloJSONL` (single revealed person → 1 line, correct
+  type/domain/revealed/id; preview person omits `email`; empty result → 0 lines). `TestOutputApolloHuman`
+  (header + row; revealed shows Email column; preview shows note; empty → "No people found"). Use
+  `bytes.Buffer`. Pattern: `cmd_enum_hunter_test.go:153-268`.
+**Step 2 — run, expect FAIL** (`go test ./pkg/enum/apollo/ ./cmd/brutus/ -run 'Apollo'`).
+**Step 3 — implement** `SearchPeople`, `RevealEmails`, both output functions.
+**Step 4 — run, expect PASS.**
+**Step 5 — commit:** `feat(enum): add apollo pagination, email reveal and output formatters`
+
+**Exit Criteria:**
+- [ ] `TestSearchPeople_Pagination` (5 subtests) + `TestSearchPeople_ContextCancellation` pass (verify: `go test ./pkg/enum/apollo/ -run TestSearchPeople -v`)
+- [ ] `--limit=2` over 5 people returns exactly 2; mid-pagination 429 surfaces `ErrRateLimited` (asserted)
+- [ ] 3 `RevealEmails` tests pass: merge, skip-empty-id, serial-count = N (verify: `go test ./pkg/enum/apollo/ -run TestRevealEmails -v`)
+- [ ] 2 output tests pass; preview JSONL omits `email`, revealed JSONL includes it (verify: `go test ./cmd/brutus/ -run TestOutputApollo -v`)
+- [ ] No duplicate sanitizer (verify: `grep -c 'func sanitizeTerminal' cmd/brutus/*.go` returns 1)
+
+**Dependencies:** T002.
+
+---
+
+## T004: Apollo command, flags, runEnumApollo, resolveApolloAPIKey, classifyApolloError
+
+**Files:**
+- Create: `cmd/brutus/cmd_enum_apollo.go`
+- Test: `cmd/brutus/cmd_enum_apollo_test.go` (extend)
+
+**Implementation notes:**
+- Mirror `cmd_enum_hunter.go:30-139`. File-local flags: `flagApolloDomain`, `flagApolloTitles`
+  (`[]string` via `StringSliceVar`), `flagApolloReveal` (bool), `flagApolloLimit` (int, default 25),
+  `flagApolloAPIKey`.
+- `enumApolloCmd` cobra command (`Use:"apollo"`, Short/Long/Example). Example MUST show: free
+  discovery; `--titles` filter; `--reveal` with a **credit warning**; the `--api-key`
+  process-list/history warning + prefer-`APOLLO_API_KEY` note (P0-1d — use the warning string
+  exactly as `cmd_enum_hunter.go:61-62`).
+- `init()`: declare flags; `--domain`/`-d`; `MarkFlagRequired("domain")`.
+- `runEnumApollo` (mirror `cmd_enum_hunter.go:68-113`): require domain → `resolveApolloAPIKey` →
+  `setupOutputWriter(flagOutputFile)` (set `flagJSON=true` if forceJSON) → `signal.NotifyContext(...,
+  os.Interrupt, syscall.SIGTERM)` → stderr progress if `!quiet && !json` → compute pageSize =
+  `min(limit,100)` (or `defaultPageSize` when limit==0) → `apollo.NewClient(key, flagTimeout,
+  pageSize)` → `SearchPeople(ctx, domain, titles, limit)` → if `flagApolloReveal`: stderr cost
+  notice `[*] --reveal will consume Apollo credits for N people` (N=len(result.People)) when
+  `!quiet && !json`, then `RevealEmails(ctx, result)` → `classifyApolloError` on any error →
+  `outputApolloJSONL`/`outputApolloHuman`.
+- `resolveApolloAPIKey(flagValue string) (string, error)`: flag, else `os.Getenv("APOLLO_API_KEY")`,
+  else error mentioning `APOLLO_API_KEY`. Mirror `cmd_enum_hunter.go:117-125`.
+- `classifyApolloError(err) error`: switch `errors.Is` on Unauthorized/Forbidden/BadRequest/
+  RateLimited → actionable key-free messages; default wraps. Mirror `cmd_enum_hunter.go:128-139`.
+
+**Step 1 — failing test:** `TestResolveApolloAPIKey` (table: flag wins over env; env when flag
+empty; error when both empty — assert message contains `APOLLO_API_KEY`; use `t.Setenv`). Pattern:
+`cmd_enum_hunter_test.go:33-74`. `TestClassifyApolloError_NoKeyLeak` (P0-1, mirror security-assessment
+§2.1): feed a sentinel key `const sentinelKey = "SECRETKEY-DO-NOT-LEAK-abc123"` via
+`&apollo.APIError{StatusCode:401, Details:sentinelKey}` (vendor echoed key into body) plus 429/403/422
+and a wrapped 500-with-sentinel; for EVERY case assert `NotContains(out, sentinelKey)` AND
+`NotContains(out, "X-Api-Key")` AND `NotContains(out, "api-key")`. Pattern: `cmd_enum_hunter_test.go:76-113`.
+**Step 2 — run, expect FAIL.**
+**Step 3 — implement** the command file.
+**Step 4 — run, expect PASS.**
+**Step 5 — commit:** `feat(enum): add apollo subcommand`
+
+**Exit Criteria:**
+- [ ] `TestResolveApolloAPIKey` (3 subtests) pass (verify: `go test ./cmd/brutus/ -run TestResolveApolloAPIKey -v`)
+- [ ] `TestClassifyApolloError_NoKeyLeak` (5 cases incl. sentinel-in-Details + wrapped) passes; every error asserted NOT to contain the sentinel key, `X-Api-Key`, or `api-key` (P0-1)
+- [ ] `go vet ./cmd/brutus/` exit 0
+
+**Dependencies:** T003.
+
+---
+
+## T006: Register apollo subcommand + update enum help text (SHARED FILE — see conflict rules)
+
+**Files:**
+- Modify: `cmd/brutus/cmd_enum.go` (`init()` AddCommand list ~line 111; `Long`/`Example` ~lines 44-66)
+- Test: `cmd/brutus/cmd_enum_apollo_test.go` (extend)
+
+**Implementation notes:**
+- Add `enumCmd.AddCommand(enumApolloCmd)` on its **own line** after the existing
+  `enumCmd.AddCommand(...)` calls (`cmd_enum.go:106-111`).
+- Add an `apollo` line to the `Long` subcommand list, the `brutus enum apollo --help` hint, and one
+  `Example` line (mirror the existing hunter entries at `cmd_enum.go:44,51,62-63`).
+- **CONFLICT RULE:** this is one of the two shared files. Use the own-line discipline from the
+  Parallelization section. Prefer landing this immediately before/after T105 (do not co-edit
+  `cmd_enum.go` concurrently with Track B).
+
+**Step 1 — failing test:** `TestEnumApolloRegistered` (mirror `cmd_enum_hunter_test.go:119-147`):
+walk `enumCmd.Commands()`, find `Use=="apollo"`; assert flags `--domain`, `--titles`, `--reveal`,
+`--limit`, `--api-key` exist; assert `-d` shorthand; assert `--domain` marked required.
+**Step 2 — run, expect FAIL** (command not registered).
+**Step 3 — implement** registration + help text.
+**Step 4 — run, expect PASS.**
+**Step 5 — commit:** `feat(enum): register apollo subcommand`
+
+**Exit Criteria:**
+- [ ] `TestEnumApolloRegistered` passes (verify: `go test ./cmd/brutus/ -run TestEnumApolloRegistered -v`)
+- [ ] 5 flags + `-d` shorthand asserted present; `--domain` required
+- [ ] `enumCmd` has exactly one `apollo` subcommand (asserted)
+
+**Dependencies:** T004. (Shared file with T105 — serialize per conflict rules.)
+
+---
+
+# TRACK B — Lusha (`pkg/enum/lusha/` + `cmd/brutus/cmd_enum_lusha*.go`)
+
+---
+
+## T101: Lusha types, sentinels, APIError+Unwrap, toContact
+
+**Files:**
+- Create: `pkg/enum/lusha/lusha.go`
+- Test: `pkg/enum/lusha/lusha_test.go`
+
+**Implementation notes:**
+- Apache header (copy from `hunter.go:1-13`) + package doc.
+- Sentinels: `ErrUnauthorized` (401), `ErrForbidden` (403), `ErrNoCredits` (402), `ErrRateLimited`
+  (429), `ErrNotFound` (404 — UNVERIFIED no-match signal, §11). Architecture §3.5.
+- `APIError{StatusCode int; Details string}` + `Error()` + `Unwrap()` (401→Unauthorized,
+  403→Forbidden, 402→NoCredits, 429→RateLimited, 404→NotFound, else nil).
+- Public types `ContactQuery`, `RevealOptions`, `EmailEntry`, `PhoneEntry`, `Contact`
+  (architecture §3.3).
+- Unexported request/response structs (architecture §11 isolation): `lushaEnrichRequest` (identity
+  + reveal control), `lushaEnrichResponse{EmailAddresses []lushaEmail; PhoneNumbers []lushaPhone;
+  Name, JobTitle string; Company ...}`, `lushaEmail`, `lushaPhone`.
+- `toContact(*lushaEnrichResponse) *Contact` mapper (architecture §3.3). Map `doNotCall` → `PhoneEntry.DoNotCall`.
+- Consts: `defaultBaseURL = "https://api.lusha.com"`, `enrichPath = "/v3/contacts/search-and-enrich"`,
+  `headerAPIKey = "api_key"`.
+- **P0-1b:** `apiKey` field unexported, no JSON tag, no getter.
+
+**Step 1 — failing test:** `TestToContact` (email + phone arrays map; `DoNotCall` preserved; name/
+title/company map). `TestAPIError_Unwrap` (table: 401→Unauthorized, 402→NoCredits, 403→Forbidden,
+404→NotFound, 429→RateLimited, 500→nil for each). `TestAPIError_Error`. Pattern: `hunter_test.go:37-91`.
+**Step 2 — run, expect FAIL.**
+**Step 3 — implement** types/errors/converter/consts.
+**Step 4 — run, expect PASS.**
+**Step 5 — commit:** `feat(enum): add lusha client types and sentinel errors`
+
+**Exit Criteria:**
+- [ ] 3 test functions pass (verify: `go test ./pkg/enum/lusha/ -run 'TestToContact|TestAPIError' -v`)
+- [ ] `go vet ./pkg/enum/lusha/` exit 0
+- [ ] `errors.Is(&APIError{StatusCode:402}, ErrNoCredits)` true; `DoNotCall` round-trips (asserted)
+
+**Dependencies:** none. (Independent of Track A.)
+
+---
+
+## T102: Lusha Client, NewClient, do helper, buildEnrichRequest, Enrich
+
+**Files:**
+- Modify: `pkg/enum/lusha/lusha.go`
+- Test: `pkg/enum/lusha/lusha_test.go`
+
+**Implementation notes:**
+- `Client` struct + `NewClient(apiKey string, timeout time.Duration) *Client` (architecture §3.1;
+  no pageSize). `httpClient: enum.NewEnumHTTPClient(timeout)`.
+- `do(ctx, method, path string, body any) ([]byte, error)`: JSON-encode body, set
+  `req.Header.Set(headerAPIKey, c.apiKey)` + `Content-Type: application/json`, `Do`,
+  `defer Body.Close()`, read via `enum.ReadResponseBody(resp, 0)` (P0-3), map non-2xx → `*APIError`
+  (envelope details or `resp.Status`). **P0-1: never log key/header/body. P0-1c: NO
+  `httputil.Dump*` (captures the `api_key` header).**
+- `buildEnrichRequest(q ContactQuery, r RevealOptions) lushaEnrichRequest`: map exactly one identity
+  group + reveal flags to the v3 request shape (architecture §11 — field names isolated here).
+- `Enrich(ctx, q ContactQuery, r RevealOptions) (*Contact, error)`: `do` POST `enrichPath` → decode
+  `lushaEnrichResponse` → `toContact`. Empty 200 (no datapoints) → `*Contact` with empty slices
+  (not an error). 404 → `ErrNotFound` via `do` mapping.
+- Add `newTestClient(baseURL string) *Client` helper overriding `c.baseURL`.
+
+**Step 1 — failing test:** `TestEnrich_Success` (httptest returns 1 email + 1 phone with
+`doNotCall:true` → `Contact` has both; DNC preserved; assert `api_key` header sent and NOT in URL;
+capture+assert request body contains the identity). `TestBuildEnrichRequest` (table: name+company,
+name+domain, email-only, linkedin-only → correct request shape per group). `TestEnrich_401`
+(→ `ErrUnauthorized`). `TestEnrich_402` (→ `ErrNoCredits`). `TestEnrich_429` (→ `ErrRateLimited`).
+`TestEnrich_EmptyMatch` (200 + empty arrays → `*Contact` empty, no error). `TestEnrich_MalformedJSON`
+(→ decode error). `TestEnrich_ContextCancellation` (slow server + short ctx → error). Pattern:
+`hunter_test.go:128-229, 347-367`.
+**Step 2 — run, expect FAIL.**
+**Step 3 — implement** `Client`, `NewClient`, `do`, `buildEnrichRequest`, `Enrich`.
+**Step 4 — run, expect PASS.**
+**Step 5 — commit:** `feat(enum): add lusha v3 search-and-enrich client`
+
+**Exit Criteria:**
+- [ ] 8 test functions pass (verify: `go test ./pkg/enum/lusha/ -run 'TestEnrich|TestBuildEnrichRequest' -v`)
+- [ ] `api_key` set as header, absent from URL; key absent from any captured request log (asserted)
+- [ ] empty 200 returns empty `*Contact` not error; 402→`ErrNoCredits`; malformed JSON→decode error (asserted)
+- [ ] body read via `enum.ReadResponseBody` (code read: no raw `io.ReadAll(resp.Body)`)
+- [ ] no `httputil.Dump*` in package (verify: `grep -rn 'httputil.Dump' pkg/enum/lusha/` returns nothing) (P0-1c)
+
+**Dependencies:** T101.
+
+---
+
+## T103: Lusha output formatters (SHARED FILE — append-only)
+
+**Files:**
+- Modify: `cmd/brutus/cmd_enum_output.go` (APPEND `outputLushaHuman` + `outputLushaJSONL` at end)
+- Test: `cmd/brutus/cmd_enum_lusha_test.go` (create)
+
+**Implementation notes:**
+- APPEND-ONLY (conflict rule). Reuse `sanitizeTerminal`/`truncate` — do NOT redefine (DRY).
+- `outputLushaHuman(w io.Writer, c *lusha.Contact, useColor bool)` — architecture §9: header
+  `Lusha: <sanitized identity/name summary>`; email rows (`address | type | confidence`); phone rows
+  (`number | type | DNC`) with an explicit `DNC` marker when `DoNotCall`; every API string
+  `sanitizeTerminal`+`truncate` (P0-4); empty contact → `No contact data returned`.
+- `outputLushaJSONL(w io.Writer, c *lusha.Contact)` — local struct, `type:"lusha"`,
+  `name/job_title/company` (`omitempty`), `emails[]` (address/type/confidence) and `phones[]`
+  (number/type/`do_not_call` bool), `omitempty` on the arrays. One JSON object (single contact).
+
+**Step 1 — failing test** (`cmd_enum_lusha_test.go`): `TestOutputLushaJSONL` (contact with 1 email +
+1 DNC phone → 1 line, `type:"lusha"`, `phones[0].do_not_call==true`; empty contact → object with no
+emails/phones arrays). `TestOutputLushaHuman` (renders email + phone rows; DNC phone shows `DNC`
+marker; empty → "No contact data returned"). Use `bytes.Buffer`. Pattern: `cmd_enum_hunter_test.go:153-268`.
+**Step 2 — run, expect FAIL** (`go test ./cmd/brutus/ -run TestOutputLusha`).
+**Step 3 — implement** both functions (append).
+**Step 4 — run, expect PASS.**
+**Step 5 — commit:** `feat(enum): add lusha output formatters`
+
+**Exit Criteria:**
+- [ ] 2 output test functions pass (verify: `go test ./cmd/brutus/ -run TestOutputLusha -v`)
+- [ ] DNC phone renders `DNC` marker (human) and `do_not_call:true` (JSONL) (asserted)
+- [ ] No duplicate sanitizer (verify: `grep -c 'func sanitizeTerminal' cmd/brutus/*.go` returns 1)
+
+**Dependencies:** T102. (Shared file with T003 — append-only, no overlap.)
+
+---
+
+## T104: Lusha command, flags, runEnumLusha, resolveLushaAPIKey, classifyLushaError, identity validation
+
+**Files:**
+- Create: `cmd/brutus/cmd_enum_lusha.go`
+- Test: `cmd/brutus/cmd_enum_lusha_test.go` (extend)
+
+**Implementation notes:**
+- Mirror `cmd_enum_hunter.go:30-139`. File-local flags: `flagLushaFirstName`, `flagLushaLastName`,
+  `flagLushaCompany`, `flagLushaDomain`, `flagLushaEmail`, `flagLushaLinkedin`, `flagLushaPhone`
+  (bool), `flagLushaEmailOnly` (bool), `flagLushaAPIKey`.
+- `enumLushaCmd` (`Use:"lusha"`, Short/Long/Example). Example shows each identity form (name+company,
+  email, linkedin), `--phone`, and the **always-costs-credits** note + `--api-key` warning (P0-1d,
+  exact warning string per `cmd_enum_hunter.go:61-62`) + prefer `LUSHA_API_KEY`.
+- `init()`: declare flags; do NOT `MarkFlagRequired` (identity validated in Run).
+- `validateLushaIdentity()` helper (architecture §9): exactly one of {name group | email | linkedin};
+  name group requires first+last+exactly-one-of(company|domain); `--phone` and `--email-only`
+  mutually exclusive. Return actionable errors. (Pure function on the flag values — testable without
+  a server, per `preferring-simple-solutions`.)
+- `runEnumLusha` (mirror `cmd_enum_hunter.go:68-113`): `validateLushaIdentity` → `resolveLushaAPIKey`
+  → `setupOutputWriter` (set `flagJSON=true` if forceJSON) → `signal.NotifyContext` →
+  **unconditional** stderr cost notice `[*] lusha enrichment consumes credits` when `!quiet && !json`
+  → build `ContactQuery` + `RevealOptions` (default email; `--phone` adds phone; `--email-only`
+  forces email-only) → `lusha.NewClient(key, flagTimeout)` → `Enrich(ctx, query, reveal)` →
+  `classifyLushaError` on error → `outputLushaJSONL`/`outputLushaHuman`.
+- `resolveLushaAPIKey(flagValue)`: flag, else `os.Getenv("LUSHA_API_KEY")`, else error mentioning
+  `LUSHA_API_KEY`. Mirror `cmd_enum_hunter.go:117-125`.
+- `classifyLushaError(err)`: switch `errors.Is` on Unauthorized/Forbidden/NoCredits/RateLimited/
+  NotFound → actionable key-free messages; default wraps.
+
+**Step 1 — failing test:** `TestValidateLushaIdentity` (table: valid name+company; valid
+name+domain; valid email; valid linkedin; ERROR none set; ERROR two groups (email+linkedin); ERROR
+name without last-name; ERROR name without company/domain; ERROR `--phone`+`--email-only` together).
+`TestResolveLushaAPIKey` (flag wins; env fallback; error mentions `LUSHA_API_KEY`; `t.Setenv`).
+`TestClassifyLushaError_NoKeyLeak` (sentinel-in-Details per security-assessment §2.1: each sentinel
++ a wrapped 500 with `Details:sentinelKey`; **all** assert `NotContains(out, sentinelKey)` AND
+`NotContains(out, "api_key")` — P0-1). Pattern: `cmd_enum_hunter_test.go:33-113`.
+**Step 2 — run, expect FAIL.**
+**Step 3 — implement** the command file + validation helper.
+**Step 4 — run, expect PASS.**
+**Step 5 — commit:** `feat(enum): add lusha subcommand with identity validation`
+
+**Exit Criteria:**
+- [ ] `TestValidateLushaIdentity` (9 subtests incl. mutual-exclusion + incomplete name) pass (verify: `go test ./cmd/brutus/ -run TestValidateLushaIdentity -v`)
+- [ ] `TestResolveLushaAPIKey` (3 subtests) + `TestClassifyLushaError_NoKeyLeak` (≥5 cases) pass; every error asserted NOT to contain the sentinel key or `api_key` (P0-1)
+- [ ] `go vet ./cmd/brutus/` exit 0
+
+**Dependencies:** T103.
+
+---
+
+## T105: Register lusha subcommand + update enum help text (SHARED FILE — see conflict rules)
+
+**Files:**
+- Modify: `cmd/brutus/cmd_enum.go` (`init()` AddCommand list ~line 111; `Long`/`Example`)
+- Test: `cmd/brutus/cmd_enum_lusha_test.go` (extend)
+
+**Implementation notes:**
+- Add `enumCmd.AddCommand(enumLushaCmd)` on its **own line** after the existing AddCommand calls.
+- Add a `lusha` line to the `Long` subcommand list, a `--help` hint, and one `Example` line (mirror
+  hunter entries).
+- **CONFLICT RULE:** shared file with T006. Own-line discipline; serialize with T006 (land one then
+  the other; do not co-edit `cmd_enum.go` concurrently).
+
+**Step 1 — failing test:** `TestEnumLushaRegistered` (mirror `cmd_enum_hunter_test.go:119-147`):
+find `Use=="lusha"`; assert flags `--first-name`, `--last-name`, `--company`, `--domain`, `--email`,
+`--linkedin`, `--phone`, `--email-only`, `--api-key` exist; `--domain` NOT required (cobra).
+**Step 2 — run, expect FAIL.**
+**Step 3 — implement** registration + help text.
+**Step 4 — run, expect PASS.**
+**Step 5 — commit:** `feat(enum): register lusha subcommand`
+
+**Exit Criteria:**
+- [ ] `TestEnumLushaRegistered` passes (verify: `go test ./cmd/brutus/ -run TestEnumLushaRegistered -v`)
+- [ ] 9 flags asserted present
+- [ ] `enumCmd` has exactly one `lusha` subcommand (asserted)
+
+**Dependencies:** T104. (Shared file with T006 — serialize.)
+
+---
+
+## T200: Final verification gate (both tracks)
+
+**Files:** none (verification only).
+
+**Step 1 — build:** `go build ./...`
+**Step 2 — vet:** `go vet ./...`
+**Step 3 — full tests:** `go test ./pkg/enum/apollo/ ./pkg/enum/lusha/ ./cmd/brutus/`
+**Step 4 — race:** `go test -race ./pkg/enum/apollo/ ./pkg/enum/lusha/`
+**Step 5 — smoke (no creds):** `go run ./cmd/brutus enum apollo --help` shows all 5 flags + `--reveal`
+credit warning; `go run ./cmd/brutus enum lusha --help` shows all 9 flags + always-costs-credits note.
+**Step 6 — leak grep (P0-1/P0-1c):** `grep -rn 'apiKey\|X-Api-Key\|api_key\|httputil.Dump' pkg/enum/apollo/ pkg/enum/lusha/ cmd/brutus/cmd_enum_apollo.go cmd/brutus/cmd_enum_lusha.go` — manually confirm none feed a log/print/error sink and no request-dumping exists.
+**Step 7 — DRY check:** `grep -c 'func sanitizeTerminal' cmd/brutus/*.go` returns 1; `grep -c 'func truncate' cmd/brutus/*.go` returns 1.
+
+**Exit Criteria:**
+- [ ] `go build ./...` exit 0
+- [ ] `go vet ./...` exit 0
+- [ ] `go test ./pkg/enum/apollo/ ./pkg/enum/lusha/ ./cmd/brutus/` exit 0, 0 failures
+- [ ] `go test -race ./pkg/enum/apollo/ ./pkg/enum/lusha/` exit 0
+- [ ] `enum apollo --help` lists 5 flags + `--reveal` credit warning; `enum lusha --help` lists 9 flags + credit note (verify: run both)
+- [ ] Leak grep reviewed: neither API key reaches a log/print/error sink; no `httputil.Dump*` (P0-1/P0-1c manual confirmation)
+- [ ] sanitizeTerminal/truncate defined exactly once each (DRY)
+
+**Dependencies:** T006 + T105.
+
+---
+
+## Task Dependency Graph
+
+```
+Track A (Apollo, pkg/enum/apollo + cmd_enum_apollo*):
+  T001 (types/errors) → T002 (client/do/search/match) → T003 (pagination/reveal/output) → T004 (command) → T006 (register*)
+
+Track B (Lusha, pkg/enum/lusha + cmd_enum_lusha*):
+  T101 (types/errors) → T102 (client/do/enrich) → T103 (output*) → T104 (command) → T105 (register*)
+
+  T006* + T105*  →  T200 (final gate)
+  (* shared cmd_enum.go — serialize T006/T105; T003/T103 share cmd_enum_output.go append-only)
+```
+
+## Security Checklist (verify across all tasks before done — see security-assessment.md)
+
+- [ ] **P0-1:** Apollo `X-Api-Key` / Lusha `api_key` never logged. Asserted in T002/T102 (key set as
+  header, not in URL; not in captured request log) and T004/T104 (sentinel-in-`APIError.Details`
+  never surfaces in any classified error). Manual grep in T200.
+- [ ] **P0-1b:** key held in unexported `apiKey` struct field, no JSON tag, no getter (T001/T101).
+- [ ] **P0-1c:** NO `httputil.DumpRequest`/`DumpResponse` anywhere in `pkg/enum/apollo/` or
+  `pkg/enum/lusha/` (header-based auth → dumping would capture the key). Grep-asserted T002/T102/T200.
+- [ ] **P0-1d:** `--api-key` help carries the process-list/history warning; env var documented as
+  preferred default (T004/T104).
+- [ ] **P0-3:** every HTTP response read via `enum.ReadResponseBody(resp, 0)` (search, match, enrich).
+  Code-reviewed in T002/T102; no raw `io.ReadAll(resp.Body)` in either package.
+- [ ] **P0-4:** `sanitizeTerminal` applied to every API-sourced string in `outputApolloHuman` and
+  `outputLushaHuman` (T003/T103). JSONL relies on `encoding/json` escaping.
+- [ ] **P0-5:** 429 surfaced as `ErrRateLimited` with actionable message; NO silent auto-retry.
+- [ ] **P0-6/P0-7 (cost rails):** Apollo `--reveal` opt-in, bounded by `--limit` (default 25) +
+  stderr cost notice (T004); Lusha unconditional credit notice (T104).
+- [ ] Sentinels static; `APIError.Details` carries only `resp.Status`/server-envelope text, never
+  the request body or key.
+- [ ] **P1-PII:** `-o` output file written `0o600` — already satisfied by `setupOutputWriter`
+  (`flags.go:312`); no new file-writing code introduced.
+
+---
+
+## Metadata
+
+```json
+{
+  "agent": "capability-lead",
+  "output_type": "integration-architecture",
+  "timestamp": "2026-06-25",
+  "feature_directory": "/Users/engineer/github/brutus/.worktrees/apollo-lusha-enum/.feature-development",
+  "skills_invoked": ["using-skills", "focusing-on-the-goal", "enforcing-evidence-based-analysis", "preferring-simple-solutions", "adhering-to-dry", "adhering-to-yagni", "analyzing-with-adversarial-pov", "plan-write", "persisting-agent-outputs", "using-todowrite", "verifying-before-completion", "gateway-backend", "gateway-integrations"],
+  "library_skills_read": [
+    "/Users/engineer/.claude/plugins/cache/praetorian-ai-marketplace/engineering/1.38.17/skill-library/development/error-handling-patterns/SKILL.md"
+  ],
+  "source_files_verified": [
+    "pkg/enum/hunter/hunter.go:33-282",
+    "pkg/enum/hunter/hunter_test.go:1-368",
+    "cmd/brutus/cmd_enum_hunter.go:30-139",
+    "cmd/brutus/cmd_enum_hunter_test.go:1-353",
+    "cmd/brutus/cmd_enum_output.go:290-449",
+    "cmd/brutus/cmd_enum.go:30-112",
+    "cmd/brutus/flags.go:300-368",
+    "pkg/enum/httpclient.go:1-65",
+    "go.mod:1-32",
+    ".feature-development/security-assessment.md:1-99"
+  ],
+  "status": "complete",
+  "handoff": {
+    "next_agent": "integration-developer",
+    "context": "Execute Track A (T001-T004,T006) and Track B (T101-T105) in parallel; only cmd_enum.go (T006/T105) and cmd_enum_output.go (T003/T103) are shared — serialize cmd_enum.go edits, cmd_enum_output.go is append-only. TDD per task. Verify Apollo paths/fields and Lusha v3 schema against live docs/key (isolated in consts/structs); httptest tests pass regardless. Then T200 final gate."
+  }
+}
+```

--- a/.feature-development/security-assessment.md
+++ b/.feature-development/security-assessment.md
@@ -1,0 +1,254 @@
+# Security Architecture Assessment: `brutus enum apollo` + `brutus enum lusha`
+
+**Author:** security-lead
+**Date:** 2026-06-25
+**Status:** Architecture review — pre-implementation security gate (Phase 7)
+**Feature:** Apollo.io + Lusha paid-HUMINT-API contact enumeration subcommands for the Brutus Go CLI
+**Framing:** Brutus is an authorized offensive-security / OSINT tool used in pentest engagements. The controls below exist to prevent credential leakage, terminal injection, runaway spend, and accidental ToS violations — **not** to block the feature. Every control is scoped to a short-lived, single-operator CLI. Anything heavier (zeroing, audit infra, DI) is explicitly rejected as YAGNI.
+
+---
+
+## 0. Evidence Base (verified by reading source this session — not assumed)
+
+| Claim | Verified location | Note |
+| --- | --- | --- |
+| `enum.ReadResponseBody(resp, 0)` caps body at 1 MB (P0-3 primitive) | `pkg/enum/httpclient.go:60-65`; default `maxResponseBody = 1<<20` at `:28` | Reuse as-is for **every** call. |
+| `NewEnumHTTPClient` suppresses redirects + sets UA | `pkg/enum/httpclient.go:48-56` (`CheckRedirect → http.ErrUseLastResponse`) | Reuse; never build a bare `http.Client`. |
+| `sanitizeTerminal()` strips C0/C1 + full ANSI/VT100 (P0-4 primitive) | `cmd/brutus/cmd_enum_output.go:306-369` | Same `package main` — call directly, no import. (The older zoominfo doc cites `:198`; current worktree line is `:306`.) |
+| `truncate()` rune-safe truncation | `cmd/brutus/cmd_enum_output.go:372-381+` | Pair with `sanitizeTerminal` on every human field. |
+| Key-free credential resolution (flag → env → key-free error) | `resolveHunterAPIKey` `cmd/brutus/cmd_enum_hunter.go:117-125` | Mirror exactly per service. |
+| Key-free error classification | `classifyHunterError` `cmd/brutus/cmd_enum_hunter.go:128-139` | Mirror; map sentinels to static text. |
+| Verbose logs counts/status only — never key/URL | `cmd/brutus/cmd_enum_hunter.go:103-105` | `logVerbose(flagVerbose, "...counts...")`. |
+| The no-key-leak unit-test assertion already in use | `cmd/brutus/cmd_enum_hunter_test.go:109-110` (`assert.NotContains(t, result.Error(), "api_key")`) | This is the canonical negative test to extend. |
+| Hunter puts its key in the **query string** (API contract) | `pkg/enum/hunter/hunter.go:171-179` | **Apollo/Lusha do NOT** — they use headers, which is strictly safer. See §1 note. |
+| ZoomInfo precedent for free-search / paid-enrich gating + ToS notice | `.worktrees/zoominfo-enum/.feature-development/security-assessment.md` (P0-6, P0-10) | Apollo `--reveal` mirrors ZoomInfo `--enrich`. |
+
+**The codebase operates a labeled control taxonomy (P0-1, P0-3, P0-4).** This assessment reuses that numbering and extends it for the Apollo/Lusha-specific threats (header-based key leak vector, free/paid split, always-paid Lusha enrich, DNC flag, ToS).
+
+---
+
+## 1. Threat Model
+
+### Trust boundaries
+
+```
+[operator shell] --flags/env--> [brutus process memory] --HTTPS hdr--> [api.apollo.io | api.lusha.com]
+                                       |
+                                       +--stdout (human table / JSONL)--> [terminal | -o file | pipe]
+                                       +--stderr (verbose / errors / cost notice)--> [terminal | log capture]
+```
+
+Three boundaries matter: (1) **shell → process** — how the key enters (process list / shell history exposure via `--api-key`); (2) **process → vendor** — TLS transport, key in a request header, bounded response handling; (3) **process → output sinks** — attacker-or-third-party-controlled PII (names, titles, company, email, phone) crossing into a terminal or a PII file.
+
+### STRIDE applied
+
+| Threat | Apollo/Lusha-specific vector | Control |
+| --- | --- | --- |
+| **Spoofing** | Endpoint impersonating the vendor to harvest the API key | TLS verification (default; never `InsecureSkipVerify`); pin scheme `https`; no redirect following (reuse `NewEnumHTTPClient`, `httpclient.go:51`) |
+| **Tampering** | MITM altering response, or a hostile/oversized body to OOM the process | TLS + bounded read `enum.ReadResponseBody` on **every** call (P0-3) |
+| **Repudiation** | Out of scope — single-operator CLI, not a shared service. No audit trail (YAGNI). | Documented as accepted non-control |
+| **Information Disclosure** | (a) API key leaking into errors / verbose / `httputil.DumpRequest` (header capture) / process list. (b) Personal emails + phones written to a world-readable `-o` file. (c) ANSI-laced PII fields manipulating the operator's terminal. | P0-1 (key-free logging), P0-1c (no request dumping), P0-4 (terminal sanitization), P1-PII (file perms) |
+| **Denial of Service** | (a) Hostile oversized response. (b) The tool tripping vendor 429s and locking the operator's paid account. | Bounded read; surface 429 as actionable error, **no silent auto-retry** (P0-5) |
+| **Elevation of Privilege** | N/A for a standalone CLI. The real "escalation" is **credit/cost escalation** — Apollo `--reveal` and Lusha enrich spend money. | P0-6 (Apollo `--reveal` opt-in), P0-7 (cost notice + bounded `--limit`) |
+
+### Highest-value assets (ranked)
+1. **The API key** (`APOLLO_API_KEY` / `LUSHA_API_KEY`) — long-lived, reusable, grants full paid API access + spends credits. Single most sensitive value.
+2. **Returned PII** (personal emails, phone numbers, DNC status) — privacy liability **and** a paid resource the operator already spent credits on.
+3. **Credit balance** — finite, paid; a 10k-contact reveal loop is a real-money DoS against the operator.
+
+### Note on the header-vs-query-string key (Apollo/Lusha are safer than Hunter here)
+Hunter places `api_key` in the URL query string because its API contract requires it (`hunter.go:171-179`), which is why Hunter's mitigation is "never log the full URL." **Apollo (`X-Api-Key`) and Lusha (`api_key`) send the key in a request header instead — strictly better**, because the key cannot land in proxy access logs or `Referer` headers. The leak vector shifts: the danger for header-based auth is any helper that dumps the full request (`httputil.DumpRequest`/`DumpResponse`), which captures headers. Hence **P0-1c** below explicitly forbids request dumping.
+
+---
+
+## 2. Required Security Controls
+
+Legend: **P0 = must implement before merge.** **P1 = should implement; flag in review if skipped.** "Service" = `apollo` and `lusha` each get their own copy of the named symbol (`resolveApolloAPIKey`/`resolveLushaAPIKey`, etc.) — no premature shared abstraction (Rule of Three not met; KISS).
+
+### 2.1 Credential handling (P0-1 family)
+
+| ID | Pri | Control | Implementation (exact code locations the developer will create) |
+| --- | --- | --- | --- |
+| **P0-1** | P0 | **API key NEVER logged.** No key substring in any error, verbose line, or stderr notice. | `classifyApolloError` / `classifyLushaError` (new, in `cmd/brutus/cmd_enum_apollo.go` / `cmd_enum_lusha.go`) return only status-derived static text — mirror `classifyHunterError` (`cmd_enum_hunter.go:128-139`). `logVerbose` lines reference **counts/page/status only**, mirroring `cmd_enum_hunter.go:103-105`. |
+| **P0-1b** | P0 | **Key stored in unexported struct field only.** | `apollo.Client` / `lusha.Client` hold `apiKey string` (lowercase, unexported), mirroring `hunter.Client` (`hunter.go:99-104`). No getters, no JSON tags on it. |
+| **P0-1c** | P0 | **No full-request dumping.** Because the key rides in a header (`X-Api-Key` / `api_key`), `httputil.DumpRequest`/`DumpResponse` would capture it. | Forbid `httputil.Dump*` anywhere in `pkg/enum/apollo/` and `pkg/enum/lusha/`. The error path logs status code + endpoint name only. Set the auth header inline in the per-request builder (mirror how Hunter builds requests in `fetchPage`, `hunter.go:171-189`, but via `req.Header.Set("X-Api-Key", c.apiKey)` / `req.Header.Set("api_key", c.apiKey)` — never in the URL). |
+| **P0-1d** | P0 | **`--api-key` flag help carries the process-list/history warning.** | Flag registration in each command's `init()` must use the warning string exactly as `cmd_enum_hunter.go:61-62` does. Document `APOLLO_API_KEY` / `LUSHA_API_KEY` as the preferred default in `Long:`/`Example:` text. Resolution precedence flag→env→key-free error via `resolveApolloAPIKey`/`resolveLushaAPIKey` (mirror `resolveHunterAPIKey`, `cmd_enum_hunter.go:117-125`). |
+| **P1-1** | P1 | **No credential-zeroing routine.** | Go strings are immutable / GC-copyable; zeroing is theatre for a short-lived CLI. Deliberate non-control (KISS). Do not write `Zero()`. |
+
+#### P0-1 enforcement — the mandatory negative test (each service MUST pass)
+Extend the existing pattern at `cmd_enum_hunter_test.go:109-110`. For **each** service, a table-driven test feeds a sentinel API key value through both the error classifier and the verbose-logging path and asserts the key never appears:
+
+```go
+// cmd/brutus/cmd_enum_apollo_test.go  (and _lusha_test.go, mutatis mutandis)
+const sentinelKey = "SECRETKEY-DO-NOT-LEAK-abc123"
+
+func TestClassifyApolloError_NoKeyLeak(t *testing.T) {
+    cases := []error{
+        &apollo.APIError{StatusCode: 401, Details: sentinelKey}, // vendor echoed key into body
+        &apollo.APIError{StatusCode: 429, Details: "rate limit"},
+        &apollo.APIError{StatusCode: 403, Details: "forbidden"},
+        &apollo.APIError{StatusCode: 422, Details: "bad params"},
+        fmt.Errorf("wrapped: %w", &apollo.APIError{StatusCode: 500, Details: sentinelKey}),
+    }
+    for _, in := range cases {
+        out := classifyApolloError(in).Error()
+        assert.NotContains(t, out, sentinelKey)       // key never surfaces
+        assert.NotContains(t, out, "X-Api-Key")        // header name not echoed
+    }
+}
+```
+
+Plus a verbose-path assertion: capture stderr while `runEnumApollo` logs at `--verbose`, and `assert.NotContains(t, stderr, sentinelKey)`. The crucial twist vs. Hunter: include the case where the **vendor echoes the key back in the error body** (`Details: sentinelKey`) — the classifier must NOT pass vendor `Details` through verbatim; it returns its own static message.
+
+### 2.2 HTTP request / response security (P0-3, P0-5)
+
+| ID | Pri | Control | Implementation |
+| --- | --- | --- | --- |
+| **P0-3** | P0 | **Bounded read on EVERY call.** | `enum.ReadResponseBody(resp, 0)` (1 MB cap, `httpclient.go:60-65`) for **every** HTTP response: Apollo `mixed_people/api_search` (search), Apollo `people/match` (each reveal), Lusha `v3/contacts/search-and-enrich`, Lusha `v3/contacts/enrich`. Never `io.ReadAll(resp.Body)` directly. Mirror `hunter.go:193`. If a legitimate search page can exceed 1 MB (Apollo `per_page` ≤100 — unlikely), pass an explicit higher cap; never uncapped. |
+| **P0-3b** | P0 | **HTTPS-only + reuse the safe client.** | Build via `enum.NewEnumHTTPClient(timeout)` in each `NewClient` (mirror `hunter.go:114`). Assert base URL scheme is `https` and host is the expected vendor host so a typo/config can't downgrade to plaintext. |
+| **P0-5** | P0 | **429 surfaces as an actionable error; no silent auto-retry.** A paid account can be locked by aggressive retries. | Map 429 → `ErrRateLimited` sentinel (mirror `hunter.go:35` + `APIError.Unwrap` `hunter.go:82-92`). `classifyXError` returns "rate limit exceeded — wait and retry, or lower --limit" (mirror `cmd_enum_hunter.go:132-133`). **No retry loop.** Lusha rate-limit headers (`x-rate-limit-daily`, `x-daily-requests-left`) are read for `--verbose` display **only**, never for flow control. |
+
+### 2.3 Untrusted-data / output security (P0-4)
+
+Apollo and Lusha return attacker-or-third-party-controlled strings: `name`, `first_name`, `last_name`, `title`/`jobTitle`, `organization`/`company`, `email`, `phone`, `seniority`, `department`. Any of these can carry ANSI/VT100 escape sequences → terminal injection (cursor manipulation, fake prompts, clipboard hijack on some terminals).
+
+| ID | Pri | Control | Implementation |
+| --- | --- | --- | --- |
+| **P0-4** | P0 | **Every API-sourced string in HUMAN output passes through `sanitizeTerminal()` then `truncate()`.** | In `outputApolloHuman` / `outputLushaHuman` (new, in `cmd/brutus/cmd_enum_output.go`), wrap **every** vendor field exactly as `outputHunterHuman` does (the Hunter human formatter at `cmd_enum_output.go:385-460` wraps each field in `sanitizeTerminal(...)` then `truncate(...)`). This explicitly includes `email` and `phone` — they are vendor-controlled too. |
+| **P0-4b** | P0 | **Do NOT sanitize JSONL output.** | `encoding/json` already escapes control chars into `\uXXXX` (documented at `cmd_enum_output.go:303-305`), so JSONL is safe and must stay byte-faithful for downstream tooling. `outputApolloJSONL` / `outputLushaJSONL` rely on `encoding/json` + `omitempty` only — mirror `outputHunterJSONL` (`cmd_enum_output.go:385-460`). Sanitizing JSON would corrupt legitimate data. |
+
+#### P0-4 enforcement — mandatory test
+A test feeding an ANSI-laced value through the human formatter for **each** service, mirroring `TestSanitizeTerminal` (`cmd_enum_hunter_test.go:270-329`):
+
+```go
+result := &apollo.Result{People: []apollo.Person{{
+    Name:    "Eve\x1b[2J\x1b[31mPwned",
+    Title:   "CEO\x1b]0;hijack\x07",
+    Email:   "eve@evil\x1b[1m.com",
+}}}
+var buf bytes.Buffer
+outputApolloHuman(&buf, result, false)
+out := buf.String()
+assert.NotContains(t, out, "\x1b")  // no ESC survives to the terminal
+```
+
+### 2.4 PII / compliance handling (P0-DNC, P0-ToS)
+
+These APIs return personal emails + phone numbers; Lusha additionally returns a **Do-Not-Call (DNC)** flag per phone. Apollo personal-email reveal and Lusha contact enrichment are deliberate PII-pulling operations in an authorized engagement.
+
+| ID | Pri | Control | Implementation |
+| --- | --- | --- | --- |
+| **P0-DNC** | P0 | **Surface the Lusha DNC flag — never hide or drop it.** Suppressing a DNC flag could lead an operator to contact a number they must not. | Map the per-phone `doNotCall` field into the `lusha.Phone` struct; render it in `outputLushaHuman` (e.g. a `DNC` column / `[DNC]` marker) and include it in `outputLushaJSONL` (`"do_not_call": true`, **not** `omitempty` when true — but a plain bool with `omitempty` drops `false`, which is acceptable since absence = not-flagged; document this). Field name is UNVERIFIED per discovery §3 — isolate in the struct, flag for live-key check. |
+| **P1-PII** | P1 | **No local persistence beyond the user's `-o` file; restrict its perms.** | Do NOT write any cache/temp/history file. The only PII sink is the operator-chosen `-o` path via the existing `setupOutputWriter` (used by Hunter at `cmd_enum_hunter.go:80`). Confirm `setupOutputWriter` creates files `0600`; if it creates world-readable files, raise as a finding and match/raise existing behavior rather than special-casing — do not fork output handling. |
+| **P0-ToS** | P0 | **One-line authorized-use / ToS note in each command's help.** Apollo and Lusha ToS restrict use to authorized, contractually-permitted purposes. | Add a single line to each `Long:` help text (mirror `enumHunterCmd.Long` structure, `cmd_enum_hunter.go:41-46`): e.g. *"You are responsible for ensuring your use complies with the provider's Terms of Service and that you have authorization to enumerate the targeted individuals/organizations."* If a vendor returns a legal-block status (HTTP 451-equivalent), define an `ErrLegalReasons` sentinel like `hunter.go:36`. |
+
+**GDPR / CCPA context (brief, no over-engineering):** personal emails and phone numbers are personal data under GDPR (lawful-basis / data-minimization obligations sit with the operator and the engagement's legal authorization) and personal information under CCPA. The CLI's role is correctly limited to (a) not persisting beyond the user's explicit `-o` file (P1-PII), (b) surfacing DNC so the operator can honor suppression (P0-DNC), and (c) the authorized-use note (P0-ToS). Building consent-tracking, retention timers, or data-subject tooling into a pentest CLI would be scope creep (YAGNI) — those are engagement/process controls, not CLI controls. Document this boundary; do not implement it.
+
+### 2.5 Cost / abuse controls (paid credits — P0-6, P0-7)
+
+| ID | Pri | Control | Implementation |
+| --- | --- | --- | --- |
+| **P0-6** | P0 | **Apollo: paid reveal is explicit opt-in via `--reveal` (default off).** Apollo `mixed_people/api_search` is FREE and returns no email/phone; `people/match` with `reveal_personal_emails` spends credits + returns PII. The default path must spend **zero** credits. | Gate the `people/match` call behind `--reveal` (default `false`), mirroring ZoomInfo `--enrich` (zoominfo assessment P0-6). Keep search and reveal as **distinct client methods** (`apollo.Client.Search` vs `apollo.Client.Reveal`) so the free path can never accidentally call the paid one. **Lusha note:** Lusha enrichment is *always* paid (it has no free tier — that is the command's entire purpose), so Lusha needs **no** gate flag; the cost notice (P0-7) is unconditional instead. |
+| **P0-7** | P0 | **Stderr cost notice before any spend.** Operator must see that credits are about to be consumed. | Before issuing paid calls — Apollo when `--reveal` is set, Lusha always — print a one-line stderr notice (suppressed under `--quiet`/`--json`, mirroring the stderr-gating at `cmd_enum_hunter.go:92-95`): e.g. *"Revealing N contacts via Apollo people/match — this consumes paid credits."* State the count N (= number to be revealed after `--limit` is applied) so the operator sees the magnitude before it happens. |
+| **P0-8** | P0 | **Bounded default `--limit` to prevent a credit blowout.** Without a cap, a domain with 10k people × `--reveal` = a 10k-credit drain in one command. | `--limit` flag (default **25**, per discovery §5 recommendation) caps the number of contacts revealed/enriched. For Apollo, `--limit` bounds how many discovered `id`s are passed to `people/match`. Make the default conservative and document that raising it raises spend. (Note: Hunter's `--limit` is a *page size*, `cmd_enum_hunter.go:63`; here `--limit` is a *spend cap* — different semantics, document clearly in help text to avoid operator confusion.) |
+| **P1-2** | P1 | **`--dry-run` for the paid path:** report how many contacts *would* be revealed/enriched (and thus credits spent) without spending. | Cheap, high operator value, prevents surprise drain. Recommended, not blocking. |
+
+### 2.6 Apollo phone-via-webhook — confirmed OUT of scope, and that is the secure choice
+
+Discovery §2 establishes Apollo delivers phone numbers **asynchronously via a `webhook_url`**, not in the `people/match` response. **Avoiding `reveal_phone_number`/`webhook_url` is both the simpler and the more secure design**, and the assessment affirms it as a deliberate security decision, not just a feature cut:
+
+- **No inbound listener.** A CLI that registered a `webhook_url` would have to either stand up a local HTTP server (inbound attack surface on the operator's host: unauthenticated POST endpoint, port exposure, firewall implications) or rely on a third-party relay (the relay then sees the operator's harvested phone data — a new disclosure boundary).
+- **No SSRF / callback surface.** Supplying a server-controlled `webhook_url` to Apollo and processing whatever Apollo (or anything spoofing it) POSTs back introduces an unauthenticated-callback / SSRF-adjacent surface with no authentication of the caller. A short-lived CLI cannot validate webhook authenticity meaningfully.
+- **Decision recorded:** Apollo v1 reveals **emails only** (`reveal_personal_emails`). Phone is out of scope (YAGNI + attack-surface reduction). If phone is ever needed, it is a separate design requiring an authenticated callback channel — not an incremental flag.
+
+---
+
+## 3. FOLLOW / AVOID (verified patterns)
+
+### FOLLOW
+- **Credential resolution:** copy `resolveHunterAPIKey` (`cmd_enum_hunter.go:117-125`) → `resolveApolloAPIKey` / `resolveLushaAPIKey`. Flag → env → key-free error.
+- **HTTP client:** `enum.NewEnumHTTPClient(timeout)` (`httpclient.go:48`) inside each `NewClient`. Never a bare `http.Client`.
+- **Bounded read:** `enum.ReadResponseBody(resp, 0)` (`httpclient.go:60`) on every response.
+- **Typed sentinels + `Unwrap()`:** `apollo.APIError`/`lusha.APIError` with `ErrUnauthorized`/`ErrRateLimited`/`ErrForbidden`/`ErrBadRequest` (+ `ErrNoCredits` for Lusha 402/quota per discovery §3) — mirror `hunter.go:32-92`. Classify in the command layer (`classifyXError`).
+- **Terminal sanitization in human output:** wrap every field in `sanitizeTerminal()` then `truncate()` (`outputHunterHuman` pattern, `cmd_enum_output.go:385-460`).
+- **Raw JSONL:** rely on `encoding/json` + `omitempty`; no manual sanitization (`outputHunterJSONL`).
+- **Key-free verbose logging:** `logVerbose(flagVerbose, "...counts...")` (`cmd_enum_hunter.go:104`).
+- **Stderr gating:** `if !flagQuiet && !flagJSON { ... stderr ... }` (`cmd_enum_hunter.go:92-95`) — applies to the cost notice too.
+- **Signal-aware context:** `signal.NotifyContext` (`cmd_enum_hunter.go:89`) — ctrl-C must cleanly abort a multi-page / multi-reveal run between requests.
+
+### AVOID
+- **Do NOT** put the API key in a URL query string — Apollo/Lusha use headers (`X-Api-Key` / `api_key`); keep it there so it can't reach proxy logs.
+- **Do NOT** use `httputil.DumpRequest`/`DumpResponse` — captures the auth header (P0-1c).
+- **Do NOT** pass the vendor's error `Details` body straight into a user-facing error — the vendor may echo the key; return your own static message (P0-1).
+- **Do NOT** `io.ReadAll(resp.Body)` directly — always the bounded reader (P0-3).
+- **Do NOT** auto-retry 429 — surface it; protect the operator's paid account (P0-5).
+- **Do NOT** spend credits on any default path; Apollo reveal is opt-in (P0-6), Lusha enrich announces cost (P0-7).
+- **Do NOT** register a `webhook_url` / open an inbound listener for Apollo phone (§2.6).
+- **Do NOT** hide the Lusha DNC flag (P0-DNC).
+- **Do NOT** extract a premature "HUMINT provider" interface (Rule of Three not met; KISS) or add credential-zeroing (P1-1).
+- **Do NOT** persist PII anywhere except the operator's `-o` file (P1-PII).
+
+---
+
+## 4. Required tests (enforced by tester/reviewer)
+
+| Test | Asserts | Per |
+| --- | --- | --- |
+| `TestClassifyXError_NoKeyLeak` (incl. vendor-echoes-key-in-body case) | key + header name never appear in any classified error (extends `cmd_enum_hunter_test.go:109-110`) | apollo, lusha |
+| Verbose-path no-leak | sentinel key absent from captured stderr at `--verbose` | apollo, lusha |
+| `TestOutputXHuman` ANSI injection | no `\x1b` survives to human output (extends `TestSanitizeTerminal`) | apollo, lusha |
+| `TestOutputXJSONL` | valid JSON, `omitempty` drops blanks, byte-faithful (no sanitization) | apollo, lusha |
+| Apollo default-path-no-spend | default (no `--reveal`) never calls `people/match` (httptest server records hits) | apollo |
+| Cost-notice emitted | stderr contains the credit notice before paid call; suppressed under `--quiet`/`--json` | apollo (on `--reveal`), lusha (always) |
+| `--limit` spend cap | with N>limit discovered, exactly `limit` reveal/enrich calls are made | apollo, lusha |
+| DNC surfaced | `doNotCall` value appears in both human and JSONL output | lusha |
+
+`go test ./...` must pass; `go test -race` only if any concurrency is introduced (default design is sequential, like Hunter — no race surface).
+
+---
+
+## 5. Verdict
+
+**APPROVED to proceed to implementation, conditioned on all P0 controls landing in the plan and the §4 tests enforced.** The Hunter.io integration supplies verified, secure primitives that cover P0-1 (key-free logging), P0-3 (bounded read), and P0-4 (terminal sanitization) directly via reuse. Apollo/Lusha are **lower** net-new risk than ZoomInfo (single API key each, header-based auth, no PKI/JWT lifecycle). The Apollo/Lusha-specific P0 deltas the Hunter template does not cover are: **P0-1c** (no request dumping — header leak vector), **P0-5** (429 no-auto-retry to protect a paid account), **P0-6/P0-7/P0-8** (Apollo reveal opt-in + unconditional Lusha cost notice + bounded `--limit` spend cap), **P0-DNC** (surface Lusha DNC), and **P0-ToS** (authorized-use note). Apollo phone-via-webhook is correctly out of scope and its avoidance is affirmed as the secure choice (no inbound/SSRF surface, §2.6).
+
+**Handoff:** `backend-developer` — implement two independent subcommands following the Hunter.io template (`pkg/enum/hunter/hunter.go`, `cmd/brutus/cmd_enum_hunter.go`, `cmd/brutus/cmd_enum_output.go`) with the §2 controls. `sanitizeTerminal`/`truncate` live in `cmd_enum_output.go:306-381`; reuse `enum.ReadResponseBody` and `enum.NewEnumHTTPClient` from `pkg/enum/httpclient.go`. Field names in Lusha v3 responses (incl. DNC) are unverified — isolate in structs and confirm against a live key.
+
+---
+
+## Metadata
+
+```json
+{
+  "agent": "security-lead",
+  "output_type": "security-architecture",
+  "timestamp": "2026-06-25T00:00:00Z",
+  "feature_directory": "/Users/engineer/github/brutus/.worktrees/apollo-lusha-enum/.feature-development",
+  "skills_invoked": [
+    "using-skills",
+    "focusing-on-the-goal",
+    "enforcing-evidence-based-analysis",
+    "gateway-security",
+    "persisting-agent-outputs",
+    "verifying-before-completion",
+    "using-todowrite"
+  ],
+  "library_skills_read": [
+    "/Users/engineer/.claude/plugins/cache/praetorian-ai-marketplace/engineering/1.38.17/skill-library/security/secrets-management/SKILL.md",
+    "/Users/engineer/.claude/plugins/cache/praetorian-ai-marketplace/engineering/1.38.17/skill-library/security/reviewing-backend-security/SKILL.md"
+  ],
+  "source_files_verified": [
+    "pkg/enum/httpclient.go:28-65",
+    "pkg/enum/hunter/hunter.go:32-213",
+    "cmd/brutus/cmd_enum_hunter.go:30-139",
+    "cmd/brutus/cmd_enum_output.go:299-381",
+    "cmd/brutus/cmd_enum_hunter_test.go:33-352",
+    ".worktrees/apollo-lusha-enum/.feature-development/discovery.md:1-132",
+    ".worktrees/zoominfo-enum/.feature-development/security-assessment.md:1-219"
+  ],
+  "status": "complete",
+  "handoff": {
+    "next_agent": "backend-developer",
+    "context": "Implement apollo + lusha enum subcommands following Hunter.io template with all P0 controls (P0-1 key-free logging incl. P0-1c no httputil.Dump request dumping since key is in a header; P0-3 bounded read on every call; P0-4 terminal sanitization on every human field incl. email/phone; P0-5 429 no-auto-retry; P0-6 Apollo --reveal opt-in; P0-7 stderr cost notice before spend, unconditional for Lusha; P0-8 bounded --limit default 25 spend cap; P0-DNC surface Lusha DNC flag; P0-ToS authorized-use note in Long help). Apollo phone-via-webhook OUT of scope (no inbound/SSRF surface). sanitizeTerminal/truncate at cmd_enum_output.go:306-381. Required negative test: sentinel key never appears in classifier output or verbose stderr, including the vendor-echoes-key-in-body case."
+  }
+}
+```

--- a/cmd/brutus/cmd_enum.go
+++ b/cmd/brutus/cmd_enum.go
@@ -46,6 +46,8 @@ Subcommands:
   hunter     Discover people and emails via Hunter.io Domain Search
   dehashed   Collect breach-exposed identity data for a domain via DeHashed
   teams      Authenticate with Microsoft Entra ID via device code flow
+  apollo     Discover people/emails for a domain via Apollo.io (opt-in --reveal enrichment)
+  lusha      Enrich a single contact (email/phone) via Lusha
 
 See subcommand help for details:
   brutus enum oracles --help
@@ -53,7 +55,9 @@ See subcommand help for details:
   brutus enum generate --help
   brutus enum hunter --help
   brutus enum dehashed --help
-  brutus enum teams --help`,
+  brutus enum teams --help
+  brutus enum apollo --help
+  brutus enum lusha --help`,
 	Example: `  # Account-existence oracle enumeration
   brutus enum oracles --domain praetorian.com -e test@praetorian.com --known-valid admin@praetorian.com
 
@@ -68,6 +72,12 @@ See subcommand help for details:
 
   # Collect breach-exposed identity data via DeHashed
   brutus enum dehashed --domain example.com
+
+  # Discover people via Apollo.io
+  brutus enum apollo --domain example.com
+
+  # Enrich a contact via Lusha
+  brutus enum lusha --first-name Jane --last-name Doe --company "Example Inc"
 
   # Authenticate with Microsoft Entra ID via device code
   brutus enum teams auth --tenant contoso.com`,
@@ -124,6 +134,8 @@ func init() {
 	enumCmd.AddCommand(enumDehashedCmd)
 	enumCmd.AddCommand(enumCustomCmd)
 	enumCmd.AddCommand(enumTeamsCmd)
+	enumCmd.AddCommand(enumApolloCmd)
+	enumCmd.AddCommand(enumLushaCmd)
 }
 
 // runEnumGenerate handles the "enum generate" subcommand.

--- a/cmd/brutus/cmd_enum_apollo.go
+++ b/cmd/brutus/cmd_enum_apollo.go
@@ -84,6 +84,15 @@ func runEnumApollo(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--domain/-d is required")
 	}
 
+	// Bound credit spend: reject a negative cap outright, and reject an unbounded
+	// cap (0 = no cap) combined with --reveal (which spends credits per person).
+	if flagApolloLimit < 0 {
+		return fmt.Errorf("--limit must be >= 0")
+	}
+	if flagApolloReveal && flagApolloLimit == 0 {
+		return fmt.Errorf("--reveal requires a positive --limit to bound credit spend")
+	}
+
 	apiKey, err := resolveApolloAPIKey(flagApolloAPIKey)
 	if err != nil {
 		return err
@@ -106,9 +115,28 @@ func runEnumApollo(cmd *cobra.Command, args []string) error {
 			dim(useColor, SymbolInfo), flagApolloDomain)
 	}
 
+	emitResult := func(result *apollo.DomainResult) {
+		if result == nil {
+			return
+		}
+		// Verbose: log counts only — never log the key or URL (P0-1 security requirement).
+		logVerbose(flagVerbose, "Apollo returned %d people (total available: %d, revealed: %t)",
+			len(result.People), result.Total, result.Revealed)
+		if flagJSON {
+			outputApolloJSONL(jsonWriter, result)
+		} else {
+			outputApolloHuman(os.Stdout, result, useColor)
+		}
+	}
+
 	client := apollo.NewClient(apiKey, flagTimeout, pageSizeForLimit(flagApolloLimit))
 	result, err := client.SearchPeople(ctx, flagApolloDomain, flagApolloTitles, flagApolloLimit)
 	if err != nil {
+		// Output any partial discovery (SearchPeople returns partial + err) before
+		// surfacing the classified, nonzero-exit error — discovered contacts are free.
+		if result != nil && len(result.People) > 0 {
+			emitResult(result)
+		}
 		return classifyApolloError(err)
 	}
 
@@ -118,19 +146,16 @@ func runEnumApollo(cmd *cobra.Command, args []string) error {
 				dim(useColor, SymbolInfo), len(result.People))
 		}
 		if err := client.RevealEmails(ctx, result); err != nil {
+			// Output the partial result (emails merged so far are paid for) before
+			// surfacing the classified, nonzero-exit error.
+			if len(result.People) > 0 {
+				emitResult(result)
+			}
 			return classifyApolloError(err)
 		}
 	}
 
-	// Verbose: log counts only — never log the key or URL (P0-1 security requirement).
-	logVerbose(flagVerbose, "Apollo returned %d people (total available: %d, revealed: %t)",
-		len(result.People), result.Total, result.Revealed)
-
-	if flagJSON {
-		outputApolloJSONL(jsonWriter, result)
-	} else {
-		outputApolloHuman(os.Stdout, result, useColor)
-	}
+	emitResult(result)
 	return nil
 }
 
@@ -147,10 +172,10 @@ func resolveApolloAPIKey(flagValue string) (string, error) {
 }
 
 // classifyApolloError converts apollo sentinel errors into actionable, key-free
-// messages. It returns ONLY static, status-derived text and NEVER includes the
-// vendor APIError.Details — which can echo the request body or even the key back
-// (P0-1). The default branch therefore reports the HTTP status code alone (never
-// %w-wrapping the underlying error, whose Error() embeds Details).
+// messages. For *APIError it returns ONLY status-derived text and NEVER includes
+// the vendor APIError.Details — which can echo the request body or even the key
+// back (P0-1). For non-API errors (network/DNS/timeout — no vendor details) it
+// %w-wraps the cause to preserve debuggability.
 func classifyApolloError(err error) error {
 	switch {
 	case errors.Is(err, apollo.ErrUnauthorized):
@@ -163,12 +188,15 @@ func classifyApolloError(err error) error {
 		return fmt.Errorf("apollo: rate limit exceeded — wait and retry, or lower --limit")
 	}
 	// Unknown error. If it carries an *APIError, report only its status code —
-	// never its Details (P0-1). Otherwise report a generic, key-free message.
+	// never its Details (P0-1); APIError.Error() is now status-only, but we keep
+	// the explicit status-code text here regardless. Otherwise (network/DNS/
+	// timeout — no vendor details) %w-wrap it to preserve debuggability, matching
+	// classifyHunterError.
 	var apiErr *apollo.APIError
 	if errors.As(err, &apiErr) {
 		return fmt.Errorf("apollo people search failed (HTTP %d)", apiErr.StatusCode)
 	}
-	return fmt.Errorf("apollo people search failed")
+	return fmt.Errorf("apollo people search failed: %w", err)
 }
 
 // pageSizeForLimit derives the people-search per_page from --limit: min(limit, 100),

--- a/cmd/brutus/cmd_enum_apollo.go
+++ b/cmd/brutus/cmd_enum_apollo.go
@@ -1,0 +1,186 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/spf13/cobra"
+
+	"github.com/praetorian-inc/brutus/pkg/enum/apollo"
+)
+
+// File-local flag variables for the apollo subcommand.
+// Separate from flagEnumDomain to avoid cross-command state bleed.
+var (
+	flagApolloDomain string
+	flagApolloTitles []string
+	flagApolloReveal bool
+	flagApolloLimit  int
+	flagApolloAPIKey string
+)
+
+var enumApolloCmd = &cobra.Command{
+	Use:   "apollo",
+	Short: "Discover people for a domain via Apollo.io, optionally revealing emails",
+	Long: `Query the Apollo.io people-search API to discover people associated with a
+company domain: id, name, job title, seniority, department, and organization.
+Discovery is free and returns no email/phone. With --reveal, emails are looked
+up per person via the people/match API — this CONSUMES APOLLO CREDITS, bounded
+by --limit. Standalone — does not feed the saas enumeration pipeline.
+
+Authorized use only: respect Apollo.io's Terms of Service and only enumerate
+domains you are authorized to assess.
+
+Requires an Apollo.io API key via the APOLLO_API_KEY environment variable
+(or the --api-key flag).`,
+	Example: `  # Discover people for a domain — free, no emails (key from APOLLO_API_KEY)
+  brutus enum apollo --domain example.com
+
+  # Filter by job titles
+  brutus enum apollo -d example.com --titles "VP Engineering" --titles "CTO"
+
+  # Reveal emails for the discovered people (CONSUMES CREDITS, bounded by --limit)
+  brutus enum apollo -d example.com --reveal --limit 100
+
+  # Provide the key explicitly (note: visible in process list / shell history)
+  brutus enum apollo -d example.com --api-key abc123`,
+	RunE: runEnumApollo,
+}
+
+func init() {
+	f := enumApolloCmd.Flags()
+	f.StringVarP(&flagApolloDomain, "domain", "d", "", "Company domain to discover people for (required)")
+	f.StringSliceVar(&flagApolloTitles, "titles", nil, "Optional job-title filter (repeatable or comma-separated)")
+	f.BoolVar(&flagApolloReveal, "reveal", false, "Reveal emails for discovered people via people/match (CONSUMES CREDITS, bounded by --limit)")
+	f.IntVar(&flagApolloLimit, "limit", 100, "Max people to return AND max to reveal (bounds credit spend; 0 = no cap)")
+	f.StringVar(&flagApolloAPIKey, "api-key", "",
+		"Apollo.io API key (overrides APOLLO_API_KEY; WARNING: visible in process list and shell history — prefer APOLLO_API_KEY)")
+	_ = enumApolloCmd.MarkFlagRequired("domain")
+}
+
+// runEnumApollo implements the "enum apollo" subcommand.
+func runEnumApollo(cmd *cobra.Command, args []string) error {
+	useColor := isColorEnabled(flagNoColor)
+
+	if flagApolloDomain == "" {
+		return fmt.Errorf("--domain/-d is required")
+	}
+
+	apiKey, err := resolveApolloAPIKey(flagApolloAPIKey)
+	if err != nil {
+		return err
+	}
+
+	jsonWriter, forceJSON, closeOutput, err := setupOutputWriter(flagOutputFile)
+	if err != nil {
+		return err
+	}
+	defer closeOutput()
+	if forceJSON {
+		flagJSON = true
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if !flagQuiet && !flagJSON {
+		fmt.Fprintf(os.Stderr, "%s Querying Apollo.io people search for %s...\n",
+			dim(useColor, SymbolInfo), flagApolloDomain)
+	}
+
+	client := apollo.NewClient(apiKey, flagTimeout, pageSizeForLimit(flagApolloLimit))
+	result, err := client.SearchPeople(ctx, flagApolloDomain, flagApolloTitles, flagApolloLimit)
+	if err != nil {
+		return classifyApolloError(err)
+	}
+
+	if flagApolloReveal {
+		if !flagQuiet && !flagJSON && len(result.People) > 0 {
+			fmt.Fprintf(os.Stderr, "%s --reveal will consume Apollo credits for %d people\n",
+				dim(useColor, SymbolInfo), len(result.People))
+		}
+		if err := client.RevealEmails(ctx, result); err != nil {
+			return classifyApolloError(err)
+		}
+	}
+
+	// Verbose: log counts only — never log the key or URL (P0-1 security requirement).
+	logVerbose(flagVerbose, "Apollo returned %d people (total available: %d, revealed: %t)",
+		len(result.People), result.Total, result.Revealed)
+
+	if flagJSON {
+		outputApolloJSONL(jsonWriter, result)
+	} else {
+		outputApolloHuman(os.Stdout, result, useColor)
+	}
+	return nil
+}
+
+// resolveApolloAPIKey returns the flag value if set, else APOLLO_API_KEY env var.
+// The key is never logged (P0-1 security requirement).
+func resolveApolloAPIKey(flagValue string) (string, error) {
+	if flagValue != "" {
+		return flagValue, nil
+	}
+	if key := os.Getenv("APOLLO_API_KEY"); key != "" {
+		return key, nil
+	}
+	return "", fmt.Errorf("apollo API key required: set APOLLO_API_KEY or pass --api-key")
+}
+
+// classifyApolloError converts apollo sentinel errors into actionable, key-free
+// messages. It returns ONLY static, status-derived text and NEVER includes the
+// vendor APIError.Details — which can echo the request body or even the key back
+// (P0-1). The default branch therefore reports the HTTP status code alone (never
+// %w-wrapping the underlying error, whose Error() embeds Details).
+func classifyApolloError(err error) error {
+	switch {
+	case errors.Is(err, apollo.ErrUnauthorized):
+		return fmt.Errorf("apollo: invalid or missing API key (check APOLLO_API_KEY / --api-key)")
+	case errors.Is(err, apollo.ErrForbidden):
+		return fmt.Errorf("apollo: access forbidden — your plan or permissions do not allow this request")
+	case errors.Is(err, apollo.ErrBadRequest):
+		return fmt.Errorf("apollo: invalid request parameters (check --domain and --titles)")
+	case errors.Is(err, apollo.ErrRateLimited):
+		return fmt.Errorf("apollo: rate limit exceeded — wait and retry, or lower --limit")
+	}
+	// Unknown error. If it carries an *APIError, report only its status code —
+	// never its Details (P0-1). Otherwise report a generic, key-free message.
+	var apiErr *apollo.APIError
+	if errors.As(err, &apiErr) {
+		return fmt.Errorf("apollo people search failed (HTTP %d)", apiErr.StatusCode)
+	}
+	return fmt.Errorf("apollo people search failed")
+}
+
+// pageSizeForLimit derives the people-search per_page from --limit: min(limit, 100),
+// or defaultPageSize (100) when limit is unbounded (0). This never requests a
+// per_page above Apollo's 100 max while --limit separately bounds the accumulated
+// total inside SearchPeople.
+func pageSizeForLimit(limit int) int {
+	if limit <= 0 {
+		return 100
+	}
+	if limit > 100 {
+		return 100
+	}
+	return limit
+}

--- a/cmd/brutus/cmd_enum_apollo_output.go
+++ b/cmd/brutus/cmd_enum_apollo_output.go
@@ -1,0 +1,135 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/praetorian-inc/brutus/pkg/enum/apollo"
+)
+
+// outputApolloHuman renders Apollo people-search results as an aligned table.
+// All attacker-controlled strings are sanitized via sanitizeTerminal (P0-4).
+// Columns adapt: preview (no emails) shows Name|Title|Dept|Org; revealed adds
+// Email|Status.
+func outputApolloHuman(w io.Writer, result *apollo.DomainResult, useColor bool) {
+	_, _ = fmt.Fprintf(w, "\n%s %s\n", dim(useColor, SymbolInfo),
+		heading(useColor, "Apollo: "+sanitizeTerminal(result.Domain)))
+	_, _ = fmt.Fprintf(w, "  People found: %d (total: %d)\n", len(result.People), result.Total)
+
+	if !result.Revealed {
+		_, _ = fmt.Fprintf(w, "  %s\n",
+			dim(useColor, "(preview — run with --reveal for emails; consumes credits)"))
+	}
+
+	if len(result.People) == 0 {
+		_, _ = fmt.Fprintf(w, "\n  %s No people found for this domain\n", dim(useColor, SymbolInfo))
+		_, _ = fmt.Fprintln(w)
+		return
+	}
+
+	if result.Revealed {
+		_, _ = fmt.Fprintf(w, "\n  %s%-28s %-22s %-12s %-22s %-32s %-10s%s\n",
+			colorIf(useColor, ColorBold),
+			"Name", "Title", "Dept", "Org", "Email", "Status",
+			colorIf(useColor, ColorReset))
+	} else {
+		_, _ = fmt.Fprintf(w, "\n  %s%-28s %-22s %-12s %-22s%s\n",
+			colorIf(useColor, ColorBold),
+			"Name", "Title", "Dept", "Org",
+			colorIf(useColor, ColorReset))
+	}
+
+	for i := range result.People {
+		p := &result.People[i]
+		name := personName(p)
+		if result.Revealed {
+			_, _ = fmt.Fprintf(w, "  %-28s %-22s %-12s %-22s %s%-32s%s %-10s\n",
+				truncate(name, 28),
+				truncate(sanitizeTerminal(p.Title), 22),
+				truncate(sanitizeTerminal(p.Department), 12),
+				truncate(sanitizeTerminal(p.Organization), 22),
+				colorIf(useColor, ColorGreen),
+				truncate(sanitizeTerminal(p.Email), 32),
+				colorIf(useColor, ColorReset),
+				truncate(sanitizeTerminal(p.EmailStatus), 10))
+		} else {
+			_, _ = fmt.Fprintf(w, "  %-28s %-22s %-12s %-22s\n",
+				truncate(name, 28),
+				truncate(sanitizeTerminal(p.Title), 22),
+				truncate(sanitizeTerminal(p.Department), 12),
+				truncate(sanitizeTerminal(p.Organization), 22))
+		}
+	}
+	_, _ = fmt.Fprintln(w)
+}
+
+// outputApolloJSONL writes one JSON object per discovered person.
+// encoding/json already escapes control characters, so no sanitization needed.
+// Preview (un-revealed) people omit email/email_status via omitempty so a
+// consumer never misreads a blank email as confirmed-absent.
+func outputApolloJSONL(w io.Writer, result *apollo.DomainResult) {
+	type apolloJSON struct {
+		Type         string `json:"type"`
+		Domain       string `json:"domain"`
+		Revealed     bool   `json:"revealed"`
+		ID           string `json:"id"`
+		Name         string `json:"name,omitempty"`
+		FirstName    string `json:"first_name,omitempty"`
+		LastName     string `json:"last_name,omitempty"`
+		Title        string `json:"title,omitempty"`
+		Seniority    string `json:"seniority,omitempty"`
+		Department   string `json:"department,omitempty"`
+		Organization string `json:"organization,omitempty"`
+		Email        string `json:"email,omitempty"`
+		EmailStatus  string `json:"email_status,omitempty"`
+	}
+
+	enc := json.NewEncoder(w)
+	for i := range result.People {
+		p := &result.People[i]
+		jr := apolloJSON{
+			Type:         "apollo",
+			Domain:       result.Domain,
+			Revealed:     p.Revealed,
+			ID:           p.ID,
+			Name:         p.Name,
+			FirstName:    p.FirstName,
+			LastName:     p.LastName,
+			Title:        p.Title,
+			Seniority:    p.Seniority,
+			Department:   p.Department,
+			Organization: p.Organization,
+			Email:        p.Email,
+			EmailStatus:  p.EmailStatus,
+		}
+		if err := enc.Encode(jr); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "Error encoding apollo JSON: %v\n", err)
+		}
+	}
+}
+
+// personName returns the sanitized display name, preferring Apollo's full Name
+// and falling back to "First Last".
+func personName(p *apollo.Person) string {
+	if p.Name != "" {
+		return sanitizeTerminal(p.Name)
+	}
+	return strings.TrimSpace(sanitizeTerminal(p.FirstName) + " " + sanitizeTerminal(p.LastName))
+}

--- a/cmd/brutus/cmd_enum_apollo_test.go
+++ b/cmd/brutus/cmd_enum_apollo_test.go
@@ -17,6 +17,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -120,6 +121,60 @@ func TestClassifyApolloError_NoKeyLeak(t *testing.T) {
 				"header name X-Api-Key must not appear in classified error")
 		})
 	}
+}
+
+// TestClassifyApolloError_NetworkWrap verifies that non-*APIError (network/DNS/
+// timeout) errors are %w-wrapped by classifyApolloError so errors.Is chains work,
+// while still not leaking any vendor details.
+func TestClassifyApolloError_NetworkWrap(t *testing.T) {
+	networkErr := errors.New("dial tcp: connection timeout")
+	result := classifyApolloError(networkErr)
+	require.Error(t, result)
+	// The network error must be wrapped (errors.Is unwraps the chain).
+	assert.True(t, errors.Is(result, networkErr),
+		"classifyApolloError must %w-wrap non-*APIError so errors.Is works")
+	// The error message must contain the original cause for debuggability.
+	assert.Contains(t, result.Error(), "timeout")
+}
+
+// ---------------------------------------------------------------------------
+// T005: runEnumApollo input validation (--limit < 0, --reveal with --limit 0)
+// ---------------------------------------------------------------------------
+
+// resetApolloFlags resets the package-level apollo flag vars to safe defaults.
+func resetApolloFlags() {
+	flagApolloDomain = "example.com"
+	flagApolloTitles = nil
+	flagApolloReveal = false
+	flagApolloLimit = 100
+	flagApolloAPIKey = ""
+}
+
+// TestRunEnumApollo_RejectsNegativeLimit asserts that --limit < 0 is rejected
+// with an actionable error before any network call is made.
+func TestRunEnumApollo_RejectsNegativeLimit(t *testing.T) {
+	resetApolloFlags()
+	flagApolloLimit = -1
+
+	err := runEnumApollo(enumApolloCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--limit",
+		"error must mention --limit so the operator knows what to fix")
+}
+
+// TestRunEnumApollo_RejectsRevealWithZeroLimit asserts that --reveal combined
+// with --limit 0 (unbounded) is rejected to prevent unbounded credit spend.
+func TestRunEnumApollo_RejectsRevealWithZeroLimit(t *testing.T) {
+	resetApolloFlags()
+	flagApolloReveal = true
+	flagApolloLimit = 0
+
+	err := runEnumApollo(enumApolloCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--reveal",
+		"error must mention --reveal so the operator understands the constraint")
+	assert.Contains(t, err.Error(), "--limit",
+		"error must mention --limit so the operator knows how to fix it")
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/brutus/cmd_enum_apollo_test.go
+++ b/cmd/brutus/cmd_enum_apollo_test.go
@@ -1,0 +1,306 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/brutus/pkg/enum/apollo"
+)
+
+// ---------------------------------------------------------------------------
+// T004: resolveApolloAPIKey + classifyApolloError (security: no key leak)
+// ---------------------------------------------------------------------------
+
+func TestResolveApolloAPIKey(t *testing.T) {
+	tests := []struct {
+		name      string
+		flagValue string
+		envValue  string
+		wantKey   string
+		wantErr   bool
+	}{
+		{
+			name:      "flag value takes priority over env",
+			flagValue: "flag-key",
+			envValue:  "env-key",
+			wantKey:   "flag-key",
+		},
+		{
+			name:      "env var used when flag is empty",
+			flagValue: "",
+			envValue:  "env-key",
+			wantKey:   "env-key",
+		},
+		{
+			name:      "error when both empty — mentions APOLLO_API_KEY",
+			flagValue: "",
+			envValue:  "",
+			wantErr:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("APOLLO_API_KEY", tc.envValue)
+			key, err := resolveApolloAPIKey(tc.flagValue)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "APOLLO_API_KEY",
+					"error message must mention APOLLO_API_KEY so the operator knows what to set")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantKey, key)
+		})
+	}
+}
+
+// sentinelKey is deliberately placed in APIError.Details to simulate a vendor
+// echoing back the API key inside an error body. classifyApolloError MUST NOT
+// surface this value in its output (P0-1 security requirement).
+const sentinelKey = "SECRETKEY-DO-NOT-LEAK-abc123"
+
+func TestClassifyApolloError_NoKeyLeak(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "401 with sentinel in Details",
+			err:  &apollo.APIError{StatusCode: 401, Details: sentinelKey},
+		},
+		{
+			name: "429 rate limited",
+			err:  &apollo.APIError{StatusCode: 429, Details: "rate limit"},
+		},
+		{
+			name: "403 forbidden",
+			err:  &apollo.APIError{StatusCode: 403, Details: "forbidden"},
+		},
+		{
+			name: "422 bad request",
+			err:  &apollo.APIError{StatusCode: 422, Details: "bad params"},
+		},
+		{
+			name: "wrapped 500 with sentinel in Details",
+			err:  fmt.Errorf("wrapped: %w", &apollo.APIError{StatusCode: 500, Details: sentinelKey}),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := classifyApolloError(tc.err).Error()
+
+			// P0-1: sentinel API key value must never appear in the output.
+			assert.NotContains(t, out, sentinelKey,
+				"API key value must never appear in classified error")
+
+			// P0-1: header name must never appear in the output either.
+			assert.NotContains(t, out, "X-Api-Key",
+				"header name X-Api-Key must not appear in classified error")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// T003 cmd: outputApolloJSONL + outputApolloHuman
+// ---------------------------------------------------------------------------
+
+func TestOutputApolloJSONL(t *testing.T) {
+	t.Run("preview person omits email field", func(t *testing.T) {
+		result := &apollo.DomainResult{
+			Domain:   "example.com",
+			Revealed: false,
+			People: []apollo.Person{
+				{
+					ID:           "p1",
+					Name:         "Alice Smith",
+					FirstName:    "Alice",
+					LastName:     "Smith",
+					Title:        "Engineer",
+					Seniority:    "senior",
+					Department:   "Engineering",
+					Organization: "ACME Corp",
+					// Email is empty — preview mode (no --reveal)
+					Revealed: false,
+				},
+			},
+			Total: 1,
+		}
+		var buf bytes.Buffer
+		outputApolloJSONL(&buf, result)
+
+		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+		require.Len(t, lines, 1, "expected exactly 1 JSONL line")
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[0]), &obj))
+
+		assert.Equal(t, "apollo", obj["type"])
+		assert.Equal(t, "example.com", obj["domain"])
+		assert.Equal(t, "p1", obj["id"])
+		assert.Equal(t, false, obj["revealed"])
+
+		// Preview mode: email must be omitted (omitempty) — not present as empty string.
+		_, hasEmail := obj["email"]
+		assert.False(t, hasEmail, "email must be omitted in preview JSONL (omitempty)")
+		_, hasEmailStatus := obj["email_status"]
+		assert.False(t, hasEmailStatus, "email_status must be omitted in preview JSONL (omitempty)")
+	})
+
+	t.Run("revealed person includes email", func(t *testing.T) {
+		result := &apollo.DomainResult{
+			Domain:   "example.com",
+			Revealed: true,
+			People: []apollo.Person{
+				{
+					ID:          "p1",
+					Name:        "Alice Smith",
+					Email:       "alice@example.com",
+					EmailStatus: "verified",
+					Revealed:    true,
+				},
+			},
+			Total: 1,
+		}
+		var buf bytes.Buffer
+		outputApolloJSONL(&buf, result)
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &obj))
+
+		assert.Equal(t, "alice@example.com", obj["email"])
+		assert.Equal(t, "verified", obj["email_status"])
+		assert.Equal(t, true, obj["revealed"])
+	})
+
+	t.Run("empty result emits zero lines", func(t *testing.T) {
+		result := &apollo.DomainResult{Domain: "empty.com"}
+		var buf bytes.Buffer
+		outputApolloJSONL(&buf, result)
+		assert.Empty(t, strings.TrimSpace(buf.String()), "empty result must produce no JSONL output")
+	})
+}
+
+func TestOutputApolloHuman(t *testing.T) {
+	t.Run("renders header and person row in preview mode", func(t *testing.T) {
+		result := &apollo.DomainResult{
+			Domain:   "example.com",
+			Revealed: false,
+			People: []apollo.Person{
+				{
+					ID:           "p1",
+					Name:         "Alice Smith",
+					Title:        "VP Engineering",
+					Department:   "Engineering",
+					Organization: "ACME Corp",
+				},
+			},
+			Total: 1,
+		}
+		var buf bytes.Buffer
+		outputApolloHuman(&buf, result, false)
+		out := buf.String()
+
+		assert.Contains(t, out, "Apollo:")
+		assert.Contains(t, out, "example.com")
+		assert.Contains(t, out, "Alice Smith")
+		assert.Contains(t, out, "VP Engineering")
+		// Preview note must appear when not revealed.
+		assert.Contains(t, out, "--reveal", "preview note must mention --reveal")
+	})
+
+	t.Run("revealed shows Email column and values", func(t *testing.T) {
+		result := &apollo.DomainResult{
+			Domain:   "example.com",
+			Revealed: true,
+			People: []apollo.Person{
+				{
+					ID:          "p1",
+					Name:        "Alice Smith",
+					Email:       "alice@example.com",
+					EmailStatus: "verified",
+					Revealed:    true,
+				},
+			},
+			Total: 1,
+		}
+		var buf bytes.Buffer
+		outputApolloHuman(&buf, result, false)
+		out := buf.String()
+
+		assert.Contains(t, out, "Email")
+		assert.Contains(t, out, "alice@example.com")
+		assert.Contains(t, out, "verified")
+	})
+
+	t.Run("empty result shows no-people message", func(t *testing.T) {
+		result := &apollo.DomainResult{Domain: "empty.com"}
+		var buf bytes.Buffer
+		outputApolloHuman(&buf, result, false)
+		out := buf.String()
+		assert.Contains(t, out, "No people found")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// T006: enumApolloCmd registration
+// ---------------------------------------------------------------------------
+
+func TestEnumApolloRegistered(t *testing.T) {
+	var found bool
+	for _, cmd := range enumCmd.Commands() {
+		if cmd.Use != "apollo" {
+			continue
+		}
+		found = true
+
+		// Required flags must exist.
+		domainFlag := cmd.Flags().Lookup("domain")
+		require.NotNil(t, domainFlag, "--domain flag must exist")
+
+		titlesFlag := cmd.Flags().Lookup("titles")
+		require.NotNil(t, titlesFlag, "--titles flag must exist")
+
+		revealFlag := cmd.Flags().Lookup("reveal")
+		require.NotNil(t, revealFlag, "--reveal flag must exist")
+
+		limitFlag := cmd.Flags().Lookup("limit")
+		require.NotNil(t, limitFlag, "--limit flag must exist")
+
+		apiKeyFlag := cmd.Flags().Lookup("api-key")
+		require.NotNil(t, apiKeyFlag, "--api-key flag must exist")
+
+		// -d shorthand must exist.
+		domainShort := cmd.Flags().ShorthandLookup("d")
+		require.NotNil(t, domainShort, "-d shorthand for --domain must exist")
+
+		// --domain must be marked required via cobra annotation.
+		annotations := domainFlag.Annotations
+		_, isRequired := annotations["cobra_annotation_bash_completion_one_required_flag"]
+		assert.True(t, isRequired, "--domain must be marked as required")
+
+		break
+	}
+	require.True(t, found, "apollo subcommand must be registered with enumCmd")
+}

--- a/cmd/brutus/cmd_enum_lusha.go
+++ b/cmd/brutus/cmd_enum_lusha.go
@@ -1,0 +1,238 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/spf13/cobra"
+
+	"github.com/praetorian-inc/brutus/pkg/enum/lusha"
+)
+
+// File-local flag variables for the lusha subcommand.
+// Separate from other enum commands to avoid cross-command state bleed.
+var (
+	flagLushaFirstName string
+	flagLushaLastName  string
+	flagLushaCompany   string
+	flagLushaDomain    string
+	flagLushaEmail     string
+	flagLushaLinkedin  string
+	flagLushaPhone     bool
+	flagLushaEmailOnly bool
+	flagLushaAPIKey    string
+)
+
+var enumLushaCmd = &cobra.Command{
+	Use:   "lusha",
+	Short: "Enrich a single person identity to emails and phones via Lusha v3",
+	Long: `Resolve one person identity to an enriched contact (emails and phone
+numbers) via the Lusha v3 search-and-enrich API. Provide exactly one identity:
+a name (--first-name + --last-name) with a --company or --domain, OR an --email,
+OR a --linkedin URL. Standalone — does not feed the saas enumeration pipeline.
+
+Every invocation consumes Lusha credits (the command has no free tier). Phone
+numbers may carry a Do-Not-Call (DNC) flag, which is always shown — do not
+contact a DNC number. You are responsible for ensuring your use complies with
+the provider's Terms of Service and that you have authorization to enumerate the
+targeted individuals/organizations.
+
+Requires a Lusha API key via the LUSHA_API_KEY environment variable
+(or the --api-key flag).`,
+	Example: `  # Enrich by name + company (key from LUSHA_API_KEY)
+  brutus enum lusha --first-name Ada --last-name Lovelace --company Analytical
+
+  # Enrich by name + company domain
+  brutus enum lusha --first-name Ada --last-name Lovelace --domain example.com
+
+  # Enrich by email
+  brutus enum lusha --email ada@example.com
+
+  # Enrich by LinkedIn URL, also request phone numbers
+  brutus enum lusha --linkedin https://linkedin.com/in/ada --phone
+
+  # Provide the key explicitly (note: visible in process list / shell history)
+  brutus enum lusha --email ada@example.com --api-key abc123`,
+	RunE: runEnumLusha,
+}
+
+func init() {
+	f := enumLushaCmd.Flags()
+	f.StringVar(&flagLushaFirstName, "first-name", "", "First name (with --last-name and --company or --domain)")
+	f.StringVar(&flagLushaLastName, "last-name", "", "Last name (with --first-name)")
+	f.StringVar(&flagLushaCompany, "company", "", "Company name (with the name pair)")
+	f.StringVar(&flagLushaDomain, "domain", "", "Company domain (alternative to --company)")
+	f.StringVar(&flagLushaEmail, "email", "", "Enrich by email address (mutually exclusive identity)")
+	f.StringVar(&flagLushaLinkedin, "linkedin", "", "Enrich by LinkedIn profile URL (mutually exclusive identity)")
+	f.BoolVar(&flagLushaPhone, "phone", false, "Request phone datapoints in addition to email")
+	f.BoolVar(&flagLushaEmailOnly, "email-only", false, "Request only email datapoints (mutually exclusive with --phone)")
+	f.StringVar(&flagLushaAPIKey, "api-key", "",
+		"Lusha API key (overrides LUSHA_API_KEY; WARNING: visible in process list and shell history — prefer LUSHA_API_KEY)")
+	// No MarkFlagRequired — identity is validated in runEnumLusha.
+}
+
+// runEnumLusha implements the "enum lusha" subcommand.
+func runEnumLusha(cmd *cobra.Command, args []string) error {
+	useColor := isColorEnabled(flagNoColor)
+
+	if err := validateLushaIdentity(); err != nil {
+		return err
+	}
+
+	apiKey, err := resolveLushaAPIKey(flagLushaAPIKey)
+	if err != nil {
+		return err
+	}
+
+	jsonWriter, forceJSON, closeOutput, err := setupOutputWriter(flagOutputFile)
+	if err != nil {
+		return err
+	}
+	defer closeOutput()
+	if forceJSON {
+		flagJSON = true
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	// Unconditional cost notice — Lusha enrichment always spends credits (P0-7).
+	if !flagQuiet && !flagJSON {
+		fmt.Fprintf(os.Stderr, "%s lusha enrichment consumes credits\n", dim(useColor, SymbolInfo))
+	}
+
+	query := lusha.ContactQuery{
+		FirstName:     flagLushaFirstName,
+		LastName:      flagLushaLastName,
+		CompanyName:   flagLushaCompany,
+		CompanyDomain: flagLushaDomain,
+		Email:         flagLushaEmail,
+		LinkedinURL:   flagLushaLinkedin,
+	}
+	reveal := lusha.RevealOptions{Email: true, Phone: flagLushaPhone}
+	if flagLushaEmailOnly {
+		reveal = lusha.RevealOptions{Email: true, Phone: false}
+	}
+
+	client := lusha.NewClient(apiKey, flagTimeout)
+	contact, err := client.Enrich(ctx, query, reveal)
+	if err != nil {
+		return classifyLushaError(err)
+	}
+
+	// Verbose: log counts only — never the key (P0-1).
+	logVerbose(flagVerbose, "Lusha returned %d emails and %d phones",
+		len(contact.Emails), len(contact.Phones))
+
+	if flagJSON {
+		outputLushaJSONL(jsonWriter, contact)
+	} else {
+		outputLushaHuman(os.Stdout, contact, useColor)
+	}
+	return nil
+}
+
+// validateLushaIdentity enforces that exactly one identity group is set:
+// (1) name group: --first-name + --last-name + exactly one of (--company | --domain),
+// (2) --email, or (3) --linkedin. --phone and --email-only are mutually exclusive.
+// Pure function over the flag values — no network, trivially testable.
+func validateLushaIdentity() error {
+	if flagLushaPhone && flagLushaEmailOnly {
+		return fmt.Errorf("--phone and --email-only are mutually exclusive")
+	}
+
+	hasName := flagLushaFirstName != "" || flagLushaLastName != "" ||
+		flagLushaCompany != "" || flagLushaDomain != ""
+	hasEmail := flagLushaEmail != ""
+	hasLinkedin := flagLushaLinkedin != ""
+
+	groups := 0
+	if hasName {
+		groups++
+	}
+	if hasEmail {
+		groups++
+	}
+	if hasLinkedin {
+		groups++
+	}
+
+	if groups == 0 {
+		return fmt.Errorf("an identity is required: provide --first-name + --last-name + (--company or --domain), or --email, or --linkedin")
+	}
+	if groups > 1 {
+		return fmt.Errorf("provide exactly one identity: use a name group, OR --email, OR --linkedin (not more than one)")
+	}
+
+	if !hasName {
+		return nil
+	}
+
+	if flagLushaFirstName == "" || flagLushaLastName == "" {
+		return fmt.Errorf("the name identity requires both --first-name and --last-name")
+	}
+	if flagLushaCompany == "" && flagLushaDomain == "" {
+		return fmt.Errorf("the name identity requires --company or --domain")
+	}
+	if flagLushaCompany != "" && flagLushaDomain != "" {
+		return fmt.Errorf("provide either --company or --domain for the name identity, not both")
+	}
+	return nil
+}
+
+// resolveLushaAPIKey returns the flag value if set, else LUSHA_API_KEY env var.
+// The key is never logged (P0-1 security requirement).
+func resolveLushaAPIKey(flagValue string) (string, error) {
+	if flagValue != "" {
+		return flagValue, nil
+	}
+	if key := os.Getenv("LUSHA_API_KEY"); key != "" {
+		return key, nil
+	}
+	return "", fmt.Errorf("lusha API key required: set LUSHA_API_KEY or pass --api-key")
+}
+
+// classifyLushaError converts lusha sentinel errors into actionable, key-free
+// messages. It returns only static, status-derived text and never echoes the
+// vendor's APIError.Details (which could carry the key) (P0-1).
+func classifyLushaError(err error) error {
+	switch {
+	case errors.Is(err, lusha.ErrUnauthorized):
+		return fmt.Errorf("lusha: invalid or missing API key (check LUSHA_API_KEY / --api-key)")
+	case errors.Is(err, lusha.ErrNoCredits):
+		return fmt.Errorf("lusha: insufficient credits — top up your Lusha account")
+	case errors.Is(err, lusha.ErrForbidden):
+		return fmt.Errorf("lusha: access forbidden (plan or permissions)")
+	case errors.Is(err, lusha.ErrNotFound):
+		return fmt.Errorf("lusha: no contact found for the provided identity")
+	case errors.Is(err, lusha.ErrRateLimited):
+		return fmt.Errorf("lusha: rate limit exceeded — wait and retry")
+	}
+	// Unknown error. If it carries an *APIError, report only its status code —
+	// never its Details, whose Error() can echo the request body or even the key
+	// back (P0-1). Otherwise report a generic, key-free message (never
+	// %w-wrapping the underlying error, whose Error() embeds Details).
+	var apiErr *lusha.APIError
+	if errors.As(err, &apiErr) {
+		return fmt.Errorf("lusha enrichment failed (HTTP %d)", apiErr.StatusCode)
+	}
+	return fmt.Errorf("lusha enrichment failed")
+}

--- a/cmd/brutus/cmd_enum_lusha.go
+++ b/cmd/brutus/cmd_enum_lusha.go
@@ -211,8 +211,10 @@ func resolveLushaAPIKey(flagValue string) (string, error) {
 }
 
 // classifyLushaError converts lusha sentinel errors into actionable, key-free
-// messages. It returns only static, status-derived text and never echoes the
-// vendor's APIError.Details (which could carry the key) (P0-1).
+// messages. For *APIError it returns only status-derived text and never echoes
+// the vendor's APIError.Details (which could carry the key) (P0-1). For non-API
+// errors (network/DNS/timeout — no vendor details) it %w-wraps the cause to
+// preserve debuggability.
 func classifyLushaError(err error) error {
 	switch {
 	case errors.Is(err, lusha.ErrUnauthorized):
@@ -227,12 +229,13 @@ func classifyLushaError(err error) error {
 		return fmt.Errorf("lusha: rate limit exceeded — wait and retry")
 	}
 	// Unknown error. If it carries an *APIError, report only its status code —
-	// never its Details, whose Error() can echo the request body or even the key
-	// back (P0-1). Otherwise report a generic, key-free message (never
-	// %w-wrapping the underlying error, whose Error() embeds Details).
+	// never its Details (P0-1); APIError.Error() is now status-only, but we keep
+	// the explicit status-code text here regardless. Otherwise (network/DNS/
+	// timeout — no vendor details) %w-wrap it to preserve debuggability, matching
+	// classifyHunterError.
 	var apiErr *lusha.APIError
 	if errors.As(err, &apiErr) {
 		return fmt.Errorf("lusha enrichment failed (HTTP %d)", apiErr.StatusCode)
 	}
-	return fmt.Errorf("lusha enrichment failed")
+	return fmt.Errorf("lusha enrichment failed: %w", err)
 }

--- a/cmd/brutus/cmd_enum_lusha_output.go
+++ b/cmd/brutus/cmd_enum_lusha_output.go
@@ -1,0 +1,143 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/praetorian-inc/brutus/pkg/enum/lusha"
+)
+
+// outputLushaHuman renders a Lusha enriched contact as aligned tables.
+// All vendor-controlled strings are sanitized via sanitizeTerminal then
+// truncated (P0-4). The per-phone Do-Not-Call flag is surfaced explicitly as a
+// DNC marker so the operator can honor suppression (P0-DNC).
+func outputLushaHuman(w io.Writer, c *lusha.Contact, useColor bool) {
+	summary := lushaIdentitySummary(c)
+	_, _ = fmt.Fprintf(w, "\n%s %s\n", dim(useColor, SymbolInfo),
+		heading(useColor, "Lusha: "+summary))
+
+	if c.JobTitle != "" {
+		_, _ = fmt.Fprintf(w, "  Title:   %s\n", sanitizeTerminal(c.JobTitle))
+	}
+	if c.Company != "" {
+		_, _ = fmt.Fprintf(w, "  Company: %s\n", sanitizeTerminal(c.Company))
+	}
+
+	if len(c.Emails) == 0 && len(c.Phones) == 0 {
+		_, _ = fmt.Fprintf(w, "\n  %s No contact data returned\n", dim(useColor, SymbolInfo))
+		_, _ = fmt.Fprintln(w)
+		return
+	}
+
+	if len(c.Emails) > 0 {
+		_, _ = fmt.Fprintf(w, "\n  %s%-40s %-12s %-12s%s\n",
+			colorIf(useColor, ColorBold),
+			"Email", "Type", "Confidence",
+			colorIf(useColor, ColorReset))
+		for i := range c.Emails {
+			e := &c.Emails[i]
+			_, _ = fmt.Fprintf(w, "  %s%-40s%s %-12s %-12s\n",
+				colorIf(useColor, ColorGreen),
+				truncate(sanitizeTerminal(e.Address), 40),
+				colorIf(useColor, ColorReset),
+				truncate(sanitizeTerminal(e.Type), 12),
+				truncate(sanitizeTerminal(e.Confidence), 12))
+		}
+	}
+
+	if len(c.Phones) > 0 {
+		_, _ = fmt.Fprintf(w, "\n  %s%-24s %-12s %-5s%s\n",
+			colorIf(useColor, ColorBold),
+			"Phone", "Type", "DNC",
+			colorIf(useColor, ColorReset))
+		for i := range c.Phones {
+			p := &c.Phones[i]
+			dnc := ""
+			if p.DoNotCall {
+				dnc = "DNC"
+			}
+			_, _ = fmt.Fprintf(w, "  %-24s %-12s %s%-5s%s\n",
+				truncate(sanitizeTerminal(p.Number), 24),
+				truncate(sanitizeTerminal(p.Type), 12),
+				colorIf(useColor, ColorYellow), dnc, colorIf(useColor, ColorReset))
+		}
+	}
+	_, _ = fmt.Fprintln(w)
+}
+
+// outputLushaJSONL writes the contact as a single JSON line.
+// encoding/json already escapes control characters, so no sanitization needed.
+// The per-phone do_not_call bool is always emitted to surface DNC (P0-DNC).
+func outputLushaJSONL(w io.Writer, c *lusha.Contact) {
+	type emailJSON struct {
+		Address    string `json:"address"`
+		Type       string `json:"type,omitempty"`
+		Confidence string `json:"confidence,omitempty"`
+	}
+	type phoneJSON struct {
+		Number    string `json:"number"`
+		Type      string `json:"type,omitempty"`
+		DoNotCall bool   `json:"do_not_call"`
+	}
+	type contactJSON struct {
+		Type     string      `json:"type"`
+		Name     string      `json:"name,omitempty"`
+		JobTitle string      `json:"job_title,omitempty"`
+		Company  string      `json:"company,omitempty"`
+		Emails   []emailJSON `json:"emails,omitempty"`
+		Phones   []phoneJSON `json:"phones,omitempty"`
+	}
+
+	jr := contactJSON{
+		Type:     "lusha",
+		Name:     c.Name,
+		JobTitle: c.JobTitle,
+		Company:  c.Company,
+	}
+	for i := range c.Emails {
+		e := &c.Emails[i]
+		jr.Emails = append(jr.Emails, emailJSON{
+			Address:    e.Address,
+			Type:       e.Type,
+			Confidence: e.Confidence,
+		})
+	}
+	for i := range c.Phones {
+		p := &c.Phones[i]
+		jr.Phones = append(jr.Phones, phoneJSON{
+			Number:    p.Number,
+			Type:      p.Type,
+			DoNotCall: p.DoNotCall,
+		})
+	}
+
+	enc := json.NewEncoder(w)
+	if err := enc.Encode(jr); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Error encoding lusha JSON: %v\n", err)
+	}
+}
+
+// lushaIdentitySummary builds a short, sanitized label for the contact header.
+func lushaIdentitySummary(c *lusha.Contact) string {
+	if name := strings.TrimSpace(sanitizeTerminal(c.Name)); name != "" {
+		return name
+	}
+	return "contact"
+}

--- a/cmd/brutus/cmd_enum_lusha_test.go
+++ b/cmd/brutus/cmd_enum_lusha_test.go
@@ -17,6 +17,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -173,9 +174,9 @@ func resetLushaFlags() {
 
 func TestValidateLushaIdentity(t *testing.T) {
 	tests := []struct {
-		name      string
-		setup     func()
-		wantErr   bool
+		name        string
+		setup       func()
+		wantErr     bool
 		errContains string
 	}{
 		{
@@ -211,9 +212,9 @@ func TestValidateLushaIdentity(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:      "ERROR: no identity set",
-			setup:     func() {},
-			wantErr:   true,
+			name:        "ERROR: no identity set",
+			setup:       func() {},
+			wantErr:     true,
 			errContains: "identity is required",
 		},
 		{
@@ -222,7 +223,7 @@ func TestValidateLushaIdentity(t *testing.T) {
 				flagLushaEmail = "ada@example.com"
 				flagLushaLinkedin = "https://linkedin.com/in/ada"
 			},
-			wantErr:   true,
+			wantErr:     true,
 			errContains: "exactly one identity",
 		},
 		{
@@ -231,7 +232,7 @@ func TestValidateLushaIdentity(t *testing.T) {
 				flagLushaFirstName = "Ada"
 				flagLushaCompany = "AnalyticalCo"
 			},
-			wantErr:   true,
+			wantErr:     true,
 			errContains: "last-name",
 		},
 		{
@@ -240,7 +241,7 @@ func TestValidateLushaIdentity(t *testing.T) {
 				flagLushaFirstName = "Ada"
 				flagLushaLastName = "Lovelace"
 			},
-			wantErr:   true,
+			wantErr:     true,
 			errContains: "--company or --domain",
 		},
 		{
@@ -250,7 +251,7 @@ func TestValidateLushaIdentity(t *testing.T) {
 				flagLushaPhone = true
 				flagLushaEmailOnly = true
 			},
-			wantErr:   true,
+			wantErr:     true,
 			errContains: "mutually exclusive",
 		},
 	}
@@ -364,6 +365,19 @@ func TestClassifyLushaError_NoKeyLeak(t *testing.T) {
 				"classified error must not echo the api_key header name")
 		})
 	}
+}
+
+// TestClassifyLushaError_NetworkWrap verifies that non-*APIError (network/DNS/
+// timeout) errors are %w-wrapped by classifyLushaError so errors.Is chains work.
+func TestClassifyLushaError_NetworkWrap(t *testing.T) {
+	networkErr := errors.New("dial tcp: connection timeout")
+	result := classifyLushaError(networkErr)
+	require.Error(t, result)
+	// The network error must be wrapped (errors.Is unwraps the chain).
+	assert.True(t, errors.Is(result, networkErr),
+		"classifyLushaError must %w-wrap non-*APIError so errors.Is works")
+	// The error message must contain the original cause for debuggability.
+	assert.Contains(t, result.Error(), "timeout")
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/brutus/cmd_enum_lusha_test.go
+++ b/cmd/brutus/cmd_enum_lusha_test.go
@@ -1,0 +1,399 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/brutus/pkg/enum/lusha"
+)
+
+// ---------------------------------------------------------------------------
+// T103: outputLushaJSONL + outputLushaHuman
+// ---------------------------------------------------------------------------
+
+func TestOutputLushaJSONL(t *testing.T) {
+	t.Run("contact with email and DNC phone emits one JSON line", func(t *testing.T) {
+		c := &lusha.Contact{
+			Name:     "Ada Lovelace",
+			JobTitle: "Mathematician",
+			Company:  "AnalyticalCo",
+			Emails: []lusha.EmailEntry{
+				{Address: "ada@example.com", Type: "professional", Confidence: "high"},
+			},
+			Phones: []lusha.PhoneEntry{
+				{Number: "+1-555-0100", Type: "direct", DoNotCall: true},
+			},
+		}
+		var buf bytes.Buffer
+		outputLushaJSONL(&buf, c)
+
+		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+		require.Len(t, lines, 1, "expected exactly 1 JSONL line")
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[0]), &obj))
+		assert.Equal(t, "lusha", obj["type"])
+		assert.Equal(t, "Ada Lovelace", obj["name"])
+		assert.Equal(t, "Mathematician", obj["job_title"])
+		assert.Equal(t, "AnalyticalCo", obj["company"])
+
+		emails, ok := obj["emails"].([]interface{})
+		require.True(t, ok, "emails must be a JSON array")
+		require.Len(t, emails, 1)
+		email := emails[0].(map[string]interface{})
+		assert.Equal(t, "ada@example.com", email["address"])
+
+		phones, ok := obj["phones"].([]interface{})
+		require.True(t, ok, "phones must be a JSON array")
+		require.Len(t, phones, 1)
+		phone := phones[0].(map[string]interface{})
+		// do_not_call bool must always be emitted (P0-DNC).
+		doNotCall, exists := phone["do_not_call"]
+		require.True(t, exists, "do_not_call field must always be present")
+		assert.Equal(t, true, doNotCall, "do_not_call must be true for DNC phone")
+	})
+
+	t.Run("empty contact emits JSON object with no emails or phones arrays", func(t *testing.T) {
+		c := &lusha.Contact{}
+		var buf bytes.Buffer
+		outputLushaJSONL(&buf, c)
+
+		out := strings.TrimSpace(buf.String())
+		require.NotEmpty(t, out, "should emit one JSON object even when empty")
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(out), &obj))
+		assert.Equal(t, "lusha", obj["type"])
+		_, hasEmails := obj["emails"]
+		assert.False(t, hasEmails, "omitempty: emails array must be absent for empty contact")
+		_, hasPhones := obj["phones"]
+		assert.False(t, hasPhones, "omitempty: phones array must be absent for empty contact")
+	})
+
+	t.Run("non-DNC phone has do_not_call false", func(t *testing.T) {
+		c := &lusha.Contact{
+			Phones: []lusha.PhoneEntry{
+				{Number: "+1-555-0200", Type: "mobile", DoNotCall: false},
+			},
+		}
+		var buf bytes.Buffer
+		outputLushaJSONL(&buf, c)
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &obj))
+		phones := obj["phones"].([]interface{})
+		phone := phones[0].(map[string]interface{})
+		// do_not_call bool is always emitted — must be false here.
+		doNotCall, exists := phone["do_not_call"]
+		require.True(t, exists, "do_not_call field must always be emitted")
+		assert.Equal(t, false, doNotCall)
+	})
+}
+
+func TestOutputLushaHuman(t *testing.T) {
+	t.Run("renders email and phone rows", func(t *testing.T) {
+		c := &lusha.Contact{
+			Name:     "Ada Lovelace",
+			JobTitle: "Mathematician",
+			Company:  "AnalyticalCo",
+			Emails: []lusha.EmailEntry{
+				{Address: "ada@example.com", Type: "professional", Confidence: "high"},
+			},
+			Phones: []lusha.PhoneEntry{
+				{Number: "+1-555-0100", Type: "direct", DoNotCall: false},
+			},
+		}
+		var buf bytes.Buffer
+		outputLushaHuman(&buf, c, false)
+		out := buf.String()
+		assert.Contains(t, out, "ada@example.com")
+		assert.Contains(t, out, "professional")
+		assert.Contains(t, out, "+1-555-0100")
+		assert.Contains(t, out, "direct")
+	})
+
+	t.Run("DNC phone shows DNC marker", func(t *testing.T) {
+		c := &lusha.Contact{
+			Name: "Eve Example",
+			Phones: []lusha.PhoneEntry{
+				{Number: "+1-555-9999", Type: "mobile", DoNotCall: true},
+			},
+		}
+		var buf bytes.Buffer
+		outputLushaHuman(&buf, c, false)
+		out := buf.String()
+		assert.Contains(t, out, "DNC", "DNC phones must display DNC marker")
+		assert.Contains(t, out, "+1-555-9999")
+	})
+
+	t.Run("empty contact shows no data message", func(t *testing.T) {
+		c := &lusha.Contact{}
+		var buf bytes.Buffer
+		outputLushaHuman(&buf, c, false)
+		out := buf.String()
+		assert.Contains(t, out, "No contact data returned")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// T104: validateLushaIdentity (reads package-level flag vars directly)
+// ---------------------------------------------------------------------------
+
+// resetLushaFlags resets all lusha flag vars to zero values between subtests.
+func resetLushaFlags() {
+	flagLushaFirstName = ""
+	flagLushaLastName = ""
+	flagLushaCompany = ""
+	flagLushaDomain = ""
+	flagLushaEmail = ""
+	flagLushaLinkedin = ""
+	flagLushaPhone = false
+	flagLushaEmailOnly = false
+}
+
+func TestValidateLushaIdentity(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func()
+		wantErr   bool
+		errContains string
+	}{
+		{
+			name: "valid name + company",
+			setup: func() {
+				flagLushaFirstName = "Ada"
+				flagLushaLastName = "Lovelace"
+				flagLushaCompany = "AnalyticalCo"
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid name + domain",
+			setup: func() {
+				flagLushaFirstName = "Ada"
+				flagLushaLastName = "Lovelace"
+				flagLushaDomain = "analytical.example.com"
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid email only",
+			setup: func() {
+				flagLushaEmail = "ada@example.com"
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid linkedin only",
+			setup: func() {
+				flagLushaLinkedin = "https://linkedin.com/in/ada"
+			},
+			wantErr: false,
+		},
+		{
+			name:      "ERROR: no identity set",
+			setup:     func() {},
+			wantErr:   true,
+			errContains: "identity is required",
+		},
+		{
+			name: "ERROR: two identity groups (email + linkedin)",
+			setup: func() {
+				flagLushaEmail = "ada@example.com"
+				flagLushaLinkedin = "https://linkedin.com/in/ada"
+			},
+			wantErr:   true,
+			errContains: "exactly one identity",
+		},
+		{
+			name: "ERROR: name without last name",
+			setup: func() {
+				flagLushaFirstName = "Ada"
+				flagLushaCompany = "AnalyticalCo"
+			},
+			wantErr:   true,
+			errContains: "last-name",
+		},
+		{
+			name: "ERROR: name without company or domain",
+			setup: func() {
+				flagLushaFirstName = "Ada"
+				flagLushaLastName = "Lovelace"
+			},
+			wantErr:   true,
+			errContains: "--company or --domain",
+		},
+		{
+			name: "ERROR: --phone and --email-only together",
+			setup: func() {
+				flagLushaEmail = "ada@example.com"
+				flagLushaPhone = true
+				flagLushaEmailOnly = true
+			},
+			wantErr:   true,
+			errContains: "mutually exclusive",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resetLushaFlags()
+			tc.setup()
+			err := validateLushaIdentity()
+			if tc.wantErr {
+				require.Error(t, err)
+				if tc.errContains != "" {
+					assert.Contains(t, err.Error(), tc.errContains)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestResolveLushaAPIKey(t *testing.T) {
+	tests := []struct {
+		name      string
+		flagValue string
+		envValue  string
+		wantKey   string
+		wantErr   bool
+	}{
+		{
+			name:      "flag value takes priority over env",
+			flagValue: "flag-key",
+			envValue:  "env-key",
+			wantKey:   "flag-key",
+		},
+		{
+			name:      "env var used when flag is empty",
+			flagValue: "",
+			envValue:  "env-key",
+			wantKey:   "env-key",
+		},
+		{
+			name:      "error when both empty",
+			flagValue: "",
+			envValue:  "",
+			wantErr:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("LUSHA_API_KEY", tc.envValue)
+			key, err := resolveLushaAPIKey(tc.flagValue)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "LUSHA_API_KEY")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantKey, key)
+		})
+	}
+}
+
+// TestClassifyLushaError_NoKeyLeak verifies the P0-1 security requirement:
+// the sentinel API key value must never appear in any classified error message,
+// even if the vendor echoes the key back in the error body (APIError.Details).
+func TestClassifyLushaError_NoKeyLeak(t *testing.T) {
+	const sentinelKey = "SECRETKEY-DO-NOT-LEAK-abc123"
+
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "vendor echoes key in 401 Details",
+			err:  &lusha.APIError{StatusCode: 401, Details: sentinelKey},
+		},
+		{
+			name: "402 no credits with sentinel",
+			err:  &lusha.APIError{StatusCode: 402, Details: sentinelKey},
+		},
+		{
+			name: "403 forbidden",
+			err:  &lusha.APIError{StatusCode: 403, Details: "forbidden"},
+		},
+		{
+			name: "429 rate limited",
+			err:  &lusha.APIError{StatusCode: 429, Details: "rate limit"},
+		},
+		{
+			name: "404 not found",
+			err:  &lusha.APIError{StatusCode: 404, Details: "not found"},
+		},
+		{
+			name: "wrapped 500 with sentinel in Details",
+			err:  fmt.Errorf("wrapped: %w", &lusha.APIError{StatusCode: 500, Details: sentinelKey}),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := classifyLushaError(tc.err)
+			require.Error(t, result)
+			out := result.Error()
+			// Sentinel key must NEVER appear in any error output (P0-1).
+			assert.NotContains(t, out, sentinelKey,
+				"classified error must not leak the sentinel API key")
+			// Header name must not be echoed either.
+			assert.NotContains(t, out, "api_key",
+				"classified error must not echo the api_key header name")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// T105: Command registration
+// ---------------------------------------------------------------------------
+
+func TestEnumLushaRegistered(t *testing.T) {
+	var found bool
+	for _, cmd := range enumCmd.Commands() {
+		if cmd.Use != "lusha" {
+			continue
+		}
+		found = true
+
+		flagNames := []string{
+			"first-name", "last-name", "company", "domain",
+			"email", "linkedin", "phone", "email-only", "api-key",
+		}
+		for _, name := range flagNames {
+			f := cmd.Flags().Lookup(name)
+			require.NotNilf(t, f, "--%s flag must exist", name)
+		}
+
+		// --domain must NOT be marked required (identity validated in RunE).
+		domainFlag := cmd.Flags().Lookup("domain")
+		require.NotNil(t, domainFlag)
+		annotations := domainFlag.Annotations
+		_, isRequired := annotations["cobra_annotation_bash_completion_one_required_flag"]
+		assert.False(t, isRequired, "--domain must NOT be marked as required for lusha")
+		break
+	}
+	require.True(t, found, "lusha subcommand must be registered with enumCmd")
+}

--- a/pkg/enum/apollo/apollo.go
+++ b/pkg/enum/apollo/apollo.go
@@ -1,0 +1,379 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package apollo provides a client for the Apollo.io people search and match
+// APIs. It performs free domain people-discovery (no PII) and, on request,
+// opt-in email reveal (consumes credits). It handles pagination, typed errors,
+// and context cancellation, mirroring the Hunter.io client pattern.
+package apollo
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/praetorian-inc/brutus/pkg/enum"
+)
+
+// Sentinel errors for use with errors.Is by callers.
+var (
+	ErrUnauthorized = errors.New("invalid or missing Apollo API key")      // 401
+	ErrForbidden    = errors.New("access forbidden (plan or permissions)") // 403
+	ErrBadRequest   = errors.New("invalid request parameters")             // 422
+	ErrRateLimited  = errors.New("rate limit exceeded")                    // 429
+)
+
+const (
+	defaultBaseURL  = "https://api.apollo.io"
+	searchPath      = "/api/v1/mixed_people/api_search"
+	matchPath       = "/api/v1/people/match"
+	headerAPIKey    = "X-Api-Key"
+	defaultPageSize = 100
+	// maxPages is a hard safety cap (Apollo documents 100/page x 500 pages = 50k).
+	maxPages = 500
+)
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+// Person is one discovered contact for the domain. Email/EmailStatus are empty
+// until RevealEmails runs (opt-in, consumes credits).
+type Person struct {
+	// From people-search (FREE, no PII).
+	ID           string
+	FirstName    string
+	LastName     string
+	Name         string
+	Title        string
+	Seniority    string
+	Department   string
+	Organization string
+
+	// From people/match (CREDITS, PII) — empty unless reveal ran.
+	Email       string
+	EmailStatus string
+	Revealed    bool
+}
+
+// DomainResult is the aggregated, de-paginated result for a domain.
+type DomainResult struct {
+	Domain   string
+	People   []Person
+	Total    int  // pagination.total_entries
+	Revealed bool // true if RevealEmails ran (any credits spent)
+}
+
+// APIError is returned for any non-2xx HTTP status from Apollo.
+type APIError struct {
+	StatusCode int
+	Details    string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("apollo API error (HTTP %d): %s", e.StatusCode, e.Details)
+}
+
+// Unwrap maps status → sentinel (401/403/422/429), nil otherwise. This enables
+// errors.Is(err, apollo.ErrUnauthorized) in callers while the *APIError remains
+// retrievable via errors.As.
+func (e *APIError) Unwrap() error {
+	switch e.StatusCode {
+	case http.StatusUnauthorized:
+		return ErrUnauthorized
+	case http.StatusForbidden:
+		return ErrForbidden
+	case http.StatusUnprocessableEntity:
+		return ErrBadRequest
+	case http.StatusTooManyRequests:
+		return ErrRateLimited
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+// Client holds state for querying the Apollo people search and match APIs.
+type Client struct {
+	apiKey     string // X-Api-Key — NEVER logged (P0-1)
+	httpClient *http.Client
+	baseURL    string
+	pageSize   int // people-search per_page; <=0 => defaultPageSize
+}
+
+// NewClient builds an Apollo client. timeout is the per-request HTTP budget.
+// pageSize <= 0 falls back to defaultPageSize.
+func NewClient(apiKey string, timeout time.Duration, pageSize int) *Client {
+	if pageSize <= 0 {
+		pageSize = defaultPageSize
+	}
+	return &Client{
+		apiKey:     apiKey,
+		httpClient: enum.NewEnumHTTPClient(timeout),
+		baseURL:    defaultBaseURL,
+		pageSize:   pageSize,
+	}
+}
+
+// SearchPeople paginates people-search for domain (optionally filtered by
+// titles), accumulating up to limit people. Phase 1 is FREE and returns no PII.
+// Honors ctx cancellation between pages.
+func (c *Client) SearchPeople(ctx context.Context, domain string, titles []string, limit int) (*DomainResult, error) {
+	result := &DomainResult{Domain: domain}
+	page := 1
+
+	for {
+		people, total, err := c.searchPage(ctx, domain, titles, page)
+		if err != nil {
+			return nil, err
+		}
+		if page == 1 {
+			result.Total = total
+		}
+
+		result.People = append(result.People, people...)
+
+		fetched := len(people)
+		if fetched == 0 { // empty page
+			break
+		}
+		if limit > 0 && len(result.People) >= limit { // user cap (truncate)
+			result.People = result.People[:limit]
+			break
+		}
+		if fetched < c.pageSize { // short final page
+			break
+		}
+		if result.Total > 0 && len(result.People) >= result.Total { // known total
+			break
+		}
+		if page >= maxPages { // hard safety cap
+			break
+		}
+		if err := ctx.Err(); err != nil { // cancellation
+			return nil, err
+		}
+		page++
+	}
+
+	return result, nil
+}
+
+// RevealEmails enriches the already-discovered people in result with emails via
+// people/match, in place, serially. Consumes credits. Skips people without an
+// id. Sets Email/EmailStatus/Revealed per person (Revealed=true even when the
+// returned email is empty — partial-result honesty) and result.Revealed=true if
+// any reveal ran. Surfaces the first error (no partial swallow).
+func (c *Client) RevealEmails(ctx context.Context, result *DomainResult) error {
+	for i := range result.People {
+		p := &result.People[i]
+		if p.ID == "" { // can't match without an id
+			continue
+		}
+		email, status, err := c.matchPerson(ctx, p.ID)
+		if err != nil {
+			return err
+		}
+		p.Email, p.EmailStatus, p.Revealed = email, status, true
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+	}
+	if len(result.People) > 0 {
+		result.Revealed = true
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+// searchPage performs a single people-search POST and returns the mapped people
+// plus the reported total_entries.
+func (c *Client) searchPage(ctx context.Context, domain string, titles []string, page int) (people []Person, total int, err error) {
+	reqBody := apolloSearchRequest{
+		OrganizationDomains: []string{domain},
+		PersonTitles:        titles,
+		Page:                page,
+		PerPage:             c.pageSize,
+	}
+	body, err := c.do(ctx, http.MethodPost, searchPath, reqBody)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var resp apolloSearchResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, 0, fmt.Errorf("decoding apollo search response: %w", err)
+	}
+
+	out := make([]Person, len(resp.People))
+	for i := range resp.People {
+		out[i] = toPerson(&resp.People[i])
+	}
+	return out, resp.Pagination.TotalEntries, nil
+}
+
+// matchPerson reveals the email for a single Apollo person id. Consumes credits.
+func (c *Client) matchPerson(ctx context.Context, id string) (email, status string, err error) {
+	reqBody := apolloMatchRequest{ID: id, RevealPersonalEmails: true}
+	body, err := c.do(ctx, http.MethodPost, matchPath, reqBody)
+	if err != nil {
+		return "", "", err
+	}
+
+	var resp apolloMatchResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return "", "", fmt.Errorf("decoding apollo match response: %w", err)
+	}
+	return resp.Person.Email, resp.Person.EmailStatus, nil
+}
+
+// do is the single P0-1/P0-3 choke point: it JSON-encodes body, sets the
+// X-Api-Key header and Content-Type, issues the request, reads the response via
+// the bounded enum.ReadResponseBody (P0-3), and maps any non-2xx status to an
+// *APIError. It NEVER logs the key, the header, the body, or the URL (P0-1), and
+// NEVER uses httputil.Dump* (which would capture the X-Api-Key header) (P0-1c).
+func (c *Client) do(ctx context.Context, method, path string, body any) ([]byte, error) {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("encoding apollo request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("building apollo request: %w", err)
+	}
+	req.Header.Set(headerAPIKey, c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("apollo request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Bounded read — reuses enum.ReadResponseBody (P0-3).
+	respBody, err := enum.ReadResponseBody(resp, 0)
+	if err != nil {
+		return nil, fmt.Errorf("reading apollo response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		// Extract details from the error envelope if decodable, else resp.Status.
+		details := resp.Status
+		var errResp apolloErrorResponse
+		if json.Unmarshal(respBody, &errResp) == nil && errResp.message() != "" {
+			details = errResp.message()
+		}
+		return nil, &APIError{StatusCode: resp.StatusCode, Details: details}
+	}
+
+	return respBody, nil
+}
+
+// toPerson converts the API person struct to the public Person type. Search
+// fields only; PII (Email/EmailStatus) is left empty and Revealed=false.
+func toPerson(p *apolloPerson) Person {
+	dept := ""
+	if len(p.Departments) > 0 {
+		dept = p.Departments[0]
+	}
+	return Person{
+		ID:           p.ID,
+		FirstName:    p.FirstName,
+		LastName:     p.LastName,
+		Name:         p.Name,
+		Title:        p.Title,
+		Seniority:    p.Seniority,
+		Department:   dept,
+		Organization: p.Organization.Name,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// JSON-mapping structs (unexported — map to the Apollo API shapes).
+//
+// NOTE (UNVERIFIED): the request/response field names and endpoint paths below
+// are derived from Apollo docs (architecture §7) and have NOT been verified
+// against a live key. They are intentionally isolated here so a single edit
+// corrects any mismatch without touching control flow. httptest tests use
+// controlled payloads and pass regardless of live-schema correctness.
+// ---------------------------------------------------------------------------
+
+type apolloSearchRequest struct {
+	OrganizationDomains []string `json:"q_organization_domains_list,omitempty"`
+	PersonTitles        []string `json:"person_titles,omitempty"`
+	Page                int      `json:"page"`
+	PerPage             int      `json:"per_page"`
+}
+
+type apolloSearchResponse struct {
+	People     []apolloPerson   `json:"people"`
+	Pagination apolloPagination `json:"pagination"`
+}
+
+type apolloPagination struct {
+	Page         int `json:"page"`
+	PerPage      int `json:"per_page"`
+	TotalEntries int `json:"total_entries"`
+	TotalPages   int `json:"total_pages"`
+}
+
+type apolloMatchRequest struct {
+	ID                   string `json:"id"`
+	RevealPersonalEmails bool   `json:"reveal_personal_emails"`
+}
+
+type apolloMatchResponse struct {
+	Person apolloPerson `json:"person"`
+}
+
+type apolloPerson struct {
+	ID           string             `json:"id"`
+	FirstName    string             `json:"first_name"`
+	LastName     string             `json:"last_name"`
+	Name         string             `json:"name"`
+	Title        string             `json:"title"`
+	Seniority    string             `json:"seniority"`
+	Departments  []string           `json:"departments"`
+	Organization apolloOrganization `json:"organization"`
+	Email        string             `json:"email"`
+	EmailStatus  string             `json:"email_status"`
+}
+
+type apolloOrganization struct {
+	Name string `json:"name"`
+}
+
+// apolloErrorResponse models Apollo's error envelope. Apollo has used both
+// "error" and "message" keys across endpoints; check both. (UNVERIFIED — §7.)
+type apolloErrorResponse struct {
+	Error   string `json:"error"`
+	Message string `json:"message"`
+}
+
+func (e apolloErrorResponse) message() string {
+	if e.Error != "" {
+		return e.Error
+	}
+	return e.Message
+}

--- a/pkg/enum/apollo/apollo.go
+++ b/pkg/enum/apollo/apollo.go
@@ -82,11 +82,16 @@ type DomainResult struct {
 // APIError is returned for any non-2xx HTTP status from Apollo.
 type APIError struct {
 	StatusCode int
-	Details    string
+	// Details holds server-derived text (resp.Status or error-envelope message)
+	// for internal/debug use. It is deliberately EXCLUDED from Error() so a
+	// caller that logs the error cannot leak echoed keys/PII (P0-1).
+	Details string
 }
 
+// Error returns ONLY status-derived text. It does NOT include Details, which
+// could echo vendor response content back into logs (P0-1).
 func (e *APIError) Error() string {
-	return fmt.Sprintf("apollo API error (HTTP %d): %s", e.StatusCode, e.Details)
+	return fmt.Sprintf("apollo API error (HTTP %d)", e.StatusCode)
 }
 
 // Unwrap maps status → sentinel (401/403/422/429), nil otherwise. This enables
@@ -142,7 +147,9 @@ func (c *Client) SearchPeople(ctx context.Context, domain string, titles []strin
 	for {
 		people, total, err := c.searchPage(ctx, domain, titles, page)
 		if err != nil {
-			return nil, err
+			// Return the partial result alongside the error so the caller still
+			// has the contacts discovered on earlier pages.
+			return result, err
 		}
 		if page == 1 {
 			result.Total = total
@@ -168,7 +175,7 @@ func (c *Client) SearchPeople(ctx context.Context, domain string, titles []strin
 			break
 		}
 		if err := ctx.Err(); err != nil { // cancellation
-			return nil, err
+			return result, err
 		}
 		page++
 	}
@@ -179,8 +186,10 @@ func (c *Client) SearchPeople(ctx context.Context, domain string, titles []strin
 // RevealEmails enriches the already-discovered people in result with emails via
 // people/match, in place, serially. Consumes credits. Skips people without an
 // id. Sets Email/EmailStatus/Revealed per person (Revealed=true even when the
-// returned email is empty — partial-result honesty) and result.Revealed=true if
-// any reveal ran. Surfaces the first error (no partial swallow).
+// returned email is empty — partial-result honesty) and sets result.Revealed=true
+// on the FIRST successful match so spent credits are reflected even if a later
+// match fails. Surfaces the first error (no partial swallow), leaving
+// already-merged emails intact.
 func (c *Client) RevealEmails(ctx context.Context, result *DomainResult) error {
 	for i := range result.People {
 		p := &result.People[i]
@@ -189,15 +198,18 @@ func (c *Client) RevealEmails(ctx context.Context, result *DomainResult) error {
 		}
 		email, status, err := c.matchPerson(ctx, p.ID)
 		if err != nil {
+			// On error, return it but leave the emails merged so far intact;
+			// result.Revealed is already true if any earlier reveal succeeded.
 			return err
 		}
 		p.Email, p.EmailStatus, p.Revealed = email, status, true
+		// Mark the aggregate as revealed on the FIRST successful match — credits
+		// have been spent, so the partial result must reflect that even if a
+		// later match fails.
+		result.Revealed = true
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-	}
-	if len(result.People) > 0 {
-		result.Revealed = true
 	}
 	return nil
 }

--- a/pkg/enum/apollo/apollo_test.go
+++ b/pkg/enum/apollo/apollo_test.go
@@ -1,0 +1,546 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apollo
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+// newTestClient creates a Client pointed at baseURL, overriding the default
+// base URL set by NewClient. Mirrors hunter_test.go:122-126.
+func newTestClient(baseURL string) *Client {
+	c := NewClient("testkey", 5*time.Second, 10)
+	c.baseURL = baseURL
+	return c
+}
+
+// ---------------------------------------------------------------------------
+// T001: toPerson + APIError
+// ---------------------------------------------------------------------------
+
+func TestToPerson(t *testing.T) {
+	src := &apolloPerson{
+		ID:          "abc123",
+		FirstName:   "Alice",
+		LastName:    "Smith",
+		Name:        "Alice Smith",
+		Title:       "VP Engineering",
+		Seniority:   "director",
+		Departments: []string{"Engineering", "Product"},
+		Organization: apolloOrganization{Name: "Example Corp"},
+	}
+	got := toPerson(src)
+
+	assert.Equal(t, "abc123", got.ID)
+	assert.Equal(t, "Alice", got.FirstName)
+	assert.Equal(t, "Smith", got.LastName)
+	assert.Equal(t, "Alice Smith", got.Name)
+	assert.Equal(t, "VP Engineering", got.Title)
+	assert.Equal(t, "director", got.Seniority)
+	assert.Equal(t, "Engineering", got.Department, "first department should be used")
+	assert.Equal(t, "Example Corp", got.Organization)
+
+	// PII fields must remain empty — search result is free, no email.
+	assert.Empty(t, got.Email, "Email must be empty in search result")
+	assert.Empty(t, got.EmailStatus, "EmailStatus must be empty in search result")
+	assert.False(t, got.Revealed, "Revealed must be false in search result")
+}
+
+func TestToPerson_EmptyDepartments(t *testing.T) {
+	src := &apolloPerson{
+		ID:   "empty-dept",
+		Name: "Bob",
+	}
+	got := toPerson(src)
+	assert.Empty(t, got.Department, "empty departments slice should yield empty Department")
+}
+
+func TestAPIError_Unwrap(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		sentinel   error
+		wantIs     bool
+	}{
+		{"401 maps to ErrUnauthorized", http.StatusUnauthorized, ErrUnauthorized, true},
+		{"403 maps to ErrForbidden", http.StatusForbidden, ErrForbidden, true},
+		{"422 maps to ErrBadRequest", http.StatusUnprocessableEntity, ErrBadRequest, true},
+		{"429 maps to ErrRateLimited", http.StatusTooManyRequests, ErrRateLimited, true},
+		{"500 does not map to ErrUnauthorized", http.StatusInternalServerError, ErrUnauthorized, false},
+		{"500 does not map to ErrForbidden", http.StatusInternalServerError, ErrForbidden, false},
+		{"500 does not map to ErrBadRequest", http.StatusInternalServerError, ErrBadRequest, false},
+		{"500 does not map to ErrRateLimited", http.StatusInternalServerError, ErrRateLimited, false},
+		{"500 Unwrap returns nil", http.StatusInternalServerError, nil, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := &APIError{StatusCode: tc.statusCode, Details: "test"}
+			if tc.sentinel == nil {
+				// Special case: assert Unwrap() is nil.
+				assert.Nil(t, err.Unwrap())
+				return
+			}
+			assert.Equal(t, tc.wantIs, errors.Is(err, tc.sentinel))
+		})
+	}
+}
+
+func TestAPIError_Error(t *testing.T) {
+	err := &APIError{StatusCode: 401, Details: "No valid API key"}
+	msg := err.Error()
+	assert.Contains(t, msg, "401")
+	assert.Contains(t, msg, "No valid API key")
+}
+
+// ---------------------------------------------------------------------------
+// T002: searchPage + matchPerson + do
+// ---------------------------------------------------------------------------
+
+func makeSearchResponse(people []apolloPerson, total, page, perPage int) []byte {
+	resp := apolloSearchResponse{
+		People: people,
+		Pagination: apolloPagination{
+			Page:         page,
+			PerPage:      perPage,
+			TotalEntries: total,
+		},
+	}
+	b, _ := json.Marshal(resp)
+	return b
+}
+
+func makeMatchResponse(email, emailStatus string) []byte {
+	resp := apolloMatchResponse{
+		Person: apolloPerson{
+			Email:       email,
+			EmailStatus: emailStatus,
+		},
+	}
+	b, _ := json.Marshal(resp)
+	return b
+}
+
+func TestSearchPage_Decode(t *testing.T) {
+	people := []apolloPerson{
+		{
+			ID:           "p1",
+			FirstName:    "Alice",
+			LastName:     "Smith",
+			Name:         "Alice Smith",
+			Title:        "Engineer",
+			Seniority:    "senior",
+			Departments:  []string{"Engineering"},
+			Organization: apolloOrganization{Name: "ACME Corp"},
+		},
+		{
+			ID:           "p2",
+			FirstName:    "Bob",
+			LastName:     "Jones",
+			Name:         "Bob Jones",
+			Title:        "Manager",
+			Organization: apolloOrganization{Name: "ACME Corp"},
+		},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(makeSearchResponse(people, 2, 1, 10))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	got, total, err := c.searchPage(context.Background(), "example.com", nil, 1)
+	require.NoError(t, err)
+	assert.Equal(t, 2, total)
+	require.Len(t, got, 2)
+
+	assert.Equal(t, "p1", got[0].ID)
+	assert.Equal(t, "Alice Smith", got[0].Name)
+	assert.Equal(t, "Engineer", got[0].Title)
+	assert.Equal(t, "ACME Corp", got[0].Organization)
+	assert.Empty(t, got[0].Email, "Email must be empty in search result")
+	assert.False(t, got[0].Revealed, "Revealed must be false in search result")
+
+	assert.Equal(t, "p2", got[1].ID)
+}
+
+func TestSearchPage_401(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"invalid api key"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	_, _, err := c.searchPage(context.Background(), "example.com", nil, 1)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrUnauthorized), "expected ErrUnauthorized, got %v", err)
+
+	var apiErr *APIError
+	require.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, 401, apiErr.StatusCode)
+}
+
+func TestSearchPage_422(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"message":"invalid params"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	_, _, err := c.searchPage(context.Background(), "example.com", nil, 1)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrBadRequest), "expected ErrBadRequest, got %v", err)
+}
+
+func TestMatchPerson_Decode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(makeMatchResponse("alice@example.com", "verified"))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	email, status, err := c.matchPerson(context.Background(), "p1")
+	require.NoError(t, err)
+	assert.Equal(t, "alice@example.com", email)
+	assert.Equal(t, "verified", status)
+}
+
+func TestDo_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("not-json{{{"))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	// searchPage uses do() internally; a 200 with bad JSON triggers a decode error.
+	_, _, err := c.searchPage(context.Background(), "example.com", nil, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decoding apollo search response")
+}
+
+func TestDo_SetsAuthHeader(t *testing.T) {
+	var capturedHeader string
+	var capturedURL string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeader = r.Header.Get(headerAPIKey)
+		capturedURL = r.URL.String()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(makeSearchResponse(nil, 0, 1, 10))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	_, _, err := c.searchPage(context.Background(), "example.com", nil, 1)
+	require.NoError(t, err)
+
+	// X-Api-Key must be set as a header with the correct value.
+	assert.Equal(t, "testkey", capturedHeader, "X-Api-Key header must be set")
+
+	// The key must NOT appear in the request URL (P0-1: header-based auth only).
+	assert.NotContains(t, capturedURL, "testkey", "API key must not appear in URL")
+}
+
+// ---------------------------------------------------------------------------
+// T003: SearchPeople pagination + RevealEmails
+// ---------------------------------------------------------------------------
+
+// pagedSearchServer returns an httptest.Server that serves paginated Apollo
+// search results (page-based, not offset-based). Each request must include a
+// `page` field in the JSON body. midErrPage triggers a 429 when page >= midErrPage.
+func pagedSearchServer(t *testing.T, allPeople []apolloPerson, total, pageSize, midErrPage int) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var requestCount atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+
+		var req apolloSearchRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		page := req.Page
+		if page <= 0 {
+			page = 1
+		}
+
+		if midErrPage > 0 && page >= midErrPage {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":"rate limit exceeded"}`))
+			return
+		}
+
+		start := (page - 1) * pageSize
+		end := start + pageSize
+		if start > len(allPeople) {
+			start = len(allPeople)
+		}
+		if end > len(allPeople) {
+			end = len(allPeople)
+		}
+		pageSlice := allPeople[start:end]
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(makeSearchResponse(pageSlice, total, page, pageSize))
+	}))
+
+	return srv, &requestCount
+}
+
+func makePerson(id string) apolloPerson {
+	return apolloPerson{
+		ID:    id,
+		Name:  "Person " + id,
+		Title: "Engineer",
+		Organization: apolloOrganization{Name: "Corp"},
+	}
+}
+
+func TestSearchPeople_Pagination(t *testing.T) {
+	tests := []struct {
+		name         string
+		allPeople    []apolloPerson
+		total        int
+		pageSize     int
+		limit        int
+		midErrPage   int
+		wantPeople   int
+		wantRequests int32
+		wantErr      error
+	}{
+		{
+			name:         "single page — all fit",
+			allPeople:    []apolloPerson{makePerson("p1"), makePerson("p2"), makePerson("p3")},
+			total:        3,
+			pageSize:     10,
+			limit:        0,
+			wantPeople:   3,
+			wantRequests: 1,
+		},
+		{
+			name: "two full pages plus short final",
+			allPeople: []apolloPerson{
+				makePerson("p1"), makePerson("p2"),
+				makePerson("p3"), makePerson("p4"),
+				makePerson("p5"),
+			},
+			total:        5,
+			pageSize:     2,
+			limit:        0,
+			wantPeople:   5,
+			wantRequests: 3,
+		},
+		{
+			name:         "empty domain — 0 people, 1 request",
+			allPeople:    []apolloPerson{},
+			total:        0,
+			pageSize:     10,
+			limit:        0,
+			wantPeople:   0,
+			wantRequests: 1,
+		},
+		{
+			name: "--limit=2 of 5 available returns exactly 2",
+			allPeople: []apolloPerson{
+				makePerson("p1"), makePerson("p2"),
+				makePerson("p3"), makePerson("p4"),
+				makePerson("p5"),
+			},
+			total:        5,
+			pageSize:     10,
+			limit:        2,
+			wantPeople:   2,
+			wantRequests: 1,
+		},
+		{
+			name: "mid-pagination 429 → ErrRateLimited",
+			allPeople: []apolloPerson{
+				makePerson("p1"), makePerson("p2"),
+				makePerson("p3"),
+			},
+			total:        3,
+			pageSize:     2,
+			limit:        0,
+			midErrPage:   2,
+			wantErr:      ErrRateLimited,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, reqCount := pagedSearchServer(t, tc.allPeople, tc.total, tc.pageSize, tc.midErrPage)
+			defer srv.Close()
+
+			c := newTestClient(srv.URL)
+			c.pageSize = tc.pageSize
+
+			result, err := c.SearchPeople(context.Background(), "example.com", nil, tc.limit)
+
+			if tc.wantErr != nil {
+				require.Error(t, err)
+				assert.True(t, errors.Is(err, tc.wantErr), "expected %v, got %v", tc.wantErr, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantPeople, len(result.People))
+			assert.Equal(t, tc.wantRequests, reqCount.Load())
+		})
+	}
+}
+
+func TestSearchPeople_ContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Simulate a slow server that outlasts the context timeout.
+		time.Sleep(200 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(makeSearchResponse([]apolloPerson{makePerson("p1")}, 100, 1, 1))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	c.pageSize = 1
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := c.SearchPeople(ctx, "example.com", nil, 0)
+	require.Error(t, err, "expected error due to context cancellation")
+}
+
+// ---------------------------------------------------------------------------
+// RevealEmails tests
+// ---------------------------------------------------------------------------
+
+func TestRevealEmails_Merge(t *testing.T) {
+	// 3 people: server returns email for p1, email for p2, empty for p3.
+	// All 3 should get Revealed=true (partial-result honesty); result.Revealed=true.
+	responses := map[string]string{
+		"p1": "alice@example.com",
+		"p2": "bob@example.com",
+		"p3": "", // no email returned
+	}
+	statuses := map[string]string{
+		"p1": "verified",
+		"p2": "verified",
+		"p3": "unknown",
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req apolloMatchRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		email := responses[req.ID]
+		status := statuses[req.ID]
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(makeMatchResponse(email, status))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	result := &DomainResult{
+		Domain: "example.com",
+		People: []Person{
+			{ID: "p1"},
+			{ID: "p2"},
+			{ID: "p3"},
+		},
+	}
+
+	err := c.RevealEmails(context.Background(), result)
+	require.NoError(t, err)
+
+	assert.Equal(t, "alice@example.com", result.People[0].Email)
+	assert.True(t, result.People[0].Revealed)
+
+	assert.Equal(t, "bob@example.com", result.People[1].Email)
+	assert.True(t, result.People[1].Revealed)
+
+	// Third person: empty email but still Revealed=true (partial-result honesty).
+	assert.Empty(t, result.People[2].Email)
+	assert.True(t, result.People[2].Revealed, "Revealed=true even when email is empty")
+
+	// result.Revealed is set when there were people to reveal.
+	assert.True(t, result.Revealed)
+}
+
+func TestRevealEmails_SkipsEmptyID(t *testing.T) {
+	var requestCount atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(makeMatchResponse("alice@example.com", "verified"))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	result := &DomainResult{
+		Domain: "example.com",
+		People: []Person{
+			{ID: ""},    // must be skipped — no match call
+			{ID: "p2"},  // should be revealed
+			{ID: ""},    // must be skipped
+		},
+	}
+
+	err := c.RevealEmails(context.Background(), result)
+	require.NoError(t, err)
+
+	// Only the person with a non-empty ID should have triggered a request.
+	assert.Equal(t, int32(1), requestCount.Load(), "only 1 match request for the non-empty ID")
+	assert.False(t, result.People[0].Revealed, "empty-ID person should not be revealed")
+	assert.True(t, result.People[1].Revealed)
+	assert.False(t, result.People[2].Revealed, "empty-ID person should not be revealed")
+}
+
+func TestRevealEmails_SerialCount(t *testing.T) {
+	var requestCount atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(makeMatchResponse(fmt.Sprintf("user%d@example.com", requestCount.Load()), "verified"))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	result := &DomainResult{
+		Domain: "example.com",
+		People: []Person{
+			{ID: "p1"}, {ID: "p2"}, {ID: "p3"}, {ID: "p4"}, {ID: "p5"},
+		},
+	}
+
+	err := c.RevealEmails(context.Background(), result)
+	require.NoError(t, err)
+	assert.Equal(t, int32(5), requestCount.Load(), "exactly 5 match requests for 5 people")
+}

--- a/pkg/enum/apollo/apollo_test.go
+++ b/pkg/enum/apollo/apollo_test.go
@@ -47,13 +47,13 @@ func newTestClient(baseURL string) *Client {
 
 func TestToPerson(t *testing.T) {
 	src := &apolloPerson{
-		ID:          "abc123",
-		FirstName:   "Alice",
-		LastName:    "Smith",
-		Name:        "Alice Smith",
-		Title:       "VP Engineering",
-		Seniority:   "director",
-		Departments: []string{"Engineering", "Product"},
+		ID:           "abc123",
+		FirstName:    "Alice",
+		LastName:     "Smith",
+		Name:         "Alice Smith",
+		Title:        "VP Engineering",
+		Seniority:    "director",
+		Departments:  []string{"Engineering", "Product"},
 		Organization: apolloOrganization{Name: "Example Corp"},
 	}
 	got := toPerson(src)
@@ -114,10 +114,13 @@ func TestAPIError_Unwrap(t *testing.T) {
 }
 
 func TestAPIError_Error(t *testing.T) {
-	err := &APIError{StatusCode: 401, Details: "No valid API key"}
+	// Error() must include the HTTP status code.
+	err := &APIError{StatusCode: 401, Details: "SECRETKEY-DO-NOT-LEAK"}
 	msg := err.Error()
 	assert.Contains(t, msg, "401")
-	assert.Contains(t, msg, "No valid API key")
+	// P0-1 security fix: Details must NOT appear in Error() output.
+	assert.NotContains(t, msg, "SECRETKEY-DO-NOT-LEAK",
+		"APIError.Error() must not include Details (P0-1 key-leak prevention)")
 }
 
 // ---------------------------------------------------------------------------
@@ -318,9 +321,9 @@ func pagedSearchServer(t *testing.T, allPeople []apolloPerson, total, pageSize, 
 
 func makePerson(id string) apolloPerson {
 	return apolloPerson{
-		ID:    id,
-		Name:  "Person " + id,
-		Title: "Engineer",
+		ID:           id,
+		Name:         "Person " + id,
+		Title:        "Engineer",
 		Organization: apolloOrganization{Name: "Corp"},
 	}
 }
@@ -382,16 +385,17 @@ func TestSearchPeople_Pagination(t *testing.T) {
 			wantRequests: 1,
 		},
 		{
-			name: "mid-pagination 429 → ErrRateLimited",
+			name: "mid-pagination 429 → ErrRateLimited, partial result non-nil",
 			allPeople: []apolloPerson{
 				makePerson("p1"), makePerson("p2"),
 				makePerson("p3"),
 			},
-			total:        3,
-			pageSize:     2,
-			limit:        0,
-			midErrPage:   2,
-			wantErr:      ErrRateLimited,
+			total:      3,
+			pageSize:   2,
+			limit:      0,
+			midErrPage: 2,
+			wantPeople: 2, // first page of 2 fetched before error
+			wantErr:    ErrRateLimited,
 		},
 	}
 
@@ -408,6 +412,10 @@ func TestSearchPeople_Pagination(t *testing.T) {
 			if tc.wantErr != nil {
 				require.Error(t, err)
 				assert.True(t, errors.Is(err, tc.wantErr), "expected %v, got %v", tc.wantErr, err)
+				// SearchPeople returns a non-nil partial result even on mid-pagination error.
+				require.NotNil(t, result, "partial result must be non-nil on mid-pagination error")
+				assert.Equal(t, tc.wantPeople, len(result.People),
+					"partial result must contain pages fetched before error")
 				return
 			}
 
@@ -506,9 +514,9 @@ func TestRevealEmails_SkipsEmptyID(t *testing.T) {
 	result := &DomainResult{
 		Domain: "example.com",
 		People: []Person{
-			{ID: ""},    // must be skipped — no match call
-			{ID: "p2"},  // should be revealed
-			{ID: ""},    // must be skipped
+			{ID: ""},   // must be skipped — no match call
+			{ID: "p2"}, // should be revealed
+			{ID: ""},   // must be skipped
 		},
 	}
 
@@ -543,4 +551,46 @@ func TestRevealEmails_SerialCount(t *testing.T) {
 	err := c.RevealEmails(context.Background(), result)
 	require.NoError(t, err)
 	assert.Equal(t, int32(5), requestCount.Load(), "exactly 5 match requests for 5 people")
+}
+
+// TestRevealEmails_ResultRevealedOnFirstSuccess asserts that result.Revealed is
+// set to true after the FIRST successful match, even if a later match fails.
+// This reflects that credits were spent for the successful reveals.
+func TestRevealEmails_ResultRevealedOnFirstSuccess(t *testing.T) {
+	var callCount atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := callCount.Add(1)
+		if n == 1 {
+			// First match succeeds.
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(makeMatchResponse("alice@example.com", "verified"))
+			return
+		}
+		// Second match returns a 429 — simulates a failure after the first success.
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":"rate limit exceeded"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	result := &DomainResult{
+		Domain: "example.com",
+		People: []Person{
+			{ID: "p1"},
+			{ID: "p2"},
+		},
+	}
+
+	err := c.RevealEmails(context.Background(), result)
+	// The second match fails — RevealEmails surfaces the error.
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrRateLimited))
+
+	// result.Revealed must be true because the FIRST match succeeded (credits spent).
+	assert.True(t, result.Revealed,
+		"result.Revealed must be true once any match succeeds, even if later matches fail")
+	// First person has their email and Revealed=true.
+	assert.Equal(t, "alice@example.com", result.People[0].Email)
+	assert.True(t, result.People[0].Revealed)
 }

--- a/pkg/enum/lusha/lusha.go
+++ b/pkg/enum/lusha/lusha.go
@@ -93,11 +93,16 @@ type Contact struct {
 // APIError is returned for any non-2xx HTTP status from Lusha.
 type APIError struct {
 	StatusCode int
-	Details    string
+	// Details holds server-derived text (resp.Status or error-envelope message)
+	// for internal/debug use. It is deliberately EXCLUDED from Error() so a
+	// caller that logs the error cannot leak echoed keys/PII (P0-1).
+	Details string
 }
 
+// Error returns ONLY status-derived text. It does NOT include Details, which
+// could echo vendor response content back into logs (P0-1).
 func (e *APIError) Error() string {
-	return fmt.Sprintf("lusha API error (HTTP %d): %s", e.StatusCode, e.Details)
+	return fmt.Sprintf("lusha API error (HTTP %d)", e.StatusCode)
 }
 
 // Unwrap maps the status code to its sentinel error, nil otherwise.
@@ -205,44 +210,61 @@ func (c *Client) do(ctx context.Context, method, path string, body any) ([]byte,
 	return raw, nil
 }
 
-// buildEnrichRequest maps the identity group + reveal flags to the v3 request
-// shape. The exact v3 field names are UNVERIFIED against a live key
-// (architecture §11) — they are isolated in lushaEnrichRequest below so a
-// single struct edit corrects any mismatch without touching control flow.
+// buildEnrichRequest maps the identity group + reveal flags to the v3 batch
+// request shape: a single contact plus a reveal token list. The reveal token
+// values ("emails"/"phones") are UNVERIFIED against a live key — they are
+// isolated here so a single edit corrects any mismatch without touching control
+// flow.
 func buildEnrichRequest(q ContactQuery, r RevealOptions) lushaEnrichRequest {
+	var reveal []string
+	if r.Email {
+		reveal = append(reveal, "emails")
+	}
+	if r.Phone {
+		reveal = append(reveal, "phones")
+	}
 	return lushaEnrichRequest{
-		FirstName:     q.FirstName,
-		LastName:      q.LastName,
-		CompanyName:   q.CompanyName,
-		CompanyDomain: q.CompanyDomain,
-		Email:         q.Email,
-		LinkedinURL:   q.LinkedinURL,
-		RevealEmails:  r.Email,
-		RevealPhones:  r.Phone,
+		Contacts: []lushaReqContact{{
+			FirstName:     q.FirstName,
+			LastName:      q.LastName,
+			CompanyName:   q.CompanyName,
+			CompanyDomain: q.CompanyDomain,
+			Email:         q.Email,
+			LinkedinURL:   q.LinkedinURL,
+		}},
+		Reveal: reveal,
 	}
 }
 
-// toContact converts the v3 response into the public Contact type, preserving
-// the per-phone DoNotCall flag (P0-DNC).
+// toContact converts the v3 batch response into the public Contact type,
+// reading the single Results[0] entry and preserving the per-phone DoNotCall
+// flag (P0-DNC). An empty Results yields an empty *Contact (no error).
 func toContact(resp *lushaEnrichResponse) *Contact {
+	if len(resp.Results) == 0 {
+		return &Contact{}
+	}
+	r := resp.Results[0]
+
+	name := r.FirstName
+	if r.LastName != "" {
+		if name != "" {
+			name += " "
+		}
+		name += r.LastName
+	}
+
 	c := &Contact{
-		Name:     resp.Name,
-		JobTitle: resp.JobTitle,
-		Company:  resp.Company,
+		Name:     name,
+		JobTitle: r.JobTitle.Title,
+		Company:  r.Company.Name,
 	}
-	for _, e := range resp.EmailAddresses {
-		c.Emails = append(c.Emails, EmailEntry{
-			Address:    e.Address,
-			Type:       e.Type,
-			Confidence: e.Confidence,
-		})
+	// lushaEmail/lushaPhone are field-for-field identical to EmailEntry/PhoneEntry,
+	// so convert directly per element (staticcheck S1016).
+	for _, e := range r.ContactMethods.Emails {
+		c.Emails = append(c.Emails, EmailEntry(e))
 	}
-	for _, p := range resp.PhoneNumbers {
-		c.Phones = append(c.Phones, PhoneEntry{
-			Number:    p.Number,
-			Type:      p.Type,
-			DoNotCall: p.DoNotCall,
-		})
+	for _, p := range r.ContactMethods.Phones {
+		c.Phones = append(c.Phones, PhoneEntry(p))
 	}
 	return c
 }
@@ -254,33 +276,56 @@ func toContact(resp *lushaEnrichResponse) *Contact {
 // pass regardless of live-schema correctness.
 // ---------------------------------------------------------------------------
 
-// lushaEnrichRequest is the v3 search-and-enrich request body.
-// UNVERIFIED field names (firstName/lastName/companyName/companyDomain/email/
-// linkedinUrl + reveal control shape) — flag for live-key verification.
+// lushaEnrichRequest is the v3 search-and-enrich request body. The real v3
+// POST /v3/contacts/search-and-enrich uses a BATCH shape: a contacts array
+// (we send a single contact) plus a reveal token list.
 type lushaEnrichRequest struct {
+	Contacts []lushaReqContact `json:"contacts"`
+	// Reveal is the datapoint-family token list, e.g. ["emails","phones"].
+	// NOTE: the exact reveal token values ("emails"/"phones") remain UNVERIFIED
+	// against a live key (residual live-schema risk flagged in review).
+	Reveal []string `json:"reveal"`
+}
+
+// lushaReqContact is one identity in the batch. Exactly one identity group is
+// set: firstName+lastName+(companyName|companyDomain) | email | linkedinUrl.
+type lushaReqContact struct {
 	FirstName     string `json:"firstName,omitempty"`
 	LastName      string `json:"lastName,omitempty"`
 	CompanyName   string `json:"companyName,omitempty"`
 	CompanyDomain string `json:"companyDomain,omitempty"`
 	Email         string `json:"email,omitempty"`
 	LinkedinURL   string `json:"linkedinUrl,omitempty"`
-	RevealEmails  bool   `json:"revealEmails"`
-	RevealPhones  bool   `json:"revealPhoneNumbers"`
 }
 
-// lushaEnrichResponse is the v3 search-and-enrich response body.
-// UNVERIFIED: emailAddresses[]{address,type,confidence} ("email" vs "address"
-// key uncertain), phoneNumbers[]{number,type,doNotCall}, name, jobTitle,
-// company — flag for live-key verification.
+// lushaEnrichResponse is the v3 search-and-enrich response body. results is a
+// batch parallel to the request contacts; we send one contact so read
+// Results[0].
 type lushaEnrichResponse struct {
-	Name           string       `json:"name"`
-	JobTitle       string       `json:"jobTitle"`
-	Company        string       `json:"company"`
-	EmailAddresses []lushaEmail `json:"emailAddresses"`
-	PhoneNumbers   []lushaPhone `json:"phoneNumbers"`
+	RequestID string        `json:"requestId"`
+	Results   []lushaResult `json:"results"`
+}
+
+// lushaResult is one enriched contact from the batch.
+type lushaResult struct {
+	FirstName string `json:"firstName"`
+	LastName  string `json:"lastName"`
+	JobTitle  struct {
+		Title string `json:"title"`
+	} `json:"jobTitle"`
+	Company struct {
+		Name   string `json:"name"`
+		Domain string `json:"domain"`
+	} `json:"company"`
+	ContactMethods struct {
+		Emails []lushaEmail `json:"emails"`
+		Phones []lushaPhone `json:"phones"`
+	} `json:"contactMethods"`
 }
 
 type lushaEmail struct {
+	// NOTE: the email field key ("address" vs "email") remains UNVERIFIED against
+	// a live key — residual live-schema risk flagged in review.
 	Address    string `json:"address"`
 	Type       string `json:"type"`
 	Confidence string `json:"confidence"`

--- a/pkg/enum/lusha/lusha.go
+++ b/pkg/enum/lusha/lusha.go
@@ -1,0 +1,299 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package lusha provides a client for the Lusha v3 search-and-enrich API.
+// It resolves a single person identity to an enriched contact (emails + phones),
+// with typed errors and context cancellation. A single Enrich call spends credits.
+package lusha
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/praetorian-inc/brutus/pkg/enum"
+)
+
+// Sentinel errors for use with errors.Is by callers.
+var (
+	ErrUnauthorized = errors.New("invalid or missing Lusha API key") // 401
+	ErrForbidden    = errors.New("access forbidden")                 // 403
+	ErrNoCredits    = errors.New("insufficient Lusha credits")       // 402
+	ErrRateLimited  = errors.New("rate limit exceeded")              // 429
+	ErrNotFound     = errors.New("no contact found for identity")    // 404
+)
+
+const (
+	defaultBaseURL = "https://api.lusha.com"
+	enrichPath     = "/v3/contacts/search-and-enrich"
+	// headerAPIKey is the Lusha auth header name. UNVERIFIED against a live key
+	// (discovery §3 / architecture §11) — isolated here for a single-edit fix.
+	headerAPIKey = "api_key"
+)
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+// ContactQuery carries exactly one identity group (validated at the CLI layer).
+type ContactQuery struct {
+	FirstName     string
+	LastName      string
+	CompanyName   string // pairs with FirstName+LastName
+	CompanyDomain string // alternative to CompanyName
+	Email         string
+	LinkedinURL   string
+}
+
+// RevealOptions controls which datapoint families are requested (all cost credits).
+type RevealOptions struct {
+	Email bool
+	Phone bool
+}
+
+// EmailEntry is one returned email address.
+type EmailEntry struct {
+	Address    string
+	Type       string
+	Confidence string
+}
+
+// PhoneEntry is one returned phone number. DoNotCall is a compliance signal
+// that MUST be surfaced to the operator (P0-DNC) — never hidden.
+type PhoneEntry struct {
+	Number    string
+	Type      string
+	DoNotCall bool
+}
+
+// Contact is the enriched result for one identity.
+type Contact struct {
+	Name     string
+	JobTitle string
+	Company  string
+	Emails   []EmailEntry
+	Phones   []PhoneEntry
+}
+
+// APIError is returned for any non-2xx HTTP status from Lusha.
+type APIError struct {
+	StatusCode int
+	Details    string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("lusha API error (HTTP %d): %s", e.StatusCode, e.Details)
+}
+
+// Unwrap maps the status code to its sentinel error, nil otherwise.
+// This enables errors.Is(err, lusha.ErrNoCredits) in callers; the *APIError
+// itself stays retrievable via errors.As.
+func (e *APIError) Unwrap() error {
+	switch e.StatusCode {
+	case http.StatusUnauthorized:
+		return ErrUnauthorized
+	case http.StatusPaymentRequired:
+		return ErrNoCredits
+	case http.StatusForbidden:
+		return ErrForbidden
+	case http.StatusNotFound:
+		return ErrNotFound
+	case http.StatusTooManyRequests:
+		return ErrRateLimited
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+// Client holds state for querying the Lusha v3 search-and-enrich API.
+type Client struct {
+	apiKey     string // api_key header — NEVER logged (P0-1, P0-1b)
+	httpClient *http.Client
+	baseURL    string
+}
+
+// NewClient builds a Lusha client. timeout is the per-request HTTP budget.
+// There is no page size: one identity in, one contact out.
+func NewClient(apiKey string, timeout time.Duration) *Client {
+	return &Client{
+		apiKey:     apiKey,
+		httpClient: enum.NewEnumHTTPClient(timeout),
+		baseURL:    defaultBaseURL,
+	}
+}
+
+// Enrich resolves one identity to an enriched contact via v3 search-and-enrich.
+// A 200 with no datapoints returns a *Contact with empty slices (not an error).
+func (c *Client) Enrich(ctx context.Context, q ContactQuery, r RevealOptions) (*Contact, error) {
+	body := buildEnrichRequest(q, r)
+	raw, err := c.do(ctx, http.MethodPost, enrichPath, body)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp lushaEnrichResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, fmt.Errorf("decoding lusha response: %w", err)
+	}
+	return toContact(&resp), nil
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+// do performs a single JSON request. It sets the api_key header inline (never
+// in the URL), reads the body via the bounded reader (P0-3), and maps non-2xx
+// statuses to *APIError. The key, header, body, and URL are NEVER logged
+// (P0-1); full-request dumping is forbidden (P0-1c) because the auth header
+// would be captured.
+func (c *Client) do(ctx context.Context, method, path string, body any) ([]byte, error) {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("encoding lusha request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("building lusha request: %w", err)
+	}
+	req.Header.Set(headerAPIKey, c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("lusha request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Bounded read — reuses enum.ReadResponseBody (P0-3 security requirement).
+	raw, err := enum.ReadResponseBody(resp, 0)
+	if err != nil {
+		return nil, fmt.Errorf("reading lusha response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		// Extract details from the error envelope if decodable, else resp.Status.
+		// Details is only ever resp.Status or server-envelope text — never the
+		// request body or key. The classifier (CLI layer) does not echo it.
+		details := resp.Status
+		var env lushaErrorEnvelope
+		if json.Unmarshal(raw, &env) == nil && env.Message != "" {
+			details = env.Message
+		}
+		return nil, &APIError{StatusCode: resp.StatusCode, Details: details}
+	}
+
+	return raw, nil
+}
+
+// buildEnrichRequest maps the identity group + reveal flags to the v3 request
+// shape. The exact v3 field names are UNVERIFIED against a live key
+// (architecture §11) — they are isolated in lushaEnrichRequest below so a
+// single struct edit corrects any mismatch without touching control flow.
+func buildEnrichRequest(q ContactQuery, r RevealOptions) lushaEnrichRequest {
+	return lushaEnrichRequest{
+		FirstName:     q.FirstName,
+		LastName:      q.LastName,
+		CompanyName:   q.CompanyName,
+		CompanyDomain: q.CompanyDomain,
+		Email:         q.Email,
+		LinkedinURL:   q.LinkedinURL,
+		RevealEmails:  r.Email,
+		RevealPhones:  r.Phone,
+	}
+}
+
+// toContact converts the v3 response into the public Contact type, preserving
+// the per-phone DoNotCall flag (P0-DNC).
+func toContact(resp *lushaEnrichResponse) *Contact {
+	c := &Contact{
+		Name:     resp.Name,
+		JobTitle: resp.JobTitle,
+		Company:  resp.Company,
+	}
+	for _, e := range resp.EmailAddresses {
+		c.Emails = append(c.Emails, EmailEntry{
+			Address:    e.Address,
+			Type:       e.Type,
+			Confidence: e.Confidence,
+		})
+	}
+	for _, p := range resp.PhoneNumbers {
+		c.Phones = append(c.Phones, PhoneEntry{
+			Number:    p.Number,
+			Type:      p.Type,
+			DoNotCall: p.DoNotCall,
+		})
+	}
+	return c
+}
+
+// ---------------------------------------------------------------------------
+// JSON-mapping structs (unexported) — UNVERIFIED Lusha v3 field names.
+// Architecture §11: isolated here so a single edit corrects a live mismatch
+// without touching control flow. httptest tests use controlled payloads and
+// pass regardless of live-schema correctness.
+// ---------------------------------------------------------------------------
+
+// lushaEnrichRequest is the v3 search-and-enrich request body.
+// UNVERIFIED field names (firstName/lastName/companyName/companyDomain/email/
+// linkedinUrl + reveal control shape) — flag for live-key verification.
+type lushaEnrichRequest struct {
+	FirstName     string `json:"firstName,omitempty"`
+	LastName      string `json:"lastName,omitempty"`
+	CompanyName   string `json:"companyName,omitempty"`
+	CompanyDomain string `json:"companyDomain,omitempty"`
+	Email         string `json:"email,omitempty"`
+	LinkedinURL   string `json:"linkedinUrl,omitempty"`
+	RevealEmails  bool   `json:"revealEmails"`
+	RevealPhones  bool   `json:"revealPhoneNumbers"`
+}
+
+// lushaEnrichResponse is the v3 search-and-enrich response body.
+// UNVERIFIED: emailAddresses[]{address,type,confidence} ("email" vs "address"
+// key uncertain), phoneNumbers[]{number,type,doNotCall}, name, jobTitle,
+// company — flag for live-key verification.
+type lushaEnrichResponse struct {
+	Name           string       `json:"name"`
+	JobTitle       string       `json:"jobTitle"`
+	Company        string       `json:"company"`
+	EmailAddresses []lushaEmail `json:"emailAddresses"`
+	PhoneNumbers   []lushaPhone `json:"phoneNumbers"`
+}
+
+type lushaEmail struct {
+	Address    string `json:"address"`
+	Type       string `json:"type"`
+	Confidence string `json:"confidence"`
+}
+
+type lushaPhone struct {
+	Number    string `json:"number"`
+	Type      string `json:"type"`
+	DoNotCall bool   `json:"doNotCall"`
+}
+
+// lushaErrorEnvelope is the (UNVERIFIED) shape of a v3 error body. Only its
+// Message is surfaced as APIError.Details (never the key or request body).
+type lushaErrorEnvelope struct {
+	Message string `json:"message"`
+}

--- a/pkg/enum/lusha/lusha_test.go
+++ b/pkg/enum/lusha/lusha_test.go
@@ -1,0 +1,324 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lusha
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestClient overrides baseURL for httptest usage.
+func newTestClient(baseURL string) *Client {
+	c := NewClient("testkey", 5*time.Second)
+	c.baseURL = baseURL
+	return c
+}
+
+// ---------------------------------------------------------------------------
+// T101: toContact + APIError/Unwrap
+// ---------------------------------------------------------------------------
+
+func TestToContact(t *testing.T) {
+	resp := &lushaEnrichResponse{
+		Name:     "Ada Lovelace",
+		JobTitle: "Mathematician",
+		Company:  "Analytical Engine Co",
+		EmailAddresses: []lushaEmail{
+			{Address: "ada@example.com", Type: "professional", Confidence: "high"},
+			{Address: "ada.personal@gmail.com", Type: "personal", Confidence: "medium"},
+		},
+		PhoneNumbers: []lushaPhone{
+			{Number: "+1-555-0100", Type: "direct", DoNotCall: false},
+			{Number: "+1-555-0199", Type: "mobile", DoNotCall: true},
+		},
+	}
+	got := toContact(resp)
+	assert.Equal(t, "Ada Lovelace", got.Name)
+	assert.Equal(t, "Mathematician", got.JobTitle)
+	assert.Equal(t, "Analytical Engine Co", got.Company)
+
+	require.Len(t, got.Emails, 2)
+	assert.Equal(t, "ada@example.com", got.Emails[0].Address)
+	assert.Equal(t, "professional", got.Emails[0].Type)
+	assert.Equal(t, "high", got.Emails[0].Confidence)
+	assert.Equal(t, "ada.personal@gmail.com", got.Emails[1].Address)
+
+	require.Len(t, got.Phones, 2)
+	assert.Equal(t, "+1-555-0100", got.Phones[0].Number)
+	assert.Equal(t, "direct", got.Phones[0].Type)
+	assert.False(t, got.Phones[0].DoNotCall)
+
+	assert.Equal(t, "+1-555-0199", got.Phones[1].Number)
+	assert.Equal(t, "mobile", got.Phones[1].Type)
+	// DoNotCall MUST be preserved (P0-DNC compliance requirement).
+	assert.True(t, got.Phones[1].DoNotCall, "DoNotCall flag must be preserved")
+}
+
+func TestAPIError_Unwrap(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		sentinel   error
+		wantIs     bool
+	}{
+		{"401 maps to ErrUnauthorized", http.StatusUnauthorized, ErrUnauthorized, true},
+		{"402 maps to ErrNoCredits", http.StatusPaymentRequired, ErrNoCredits, true},
+		{"403 maps to ErrForbidden", http.StatusForbidden, ErrForbidden, true},
+		{"404 maps to ErrNotFound", http.StatusNotFound, ErrNotFound, true},
+		{"429 maps to ErrRateLimited", http.StatusTooManyRequests, ErrRateLimited, true},
+		{"500 does not map to ErrUnauthorized", http.StatusInternalServerError, ErrUnauthorized, false},
+		{"500 does not map to ErrNoCredits", http.StatusInternalServerError, ErrNoCredits, false},
+		{"500 does not map to ErrRateLimited", http.StatusInternalServerError, ErrRateLimited, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := &APIError{StatusCode: tc.statusCode, Details: "test"}
+			assert.Equal(t, tc.wantIs, errors.Is(err, tc.sentinel))
+		})
+	}
+}
+
+func TestAPIError_Error(t *testing.T) {
+	err := &APIError{StatusCode: 402, Details: "no credits remaining"}
+	assert.Contains(t, err.Error(), "402")
+	assert.Contains(t, err.Error(), "no credits remaining")
+}
+
+// ---------------------------------------------------------------------------
+// T102: Enrich success + auth header + request body
+// ---------------------------------------------------------------------------
+
+func TestEnrich_Success(t *testing.T) {
+	var capturedReqBody []byte
+	var capturedAPIKey string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedAPIKey = r.Header.Get(headerAPIKey)
+
+		// api_key must NOT appear in the URL query string.
+		assert.NotContains(t, r.URL.RawQuery, "api_key",
+			"api_key must not appear in URL")
+
+		body, _ := io.ReadAll(r.Body)
+		capturedReqBody = body
+
+		resp := lushaEnrichResponse{
+			Name:     "Ada Lovelace",
+			JobTitle: "Engineer",
+			Company:  "AnalyticalCo",
+			EmailAddresses: []lushaEmail{
+				{Address: "ada@example.com", Type: "professional", Confidence: "high"},
+			},
+			PhoneNumbers: []lushaPhone{
+				{Number: "+1-555-0100", Type: "direct", DoNotCall: true},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	q := ContactQuery{
+		FirstName:   "Ada",
+		LastName:    "Lovelace",
+		CompanyName: "AnalyticalCo",
+	}
+	r := RevealOptions{Email: true, Phone: true}
+	contact, err := c.Enrich(context.Background(), q, r)
+	require.NoError(t, err)
+
+	// API key set as header, not in URL.
+	assert.Equal(t, "testkey", capturedAPIKey)
+
+	// Request body must carry the identity.
+	assert.Contains(t, string(capturedReqBody), "Ada",
+		"request body must contain identity fields")
+
+	// Contact fields mapped correctly.
+	require.NotNil(t, contact)
+	require.Len(t, contact.Emails, 1)
+	assert.Equal(t, "ada@example.com", contact.Emails[0].Address)
+
+	require.Len(t, contact.Phones, 1)
+	assert.Equal(t, "+1-555-0100", contact.Phones[0].Number)
+	assert.True(t, contact.Phones[0].DoNotCall, "DNC flag must be preserved")
+}
+
+func TestBuildEnrichRequest(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   ContactQuery
+		reveal  RevealOptions
+		wantReq lushaEnrichRequest
+	}{
+		{
+			name: "name + company",
+			query: ContactQuery{
+				FirstName:   "Ada",
+				LastName:    "Lovelace",
+				CompanyName: "AnalyticalCo",
+			},
+			reveal: RevealOptions{Email: true},
+			wantReq: lushaEnrichRequest{
+				FirstName:    "Ada",
+				LastName:     "Lovelace",
+				CompanyName:  "AnalyticalCo",
+				RevealEmails: true,
+			},
+		},
+		{
+			name: "name + domain",
+			query: ContactQuery{
+				FirstName:     "Ada",
+				LastName:      "Lovelace",
+				CompanyDomain: "analytical.example.com",
+			},
+			reveal: RevealOptions{Email: true, Phone: true},
+			wantReq: lushaEnrichRequest{
+				FirstName:     "Ada",
+				LastName:      "Lovelace",
+				CompanyDomain: "analytical.example.com",
+				RevealEmails:  true,
+				RevealPhones:  true,
+			},
+		},
+		{
+			name:   "email only",
+			query:  ContactQuery{Email: "ada@example.com"},
+			reveal: RevealOptions{Email: true},
+			wantReq: lushaEnrichRequest{
+				Email:        "ada@example.com",
+				RevealEmails: true,
+			},
+		},
+		{
+			name:   "linkedin only",
+			query:  ContactQuery{LinkedinURL: "https://linkedin.com/in/ada"},
+			reveal: RevealOptions{Email: true, Phone: true},
+			wantReq: lushaEnrichRequest{
+				LinkedinURL:  "https://linkedin.com/in/ada",
+				RevealEmails: true,
+				RevealPhones: true,
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildEnrichRequest(tc.query, tc.reveal)
+			assert.Equal(t, tc.wantReq, got)
+		})
+	}
+}
+
+func TestEnrich_401ErrUnauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"invalid API key"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	_, err := c.Enrich(context.Background(), ContactQuery{Email: "a@b.com"}, RevealOptions{Email: true})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrUnauthorized))
+}
+
+func TestEnrich_402ErrNoCredits(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusPaymentRequired)
+		_, _ = w.Write([]byte(`{"message":"insufficient credits"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	_, err := c.Enrich(context.Background(), ContactQuery{Email: "a@b.com"}, RevealOptions{Email: true})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrNoCredits))
+
+	var apiErr *APIError
+	require.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, http.StatusPaymentRequired, apiErr.StatusCode)
+}
+
+func TestEnrich_429ErrRateLimited(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"message":"rate limit exceeded"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	_, err := c.Enrich(context.Background(), ContactQuery{Email: "a@b.com"}, RevealOptions{Email: true})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrRateLimited))
+}
+
+func TestEnrich_EmptyMatch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// 200 with empty arrays — a "no match" that is not an error.
+		resp := lushaEnrichResponse{}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	contact, err := c.Enrich(context.Background(), ContactQuery{Email: "nobody@example.com"}, RevealOptions{Email: true})
+	require.NoError(t, err, "empty 200 must not return an error")
+	require.NotNil(t, contact)
+	assert.Empty(t, contact.Emails)
+	assert.Empty(t, contact.Phones)
+}
+
+func TestEnrich_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("not-json{{{"))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	_, err := c.Enrich(context.Background(), ContactQuery{Email: "a@b.com"}, RevealOptions{Email: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decoding lusha response")
+}
+
+func TestEnrich_ContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Slow server: sleep longer than the ctx deadline.
+		time.Sleep(300 * time.Millisecond)
+		resp := lushaEnrichResponse{}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := c.Enrich(ctx, ContactQuery{Email: "a@b.com"}, RevealOptions{Email: true})
+	require.Error(t, err, "context cancellation must produce an error")
+}

--- a/pkg/enum/lusha/lusha_test.go
+++ b/pkg/enum/lusha/lusha_test.go
@@ -40,17 +40,34 @@ func newTestClient(baseURL string) *Client {
 // ---------------------------------------------------------------------------
 
 func TestToContact(t *testing.T) {
+	// v3 batch response: results array with nested jobTitle/company/contactMethods.
 	resp := &lushaEnrichResponse{
-		Name:     "Ada Lovelace",
-		JobTitle: "Mathematician",
-		Company:  "Analytical Engine Co",
-		EmailAddresses: []lushaEmail{
-			{Address: "ada@example.com", Type: "professional", Confidence: "high"},
-			{Address: "ada.personal@gmail.com", Type: "personal", Confidence: "medium"},
-		},
-		PhoneNumbers: []lushaPhone{
-			{Number: "+1-555-0100", Type: "direct", DoNotCall: false},
-			{Number: "+1-555-0199", Type: "mobile", DoNotCall: true},
+		RequestID: "req-1",
+		Results: []lushaResult{
+			{
+				FirstName: "Ada",
+				LastName:  "Lovelace",
+				JobTitle: struct {
+					Title string `json:"title"`
+				}{Title: "Mathematician"},
+				Company: struct {
+					Name   string `json:"name"`
+					Domain string `json:"domain"`
+				}{Name: "Analytical Engine Co"},
+				ContactMethods: struct {
+					Emails []lushaEmail `json:"emails"`
+					Phones []lushaPhone `json:"phones"`
+				}{
+					Emails: []lushaEmail{
+						{Address: "ada@example.com", Type: "professional", Confidence: "high"},
+						{Address: "ada.personal@gmail.com", Type: "personal", Confidence: "medium"},
+					},
+					Phones: []lushaPhone{
+						{Number: "+1-555-0100", Type: "direct", DoNotCall: false},
+						{Number: "+1-555-0199", Type: "mobile", DoNotCall: true},
+					},
+				},
+			},
 		},
 	}
 	got := toContact(resp)
@@ -73,6 +90,14 @@ func TestToContact(t *testing.T) {
 	assert.Equal(t, "mobile", got.Phones[1].Type)
 	// DoNotCall MUST be preserved (P0-DNC compliance requirement).
 	assert.True(t, got.Phones[1].DoNotCall, "DoNotCall flag must be preserved")
+}
+
+func TestToContact_EmptyResults(t *testing.T) {
+	resp := &lushaEnrichResponse{RequestID: "req-2", Results: nil}
+	got := toContact(resp)
+	require.NotNil(t, got)
+	assert.Empty(t, got.Emails)
+	assert.Empty(t, got.Phones)
 }
 
 func TestAPIError_Unwrap(t *testing.T) {
@@ -100,9 +125,12 @@ func TestAPIError_Unwrap(t *testing.T) {
 }
 
 func TestAPIError_Error(t *testing.T) {
-	err := &APIError{StatusCode: 402, Details: "no credits remaining"}
+	// Error() must include the HTTP status code.
+	err := &APIError{StatusCode: 402, Details: "SECRETKEY-DO-NOT-LEAK"}
 	assert.Contains(t, err.Error(), "402")
-	assert.Contains(t, err.Error(), "no credits remaining")
+	// P0-1 security fix: Details must NOT appear in Error() output.
+	assert.NotContains(t, err.Error(), "SECRETKEY-DO-NOT-LEAK",
+		"APIError.Error() must not include Details (P0-1 key-leak prevention)")
 }
 
 // ---------------------------------------------------------------------------
@@ -123,15 +151,24 @@ func TestEnrich_Success(t *testing.T) {
 		body, _ := io.ReadAll(r.Body)
 		capturedReqBody = body
 
-		resp := lushaEnrichResponse{
-			Name:     "Ada Lovelace",
-			JobTitle: "Engineer",
-			Company:  "AnalyticalCo",
-			EmailAddresses: []lushaEmail{
-				{Address: "ada@example.com", Type: "professional", Confidence: "high"},
-			},
-			PhoneNumbers: []lushaPhone{
-				{Number: "+1-555-0100", Type: "direct", DoNotCall: true},
+		// v3 batch response shape: requestId + results array.
+		resp := map[string]interface{}{
+			"requestId": "req-test",
+			"results": []map[string]interface{}{
+				{
+					"firstName": "Ada",
+					"lastName":  "Lovelace",
+					"jobTitle":  map[string]interface{}{"title": "Engineer"},
+					"company":   map[string]interface{}{"name": "AnalyticalCo", "domain": ""},
+					"contactMethods": map[string]interface{}{
+						"emails": []map[string]interface{}{
+							{"address": "ada@example.com", "type": "work", "confidence": "95"},
+						},
+						"phones": []map[string]interface{}{
+							{"number": "+1-555-0100", "type": "mobile", "doNotCall": true},
+						},
+					},
+				},
 			},
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -167,67 +204,70 @@ func TestEnrich_Success(t *testing.T) {
 }
 
 func TestBuildEnrichRequest(t *testing.T) {
+	// v3 batch shape: {contacts:[{identity fields}], reveal:["emails","phones"]}.
 	tests := []struct {
-		name    string
-		query   ContactQuery
-		reveal  RevealOptions
-		wantReq lushaEnrichRequest
+		name        string
+		query       ContactQuery
+		reveal      RevealOptions
+		wantContact lushaReqContact
+		wantReveal  []string
 	}{
 		{
-			name: "name + company",
+			name: "name + company, email reveal only",
 			query: ContactQuery{
 				FirstName:   "Ada",
 				LastName:    "Lovelace",
 				CompanyName: "AnalyticalCo",
 			},
 			reveal: RevealOptions{Email: true},
-			wantReq: lushaEnrichRequest{
-				FirstName:    "Ada",
-				LastName:     "Lovelace",
-				CompanyName:  "AnalyticalCo",
-				RevealEmails: true,
+			wantContact: lushaReqContact{
+				FirstName:   "Ada",
+				LastName:    "Lovelace",
+				CompanyName: "AnalyticalCo",
 			},
+			wantReveal: []string{"emails"},
 		},
 		{
-			name: "name + domain",
+			name: "name + domain, email+phone reveal",
 			query: ContactQuery{
 				FirstName:     "Ada",
 				LastName:      "Lovelace",
 				CompanyDomain: "analytical.example.com",
 			},
 			reveal: RevealOptions{Email: true, Phone: true},
-			wantReq: lushaEnrichRequest{
+			wantContact: lushaReqContact{
 				FirstName:     "Ada",
 				LastName:      "Lovelace",
 				CompanyDomain: "analytical.example.com",
-				RevealEmails:  true,
-				RevealPhones:  true,
 			},
+			wantReveal: []string{"emails", "phones"},
 		},
 		{
-			name:   "email only",
+			name:   "email identity, email reveal",
 			query:  ContactQuery{Email: "ada@example.com"},
 			reveal: RevealOptions{Email: true},
-			wantReq: lushaEnrichRequest{
-				Email:        "ada@example.com",
-				RevealEmails: true,
+			wantContact: lushaReqContact{
+				Email: "ada@example.com",
 			},
+			wantReveal: []string{"emails"},
 		},
 		{
-			name:   "linkedin only",
+			name:   "linkedin identity, email+phone reveal",
 			query:  ContactQuery{LinkedinURL: "https://linkedin.com/in/ada"},
 			reveal: RevealOptions{Email: true, Phone: true},
-			wantReq: lushaEnrichRequest{
-				LinkedinURL:  "https://linkedin.com/in/ada",
-				RevealEmails: true,
-				RevealPhones: true,
+			wantContact: lushaReqContact{
+				LinkedinURL: "https://linkedin.com/in/ada",
 			},
+			wantReveal: []string{"emails", "phones"},
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got := buildEnrichRequest(tc.query, tc.reveal)
-			assert.Equal(t, tc.wantReq, got)
+			// Must be a batch with exactly one contact.
+			require.Len(t, got.Contacts, 1, "batch must have exactly one contact")
+			assert.Equal(t, tc.wantContact, got.Contacts[0])
+			assert.Equal(t, tc.wantReveal, got.Reveal)
 		})
 	}
 }
@@ -277,8 +317,8 @@ func TestEnrich_429ErrRateLimited(t *testing.T) {
 
 func TestEnrich_EmptyMatch(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// 200 with empty arrays — a "no match" that is not an error.
-		resp := lushaEnrichResponse{}
+		// v3 batch response with empty results array — a "no match", not an error.
+		resp := lushaEnrichResponse{RequestID: "req-empty", Results: []lushaResult{}}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(resp)
 	}))
@@ -309,7 +349,7 @@ func TestEnrich_ContextCancellation(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Slow server: sleep longer than the ctx deadline.
 		time.Sleep(300 * time.Millisecond)
-		resp := lushaEnrichResponse{}
+		resp := lushaEnrichResponse{RequestID: "req-slow", Results: []lushaResult{}}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(resp)
 	}))


### PR DESCRIPTION
## Summary

Adds two API-key **Human Intelligence Source** enum subcommands for employee email discovery & enrichment (phishing/OSINT engagements), mirroring the verified Hunter.io client+subcommand pattern:

- **`brutus enum apollo`** — resolve an org via Apollo's People Search API (`/api/v1/mixed_people/api_search`, free, no PII), list people (name/title/seniority/dept), and optionally unlock emails via `/people/match` with `--reveal` (consumes credits, bounded by `--limit`, default 100).
- **`brutus enum lusha`** — resolve one person identity (name+company/domain, `--email`, or `--linkedin`) to an enriched contact (emails + phone) via the **Lusha v3** `search-and-enrich` API, surfacing the Do-Not-Call flag.

Hunter.io (already shipped, #160) is untouched. The third service from the source screenshot, ZoomInfo, was explicitly out of scope.

### Why Apollo reveals emails only
Apollo phone reveal requires an async `webhook_url` — impractical for a CLI and an unnecessary inbound-callback/SSRF surface — so phone is intentionally excluded.

### Why Lusha v3 (not v2)
Lusha v2 is sunsetting (retires 2026-11-18, already emitting `Sunset` headers); v3 is GA and recommended for new integrations.

## Security (P0)
- API keys (`X-Api-Key` / `api_key`) held in unexported fields, never logged, never in the URL; `classify*Error` reports status codes only via `errors.As` (never `%w`-wraps vendor `Details`, which could echo the key — a real leak this caught & fixed in review).
- Bounded 1 MB response reads (`enum.ReadResponseBody`); terminal-injection sanitization on all human output; no `httputil.Dump*`; no silent 429 retry.
- Cost rails: Apollo `--reveal` is opt-in + `--limit`-bounded + stderr cost notice; Lusha prints an unconditional cost notice. Authorized-use note in each command's help.

Independent `backend-security` review: **APPROVED**.

## Tests
- `pkg/enum/apollo` **88.7%**, `pkg/enum/lusha` **93.6%** coverage; httptest-driven; race-clean. Full repo suite passes.

## ⚠️ Needs live-key validation
Apollo endpoint paths/field names and the Lusha v3 request/response schema are docs-derived and **isolated in unexported consts/structs** — the `httptest` tests pass regardless, but live calls should be validated against real Apollo + Lusha keys (a mismatch is a one-line struct-tag fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)