### PR TITLE
feat(enum): group passive API-key sources under `enum passive`

### DIFF
--- a/cmd/brutus/cmd_enum.go
+++ b/cmd/brutus/cmd_enum.go
@@ -43,21 +43,15 @@ Subcommands:
   oracles    Enumerate which account-existence oracles work for an organization
   kerberos   Enumerate Active Directory users via Kerberos AS-REQ
   generate   Generate email addresses or usernames from embedded name lists
-  hunter     Discover people and emails via Hunter.io Domain Search
-  dehashed   Collect breach-exposed identity data for a domain via DeHashed
   teams      Authenticate with Microsoft Entra ID via device code flow
-  apollo     Discover people/emails for a domain via Apollo.io (opt-in --reveal enrichment)
-  lusha      Enrich a single contact (email/phone) via Lusha
+  passive    API-key OSINT/HUMINT sources (Hunter, Apollo, Lusha, DeHashed)
 
 See subcommand help for details:
   brutus enum oracles --help
   brutus enum kerberos --help
   brutus enum generate --help
-  brutus enum hunter --help
-  brutus enum dehashed --help
   brutus enum teams --help
-  brutus enum apollo --help
-  brutus enum lusha --help`,
+  brutus enum passive --help`,
 	Example: `  # Account-existence oracle enumeration
   brutus enum oracles --domain praetorian.com -e test@praetorian.com --known-valid admin@praetorian.com
 
@@ -67,20 +61,14 @@ See subcommand help for details:
   # Generate emails for enumeration
   brutus enum generate --domain example.com --format flast
 
-  # Discover people via Hunter.io
-  brutus enum hunter --domain example.com
-
-  # Collect breach-exposed identity data via DeHashed
-  brutus enum dehashed --domain example.com
-
-  # Discover people via Apollo.io
-  brutus enum apollo --domain example.com
-
-  # Enrich a contact via Lusha
-  brutus enum lusha --first-name Jane --last-name Doe --company "Example Inc"
-
   # Authenticate with Microsoft Entra ID via device code
-  brutus enum teams auth --tenant contoso.com`,
+  brutus enum teams auth --tenant contoso.com
+
+  # API-key OSINT/HUMINT sources (employee email/contact discovery)
+  brutus enum passive hunter --domain example.com
+  brutus enum passive apollo --domain example.com
+  brutus enum passive lusha --first-name Jane --last-name Doe --company "Example Inc"
+  brutus enum passive dehashed --domain example.com`,
 }
 
 var enumGenerateCmd = &cobra.Command{
@@ -126,16 +114,28 @@ func init() {
 	f.StringVar(&flagEnumFormat, "format", "first.last", "Username format (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first)")
 	f.IntVar(&flagEnumGenerateLimit, "limit", 0, "Emit only the first N (most-likely) results (0 = no limit, emit all)")
 
-	// Wire commands
+	// Wire direct children of enum (unchanged commands).
 	enumCmd.AddCommand(enumGenerateCmd)
 	enumCmd.AddCommand(enumOraclesCmd)
 	enumCmd.AddCommand(enumKerberosCmd)
-	enumCmd.AddCommand(enumHunterCmd)
-	enumCmd.AddCommand(enumDehashedCmd)
 	enumCmd.AddCommand(enumCustomCmd)
 	enumCmd.AddCommand(enumTeamsCmd)
-	enumCmd.AddCommand(enumApolloCmd)
-	enumCmd.AddCommand(enumLushaCmd)
+
+	// Canonical path: the passive API-key OSINT/HUMINT sources live under "passive".
+	enumPassiveCmd.AddCommand(newEnumHunterCmd(), newEnumApolloCmd(), newEnumLushaCmd(), newEnumDehashedCmd())
+	enumCmd.AddCommand(enumPassiveCmd)
+
+	// Hidden back-compat aliases: the old "enum <name>" paths still work but are
+	// hidden from help and marked deprecated to nudge users to "enum passive
+	// <name>". A second builder instance is used per source (binding the same
+	// package-level flag vars — only one runs per invocation).
+	for _, alias := range []*cobra.Command{
+		newEnumHunterCmd(), newEnumApolloCmd(), newEnumLushaCmd(), newEnumDehashedCmd(),
+	} {
+		alias.Hidden = true
+		alias.Deprecated = `use "brutus enum passive ` + alias.Name() + `" instead`
+		enumCmd.AddCommand(alias)
+	}
 }
 
 // runEnumGenerate handles the "enum generate" subcommand.

--- a/cmd/brutus/cmd_enum_apollo.go
+++ b/cmd/brutus/cmd_enum_apollo.go
@@ -37,10 +37,16 @@ var (
 	flagApolloAPIKey   string
 )
 
-var enumApolloCmd = &cobra.Command{
-	Use:   "apollo",
-	Short: "Discover and enrich people for a domain via Apollo.io",
-	Long: `Query the Apollo.io people-search API to discover people associated with a
+// newEnumApolloCmd builds the "apollo" command. A fresh instance is constructed
+// per call so the same command can be mounted under two parents (the canonical
+// "enum passive apollo" path and the hidden back-compat "enum apollo" alias)
+// without sharing one *cobra.Command. All instances bind the same package-level
+// flag vars, which is fine since only one runs per invocation.
+func newEnumApolloCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "apollo",
+		Short: "Discover and enrich people for a domain via Apollo.io",
+		Long: `Query the Apollo.io people-search API to discover people associated with a
 company domain, then enrich each with the full matched record. By DEFAULT this
 reveals per person via the people/match API — un-obfuscated last name, email and
 status, LinkedIn/Twitter, seniority, departments, location, and employment
@@ -53,29 +59,30 @@ domains you are authorized to assess.
 
 Requires an Apollo.io API key via the APOLLO_API_KEY environment variable
 (or the --api-key flag).`,
