### PR TITLE
fix(enum/hunter): handle plan result-cap gracefully (preserve partial results)

### DIFF
--- a/cmd/brutus/cmd_enum_hunter.go
+++ b/cmd/brutus/cmd_enum_hunter.go
@@ -104,6 +104,12 @@ func runEnumHunter(cmd *cobra.Command, args []string) error {
 	logVerbose(flagVerbose, "Hunter returned %d people (total available: %d)",
 		len(result.People), result.Total)
 
+	// Plan cap hit: results were truncated. Notify on stderr (not in JSON mode).
+	if result.Truncated && !flagQuiet && !flagJSON {
+		fmt.Fprintf(os.Stderr, "%s hunter: plan result cap reached — returning first %d of %d (more available)\n",
+			dim(useColor, SymbolInfo), len(result.People), result.Total)
+	}
+
 	if flagJSON {
 		outputHunterJSONL(jsonWriter, result)
 	} else {

--- a/pkg/enum/hunter/hunter.go
+++ b/pkg/enum/hunter/hunter.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/praetorian-inc/brutus/pkg/enum"
@@ -34,7 +35,15 @@ var (
 	ErrUnauthorized = errors.New("invalid or missing API key")
 	ErrRateLimited  = errors.New("rate limit exceeded")
 	ErrLegalReasons = errors.New("unavailable for legal reasons")
+	// ErrPlanLimited signals the Hunter plan's result cap was hit mid-pagination.
+	// Search treats this as a soft stop and returns the results collected so far.
+	ErrPlanLimited = errors.New("plan result cap reached")
 )
+
+// planLimitMarker is the stable substring Hunter returns in the 400 error
+// details when the account's plan result cap is exceeded, e.g.:
+// "The search results are limited to 10 email addresses on your current plan."
+const planLimitMarker = "results are limited to"
 
 const (
 	defaultBaseURL  = "https://api.hunter.io/v2/domain-search"
@@ -65,6 +74,9 @@ type DomainResult struct {
 	Organization string
 	People       []Person
 	Total        int
+	// Truncated is true when the plan result cap was hit mid-pagination and the
+	// returned People are a partial set (Total reflects the full count available).
+	Truncated bool
 }
 
 // APIError is returned for any non-200 HTTP status from Hunter.io.
@@ -77,8 +89,9 @@ func (e *APIError) Error() string {
 	return fmt.Sprintf("hunter API error (HTTP %d): %s", e.StatusCode, e.Details)
 }
 
-// Unwrap returns the matching sentinel error for 401/429/451, nil otherwise.
-// This enables errors.Is(err, hunter.ErrUnauthorized) in callers.
+// Unwrap returns the matching sentinel error for 401/429/451, or ErrPlanLimited
+// for the specific 400 plan-cap response, nil otherwise. This enables
+// errors.Is(err, hunter.ErrUnauthorized) (and ErrPlanLimited) in callers.
 func (e *APIError) Unwrap() error {
 	switch e.StatusCode {
 	case http.StatusUnauthorized:
@@ -87,6 +100,11 @@ func (e *APIError) Unwrap() error {
 		return ErrRateLimited
 	case http.StatusUnavailableForLegalReasons:
 		return ErrLegalReasons
+	case http.StatusBadRequest:
+		// Only the plan-cap 400 maps to a sentinel; other 400s stay generic.
+		if strings.Contains(e.Details, planLimitMarker) {
+			return ErrPlanLimited
+		}
 	}
 	return nil
 }
@@ -126,6 +144,12 @@ func (c *Client) Search(ctx context.Context, domain string) (*DomainResult, erro
 	for {
 		page, err := c.fetchPage(ctx, domain, offset)
 		if err != nil {
+			// Plan result cap is a soft stop: return what we collected so far.
+			// Other errors (auth, rate limit, etc.) remain fatal.
+			if errors.Is(err, ErrPlanLimited) {
+				result.Truncated = true
+				break
+			}
 			return nil, err
 		}
 

--- a/pkg/enum/hunter/hunter_test.go
+++ b/pkg/enum/hunter/hunter_test.go
@@ -344,6 +344,119 @@ func TestSearch_Pagination(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Plan-cap pagination regression tests (fix/hunter-plan-cap-pagination)
+// ---------------------------------------------------------------------------
+
+// TestSearch_PlanLimited_ReturnsPartial verifies that when Hunter returns HTTP 400
+// with a plan-cap details message mid-pagination, Search stops cleanly and returns
+// the partial results already collected (nil error, Truncated == true).
+func TestSearch_PlanLimited_ReturnsPartial(t *testing.T) {
+	pageSize := 3
+	page1Emails := []apiEmail{
+		{Value: "a@example.com", Confidence: 80},
+		{Value: "b@example.com", Confidence: 70},
+		{Value: "c@example.com", Confidence: 65},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		offset := 0
+		_, _ = fmt.Sscanf(q.Get("offset"), "%d", &offset)
+
+		if offset > 0 {
+			// Second page: Hunter plan cap hit — return 400 with plan-limit marker.
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write(makeErrorResponse("The search results are limited to 10 email addresses on your current plan"))
+			return
+		}
+
+		// First page: full page of pageSize results (triggers continued pagination).
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(makeResponse("example.com", "Example Corp", page1Emails, 50, pageSize, 0))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	c.pageSize = pageSize
+
+	result, err := c.Search(context.Background(), "example.com")
+
+	require.NoError(t, err, "plan-cap mid-pagination must not return a fatal error")
+	assert.True(t, result.Truncated, "Truncated must be true when plan cap was hit")
+	assert.Len(t, result.People, len(page1Emails), "People must contain only the partial first-page results")
+}
+
+// TestAPIError_PlanLimited_Unwrap verifies the Unwrap sentinel mapping for the
+// plan-cap 400 vs a generic 400 that should NOT map to ErrPlanLimited.
+func TestAPIError_PlanLimited_Unwrap(t *testing.T) {
+	t.Run("plan-cap 400 is ErrPlanLimited", func(t *testing.T) {
+		err := &APIError{
+			StatusCode: http.StatusBadRequest,
+			Details:    "The search results are limited to 10 email addresses on your current plan",
+		}
+		assert.True(t, errors.Is(err, ErrPlanLimited), "plan-cap 400 must satisfy errors.Is(err, ErrPlanLimited)")
+
+		// Must also be recoverable via errors.As as a concrete *APIError.
+		var apiErr *APIError
+		require.True(t, errors.As(err, &apiErr))
+		assert.Equal(t, http.StatusBadRequest, apiErr.StatusCode)
+	})
+
+	t.Run("generic 400 is NOT ErrPlanLimited", func(t *testing.T) {
+		err := &APIError{
+			StatusCode: http.StatusBadRequest,
+			Details:    "bad request",
+		}
+		assert.False(t, errors.Is(err, ErrPlanLimited), "generic 400 must NOT satisfy errors.Is(err, ErrPlanLimited)")
+
+		// The error must still surface as a concrete *APIError (errors.As succeeds).
+		var apiErr *APIError
+		require.True(t, errors.As(err, &apiErr), "generic 400 must be retrievable via errors.As")
+		assert.Equal(t, http.StatusBadRequest, apiErr.StatusCode)
+		assert.Equal(t, "bad request", apiErr.Details)
+	})
+}
+
+// TestSearch_RateLimited_StillFatal confirms that a 429 mid-pagination is a fatal
+// error — Search must not return partial results with Truncated == true.
+// The existing table-driven case in TestSearch_Pagination covers this scenario,
+// but this explicit test makes the regression intent unambiguous.
+func TestSearch_RateLimited_StillFatal(t *testing.T) {
+	pageSize := 2
+	page1Emails := []apiEmail{
+		{Value: "a@example.com", Confidence: 80},
+		{Value: "b@example.com", Confidence: 70},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		offset := 0
+		_, _ = fmt.Sscanf(q.Get("offset"), "%d", &offset)
+
+		if offset > 0 {
+			// Second page: 429 — this must be fatal, not a soft stop.
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write(makeErrorResponse("rate limit exceeded"))
+			return
+		}
+
+		// First page: full pageSize — triggers continued pagination.
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(makeResponse("example.com", "Example Corp", page1Emails, 50, pageSize, 0))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	c.pageSize = pageSize
+
+	result, err := c.Search(context.Background(), "example.com")
+
+	require.Error(t, err, "mid-pagination 429 must return a fatal error")
+	assert.True(t, errors.Is(err, ErrRateLimited), "error must wrap ErrRateLimited")
+	assert.Nil(t, result, "no partial result must be returned for a fatal error")
+}
+
 func TestSearch_ContextCancellation(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		offset := 0


### PR DESCRIPTION
## Summary

`brutus enum hunter` was **unusable on capped Hunter plans** (e.g. Free = 10 results): the client paginates past the cap, Hunter returns `HTTP 400 "The search results are limited to N … on your current plan"`, and that was treated as fatal — **discarding the emails already collected on page 1**. Every `--limit` value failed, even though a raw single-page API call succeeds.

### Root cause
`Search` always requests the next `offset` page until it reaches the domain's full `Total`. On a capped plan the follow-up page trips the cap and 400s; `fetchPage` turned that into a fatal `*APIError`, so page-1 results were thrown away. (A raw `curl …limit=1` works because it only ever fetches one page.)

### Fix
- New sentinel **`ErrPlanLimited`** — `APIError.Unwrap()` maps a 400 whose details contain the plan-limit marker to it; other 400s stay generic and fatal (not swallowed).
- New `DomainResult.Truncated bool`.
- `Search` treats `ErrPlanLimited` mid-pagination as a **soft stop**: break and return the results collected so far with `nil` error, `Truncated=true`.
- The command prints a stderr notice when truncated (`hunter: plan result cap reached — returning first N of M (more available)`) unless `--quiet`/`--json`. API key never logged.
- 401 / 429 / 451 remain fatal (regression-tested).

### Verified live (Free key)
- Before: `Error: hunter API error (HTTP 400): The search results are limited to 10 …` (exit 1).
- After: notice + table of the first 10 of 2,138 fox.com people (exit 0).

Coverage 92.3%, race-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)