### PR TITLE
style(cmd): gofmt enum/logon test files to unblock CI lint

### DIFF
--- a/cmd/brutus/cmd_enum_oracles_teams_test.go
+++ b/cmd/brutus/cmd_enum_oracles_teams_test.go
@@ -43,7 +43,7 @@ func TestTeamsOracleAvailable(t *testing.T) {
 		want   bool
 	}{
 		{
-			name: "nil result returns false",
+			name:   "nil result returns false",
 			result: nil,
 			want:   false,
 		},

--- a/cmd/brutus/logon_flags_wiring_test.go
+++ b/cmd/brutus/logon_flags_wiring_test.go
@@ -74,10 +74,10 @@ func TestLogonFlagsWiring(t *testing.T) {
 // buildBaseConfig, and that the help text states the never-clean semantics.
 //
 // RED until the developer:
-//   1. Adds `flagFast bool` to flags.go in the Logon flags block.
-//   2. Adds `cmd.Flags().BoolVar(&flagFast, "fast", false, "...")` in registerLogonFlags.
-//   3. Adds `fast bool` field to baseConfigOptions (config.go).
-//   4. Adds `fast: flagFast` to buildBaseConfig return.
+//  1. Adds `flagFast bool` to flags.go in the Logon flags block.
+//  2. Adds `cmd.Flags().BoolVar(&flagFast, "fast", false, "...")` in registerLogonFlags.
+//  3. Adds `fast bool` field to baseConfigOptions (config.go).
+//  4. Adds `fast: flagFast` to buildBaseConfig return.
 func TestFastFlagWiring(t *testing.T) {
 	t.Cleanup(resetLogonFlags)
 	t.Run("default_false", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Two pre-existing test files were not `gofmt`-clean, keeping the CI **Lint** job red on `dev` (separate from the v1.6.0 Windows-build break already fixed in #184):
- `cmd/brutus/cmd_enum_oracles_teams_test.go`
- `cmd/brutus/logon_flags_wiring_test.go`

`gofmt -w` on exactly those two files. No logic changes; tests still pass. Unblocks `dev`'s Lint check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)