-	Example: `  # Discover AND enrich people (DEFAULT — CONSUMES CREDITS, bounded by --limit)
-  brutus enum apollo --domain example.com
+		Example: `  # Discover AND enrich people (DEFAULT — CONSUMES CREDITS, bounded by --limit)
+  brutus enum passive apollo --domain example.com
 
   # Filter by job titles
-  brutus enum apollo -d example.com --titles "VP Engineering" --titles "CTO"
+  brutus enum passive apollo -d example.com --titles "VP Engineering" --titles "CTO"
 
   # Free discovery only — thin records, no emails, no credits
-  brutus enum apollo -d example.com --no-reveal
+  brutus enum passive apollo -d example.com --no-reveal
 
   # Provide the key explicitly (note: visible in process list / shell history)
-  brutus enum apollo -d example.com --api-key abc123`,
-	RunE: runEnumApollo,
-}
+  brutus enum passive apollo -d example.com --api-key abc123`,
+		RunE: runEnumApollo,
+	}
 
-func init() {
-	f := enumApolloCmd.Flags()
+	f := cmd.Flags()
 	f.StringVarP(&flagApolloDomain, "domain", "d", "", "Company domain to discover people for (required)")
 	f.StringSliceVar(&flagApolloTitles, "titles", nil, "Optional job-title filter (repeatable or comma-separated)")
 	f.BoolVar(&flagApolloNoReveal, "no-reveal", false, "Free discovery only — skip people/match enrichment (no PII, no credits)")
 	f.IntVar(&flagApolloLimit, "limit", 100, "Max people to return AND max to reveal (bounds credit spend; 0 = no cap, requires --no-reveal)")
 	f.StringVar(&flagApolloAPIKey, "api-key", "",
 		"Apollo.io API key (overrides APOLLO_API_KEY; WARNING: visible in process list and shell history — prefer APOLLO_API_KEY)")
-	_ = enumApolloCmd.MarkFlagRequired("domain")
+	_ = cmd.MarkFlagRequired("domain")
+
+	return cmd
 }
 
 // runEnumApollo implements the "enum apollo" subcommand.

