### PR TITLE
fix(enum): correct Apollo/Lusha response schemas (verified against live APIs)

### DIFF
--- a/pkg/enum/apollo/apollo.go
+++ b/pkg/enum/apollo/apollo.go
@@ -241,7 +241,7 @@ func (c *Client) searchPage(ctx context.Context, domain string, titles []string,
 	for i := range resp.People {
 		out[i] = toPerson(&resp.People[i])
 	}
-	return out, resp.Pagination.TotalEntries, nil
+	return out, resp.TotalEntries, nil
 }
 
 // matchPerson reveals the email for a single Apollo person id. Consumes credits.
@@ -324,11 +324,11 @@ func toPerson(p *apolloPerson) Person {
 // ---------------------------------------------------------------------------
 // JSON-mapping structs (unexported — map to the Apollo API shapes).
 //
-// NOTE (UNVERIFIED): the request/response field names and endpoint paths below
-// are derived from Apollo docs (architecture §7) and have NOT been verified
-// against a live key. They are intentionally isolated here so a single edit
-// corrects any mismatch without touching control flow. httptest tests use
-// controlled payloads and pass regardless of live-schema correctness.
+// NOTE: verified against live API 2026-06-26 (total_entries top-level;
+// last_name masked pre-reveal). The request/response field names and endpoint
+// paths below are intentionally isolated here so a single edit corrects any
+// mismatch without touching control flow. httptest tests use controlled
+// payloads and pass regardless of live-schema correctness.
 // ---------------------------------------------------------------------------
 
 type apolloSearchRequest struct {
@@ -338,16 +338,11 @@ type apolloSearchRequest struct {
 	PerPage             int      `json:"per_page"`
 }
 
+// apolloSearchResponse maps the mixed_people/api_search body. total_entries is a
+// TOP-LEVEL field (the pagination object is null at the credit-free tier).
 type apolloSearchResponse struct {
-	People     []apolloPerson   `json:"people"`
-	Pagination apolloPagination `json:"pagination"`
-}
-
-type apolloPagination struct {
-	Page         int `json:"page"`
-	PerPage      int `json:"per_page"`
-	TotalEntries int `json:"total_entries"`
-	TotalPages   int `json:"total_pages"`
+	People       []apolloPerson `json:"people"`
+	TotalEntries int            `json:"total_entries"`
 }
 
 type apolloMatchRequest struct {

--- a/pkg/enum/apollo/apollo_test.go
+++ b/pkg/enum/apollo/apollo_test.go
@@ -127,14 +127,10 @@ func TestAPIError_Error(t *testing.T) {
 // T002: searchPage + matchPerson + do
 // ---------------------------------------------------------------------------
 
-func makeSearchResponse(people []apolloPerson, total, page, perPage int) []byte {
+func makeSearchResponse(people []apolloPerson, total int) []byte {
 	resp := apolloSearchResponse{
-		People: people,
-		Pagination: apolloPagination{
-			Page:         page,
-			PerPage:      perPage,
-			TotalEntries: total,
-		},
+		People:       people,
+		TotalEntries: total,
 	}
 	b, _ := json.Marshal(resp)
 	return b
@@ -174,7 +170,7 @@ func TestSearchPage_Decode(t *testing.T) {
 	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(makeSearchResponse(people, 2, 1, 10))
+		_, _ = w.Write(makeSearchResponse(people, 2))
 	}))
 	defer srv.Close()
 
@@ -260,7 +256,7 @@ func TestDo_SetsAuthHeader(t *testing.T) {
 		capturedHeader = r.Header.Get(headerAPIKey)
 		capturedURL = r.URL.String()
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(makeSearchResponse(nil, 0, 1, 10))
+		_, _ = w.Write(makeSearchResponse(nil, 0))
 	}))
 	defer srv.Close()
 
@@ -313,7 +309,7 @@ func pagedSearchServer(t *testing.T, allPeople []apolloPerson, total, pageSize, 
 		pageSlice := allPeople[start:end]
 
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(makeSearchResponse(pageSlice, total, page, pageSize))
+		_, _ = w.Write(makeSearchResponse(pageSlice, total))
 	}))
 
 	return srv, &requestCount
@@ -431,7 +427,7 @@ func TestSearchPeople_ContextCancellation(t *testing.T) {
 		// Simulate a slow server that outlasts the context timeout.
 		time.Sleep(200 * time.Millisecond)
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(makeSearchResponse([]apolloPerson{makePerson("p1")}, 100, 1, 1))
+		_, _ = w.Write(makeSearchResponse([]apolloPerson{makePerson("p1")}, 100))
 	}))
 	defer srv.Close()
 

--- a/pkg/enum/lusha/lusha.go
+++ b/pkg/enum/lusha/lusha.go
@@ -258,19 +258,27 @@ func toContact(resp *lushaEnrichResponse) *Contact {
 		JobTitle: r.JobTitle.Title,
 		Company:  r.Company.Name,
 	}
