### PR TITLE
feat(enum): capture full target data model (linkedin, dept, seniority, employment)

### DIFF
--- a/cmd/brutus/cmd_enum_apollo.go
+++ b/cmd/brutus/cmd_enum_apollo.go
@@ -30,35 +30,37 @@ import (
 // File-local flag variables for the apollo subcommand.
 // Separate from flagEnumDomain to avoid cross-command state bleed.
 var (
-	flagApolloDomain string
-	flagApolloTitles []string
-	flagApolloReveal bool
-	flagApolloLimit  int
-	flagApolloAPIKey string
+	flagApolloDomain   string
+	flagApolloTitles   []string
+	flagApolloNoReveal bool
+	flagApolloLimit    int
+	flagApolloAPIKey   string
 )
 
 var enumApolloCmd = &cobra.Command{
 	Use:   "apollo",
-	Short: "Discover people for a domain via Apollo.io, optionally revealing emails",
+	Short: "Discover and enrich people for a domain via Apollo.io",
 	Long: `Query the Apollo.io people-search API to discover people associated with a
-company domain: id, name, job title, seniority, department, and organization.
-Discovery is free and returns no email/phone. With --reveal, emails are looked
-up per person via the people/match API — this CONSUMES APOLLO CREDITS, bounded
-by --limit. Standalone — does not feed the saas enumeration pipeline.
+company domain, then enrich each with the full matched record. By DEFAULT this
+reveals per person via the people/match API — un-obfuscated last name, email and
+status, LinkedIn/Twitter, seniority, departments, location, and employment
+history — which CONSUMES APOLLO CREDITS, bounded by --limit. Pass --no-reveal for
+free discovery only (thin records: id, first name, title, organization; no PII).
+Standalone — does not feed the saas enumeration pipeline.
 
 Authorized use only: respect Apollo.io's Terms of Service and only enumerate
 domains you are authorized to assess.
 
 Requires an Apollo.io API key via the APOLLO_API_KEY environment variable
 (or the --api-key flag).`,
-	Example: `  # Discover people for a domain — free, no emails (key from APOLLO_API_KEY)
+	Example: `  # Discover AND enrich people (DEFAULT — CONSUMES CREDITS, bounded by --limit)
   brutus enum apollo --domain example.com
 
   # Filter by job titles
   brutus enum apollo -d example.com --titles "VP Engineering" --titles "CTO"
 
-  # Reveal emails for the discovered people (CONSUMES CREDITS, bounded by --limit)
-  brutus enum apollo -d example.com --reveal --limit 100
+  # Free discovery only — thin records, no emails, no credits
+  brutus enum apollo -d example.com --no-reveal
 
   # Provide the key explicitly (note: visible in process list / shell history)
   brutus enum apollo -d example.com --api-key abc123`,
@@ -69,8 +71,8 @@ func init() {
 	f := enumApolloCmd.Flags()
 	f.StringVarP(&flagApolloDomain, "domain", "d", "", "Company domain to discover people for (required)")
 	f.StringSliceVar(&flagApolloTitles, "titles", nil, "Optional job-title filter (repeatable or comma-separated)")
-	f.BoolVar(&flagApolloReveal, "reveal", false, "Reveal emails for discovered people via people/match (CONSUMES CREDITS, bounded by --limit)")
-	f.IntVar(&flagApolloLimit, "limit", 100, "Max people to return AND max to reveal (bounds credit spend; 0 = no cap)")
+	f.BoolVar(&flagApolloNoReveal, "no-reveal", false, "Free discovery only — skip people/match enrichment (no PII, no credits)")
+	f.IntVar(&flagApolloLimit, "limit", 100, "Max people to return AND max to reveal (bounds credit spend; 0 = no cap, requires --no-reveal)")
 	f.StringVar(&flagApolloAPIKey, "api-key", "",
 		"Apollo.io API key (overrides APOLLO_API_KEY; WARNING: visible in process list and shell history — prefer APOLLO_API_KEY)")
 	_ = enumApolloCmd.MarkFlagRequired("domain")
@@ -84,13 +86,17 @@ func runEnumApollo(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--domain/-d is required")
 	}
 
+	// Reveal is the default; --no-reveal opts out to free discovery only.
+	reveal := !flagApolloNoReveal
+
 	// Bound credit spend: reject a negative cap outright, and reject an unbounded
-	// cap (0 = no cap) combined with --reveal (which spends credits per person).
+	// cap (0 = no cap) while revealing (the default) since reveal spends credits
+	// per person. An unbounded cap is only allowed with --no-reveal.
 	if flagApolloLimit < 0 {
 		return fmt.Errorf("--limit must be >= 0")
 	}
-	if flagApolloReveal && flagApolloLimit == 0 {
-		return fmt.Errorf("--reveal requires a positive --limit to bound credit spend")
+	if reveal && flagApolloLimit == 0 {
+		return fmt.Errorf("revealing (the default) requires a positive --limit to bound credit spend; pass --no-reveal for unbounded free discovery")
 	}
 
 	apiKey, err := resolveApolloAPIKey(flagApolloAPIKey)
@@ -140,9 +146,9 @@ func runEnumApollo(cmd *cobra.Command, args []string) error {
 		return classifyApolloError(err)
 	}
 
-	if flagApolloReveal {
+	if reveal {
 		if !flagQuiet && !flagJSON && len(result.People) > 0 {
-			fmt.Fprintf(os.Stderr, "%s --reveal will consume Apollo credits for %d people\n",
+			fmt.Fprintf(os.Stderr, "%s revealing will consume Apollo credits for %d people (pass --no-reveal to skip)\n",
 				dim(useColor, SymbolInfo), len(result.People))
 		}
 		if err := client.RevealEmails(ctx, result); err != nil {

--- a/cmd/brutus/cmd_enum_apollo_output.go
+++ b/cmd/brutus/cmd_enum_apollo_output.go
@@ -45,9 +45,9 @@ func outputApolloHuman(w io.Writer, result *apollo.DomainResult, useColor bool) 
 	}
 
 	if result.Revealed {
-		_, _ = fmt.Fprintf(w, "\n  %s%-28s %-22s %-12s %-22s %-32s %-10s%s\n",
+		_, _ = fmt.Fprintf(w, "\n  %s%-28s %-22s %-12s %-22s %-32s %-10s %-32s%s\n",
 			colorIf(useColor, ColorBold),
-			"Name", "Title", "Dept", "Org", "Email", "Status",
+			"Name", "Title", "Dept", "Org", "Email", "Status", "LinkedIn",
 			colorIf(useColor, ColorReset))
 	} else {
 		_, _ = fmt.Fprintf(w, "\n  %s%-28s %-22s %-12s %-22s%s\n",
@@ -60,7 +60,7 @@ func outputApolloHuman(w io.Writer, result *apollo.DomainResult, useColor bool) 
 		p := &result.People[i]
 		name := personName(p)
 		if result.Revealed {
-			_, _ = fmt.Fprintf(w, "  %-28s %-22s %-12s %-22s %s%-32s%s %-10s\n",
+			_, _ = fmt.Fprintf(w, "  %-28s %-22s %-12s %-22s %s%-32s%s %-10s %-32s\n",
 				truncate(name, 28),
 				truncate(sanitizeTerminal(p.Title), 22),
 				truncate(sanitizeTerminal(p.Department), 12),
@@ -68,7 +68,8 @@ func outputApolloHuman(w io.Writer, result *apollo.DomainResult, useColor bool) 
 				colorIf(useColor, ColorGreen),
 				truncate(sanitizeTerminal(p.Email), 32),
 				colorIf(useColor, ColorReset),
-				truncate(sanitizeTerminal(p.EmailStatus), 10))
+				truncate(sanitizeTerminal(p.EmailStatus), 10),
+				truncate(sanitizeTerminal(p.LinkedinURL), 32))
 		} else {
 			_, _ = fmt.Fprintf(w, "  %-28s %-22s %-12s %-22s\n",
 				truncate(name, 28),
@@ -85,25 +86,50 @@ func outputApolloHuman(w io.Writer, result *apollo.DomainResult, useColor bool) 
 // Preview (un-revealed) people omit email/email_status via omitempty so a
 // consumer never misreads a blank email as confirmed-absent.
 func outputApolloJSONL(w io.Writer, result *apollo.DomainResult) {
-	type apolloJSON struct {
-		Type         string `json:"type"`
-		Domain       string `json:"domain"`
-		Revealed     bool   `json:"revealed"`
-		ID           string `json:"id"`
-		Name         string `json:"name,omitempty"`
-		FirstName    string `json:"first_name,omitempty"`
-		LastName     string `json:"last_name,omitempty"`
-		Title        string `json:"title,omitempty"`
-		Seniority    string `json:"seniority,omitempty"`
-		Department   string `json:"department,omitempty"`
+	type employmentJSON struct {
 		Organization string `json:"organization,omitempty"`
-		Email        string `json:"email,omitempty"`
-		EmailStatus  string `json:"email_status,omitempty"`
+		Title        string `json:"title,omitempty"`
+		StartDate    string `json:"start_date,omitempty"`
+		EndDate      string `json:"end_date,omitempty"`
+		Current      bool   `json:"current"`
+	}
+	type apolloJSON struct {
+		Type         string           `json:"type"`
+		Domain       string           `json:"domain"`
+		Revealed     bool             `json:"revealed"`
+		ID           string           `json:"id"`
+		Name         string           `json:"name,omitempty"`
+		FirstName    string           `json:"first_name,omitempty"`
+		LastName     string           `json:"last_name,omitempty"`
+		Title        string           `json:"title,omitempty"`
+		Seniority    string           `json:"seniority,omitempty"`
+		Department   string           `json:"department,omitempty"`
+		Departments  []string         `json:"departments,omitempty"`
+		Organization string           `json:"organization,omitempty"`
+		Email        string           `json:"email,omitempty"`
+		EmailStatus  string           `json:"email_status,omitempty"`
+		LinkedinURL  string           `json:"linkedin_url,omitempty"`
+		Twitter      string           `json:"twitter_url,omitempty"`
+		City         string           `json:"city,omitempty"`
+		State        string           `json:"state,omitempty"`
+		Country      string           `json:"country,omitempty"`
+		Employment   []employmentJSON `json:"employment,omitempty"`
 	}
 
 	enc := json.NewEncoder(w)
 	for i := range result.People {
 		p := &result.People[i]
+		var employment []employmentJSON
+		for j := range p.Employment {
+			e := &p.Employment[j]
+			employment = append(employment, employmentJSON{
+				Organization: e.Organization,
+				Title:        e.Title,
+				StartDate:    e.StartDate,
+				EndDate:      e.EndDate,
+				Current:      e.Current,
+			})
+		}
 		jr := apolloJSON{
 			Type:         "apollo",
 			Domain:       result.Domain,
@@ -115,9 +141,16 @@ func outputApolloJSONL(w io.Writer, result *apollo.DomainResult) {
 			Title:        p.Title,
 			Seniority:    p.Seniority,
 			Department:   p.Department,
+			Departments:  p.Departments,
 			Organization: p.Organization,
 			Email:        p.Email,
 			EmailStatus:  p.EmailStatus,
+			LinkedinURL:  p.LinkedinURL,
+			Twitter:      p.Twitter,
+			City:         p.City,
+			State:        p.State,
+			Country:      p.Country,
+			Employment:   employment,
 		}
 		if err := enc.Encode(jr); err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "Error encoding apollo JSON: %v\n", err)

--- a/cmd/brutus/cmd_enum_apollo_test.go
+++ b/cmd/brutus/cmd_enum_apollo_test.go
@@ -142,10 +142,11 @@ func TestClassifyApolloError_NetworkWrap(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // resetApolloFlags resets the package-level apollo flag vars to safe defaults.
+// Reveal is DEFAULT-ON: flagApolloNoReveal=false means reveal is active.
 func resetApolloFlags() {
 	flagApolloDomain = "example.com"
 	flagApolloTitles = nil
-	flagApolloReveal = false
+	flagApolloNoReveal = false
 	flagApolloLimit = 100
 	flagApolloAPIKey = ""
 }
@@ -162,19 +163,37 @@ func TestRunEnumApollo_RejectsNegativeLimit(t *testing.T) {
 		"error must mention --limit so the operator knows what to fix")
 }
 
-// TestRunEnumApollo_RejectsRevealWithZeroLimit asserts that --reveal combined
-// with --limit 0 (unbounded) is rejected to prevent unbounded credit spend.
+// TestRunEnumApollo_RejectsRevealWithZeroLimit asserts that reveal (the DEFAULT)
+// combined with --limit 0 (unbounded) is rejected to prevent unbounded credit
+// spend. With reveal as default, --limit 0 alone must be rejected; passing
+// --no-reveal (flagApolloNoReveal=true) with --limit 0 is allowed.
 func TestRunEnumApollo_RejectsRevealWithZeroLimit(t *testing.T) {
 	resetApolloFlags()
-	flagApolloReveal = true
+	// reveal is default (flagApolloNoReveal=false), so --limit 0 alone must fail.
 	flagApolloLimit = 0
 
 	err := runEnumApollo(enumApolloCmd, nil)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "--reveal",
-		"error must mention --reveal so the operator understands the constraint")
 	assert.Contains(t, err.Error(), "--limit",
 		"error must mention --limit so the operator knows how to fix it")
+}
+
+// TestRunEnumApollo_AllowsNoRevealWithZeroLimit asserts that --no-reveal with
+// --limit 0 (unbounded free discovery) is accepted.
+func TestRunEnumApollo_AllowsNoRevealWithZeroLimit(t *testing.T) {
+	resetApolloFlags()
+	flagApolloNoReveal = true
+	flagApolloLimit = 0
+
+	// No API key set — runEnumApollo will fail on resolveApolloAPIKey, which is
+	// expected; the important thing is it does NOT fail on the limit guard.
+	t.Setenv("APOLLO_API_KEY", "")
+	err := runEnumApollo(enumApolloCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "APOLLO_API_KEY",
+		"error must be about missing API key, not the limit guard")
+	assert.NotContains(t, err.Error(), "--limit",
+		"--no-reveal with --limit 0 must not be rejected by the limit guard")
 }
 
 // ---------------------------------------------------------------------------
@@ -337,8 +356,8 @@ func TestEnumApolloRegistered(t *testing.T) {
 		titlesFlag := cmd.Flags().Lookup("titles")
 		require.NotNil(t, titlesFlag, "--titles flag must exist")
 
-		revealFlag := cmd.Flags().Lookup("reveal")
-		require.NotNil(t, revealFlag, "--reveal flag must exist")
+		revealFlag := cmd.Flags().Lookup("no-reveal")
+		require.NotNil(t, revealFlag, "--no-reveal flag must exist")
 
 		limitFlag := cmd.Flags().Lookup("limit")
 		require.NotNil(t, limitFlag, "--limit flag must exist")

--- a/cmd/brutus/cmd_enum_lusha_output.go
+++ b/cmd/brutus/cmd_enum_lusha_output.go
@@ -34,10 +34,25 @@ func outputLushaHuman(w io.Writer, c *lusha.Contact, useColor bool) {
 		heading(useColor, "Lusha: "+summary))
 
 	if c.JobTitle != "" {
-		_, _ = fmt.Fprintf(w, "  Title:   %s\n", sanitizeTerminal(c.JobTitle))
+		_, _ = fmt.Fprintf(w, "  Title:    %s\n", truncate(sanitizeTerminal(c.JobTitle), 80))
+	}
+	if c.Seniority != "" {
+		_, _ = fmt.Fprintf(w, "  Seniority: %s\n", truncate(sanitizeTerminal(c.Seniority), 40))
+	}
+	if len(c.Departments) > 0 {
+		_, _ = fmt.Fprintf(w, "  Dept:     %s\n", truncate(sanitizeTerminal(strings.Join(c.Departments, ", ")), 80))
 	}
 	if c.Company != "" {
-		_, _ = fmt.Fprintf(w, "  Company: %s\n", sanitizeTerminal(c.Company))
+		_, _ = fmt.Fprintf(w, "  Company:  %s\n", truncate(sanitizeTerminal(c.Company), 80))
+	}
+	if c.Location != "" {
+		_, _ = fmt.Fprintf(w, "  Location: %s\n", truncate(sanitizeTerminal(c.Location), 60))
+	}
+	if c.LinkedIn != "" {
+		_, _ = fmt.Fprintf(w, "  LinkedIn: %s\n", truncate(sanitizeTerminal(c.LinkedIn), 100))
+	}
+	if line := lushaEmploymentSummary(c); line != "" {
+		_, _ = fmt.Fprintf(w, "  History:  %s\n", line)
 	}
 
 	if len(c.Emails) == 0 && len(c.Phones) == 0 {
@@ -96,20 +111,36 @@ func outputLushaJSONL(w io.Writer, c *lusha.Contact) {
 		Type      string `json:"type,omitempty"`
 		DoNotCall bool   `json:"do_not_call"`
 	}
+	type employmentJSON struct {
+		Organization string `json:"organization,omitempty"`
+		Title        string `json:"title,omitempty"`
+		Current      bool   `json:"current"`
+	}
 	type contactJSON struct {
-		Type     string      `json:"type"`
-		Name     string      `json:"name,omitempty"`
-		JobTitle string      `json:"job_title,omitempty"`
-		Company  string      `json:"company,omitempty"`
-		Emails   []emailJSON `json:"emails,omitempty"`
-		Phones   []phoneJSON `json:"phones,omitempty"`
+		Type          string           `json:"type"`
+		Name          string           `json:"name,omitempty"`
+		JobTitle      string           `json:"job_title,omitempty"`
+		Company       string           `json:"company,omitempty"`
+		CompanyDomain string           `json:"company_domain,omitempty"`
+		LinkedIn      string           `json:"linkedin,omitempty"`
+		Departments   []string         `json:"departments,omitempty"`
+		Seniority     string           `json:"seniority,omitempty"`
+		Location      string           `json:"location,omitempty"`
+		Emails        []emailJSON      `json:"emails,omitempty"`
+		Phones        []phoneJSON      `json:"phones,omitempty"`
+		Employment    []employmentJSON `json:"employment,omitempty"`
 	}
 
 	jr := contactJSON{
-		Type:     "lusha",
-		Name:     c.Name,
-		JobTitle: c.JobTitle,
-		Company:  c.Company,
+		Type:          "lusha",
+		Name:          c.Name,
+		JobTitle:      c.JobTitle,
+		Company:       c.Company,
+		CompanyDomain: c.CompanyDomain,
+		LinkedIn:      c.LinkedIn,
+		Departments:   c.Departments,
+		Seniority:     c.Seniority,
+		Location:      c.Location,
 	}
 	for i := range c.Emails {
 		e := &c.Emails[i]
@@ -127,6 +158,14 @@ func outputLushaJSONL(w io.Writer, c *lusha.Contact) {
 			DoNotCall: p.DoNotCall,
 		})
 	}
+	for i := range c.Employment {
+		em := &c.Employment[i]
+		jr.Employment = append(jr.Employment, employmentJSON{
+			Organization: em.Organization,
+			Title:        em.Title,
+			Current:      em.Current,
+		})
+	}
 
 	enc := json.NewEncoder(w)
 	if err := enc.Encode(jr); err != nil {
@@ -140,4 +179,29 @@ func lushaIdentitySummary(c *lusha.Contact) string {
 		return name
 	}
 	return "contact"
+}
+
+// lushaEmploymentSummary renders employment history compactly for the human
+// view: the current organization plus a count of prior roles. Full per-role
+// detail is available in JSONL output. Returns "" when no history is present.
+func lushaEmploymentSummary(c *lusha.Contact) string {
+	current := ""
+	prior := 0
+	for i := range c.Employment {
+		em := &c.Employment[i]
+		if em.Current && current == "" {
+			current = truncate(sanitizeTerminal(em.Organization), 60)
+			continue
+		}
+		prior++
+	}
+	switch {
+	case current != "" && prior > 0:
+		return fmt.Sprintf("%s (+%d prior)", current, prior)
+	case current != "":
+		return current
+	case prior > 0:
+		return fmt.Sprintf("%d prior role(s)", prior)
+	}
+	return ""
 }

--- a/cmd/brutus/cmd_enum_output.go
+++ b/cmd/brutus/cmd_enum_output.go
@@ -397,22 +397,23 @@ func outputHunterHuman(w io.Writer, result *hunter.DomainResult, useColor bool) 
 	}
 
 	// Header row.
-	_, _ = fmt.Fprintf(w, "\n  %s%-32s %-22s %-22s %-16s %-12s %-5s%s\n",
+	_, _ = fmt.Fprintf(w, "\n  %s%-32s %-22s %-18s %-14s %-12s %-20s %-5s%s\n",
 		colorIf(useColor, ColorBold),
-		"Email", "Name", "Title", "Phone", "Dept", "Conf",
+		"Email", "Name", "Title", "Phone", "Dept", "LinkedIn", "Conf",
 		colorIf(useColor, ColorReset))
 
 	for i := range result.People {
 		p := &result.People[i]
 		name := strings.TrimSpace(sanitizeTerminal(p.FirstName) + " " + sanitizeTerminal(p.LastName))
-		_, _ = fmt.Fprintf(w, "  %s%-32s%s %-22s %-22s %-16s %-12s %s%3d%s\n",
+		_, _ = fmt.Fprintf(w, "  %s%-32s%s %-22s %-18s %-14s %-12s %-20s %s%3d%s\n",
 			colorIf(useColor, ColorGreen),
 			truncate(sanitizeTerminal(p.Email), 32),
 			colorIf(useColor, ColorReset),
 			truncate(name, 22),
-			truncate(sanitizeTerminal(p.Position), 22),
-			truncate(sanitizeTerminal(p.Phone), 16),
+			truncate(sanitizeTerminal(p.Position), 18),
+			truncate(sanitizeTerminal(p.Phone), 14),
 			truncate(sanitizeTerminal(p.Department), 12),
+			truncate(sanitizeTerminal(p.LinkedIn), 20),
 			colorIf(useColor, ColorCyan), p.Confidence, colorIf(useColor, ColorReset))
 	}
 	_, _ = fmt.Fprintln(w)
@@ -432,6 +433,8 @@ func outputHunterJSONL(w io.Writer, result *hunter.DomainResult) {
 		Seniority    string   `json:"seniority,omitempty"`
 		Department   string   `json:"department,omitempty"`
 		Phone        string   `json:"phone_number,omitempty"`
+		LinkedIn     string   `json:"linkedin,omitempty"`
+		Twitter      string   `json:"twitter,omitempty"`
 		Confidence   int      `json:"confidence"`
 		EmailType    string   `json:"email_type,omitempty"`
 		Sources      []string `json:"sources,omitempty"`
@@ -451,6 +454,8 @@ func outputHunterJSONL(w io.Writer, result *hunter.DomainResult) {
 			Seniority:    p.Seniority,
 			Department:   p.Department,
 			Phone:        p.Phone,
+			LinkedIn:     p.LinkedIn,
+			Twitter:      p.Twitter,
 			Confidence:   p.Confidence,
 			EmailType:    p.Type,
 			Sources:      p.Sources,

--- a/pkg/enum/apollo/apollo.go
+++ b/pkg/enum/apollo/apollo.go
@@ -52,10 +52,10 @@ const (
 // Public types
 // ---------------------------------------------------------------------------
 
-// Person is one discovered contact for the domain. Email/EmailStatus are empty
-// until RevealEmails runs (opt-in, consumes credits).
+// Person is one discovered contact for the domain. The reveal-only fields are
+// empty until RevealEmails runs (default-on, consumes credits).
 type Person struct {
-	// From people-search (FREE, no PII).
+	// From people-search (FREE, thin — last_name is obfuscated/empty here).
 	ID           string
 	FirstName    string
 	LastName     string
@@ -68,7 +68,24 @@ type Person struct {
 	// From people/match (CREDITS, PII) — empty unless reveal ran.
 	Email       string
 	EmailStatus string
+	LinkedinURL string
+	Twitter     string
+	Departments []string
+	City        string
+	State       string
+	Country     string
+	Employment  []EmploymentEntry
 	Revealed    bool
+}
+
+// EmploymentEntry is one raw entry from a person's employment_history. Raw
+// pass-through — no derived fields (e.g. tenure) are computed.
+type EmploymentEntry struct {
+	Organization string
+	Title        string
+	StartDate    string
+	EndDate      string
+	Current      bool
 }
 
 // DomainResult is the aggregated, de-paginated result for a domain.
@@ -183,26 +200,28 @@ func (c *Client) SearchPeople(ctx context.Context, domain string, titles []strin
 	return result, nil
 }
 
-// RevealEmails enriches the already-discovered people in result with emails via
-// people/match, in place, serially. Consumes credits. Skips people without an
-// id. Sets Email/EmailStatus/Revealed per person (Revealed=true even when the
-// returned email is empty — partial-result honesty) and sets result.Revealed=true
-// on the FIRST successful match so spent credits are reflected even if a later
+// RevealEmails enriches the already-discovered people in result with the full
+// matched record via people/match, in place, serially. Consumes credits. Skips
+// people without an id. Merges the enriched fields (un-obfuscated last name,
+// email/status, LinkedIn/Twitter, seniority, departments, location, employment
+// history) onto each person and sets Revealed=true (even when the returned
+// email is empty — partial-result honesty), and sets result.Revealed=true on
+// the FIRST successful match so spent credits are reflected even if a later
 // match fails. Surfaces the first error (no partial swallow), leaving
-// already-merged emails intact.
+// already-merged records intact.
 func (c *Client) RevealEmails(ctx context.Context, result *DomainResult) error {
 	for i := range result.People {
 		p := &result.People[i]
 		if p.ID == "" { // can't match without an id
 			continue
 		}
-		email, status, err := c.matchPerson(ctx, p.ID)
+		matched, err := c.matchPerson(ctx, p.ID)
 		if err != nil {
-			// On error, return it but leave the emails merged so far intact;
+			// On error, return it but leave the records merged so far intact;
 			// result.Revealed is already true if any earlier reveal succeeded.
 			return err
 		}
-		p.Email, p.EmailStatus, p.Revealed = email, status, true
+		mergeReveal(p, matched)
 		// Mark the aggregate as revealed on the FIRST successful match — credits
 		// have been spent, so the partial result must reflect that even if a
 		// later match fails.
@@ -239,24 +258,26 @@ func (c *Client) searchPage(ctx context.Context, domain string, titles []string,
 
 	out := make([]Person, len(resp.People))
 	for i := range resp.People {
-		out[i] = toPerson(&resp.People[i])
+		out[i] = resp.People[i].toPerson()
 	}
 	return out, resp.TotalEntries, nil
 }
 
-// matchPerson reveals the email for a single Apollo person id. Consumes credits.
-func (c *Client) matchPerson(ctx context.Context, id string) (email, status string, err error) {
+// matchPerson reveals the full record for a single Apollo person id via
+// people/match. Consumes credits. Returns the mapped Person (search + reveal
+// fields), which the caller merges onto the discovered person.
+func (c *Client) matchPerson(ctx context.Context, id string) (Person, error) {
 	reqBody := apolloMatchRequest{ID: id, RevealPersonalEmails: true}
 	body, err := c.do(ctx, http.MethodPost, matchPath, reqBody)
 	if err != nil {
-		return "", "", err
+		return Person{}, err
 	}
 
 	var resp apolloMatchResponse
 	if err := json.Unmarshal(body, &resp); err != nil {
-		return "", "", fmt.Errorf("decoding apollo match response: %w", err)
+		return Person{}, fmt.Errorf("decoding apollo match response: %w", err)
 	}
-	return resp.Person.Email, resp.Person.EmailStatus, nil
+	return resp.Person.toPerson(), nil
 }
 
 // do is the single P0-1/P0-3 choke point: it JSON-encodes body, sets the
@@ -302,12 +323,25 @@ func (c *Client) do(ctx context.Context, method, path string, body any) ([]byte,
 	return respBody, nil
 }
 
-// toPerson converts the API person struct to the public Person type. Search
-// fields only; PII (Email/EmailStatus) is left empty and Revealed=false.
-func toPerson(p *apolloPerson) Person {
+// toPerson converts the API person struct to the public Person type, mapping
+// every field present in the payload. The search response is thin (reveal-only
+// fields are null/empty and map to zero values); the match response populates
+// the full record. Revealed is NOT set here — the caller owns that flag.
+func (p apolloPerson) toPerson() Person {
 	dept := ""
 	if len(p.Departments) > 0 {
 		dept = p.Departments[0]
+	}
+	employment := make([]EmploymentEntry, len(p.EmploymentHistory))
+	for i := range p.EmploymentHistory {
+		h := &p.EmploymentHistory[i]
+		employment[i] = EmploymentEntry{
+			Organization: h.OrganizationName,
+			Title:        h.Title,
+			StartDate:    h.StartDate,
+			EndDate:      h.EndDate,
+			Current:      h.Current,
+		}
 	}
 	return Person{
 		ID:           p.ID,
@@ -318,7 +352,35 @@ func toPerson(p *apolloPerson) Person {
 		Seniority:    p.Seniority,
 		Department:   dept,
 		Organization: p.Organization.Name,
+		Email:        p.Email,
+		EmailStatus:  p.EmailStatus,
+		LinkedinURL:  p.LinkedinURL,
+		Twitter:      p.TwitterURL,
+		Departments:  p.Departments,
+		City:         p.City,
+		State:        p.State,
+		Country:      p.Country,
+		Employment:   employment,
 	}
+}
+
+// mergeReveal merges the enriched fields from a people/match record onto the
+// discovered person, overwriting the obfuscated/empty search-tier last name and
+// filling in the reveal-only fields. Search-tier identity fields already on p
+// (ID, Name, Title, Organization) are left intact.
+func mergeReveal(p *Person, m Person) {
+	p.LastName = m.LastName
+	p.Email = m.Email
+	p.EmailStatus = m.EmailStatus
+	p.LinkedinURL = m.LinkedinURL
+	p.Twitter = m.Twitter
+	p.Seniority = m.Seniority
+	p.Departments = m.Departments
+	p.City = m.City
+	p.State = m.State
+	p.Country = m.Country
+	p.Employment = m.Employment
+	p.Revealed = true
 }
 
 // ---------------------------------------------------------------------------
@@ -355,16 +417,30 @@ type apolloMatchResponse struct {
 }
 
 type apolloPerson struct {
-	ID           string             `json:"id"`
-	FirstName    string             `json:"first_name"`
-	LastName     string             `json:"last_name"`
-	Name         string             `json:"name"`
-	Title        string             `json:"title"`
-	Seniority    string             `json:"seniority"`
-	Departments  []string           `json:"departments"`
-	Organization apolloOrganization `json:"organization"`
-	Email        string             `json:"email"`
-	EmailStatus  string             `json:"email_status"`
+	ID                string                  `json:"id"`
+	FirstName         string                  `json:"first_name"`
+	LastName          string                  `json:"last_name"`
+	Name              string                  `json:"name"`
+	Title             string                  `json:"title"`
+	Seniority         string                  `json:"seniority"`
+	Departments       []string                `json:"departments"`
+	Organization      apolloOrganization      `json:"organization"`
+	Email             string                  `json:"email"`
+	EmailStatus       string                  `json:"email_status"`
+	LinkedinURL       string                  `json:"linkedin_url"`
+	TwitterURL        string                  `json:"twitter_url"`
+	City              string                  `json:"city"`
+	State             string                  `json:"state"`
+	Country           string                  `json:"country"`
+	EmploymentHistory []apolloEmploymentEntry `json:"employment_history"`
+}
+
+type apolloEmploymentEntry struct {
+	OrganizationName string `json:"organization_name"`
+	Title            string `json:"title"`
+	StartDate        string `json:"start_date"`
+	EndDate          string `json:"end_date"`
+	Current          bool   `json:"current"`
 }
 
 type apolloOrganization struct {

--- a/pkg/enum/apollo/apollo_test.go
+++ b/pkg/enum/apollo/apollo_test.go
@@ -46,7 +46,7 @@ func newTestClient(baseURL string) *Client {
 // ---------------------------------------------------------------------------
 
 func TestToPerson(t *testing.T) {
-	src := &apolloPerson{
+	src := apolloPerson{
 		ID:           "abc123",
 		FirstName:    "Alice",
 		LastName:     "Smith",
@@ -56,7 +56,7 @@ func TestToPerson(t *testing.T) {
 		Departments:  []string{"Engineering", "Product"},
 		Organization: apolloOrganization{Name: "Example Corp"},
 	}
-	got := toPerson(src)
+	got := src.toPerson()
 
 	assert.Equal(t, "abc123", got.ID)
 	assert.Equal(t, "Alice", got.FirstName)
@@ -74,11 +74,11 @@ func TestToPerson(t *testing.T) {
 }
 
 func TestToPerson_EmptyDepartments(t *testing.T) {
-	src := &apolloPerson{
+	src := apolloPerson{
 		ID:   "empty-dept",
 		Name: "Bob",
 	}
-	got := toPerson(src)
+	got := src.toPerson()
 	assert.Empty(t, got.Department, "empty departments slice should yield empty Department")
 }
 
@@ -136,11 +136,28 @@ func makeSearchResponse(people []apolloPerson, total int) []byte {
 	return b
 }
 
+// makeMatchResponse returns a full apolloMatchResponse JSON payload with the
+// reveal-only fields populated. The extra fields (linkedin_url, last_name,
+// seniority, departments, city/state/country, employment_history) mirror what
+// people/match returns and must be preserved through mergeReveal.
 func makeMatchResponse(email, emailStatus string) []byte {
 	resp := apolloMatchResponse{
 		Person: apolloPerson{
+			FirstName:   "Alice",
+			LastName:    "Smith",
+			Name:        "Alice Smith",
 			Email:       email,
 			EmailStatus: emailStatus,
+			LinkedinURL: "https://linkedin.com/in/alice",
+			TwitterURL:  "https://twitter.com/alice",
+			Seniority:   "senior",
+			Departments: []string{"Engineering"},
+			City:        "San Francisco",
+			State:       "CA",
+			Country:     "United States",
+			EmploymentHistory: []apolloEmploymentEntry{
+				{OrganizationName: "Example Corp", Title: "Engineer", StartDate: "2020-01", Current: true},
+			},
 		},
 	}
 	b, _ := json.Marshal(resp)
@@ -228,10 +245,20 @@ func TestMatchPerson_Decode(t *testing.T) {
 	defer srv.Close()
 
 	c := newTestClient(srv.URL)
-	email, status, err := c.matchPerson(context.Background(), "p1")
+	person, err := c.matchPerson(context.Background(), "p1")
 	require.NoError(t, err)
-	assert.Equal(t, "alice@example.com", email)
-	assert.Equal(t, "verified", status)
+	assert.Equal(t, "alice@example.com", person.Email)
+	assert.Equal(t, "verified", person.EmailStatus)
+	assert.Equal(t, "https://linkedin.com/in/alice", person.LinkedinURL)
+	assert.Equal(t, "Smith", person.LastName)
+	assert.Equal(t, "senior", person.Seniority)
+	assert.Equal(t, []string{"Engineering"}, person.Departments)
+	assert.Equal(t, "San Francisco", person.City)
+	assert.Equal(t, "CA", person.State)
+	assert.Equal(t, "United States", person.Country)
+	require.Len(t, person.Employment, 1)
+	assert.Equal(t, "Example Corp", person.Employment[0].Organization)
+	assert.True(t, person.Employment[0].Current)
 }
 
 func TestDo_MalformedJSON(t *testing.T) {
@@ -448,6 +475,8 @@ func TestSearchPeople_ContextCancellation(t *testing.T) {
 func TestRevealEmails_Merge(t *testing.T) {
 	// 3 people: server returns email for p1, email for p2, empty for p3.
 	// All 3 should get Revealed=true (partial-result honesty); result.Revealed=true.
+	// makeMatchResponse now includes full reveal fields (linkedin_url, last_name,
+	// seniority, departments, city/state/country, employment_history).
 	responses := map[string]string{
 		"p1": "alice@example.com",
 		"p2": "bob@example.com",
@@ -482,9 +511,20 @@ func TestRevealEmails_Merge(t *testing.T) {
 	err := c.RevealEmails(context.Background(), result)
 	require.NoError(t, err)
 
+	// p1: full reveal fields merged.
 	assert.Equal(t, "alice@example.com", result.People[0].Email)
+	assert.Equal(t, "verified", result.People[0].EmailStatus)
+	assert.Equal(t, "https://linkedin.com/in/alice", result.People[0].LinkedinURL)
+	assert.Equal(t, "Smith", result.People[0].LastName)
+	assert.Equal(t, "senior", result.People[0].Seniority)
+	assert.Equal(t, []string{"Engineering"}, result.People[0].Departments)
+	assert.Equal(t, "San Francisco", result.People[0].City)
+	assert.Equal(t, "United States", result.People[0].Country)
+	require.Len(t, result.People[0].Employment, 1)
+	assert.True(t, result.People[0].Employment[0].Current)
 	assert.True(t, result.People[0].Revealed)
 
+	// p2: also merged.
 	assert.Equal(t, "bob@example.com", result.People[1].Email)
 	assert.True(t, result.People[1].Revealed)
 

--- a/pkg/enum/hunter/hunter.go
+++ b/pkg/enum/hunter/hunter.go
@@ -54,6 +54,8 @@ type Person struct {
 	Seniority  string
 	Department string
 	Phone      string
+	LinkedIn   string
+	Twitter    string
 	Confidence int
 	Type       string
 	Sources    []string
@@ -229,6 +231,8 @@ func toPerson(e *apiEmail) Person {
 		Seniority:  e.Seniority,
 		Department: e.Department,
 		Phone:      e.Phone,
+		LinkedIn:   e.LinkedIn,
+		Twitter:    e.Twitter,
 		Confidence: e.Confidence,
 		Type:       e.Type,
 		Sources:    sources,
@@ -261,6 +265,8 @@ type apiEmail struct {
 	Seniority  string      `json:"seniority"`
 	Department string      `json:"department"`
 	Phone      string      `json:"phone_number"`
+	LinkedIn   string      `json:"linkedin"`
+	Twitter    string      `json:"twitter"`
 	Sources    []apiSource `json:"sources"`
 }
 

--- a/pkg/enum/hunter/hunter_test.go
+++ b/pkg/enum/hunter/hunter_test.go
@@ -45,6 +45,8 @@ func TestToPerson(t *testing.T) {
 		Seniority:  "senior",
 		Department: "Engineering",
 		Phone:      "+1-555-0100",
+		LinkedIn:   "https://linkedin.com/in/alice",
+		Twitter:    "https://twitter.com/alice",
 		Sources: []apiSource{
 			{URI: "https://example.com/alice"},
 			{URI: "https://linkedin.com/in/alice"},
@@ -60,6 +62,8 @@ func TestToPerson(t *testing.T) {
 	assert.Equal(t, "senior", got.Seniority)
 	assert.Equal(t, "Engineering", got.Department)
 	assert.Equal(t, "+1-555-0100", got.Phone)
+	assert.Equal(t, "https://linkedin.com/in/alice", got.LinkedIn)
+	assert.Equal(t, "https://twitter.com/alice", got.Twitter)
 	assert.Equal(t, []string{"https://example.com/alice", "https://linkedin.com/in/alice"}, got.Sources)
 }
 

--- a/pkg/enum/lusha/lusha.go
+++ b/pkg/enum/lusha/lusha.go
@@ -81,13 +81,29 @@ type PhoneEntry struct {
 	DoNotCall bool
 }
 
+// EmploymentEntry is one role in the contact's employment history. Lusha's
+// previousEmployment carries no dates, so only Organization + Title are
+// populated; Current distinguishes the present employer (top-level
+// company/jobTitle) from prior roles.
+type EmploymentEntry struct {
+	Organization string
+	Title        string
+	Current      bool
+}
+
 // Contact is the enriched result for one identity.
 type Contact struct {
-	Name     string
-	JobTitle string
-	Company  string
-	Emails   []EmailEntry
-	Phones   []PhoneEntry
+	Name          string
+	JobTitle      string
+	Company       string
+	CompanyDomain string
+	LinkedIn      string
+	Departments   []string
+	Seniority     string
+	Location      string // country
+	Emails        []EmailEntry
+	Phones        []PhoneEntry
+	Employment    []EmploymentEntry
 }
 
 // APIError is returned for any non-2xx HTTP status from Lusha.
@@ -254,9 +270,29 @@ func toContact(resp *lushaEnrichResponse) *Contact {
 	}
 
 	c := &Contact{
-		Name:     name,
-		JobTitle: r.JobTitle.Title,
-		Company:  r.Company.Name,
+		Name:          name,
+		JobTitle:      r.JobTitle.Title,
+		Company:       r.Company.Name,
+		CompanyDomain: r.Company.Domain,
+		LinkedIn:      r.SocialLinks.Linkedin,
+		Departments:   r.JobTitle.Departments,
+		Seniority:     r.JobTitle.Seniority,
+		Location:      r.Location.Country,
+	}
+	// Employment = current role (from top-level company/jobTitle) followed by
+	// prior roles. Lusha previousEmployment lacks dates, so Current is the only
+	// temporal signal.
+	c.Employment = append(c.Employment, EmploymentEntry{
+		Organization: r.Company.Name,
+		Title:        r.JobTitle.Title,
+		Current:      true,
+	})
+	for _, pe := range r.PreviousEmployment {
+		c.Employment = append(c.Employment, EmploymentEntry{
+			Organization: pe.Company.Name,
+			Title:        pe.JobTitle.Title,
+			Current:      false,
+		})
 	}
 	// emails/phones are top-level on each result; map explicitly because the
 	// vendor field names differ from the public type (e.g. email -> Address).
@@ -319,15 +355,45 @@ type lushaEnrichResponse struct {
 type lushaResult struct {
 	FirstName string `json:"firstName"`
 	LastName  string `json:"lastName"`
+	FullName  string `json:"fullName"`
 	JobTitle  struct {
-		Title string `json:"title"`
+		Title       string   `json:"title"`
+		Departments []string `json:"departments"`
+		Seniority   string   `json:"seniority"`
 	} `json:"jobTitle"`
+	Company struct {
+		Name     string `json:"name"`
+		Domain   string `json:"domain"`
+		Industry string `json:"industry"`
+	} `json:"company"`
+	Location           lushaLocation         `json:"location"`
+	SocialLinks        lushaSocialLinks      `json:"socialLinks"`
+	PreviousEmployment []lushaPrevEmployment `json:"previousEmployment"`
+	Emails             []lushaEmail          `json:"emails"`
+	Phones             []lushaPhone          `json:"phones"`
+}
+
+// lushaSocialLinks holds the contact's social profile URLs. Only linkedin is
+// mapped today.
+type lushaSocialLinks struct {
+	Linkedin string `json:"linkedin"`
+}
+
+// lushaLocation holds geographic fields. Only country is mapped today.
+type lushaLocation struct {
+	Country string `json:"country"`
+}
+
+// lushaPrevEmployment is one prior role. The live sample carried no explicit
+// start/end dates, so only organization + title are captured.
+type lushaPrevEmployment struct {
 	Company struct {
 		Name   string `json:"name"`
 		Domain string `json:"domain"`
 	} `json:"company"`
-	Emails []lushaEmail `json:"emails"`
-	Phones []lushaPhone `json:"phones"`
+	JobTitle struct {
+		Title string `json:"title"`
+	} `json:"jobTitle"`
 }
 
 type lushaEmail struct {

--- a/pkg/enum/lusha/lusha_test.go
+++ b/pkg/enum/lusha/lusha_test.go
@@ -49,12 +49,38 @@ func TestToContact(t *testing.T) {
 				FirstName: "Ada",
 				LastName:  "Lovelace",
 				JobTitle: struct {
-					Title string `json:"title"`
-				}{Title: "Mathematician"},
+					Title       string   `json:"title"`
+					Departments []string `json:"departments"`
+					Seniority   string   `json:"seniority"`
+				}{
+					Title:       "Mathematician",
+					Departments: []string{"Research"},
+					Seniority:   "director",
+				},
 				Company: struct {
-					Name   string `json:"name"`
-					Domain string `json:"domain"`
-				}{Name: "Analytical Engine Co"},
+					Name     string `json:"name"`
+					Domain   string `json:"domain"`
+					Industry string `json:"industry"`
+				}{
+					Name:     "Analytical Engine Co",
+					Domain:   "analytical.example.com",
+					Industry: "Technology",
+				},
+				Location: lushaLocation{Country: "United Kingdom"},
+				SocialLinks: lushaSocialLinks{
+					Linkedin: "https://linkedin.com/in/ada",
+				},
+				PreviousEmployment: []lushaPrevEmployment{
+					{
+						Company: struct {
+							Name   string `json:"name"`
+							Domain string `json:"domain"`
+						}{Name: "Paramount"},
+						JobTitle: struct {
+							Title string `json:"title"`
+						}{Title: "Director"},
+					},
+				},
 				Emails: []lushaEmail{
 					{Email: "ada@example.com", Type: "professional", Confidence: "A+", UpdateDate: "2026-06-26"},
 					{Email: "ada.personal@gmail.com", Type: "personal", Confidence: "B", UpdateDate: "2026-06-26"},
@@ -70,6 +96,20 @@ func TestToContact(t *testing.T) {
 	assert.Equal(t, "Ada Lovelace", got.Name)
 	assert.Equal(t, "Mathematician", got.JobTitle)
 	assert.Equal(t, "Analytical Engine Co", got.Company)
+	assert.Equal(t, "analytical.example.com", got.CompanyDomain)
+	assert.Equal(t, "https://linkedin.com/in/ada", got.LinkedIn)
+	assert.Equal(t, []string{"Research"}, got.Departments)
+	assert.Equal(t, "director", got.Seniority)
+	assert.Equal(t, "United Kingdom", got.Location)
+
+	// Employment: current role first (Current:true), then previous (Current:false).
+	require.Len(t, got.Employment, 2, "expected current + 1 previous employment entry")
+	assert.Equal(t, "Analytical Engine Co", got.Employment[0].Organization)
+	assert.Equal(t, "Mathematician", got.Employment[0].Title)
+	assert.True(t, got.Employment[0].Current)
+	assert.Equal(t, "Paramount", got.Employment[1].Organization)
+	assert.Equal(t, "Director", got.Employment[1].Title)
+	assert.False(t, got.Employment[1].Current)
 
 	require.Len(t, got.Emails, 2)
 	// lushaEmail.Email maps to EmailEntry.Address


### PR DESCRIPTION
## Summary

Make the HUMINT enum sources collect **every field the phishing-targeting model uses** (Name, Title, Department, Email, Phone, **LinkedIn**, **Tenure/employment**, Seniority), wherever the API actually provides it. Field availability was **verified live** against Apollo/Lusha/Hunter (fox.com).

| Field | Hunter | Apollo | Lusha | DeHashed |
|---|---|---|---|---|
| Name / Title | ✅ | ✅ (last name on reveal) | ✅ | name only |
| Department / Seniority | ✅ | ✅ reveal | ✅ **(was dropped)** | ❌ |
| Email / Phone | ✅ | reveal / — | ✅ | ✅ |
| **LinkedIn** | ✅ **(was dropped)** | ✅ reveal | ✅ **(was dropped)** | ❌ |
| **Employment (tenure)** | ❌ | ✅ reveal | ✅ **(was dropped)** | ❌ |

### Changes
- **Apollo:** reveal is now **default-on** (`--no-reveal` = free discovery; `--limit` still bounds spend) since this runs with paid keys in practice. Reveal (`/people/match`) now captures the full record — un-obfuscated `last_name`, `linkedin_url`, `twitter_url`, `seniority`, `departments[]`, verified `email`, `city/state/country`, and raw `employment_history` (org/title/start/end/current).
- **Lusha:** now maps `socialLinks.linkedin`, `jobTitle.departments[]`+`seniority`, `company.domain`, `location.country`, and `previousEmployment` → `Employment[]` (current + prior). All previously dropped.
- **Hunter:** now maps the `linkedin`/`twitter` fields the domain-search API already returns.
- **DeHashed:** unchanged — breach data has no title/dept/linkedin/tenure (already collects email/name/phone/username).

**Tenure** is passed as **raw employment history** (no tenure-years computed, per decision). JSONL carries full richness; human output adds a LinkedIn column.

### Verified live (fox.com)
- Apollo (reveal default): `linkedin_url`, verified `email`, `departments`, `seniority`, full `employment[]` w/ dates.
- Lusha: `linkedin`, `departments`, `seniority`, `location`, `employment[]`.
- Hunter `linkedin` mapping confirmed via raw API (command-level live test blocked by the separate Free-plan pagination bug).

Coverage hunter 91.7% / apollo 92.0% / lusha 95.2%, race-clean.

> **Stacked on #185** (corrected Apollo/Lusha live schemas) — base will auto-retarget to `dev` when #185 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)