--- a/cmd/brutus/cmd_enum_apollo_test.go
+++ b/cmd/brutus/cmd_enum_apollo_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -157,7 +158,7 @@ func TestRunEnumApollo_RejectsNegativeLimit(t *testing.T) {
 	resetApolloFlags()
 	flagApolloLimit = -1
 
-	err := runEnumApollo(enumApolloCmd, nil)
+	err := runEnumApollo(nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--limit",
 		"error must mention --limit so the operator knows what to fix")
@@ -172,7 +173,7 @@ func TestRunEnumApollo_RejectsRevealWithZeroLimit(t *testing.T) {
 	// reveal is default (flagApolloNoReveal=false), so --limit 0 alone must fail.
 	flagApolloLimit = 0
 
-	err := runEnumApollo(enumApolloCmd, nil)
+	err := runEnumApollo(nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--limit",
 		"error must mention --limit so the operator knows how to fix it")
@@ -188,7 +189,7 @@ func TestRunEnumApollo_AllowsNoRevealWithZeroLimit(t *testing.T) {
 	// No API key set — runEnumApollo will fail on resolveApolloAPIKey, which is
 	// expected; the important thing is it does NOT fail on the limit guard.
 	t.Setenv("APOLLO_API_KEY", "")
-	err := runEnumApollo(enumApolloCmd, nil)
+	err := runEnumApollo(nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "APOLLO_API_KEY",
 		"error must be about missing API key, not the limit guard")
@@ -342,39 +343,48 @@ func TestOutputApolloHuman(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestEnumApolloRegistered(t *testing.T) {
-	var found bool
+	// 1. enumCmd must have a "passive" subcommand.
+	var passive *cobra.Command
 	for _, cmd := range enumCmd.Commands() {
-		if cmd.Use != "apollo" {
-			continue
+		if cmd.Use == "passive" {
+			passive = cmd
+			break
 		}
-		found = true
-
-		// Required flags must exist.
-		domainFlag := cmd.Flags().Lookup("domain")
-		require.NotNil(t, domainFlag, "--domain flag must exist")
-
-		titlesFlag := cmd.Flags().Lookup("titles")
-		require.NotNil(t, titlesFlag, "--titles flag must exist")
-
-		revealFlag := cmd.Flags().Lookup("no-reveal")
-		require.NotNil(t, revealFlag, "--no-reveal flag must exist")
-
-		limitFlag := cmd.Flags().Lookup("limit")
-		require.NotNil(t, limitFlag, "--limit flag must exist")
-
-		apiKeyFlag := cmd.Flags().Lookup("api-key")
-		require.NotNil(t, apiKeyFlag, "--api-key flag must exist")
-
-		// -d shorthand must exist.
-		domainShort := cmd.Flags().ShorthandLookup("d")
-		require.NotNil(t, domainShort, "-d shorthand for --domain must exist")
-
-		// --domain must be marked required via cobra annotation.
-		annotations := domainFlag.Annotations
-		_, isRequired := annotations["cobra_annotation_bash_completion_one_required_flag"]
-		assert.True(t, isRequired, "--domain must be marked as required")
-
-		break
 	}
-	require.True(t, found, "apollo subcommand must be registered with enumCmd")
+	require.NotNil(t, passive, `enumCmd must have a "passive" subcommand`)
+
+	// 2. The canonical "apollo" command must live under passive.
+	var canonicalApollo *cobra.Command
+	for _, cmd := range passive.Commands() {
+		if cmd.Use == "apollo" {
+			canonicalApollo = cmd
+			break
+		}
+	}
+	require.NotNil(t, canonicalApollo, `"apollo" must be a subcommand of enumPassiveCmd`)
+
+	// Verify expected flags on the canonical command.
+	for _, flagName := range []string{"domain", "titles", "no-reveal", "limit", "api-key"} {
+		require.NotNilf(t, canonicalApollo.Flags().Lookup(flagName),
+			"--%s flag must exist on canonical apollo", flagName)
+	}
+
+	domainShort := canonicalApollo.Flags().ShorthandLookup("d")
+	require.NotNil(t, domainShort, "-d shorthand for --domain must exist")
+
+	domainFlag := canonicalApollo.Flags().Lookup("domain")
+	_, isRequired := domainFlag.Annotations["cobra_annotation_bash_completion_one_required_flag"]
+	assert.True(t, isRequired, "--domain must be marked as required")
+
+	// 3. A hidden back-compat alias must exist directly under enumCmd.
+	var alias *cobra.Command
+	for _, cmd := range enumCmd.Commands() {
+		if cmd.Use == "apollo" {
+			alias = cmd
+			break
+		}
+	}
+	require.NotNil(t, alias, `hidden "apollo" alias must be registered directly under enumCmd`)
+	assert.True(t, alias.Hidden, "back-compat apollo alias must be Hidden")
+	assert.NotEmpty(t, alias.Deprecated, "back-compat apollo alias must be Deprecated")
 }

--- a/cmd/brutus/cmd_enum_dehashed.go
+++ b/cmd/brutus/cmd_enum_dehashed.go
@@ -38,10 +38,16 @@ var (
 	flagDehashedIncludeCombolists bool
 )
 
-var enumDehashedCmd = &cobra.Command{
-	Use:   "dehashed",
-	Short: "Collect breach-exposed identity data for a domain via DeHashed",
-	Long: `Query the DeHashed v2 search API to collect breach-exposed identity data
+// newEnumDehashedCmd builds the "dehashed" command. A fresh instance is
+// constructed per call so the same command can be mounted under two parents (the
+// canonical "enum passive dehashed" path and the hidden back-compat "enum
+// dehashed" alias) without sharing one *cobra.Command. All instances bind the
+// same package-level flag vars, which is fine since only one runs per invocation.
+func newEnumDehashedCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "dehashed",
+		Short: "Collect breach-exposed identity data for a domain via DeHashed",
+		Long: `Query the DeHashed v2 search API to collect breach-exposed identity data
 associated with a domain: emails, usernames, names, IP addresses, phone numbers,
 addresses, dates of birth, and the source breach database. Standalone — does not
 feed the saas enumeration pipeline.
@@ -62,22 +68,21 @@ Requires a DeHashed API key via the DEHASHED_API_KEY environment variable
 
 This search consumes API credits (~1 credit per page of results); use --limit
 to bound the number of results (and therefore credits) per run.`,
-	Example: `  # Collect refined breach contacts for a domain (key from DEHASHED_API_KEY)
-  brutus enum dehashed --domain example.com
+		Example: `  # Collect refined breach contacts for a domain (key from DEHASHED_API_KEY)
+  brutus enum passive dehashed --domain example.com
 
   # Keep every email (not just @example.com), unmerged, including combolists
-  brutus enum dehashed -d example.com --all-emails --no-dedup --include-combolists
+  brutus enum passive dehashed -d example.com --all-emails --no-dedup --include-combolists
 
   # Provide the key explicitly (note: visible in process list / shell history)
-  brutus enum dehashed -d example.com --api-key abc123
+  brutus enum passive dehashed -d example.com --api-key abc123
 
   # Cap results (and credit spend) and write JSONL to a file
-  brutus enum dehashed -d example.com --limit 50 -o breaches.jsonl`,
-	RunE: runEnumDehashed,
-}
+  brutus enum passive dehashed -d example.com --limit 50 -o breaches.jsonl`,
+		RunE: runEnumDehashed,
+	}
 
-func init() {
-	f := enumDehashedCmd.Flags()
+	f := cmd.Flags()
 	f.StringVarP(&flagDehashedDomain, "domain", "d", "", "Domain to search (required)")
 	f.StringVar(&flagDehashedAPIKey, "api-key", "",
 		"DeHashed API key (overrides DEHASHED_API_KEY; WARNING: visible in process list and shell history — prefer DEHASHED_API_KEY)")
@@ -85,7 +90,9 @@ func init() {
 	f.BoolVar(&flagDehashedAllEmails, "all-emails", false, "Keep all emails, not just those @<domain> (disables corporate-only filtering)")
 	f.BoolVar(&flagDehashedNoDedup, "no-dedup", false, "Do not merge records that share an email")
 	f.BoolVar(&flagDehashedIncludeCombolists, "include-combolists", false, "Include records from known aggregator/combolist source databases")
-	_ = enumDehashedCmd.MarkFlagRequired("domain")
+	_ = cmd.MarkFlagRequired("domain")
+
+	return cmd
 }
 
 // runEnumDehashed implements the "enum dehashed" subcommand.

--- a/cmd/brutus/cmd_enum_dehashed_test.go
+++ b/cmd/brutus/cmd_enum_dehashed_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -328,49 +329,66 @@ func TestOutputDehashedJSONL(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Task 11: enumDehashedCmd registration and flags (updated — new flags added)
+// Task 11: enumDehashedCmd registration and flags (updated — passive regroup)
 // ---------------------------------------------------------------------------
 
 func TestEnumDehashedRegistered(t *testing.T) {
-	var found bool
+	// 1. enumCmd must have a "passive" subcommand.
+	var passive *cobra.Command
 	for _, cmd := range enumCmd.Commands() {
-		if cmd.Use != "dehashed" {
-			continue
+		if cmd.Use == "passive" {
+			passive = cmd
+			break
 		}
-		found = true
-
-		domainFlag := cmd.Flags().Lookup("domain")
-		require.NotNil(t, domainFlag, "--domain flag must exist")
-
-		apiKeyFlag := cmd.Flags().Lookup("api-key")
-		require.NotNil(t, apiKeyFlag, "--api-key flag must exist")
-
-		limitFlag := cmd.Flags().Lookup("limit")
-		require.NotNil(t, limitFlag, "--limit flag must exist")
-
-		// Verify -d shorthand exists.
-		domainShort := cmd.Flags().ShorthandLookup("d")
-		require.NotNil(t, domainShort, "-d shorthand must exist")
-
-		// Verify --domain is marked required via cobra annotation.
-		annotations := domainFlag.Annotations
-		_, isRequired := annotations["cobra_annotation_bash_completion_one_required_flag"]
-		assert.True(t, isRequired, "--domain must be marked as required")
-
-		// Verify --limit default value is 100.
-		assert.Equal(t, "100", limitFlag.DefValue, "--limit default must be 100")
-
-		// New flags from the filtering feature.
-		allEmailsFlag := cmd.Flags().Lookup("all-emails")
-		require.NotNil(t, allEmailsFlag, "--all-emails flag must exist")
-
-		nodedupFlag := cmd.Flags().Lookup("no-dedup")
-		require.NotNil(t, nodedupFlag, "--no-dedup flag must exist")
-
-		includeCombolistsFlag := cmd.Flags().Lookup("include-combolists")
-		require.NotNil(t, includeCombolistsFlag, "--include-combolists flag must exist")
-
-		break
 	}
-	require.True(t, found, "dehashed subcommand must be registered with enumCmd")
+	require.NotNil(t, passive, `enumCmd must have a "passive" subcommand`)
+
+	// 2. The canonical "dehashed" command must live under passive.
+	var canonicalDehashed *cobra.Command
+	for _, cmd := range passive.Commands() {
+		if cmd.Use == "dehashed" {
+			canonicalDehashed = cmd
+			break
+		}
+	}
+	require.NotNil(t, canonicalDehashed, `"dehashed" must be a subcommand of enumPassiveCmd`)
+
+	// Verify expected flags on the canonical command.
+	domainFlag := canonicalDehashed.Flags().Lookup("domain")
+	require.NotNil(t, domainFlag, "--domain flag must exist")
+
+	apiKeyFlag := canonicalDehashed.Flags().Lookup("api-key")
+	require.NotNil(t, apiKeyFlag, "--api-key flag must exist")
+
+	limitFlag := canonicalDehashed.Flags().Lookup("limit")
+	require.NotNil(t, limitFlag, "--limit flag must exist")
+
+	domainShort := canonicalDehashed.Flags().ShorthandLookup("d")
+	require.NotNil(t, domainShort, "-d shorthand must exist")
+
+	_, isRequired := domainFlag.Annotations["cobra_annotation_bash_completion_one_required_flag"]
+	assert.True(t, isRequired, "--domain must be marked as required")
+
+	assert.Equal(t, "100", limitFlag.DefValue, "--limit default must be 100")
+
+	allEmailsFlag := canonicalDehashed.Flags().Lookup("all-emails")
+	require.NotNil(t, allEmailsFlag, "--all-emails flag must exist")
+
+	nodedupFlag := canonicalDehashed.Flags().Lookup("no-dedup")
+	require.NotNil(t, nodedupFlag, "--no-dedup flag must exist")
+
+	includeCombolistsFlag := canonicalDehashed.Flags().Lookup("include-combolists")
+	require.NotNil(t, includeCombolistsFlag, "--include-combolists flag must exist")
+
+	// 3. A hidden back-compat alias must exist directly under enumCmd.
+	var alias *cobra.Command
+	for _, cmd := range enumCmd.Commands() {
+		if cmd.Use == "dehashed" {
+			alias = cmd
+			break
+		}
+	}
+	require.NotNil(t, alias, `hidden "dehashed" alias must be registered directly under enumCmd`)
+	assert.True(t, alias.Hidden, "back-compat dehashed alias must be Hidden")
+	assert.NotEmpty(t, alias.Deprecated, "back-compat dehashed alias must be Deprecated")
 }

--- a/cmd/brutus/cmd_enum_hunter.go
+++ b/cmd/brutus/cmd_enum_hunter.go
@@ -35,33 +35,40 @@ var (
 	flagHunterLimit  int
 )
 
-var enumHunterCmd = &cobra.Command{
-	Use:   "hunter",
-	Short: "Discover people and emails for a domain via Hunter.io Domain Search",
-	Long: `Query the Hunter.io Domain Search API to discover people associated with a
+// newEnumHunterCmd builds the "hunter" command. A fresh instance is constructed
+// per call so the same command can be mounted under two parents (the canonical
+// "enum passive hunter" path and the hidden back-compat "enum hunter" alias)
+// without sharing one *cobra.Command. All instances bind the same package-level
+// flag vars, which is fine since only one runs per invocation.
+func newEnumHunterCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "hunter",
+		Short: "Discover people and emails for a domain via Hunter.io Domain Search",
+		Long: `Query the Hunter.io Domain Search API to discover people associated with a
 domain: email, name, job title, phone, department, seniority, confidence, and
 sources. Standalone — does not feed the saas enumeration pipeline.
 
 Requires a Hunter.io API key via the HUNTER_API_KEY environment variable
 (or the --api-key flag).`,
-	Example: `  # Discover people for a domain (key from HUNTER_API_KEY)
-  brutus enum hunter --domain example.com
+		Example: `  # Discover people for a domain (key from HUNTER_API_KEY)
+  brutus enum passive hunter --domain example.com
 
   # Provide the key explicitly (note: visible in process list / shell history)
-  brutus enum hunter -d example.com --api-key abc123
+  brutus enum passive hunter -d example.com --api-key abc123
 
   # JSONL output to a file
-  brutus enum hunter -d example.com -o people.jsonl`,
-	RunE: runEnumHunter,
-}
+  brutus enum passive hunter -d example.com -o people.jsonl`,
+		RunE: runEnumHunter,
+	}
 
-func init() {
-	f := enumHunterCmd.Flags()
+	f := cmd.Flags()
 	f.StringVarP(&flagHunterDomain, "domain", "d", "", "Domain to search (required)")
 	f.StringVar(&flagHunterAPIKey, "api-key", "",
 		"Hunter.io API key (overrides HUNTER_API_KEY; WARNING: visible in process list and shell history — prefer HUNTER_API_KEY)")
 	f.IntVar(&flagHunterLimit, "limit", 100, "Results per API page (pagination page size)")
-	_ = enumHunterCmd.MarkFlagRequired("domain")
+	_ = cmd.MarkFlagRequired("domain")
+
+	return cmd
 }
 
 // runEnumHunter implements the "enum hunter" subcommand.

--- a/cmd/brutus/cmd_enum_hunter_test.go
+++ b/cmd/brutus/cmd_enum_hunter_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -117,33 +118,52 @@ func TestClassifyHunterError(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestEnumHunterRegistered(t *testing.T) {
-	var found bool
+	// 1. enumCmd must have a "passive" subcommand.
+	var passive *cobra.Command
 	for _, cmd := range enumCmd.Commands() {
-		if cmd.Use != "hunter" {
-			continue
+		if cmd.Use == "passive" {
+			passive = cmd
+			break
 		}
-		found = true
-
-		domainFlag := cmd.Flags().Lookup("domain")
-		require.NotNil(t, domainFlag, "--domain flag must exist")
-
-		apiKeyFlag := cmd.Flags().Lookup("api-key")
-		require.NotNil(t, apiKeyFlag, "--api-key flag must exist")
-
-		limitFlag := cmd.Flags().Lookup("limit")
-		require.NotNil(t, limitFlag, "--limit flag must exist")
-
-		// Verify -d shorthand exists.
-		domainShort := cmd.Flags().ShorthandLookup("d")
-		require.NotNil(t, domainShort, "-d shorthand must exist")
-
-		// Verify --domain is marked required via cobra annotation.
-		annotations := domainFlag.Annotations
-		_, isRequired := annotations["cobra_annotation_bash_completion_one_required_flag"]
-		assert.True(t, isRequired, "--domain must be marked as required")
-		break
 	}
-	require.True(t, found, "hunter subcommand must be registered with enumCmd")
+	require.NotNil(t, passive, `enumCmd must have a "passive" subcommand`)
+
+	// 2. The canonical "hunter" command must live under passive.
+	var canonicalHunter *cobra.Command
+	for _, cmd := range passive.Commands() {
+		if cmd.Use == "hunter" {
+			canonicalHunter = cmd
+			break
+		}
+	}
+	require.NotNil(t, canonicalHunter, `"hunter" must be a subcommand of enumPassiveCmd`)
+
+	// Verify expected flags on the canonical command (cross-check with builder).
+	ref := newEnumHunterCmd()
+	for _, flagName := range []string{"domain", "api-key", "limit"} {
+		require.NotNilf(t, canonicalHunter.Flags().Lookup(flagName),
+			"--%s flag must exist on canonical hunter", flagName)
+		require.NotNilf(t, ref.Flags().Lookup(flagName),
+			"--%s flag must exist on builder output", flagName)
+	}
+	domainShort := canonicalHunter.Flags().ShorthandLookup("d")
+	require.NotNil(t, domainShort, "-d shorthand must exist")
+
+	domainFlag := canonicalHunter.Flags().Lookup("domain")
+	_, isRequired := domainFlag.Annotations["cobra_annotation_bash_completion_one_required_flag"]
+	assert.True(t, isRequired, "--domain must be marked as required")
+
+	// 3. A hidden back-compat alias must exist directly under enumCmd.
+	var alias *cobra.Command
+	for _, cmd := range enumCmd.Commands() {
+		if cmd.Use == "hunter" {
+			alias = cmd
+			break
+		}
+	}
+	require.NotNil(t, alias, `hidden "hunter" alias must be registered directly under enumCmd`)
+	assert.True(t, alias.Hidden, "back-compat hunter alias must be Hidden")
+	assert.NotEmpty(t, alias.Deprecated, "back-compat hunter alias must be Deprecated")
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/brutus/cmd_enum_lusha.go
+++ b/cmd/brutus/cmd_enum_lusha.go
@@ -41,10 +41,16 @@ var (
 	flagLushaAPIKey    string
 )
 
-var enumLushaCmd = &cobra.Command{
-	Use:   "lusha",
-	Short: "Enrich a single person identity to emails and phones via Lusha v3",
-	Long: `Resolve one person identity to an enriched contact (emails and phone
+// newEnumLushaCmd builds the "lusha" command. A fresh instance is constructed
+// per call so the same command can be mounted under two parents (the canonical
+// "enum passive lusha" path and the hidden back-compat "enum lusha" alias)
+// without sharing one *cobra.Command. All instances bind the same package-level
+// flag vars, which is fine since only one runs per invocation.
+func newEnumLushaCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "lusha",
+		Short: "Enrich a single person identity to emails and phones via Lusha v3",
+		Long: `Resolve one person identity to an enriched contact (emails and phone
 numbers) via the Lusha v3 search-and-enrich API. Provide exactly one identity:
 a name (--first-name + --last-name) with a --company or --domain, OR an --email,
 OR a --linkedin URL. Standalone — does not feed the saas enumeration pipeline.
@@ -57,25 +63,24 @@ targeted individuals/organizations.
 
 Requires a Lusha API key via the LUSHA_API_KEY environment variable
 (or the --api-key flag).`,
-	Example: `  # Enrich by name + company (key from LUSHA_API_KEY)
-  brutus enum lusha --first-name Ada --last-name Lovelace --company Analytical
+		Example: `  # Enrich by name + company (key from LUSHA_API_KEY)
+  brutus enum passive lusha --first-name Ada --last-name Lovelace --company Analytical
 
   # Enrich by name + company domain
-  brutus enum lusha --first-name Ada --last-name Lovelace --domain example.com
+  brutus enum passive lusha --first-name Ada --last-name Lovelace --domain example.com
 
   # Enrich by email
-  brutus enum lusha --email ada@example.com
+  brutus enum passive lusha --email ada@example.com
 
   # Enrich by LinkedIn URL, also request phone numbers
-  brutus enum lusha --linkedin https://linkedin.com/in/ada --phone
+  brutus enum passive lusha --linkedin https://linkedin.com/in/ada --phone
 
   # Provide the key explicitly (note: visible in process list / shell history)
-  brutus enum lusha --email ada@example.com --api-key abc123`,
-	RunE: runEnumLusha,
-}
+  brutus enum passive lusha --email ada@example.com --api-key abc123`,
+		RunE: runEnumLusha,
+	}
 
-func init() {
-	f := enumLushaCmd.Flags()
+	f := cmd.Flags()
 	f.StringVar(&flagLushaFirstName, "first-name", "", "First name (with --last-name and --company or --domain)")
 	f.StringVar(&flagLushaLastName, "last-name", "", "Last name (with --first-name)")
 	f.StringVar(&flagLushaCompany, "company", "", "Company name (with the name pair)")
@@ -87,6 +92,8 @@ func init() {
 	f.StringVar(&flagLushaAPIKey, "api-key", "",
 		"Lusha API key (overrides LUSHA_API_KEY; WARNING: visible in process list and shell history — prefer LUSHA_API_KEY)")
 	// No MarkFlagRequired — identity is validated in runEnumLusha.
+
+	return cmd
 }
 
 // runEnumLusha implements the "enum lusha" subcommand.

--- a/cmd/brutus/cmd_enum_lusha_test.go
+++ b/cmd/brutus/cmd_enum_lusha_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -385,29 +386,50 @@ func TestClassifyLushaError_NetworkWrap(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestEnumLushaRegistered(t *testing.T) {
-	var found bool
+	// 1. enumCmd must have a "passive" subcommand.
+	var passive *cobra.Command
 	for _, cmd := range enumCmd.Commands() {
-		if cmd.Use != "lusha" {
-			continue
+		if cmd.Use == "passive" {
+			passive = cmd
+			break
 		}
-		found = true
-
-		flagNames := []string{
-			"first-name", "last-name", "company", "domain",
-			"email", "linkedin", "phone", "email-only", "api-key",
-		}
-		for _, name := range flagNames {
-			f := cmd.Flags().Lookup(name)
-			require.NotNilf(t, f, "--%s flag must exist", name)
-		}
-
-		// --domain must NOT be marked required (identity validated in RunE).
-		domainFlag := cmd.Flags().Lookup("domain")
-		require.NotNil(t, domainFlag)
-		annotations := domainFlag.Annotations
-		_, isRequired := annotations["cobra_annotation_bash_completion_one_required_flag"]
-		assert.False(t, isRequired, "--domain must NOT be marked as required for lusha")
-		break
 	}
-	require.True(t, found, "lusha subcommand must be registered with enumCmd")
+	require.NotNil(t, passive, `enumCmd must have a "passive" subcommand`)
+
+	// 2. The canonical "lusha" command must live under passive.
+	var canonicalLusha *cobra.Command
+	for _, cmd := range passive.Commands() {
+		if cmd.Use == "lusha" {
+			canonicalLusha = cmd
+			break
+		}
+	}
+	require.NotNil(t, canonicalLusha, `"lusha" must be a subcommand of enumPassiveCmd`)
+
+	// Verify expected flags on the canonical command.
+	for _, name := range []string{
+		"first-name", "last-name", "company", "domain",
+		"email", "linkedin", "phone", "email-only", "api-key",
+	} {
+		require.NotNilf(t, canonicalLusha.Flags().Lookup(name),
+			"--%s flag must exist on canonical lusha", name)
+	}
+
+	// --domain must NOT be marked required (identity validated in RunE).
+	domainFlag := canonicalLusha.Flags().Lookup("domain")
+	require.NotNil(t, domainFlag)
+	_, isRequired := domainFlag.Annotations["cobra_annotation_bash_completion_one_required_flag"]
+	assert.False(t, isRequired, "--domain must NOT be marked as required for lusha")
+
+	// 3. A hidden back-compat alias must exist directly under enumCmd.
+	var alias *cobra.Command
+	for _, cmd := range enumCmd.Commands() {
+		if cmd.Use == "lusha" {
+			alias = cmd
+			break
+		}
+	}
+	require.NotNil(t, alias, `hidden "lusha" alias must be registered directly under enumCmd`)
+	assert.True(t, alias.Hidden, "back-compat lusha alias must be Hidden")
+	assert.NotEmpty(t, alias.Deprecated, "back-compat lusha alias must be Deprecated")
 }

--- a/cmd/brutus/cmd_enum_passive.go
+++ b/cmd/brutus/cmd_enum_passive.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var enumPassiveCmd = &cobra.Command{
+	Use:   "passive",
+	Short: "API-key OSINT/HUMINT sources — employee email/contact discovery & enrichment",
+	Long: `Passive OSINT/HUMINT sources that discover and enrich employee emails and
+contacts for a domain via third-party provider APIs. Each source requires its
+own API key and consumes that provider's API credits — see the per-source help
+for the relevant environment variable and credit model.
+
+Sources:
+  hunter     Discover people and emails via Hunter.io Domain Search
+  apollo     Discover and enrich people for a domain via Apollo.io
+  lusha      Enrich a single contact (email/phone) via Lusha
+  dehashed   Collect breach-exposed identity data for a domain via DeHashed
+
+These sources are standalone — they do not feed the saas enumeration pipeline.`,
+	Example: `  # Discover people via Hunter.io
+  brutus enum passive hunter --domain example.com
+
+  # Discover and enrich people via Apollo.io
+  brutus enum passive apollo --domain example.com
+
+  # Enrich a contact via Lusha
+  brutus enum passive lusha --first-name Jane --last-name Doe --company "Example Inc"
+
+  # Collect breach-exposed identity data via DeHashed
+  brutus enum passive dehashed --domain example.com`,
+}


### PR DESCRIPTION
## Summary

Hunter, Apollo, Lusha and DeHashed are all **API-key OSINT/HUMINT sources**, so they're now grouped under a new **`brutus enum passive`** parent — distinct from the active enumerators (`oracles`, `kerberos`, `teams`) and the local utilities (`generate`, `custom`).

```
brutus enum passive hunter   --domain example.com
brutus enum passive apollo   --domain example.com
brutus enum passive lusha    --email jane@example.com
brutus enum passive dehashed --domain example.com
```

### Back-compat (no breakage)
Each command is now built by a `newEnumXCmd()` builder so the same command can be mounted **twice**: under `passive` (canonical) and as a **hidden, deprecated alias** directly under `enum`. So `brutus enum hunter` (etc.) still works and just prints a deprecation notice pointing at the passive path — existing scripts keep running.

### Tree
- `enum --help` → `custom · generate · kerberos · oracles · passive · teams` (the four sources hidden).
- `enum passive --help` → `apollo · dehashed · hunter · lusha`.
- `enum dehashed --help` → still renders; `Command "dehashed" is deprecated, use "brutus enum passive dehashed" instead` (stderr, so scripting/`--json` unaffected).

No behavior change to the commands themselves — flags and RunE unchanged. Tests migrated to the builder API and assert both the canonical `passive` placement and the hidden alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)