-	// lushaEmail/lushaPhone are field-for-field identical to EmailEntry/PhoneEntry,
-	// so convert directly per element (staticcheck S1016).
-	for _, e := range r.ContactMethods.Emails {
-		c.Emails = append(c.Emails, EmailEntry(e))
+	// emails/phones are top-level on each result; map explicitly because the
+	// vendor field names differ from the public type (e.g. email -> Address).
+	for _, e := range r.Emails {
+		c.Emails = append(c.Emails, EmailEntry{
+			Address:    e.Email,
+			Type:       e.Type,
+			Confidence: e.Confidence,
+		})
 	}
-	for _, p := range r.ContactMethods.Phones {
-		c.Phones = append(c.Phones, PhoneEntry(p))
+	for _, p := range r.Phones {
+		c.Phones = append(c.Phones, PhoneEntry{
+			Number:    p.Number,
+			Type:      p.Type,
+			DoNotCall: p.DoNotCall,
+		})
 	}
 	return c
 }
 
 // ---------------------------------------------------------------------------
-// JSON-mapping structs (unexported) — UNVERIFIED Lusha v3 field names.
+// JSON-mapping structs (unexported) — verified against live API 2026-06-26.
 // Architecture §11: isolated here so a single edit corrects a live mismatch
 // without touching control flow. httptest tests use controlled payloads and
 // pass regardless of live-schema correctness.
@@ -306,7 +314,8 @@ type lushaEnrichResponse struct {
 	Results   []lushaResult `json:"results"`
 }
 
-// lushaResult is one enriched contact from the batch.
+// lushaResult is one enriched contact from the batch. emails and phones are
+// TOP-LEVEL arrays on each result (there is no contactMethods wrapper).
 type lushaResult struct {
 	FirstName string `json:"firstName"`
 	LastName  string `json:"lastName"`
@@ -317,24 +326,22 @@ type lushaResult struct {
 		Name   string `json:"name"`
 		Domain string `json:"domain"`
 	} `json:"company"`
-	ContactMethods struct {
-		Emails []lushaEmail `json:"emails"`
-		Phones []lushaPhone `json:"phones"`
-	} `json:"contactMethods"`
+	Emails []lushaEmail `json:"emails"`
+	Phones []lushaPhone `json:"phones"`
 }
 
 type lushaEmail struct {
-	// NOTE: the email field key ("address" vs "email") remains UNVERIFIED against
-	// a live key — residual live-schema risk flagged in review.
-	Address    string `json:"address"`
+	Email      string `json:"email"`
 	Type       string `json:"type"`
-	Confidence string `json:"confidence"`
+	Confidence string `json:"confidence"` // letter grade, e.g. "A+"
+	UpdateDate string `json:"updateDate"`
 }
 
 type lushaPhone struct {
-	Number    string `json:"number"`
-	Type      string `json:"type"`
-	DoNotCall bool   `json:"doNotCall"`
+	Number     string `json:"number"`
+	Type       string `json:"type"`
+	DoNotCall  bool   `json:"doNotCall"`
+	UpdateDate string `json:"updateDate"`
 }
 
 // lushaErrorEnvelope is the (UNVERIFIED) shape of a v3 error body. Only its

--- a/pkg/enum/lusha/lusha_test.go
+++ b/pkg/enum/lusha/lusha_test.go
@@ -40,7 +40,8 @@ func newTestClient(baseURL string) *Client {
 // ---------------------------------------------------------------------------
 
 func TestToContact(t *testing.T) {
-	// v3 batch response: results array with nested jobTitle/company/contactMethods.
+	// v3 batch response: results array with top-level emails/phones on each result
+	// (no contactMethods wrapper). Verified against live API 2026-06-26.
 	resp := &lushaEnrichResponse{
 		RequestID: "req-1",
 		Results: []lushaResult{
@@ -54,18 +55,13 @@ func TestToContact(t *testing.T) {
 					Name   string `json:"name"`
 					Domain string `json:"domain"`
 				}{Name: "Analytical Engine Co"},
-				ContactMethods: struct {
-					Emails []lushaEmail `json:"emails"`
-					Phones []lushaPhone `json:"phones"`
-				}{
-					Emails: []lushaEmail{
-						{Address: "ada@example.com", Type: "professional", Confidence: "high"},
-						{Address: "ada.personal@gmail.com", Type: "personal", Confidence: "medium"},
-					},
-					Phones: []lushaPhone{
-						{Number: "+1-555-0100", Type: "direct", DoNotCall: false},
-						{Number: "+1-555-0199", Type: "mobile", DoNotCall: true},
-					},
+				Emails: []lushaEmail{
+					{Email: "ada@example.com", Type: "professional", Confidence: "A+", UpdateDate: "2026-06-26"},
+					{Email: "ada.personal@gmail.com", Type: "personal", Confidence: "B", UpdateDate: "2026-06-26"},
+				},
+				Phones: []lushaPhone{
+					{Number: "+1-555-0100", Type: "direct", DoNotCall: false, UpdateDate: "2026-06-26"},
+					{Number: "+1-555-0199", Type: "mobile", DoNotCall: true, UpdateDate: "2026-06-26"},
 				},
 			},
 		},
@@ -76,9 +72,10 @@ func TestToContact(t *testing.T) {
 	assert.Equal(t, "Analytical Engine Co", got.Company)
 
 	require.Len(t, got.Emails, 2)
+	// lushaEmail.Email maps to EmailEntry.Address
 	assert.Equal(t, "ada@example.com", got.Emails[0].Address)
 	assert.Equal(t, "professional", got.Emails[0].Type)
-	assert.Equal(t, "high", got.Emails[0].Confidence)
+	assert.Equal(t, "A+", got.Emails[0].Confidence) // string grade, not numeric
 	assert.Equal(t, "ada.personal@gmail.com", got.Emails[1].Address)
 
 	require.Len(t, got.Phones, 2)
@@ -152,21 +149,22 @@ func TestEnrich_Success(t *testing.T) {
 		capturedReqBody = body
 
 		// v3 batch response shape: requestId + results array.
+		// emails/phones are TOP-LEVEL on each result (no contactMethods wrapper).
+		// email key (not address); confidence is a letter grade string.
+		// Verified against live API 2026-06-26.
 		resp := map[string]interface{}{
 			"requestId": "req-test",
 			"results": []map[string]interface{}{
 				{
-					"firstName": "Ada",
-					"lastName":  "Lovelace",
-					"jobTitle":  map[string]interface{}{"title": "Engineer"},
-					"company":   map[string]interface{}{"name": "AnalyticalCo", "domain": ""},
-					"contactMethods": map[string]interface{}{
-						"emails": []map[string]interface{}{
-							{"address": "ada@example.com", "type": "work", "confidence": "95"},
-						},
-						"phones": []map[string]interface{}{
-							{"number": "+1-555-0100", "type": "mobile", "doNotCall": true},
-						},
+					"firstName": "Rodrigo",
+					"lastName":  "Alvear",
+					"jobTitle":  map[string]interface{}{"title": "Director"},
+					"company":   map[string]interface{}{"name": "Chilevision", "domain": "chilevision.cl"},
+					"emails": []map[string]interface{}{
+						{"email": "r@chilevision.cl", "type": "work", "confidence": "A+", "updateDate": "2026-06-26"},
+					},
+					"phones": []map[string]interface{}{
+						{"number": "+56 9 8220 8875", "type": "phone", "doNotCall": false, "updateDate": "2026-06-26"},
 					},
 				},
 			},
@@ -193,14 +191,16 @@ func TestEnrich_Success(t *testing.T) {
 	assert.Contains(t, string(capturedReqBody), "Ada",
 		"request body must contain identity fields")
 
-	// Contact fields mapped correctly.
+	// Contact fields mapped correctly (live-verified shape, 2026-06-26).
 	require.NotNil(t, contact)
 	require.Len(t, contact.Emails, 1)
-	assert.Equal(t, "ada@example.com", contact.Emails[0].Address)
+	assert.Equal(t, "r@chilevision.cl", contact.Emails[0].Address)
+	assert.Equal(t, "work", contact.Emails[0].Type)
+	assert.Equal(t, "A+", contact.Emails[0].Confidence)
 
 	require.Len(t, contact.Phones, 1)
-	assert.Equal(t, "+1-555-0100", contact.Phones[0].Number)
-	assert.True(t, contact.Phones[0].DoNotCall, "DNC flag must be preserved")
+	assert.Equal(t, "+56 9 8220 8875", contact.Phones[0].Number)
+	assert.False(t, contact.Phones[0].DoNotCall, "DNC flag must be preserved as false")
 }
 
 func TestBuildEnrichRequest(t *testing.T) {


### PR DESCRIPTION
## Summary

Live-key smoke tests (the validation step flagged in #182) caught two response-binding bugs in the passive enrichment commands — now corrected against the **verified live API shapes**.

| Command | Symptom | Root cause | Fixed |
|---|---|---|---|
| **Apollo** | `total` always `0` | `total_entries` is **top-level** on `/mixed_people/api_search`, not under `pagination` (null) | reports real count (2,376 for fox.com) |
| **Lusha** | "no contact data" despite a credit-charged reveal | each `results[]` has **top-level** `emails`/`phones` (not `contactMethods`); email key is `email` not `address`; `confidence` is a string grade (`"A+"`) | email + phone now returned |

Verified live (2026-06-26):
- `enum apollo --domain fox.com` → `People found: 5 (total: 2376)`
- `enum lusha --email … --phone` → `rodrigo.alvear@chilevision.cl` (work, A+) + `+56 9 8220 8875`

`reveal:["emails","phones"]` confirmed correct (singular is API-rejected). Removed the unused `apolloPagination` struct. Apollo `last_name`/`name` are null from the credit-free search endpoint by design (masked pre-reveal) — left as-is.

Tests updated to the real shapes; coverage apollo 90.6% / lusha 95.0%, race-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)