### PR TITLE
fix(build): make teams credstore O_NOFOLLOW portable (fix Windows build)

### DIFF
--- a/cmd/brutus/teams_credstore.go
+++ b/cmd/brutus/teams_credstore.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"syscall"
 	"time"
 
 	"github.com/praetorian-inc/brutus/pkg/enum/teams"
@@ -82,7 +81,7 @@ func saveTeamsTokenFile(path string, tok *teams.TokenSet) error {
 	// Open with O_NOFOLLOW so a pre-existing symlink at path is not followed
 	// (an attacker could otherwise redirect the token write elsewhere). Token
 	// values are never included in returned errors; only path may appear (P0-1).
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC|syscall.O_NOFOLLOW, 0o600)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC|oNoFollow, 0o600)
 	if err != nil {
 		return fmt.Errorf("opening credential store %q: %w", path, err)
 	}

--- a/cmd/brutus/teams_credstore_nofollow_unix.go
+++ b/cmd/brutus/teams_credstore_nofollow_unix.go
@@ -1,0 +1,24 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package main
+
+import "syscall"
+
+// oNoFollow makes os.OpenFile refuse to follow a symlink at the token path, so
+// a pre-existing symlink cannot redirect the credential write elsewhere (see
+// saveTeamsTokenFile). syscall.O_NOFOLLOW is Unix-only, hence the build split.
+const oNoFollow = syscall.O_NOFOLLOW

--- a/cmd/brutus/teams_credstore_nofollow_windows.go
+++ b/cmd/brutus/teams_credstore_nofollow_windows.go
@@ -1,0 +1,23 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package main
+
+// Windows has no O_NOFOLLOW; creating a file symlink on Windows requires special
+// privilege, and Go's os layer does not follow them here, so 0 is the safe
+// portable fallback (the symlink-redirect concern from the Unix path does not
+// apply the same way).
+const oNoFollow = 0


### PR DESCRIPTION
## Summary

Fixes the **Windows build break** currently red on `dev` (and `main`/v1.6.0): `cmd/brutus/teams_credstore.go` used `syscall.O_NOFOLLOW`, which is **Unix-only and undefined on Windows**, so `GOOS=windows go build ./...` failed (both amd64 and arm64).

## Fix
Standard build-tag portability split:
- `teams_credstore_nofollow_unix.go` (`//go:build !windows`) → `const oNoFollow = syscall.O_NOFOLLOW` (preserves the symlink-redirect protection on Unix).
- `teams_credstore_nofollow_windows.go` (`//go:build windows`) → `const oNoFollow = 0` (Windows has no `O_NOFOLLOW`; file symlinks require special privilege and Go's os layer doesn't follow them here — 0 is the safe portable fallback).
- `teams_credstore.go` line 85 now uses `oNoFollow`; removed the now-unused `syscall` import. **Unix behavior is unchanged.**

## Verification
- `GOOS=windows GOARCH=amd64 go build ./...` ✅  `GOOS=windows GOARCH=arm64 go build ./...` ✅
- Host `go build ./...`, `go vet ./cmd/brutus/` ✅
- `go test ./cmd/brutus/ -run 'Teams|Cred'` ✅ (exercises the `oNoFollow` open path on host)

Pre-existing break (predates the enum PRs); unblocks CI for `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)