### PR TITLE
feat(enum/lusha): domain-roster enumeration (search + enrich whole company)

### DIFF
--- a/cmd/brutus/cmd_enum_lusha.go
+++ b/cmd/brutus/cmd_enum_lusha.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"syscall"
@@ -39,6 +40,7 @@ var (
 	flagLushaPhone     bool
 	flagLushaEmailOnly bool
 	flagLushaAPIKey    string
+	flagLushaLimit     int
 )
 
 // newEnumLushaCmd builds the "lusha" command. A fresh instance is constructed
@@ -54,6 +56,11 @@ func newEnumLushaCmd() *cobra.Command {
 numbers) via the Lusha v3 search-and-enrich API. Provide exactly one identity:
 a name (--first-name + --last-name) with a --company or --domain, OR an --email,
 OR a --linkedin URL. Standalone — does not feed the saas enumeration pipeline.
+
+ROSTER MODE: provide ONLY --domain (no name/email/linkedin) to enumerate a whole
+company roster via the Lusha prospecting API. Use --limit N to bound the roster
+(and credit spend); --limit 0 (the default) collects all matches. Roster mode
+consumes ~1 credit per contact searched and enriched.
 
 Every invocation consumes Lusha credits (the command has no free tier). Phone
 numbers may carry a Do-Not-Call (DNC) flag, which is always shown — do not
@@ -75,6 +82,12 @@ Requires a Lusha API key via the LUSHA_API_KEY environment variable
   # Enrich by LinkedIn URL, also request phone numbers
   brutus enum passive lusha --linkedin https://linkedin.com/in/ada --phone
 
+  # Roster: enumerate an entire company by domain (collect all — consumes credits)
+  brutus enum passive lusha --domain example.com
+
+  # Roster: cap the roster (and credit spend) at 25 contacts
+  brutus enum passive lusha --domain example.com --limit 25
+
   # Provide the key explicitly (note: visible in process list / shell history)
   brutus enum passive lusha --email ada@example.com --api-key abc123`,
 		RunE: runEnumLusha,
@@ -91,6 +104,8 @@ Requires a Lusha API key via the LUSHA_API_KEY environment variable
 	f.BoolVar(&flagLushaEmailOnly, "email-only", false, "Request only email datapoints (mutually exclusive with --phone)")
 	f.StringVar(&flagLushaAPIKey, "api-key", "",
 		"Lusha API key (overrides LUSHA_API_KEY; WARNING: visible in process list and shell history — prefer LUSHA_API_KEY)")
+	f.IntVar(&flagLushaLimit, "limit", 0,
+		"Roster mode (--domain only): max contacts to search + enrich; 0 = collect all (consumes ~1 credit/contact)")
 	// No MarkFlagRequired — identity is validated in runEnumLusha.
 
 	return cmd
@@ -121,6 +136,13 @@ func runEnumLusha(cmd *cobra.Command, args []string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	client := lusha.NewClient(apiKey, flagTimeout)
+
+	// Roster mode: enumerate a whole company by domain via the prospecting API.
+	if isLushaRosterMode() {
+		return runEnumLushaRoster(ctx, client, jsonWriter, useColor)
+	}
+
 	// Unconditional cost notice — Lusha enrichment always spends credits (P0-7).
 	if !flagQuiet && !flagJSON {
 		fmt.Fprintf(os.Stderr, "%s lusha enrichment consumes credits\n", dim(useColor, SymbolInfo))
@@ -139,7 +161,6 @@ func runEnumLusha(cmd *cobra.Command, args []string) error {
 		reveal = lusha.RevealOptions{Email: true, Phone: false}
 	}
 
-	client := lusha.NewClient(apiKey, flagTimeout)
 	contact, err := client.Enrich(ctx, query, reveal)
 	if err != nil {
 		return classifyLushaError(err)
@@ -157,13 +178,57 @@ func runEnumLusha(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// validateLushaIdentity enforces that exactly one identity group is set:
+// isLushaRosterMode reports whether the flags select domain-roster enumeration:
+// ONLY --domain is set (no --first-name/--last-name/--company/--email/--linkedin).
+// Pure function over the flag values — trivially testable.
+func isLushaRosterMode() bool {
+	return flagLushaDomain != "" &&
+		flagLushaFirstName == "" && flagLushaLastName == "" &&
+		flagLushaCompany == "" && flagLushaEmail == "" && flagLushaLinkedin == ""
+}
+
+// runEnumLushaRoster enumerates a company roster by domain and writes it out.
+// The cost notice goes to stderr (CLI layer only — the library prints nothing).
+func runEnumLushaRoster(ctx context.Context, client *lusha.Client, jsonWriter io.Writer, useColor bool) error {
+	if !flagQuiet && !flagJSON {
+		count := fmt.Sprintf("%d", flagLushaLimit)
+		if flagLushaLimit <= 0 {
+			count = "all"
+		}
+		fmt.Fprintf(os.Stderr, "%s lusha: enumerating %s — searching + enriching up to %s contacts (consumes credits)\n",
+			dim(useColor, SymbolInfo), flagLushaDomain, count)
+	}
+
+	roster, err := client.SearchDomain(ctx, flagLushaDomain, flagLushaLimit)
+	if err != nil {
+		return classifyLushaError(err)
+	}
+
+	logVerbose(flagVerbose, "Lusha roster: %d contacts, %d credits charged",
+		len(roster.Contacts), roster.CreditsCharged)
+
+	if flagJSON {
+		outputLushaDomainJSONL(jsonWriter, roster)
+	} else {
+		outputLushaDomainHuman(os.Stdout, roster, useColor)
+	}
+	return nil
+}
+
+// validateLushaIdentity enforces a valid identity selection. Roster mode (ONLY
+// --domain set) is valid for whole-company enumeration. Otherwise exactly one
+// single-contact identity group must be set:
 // (1) name group: --first-name + --last-name + exactly one of (--company | --domain),
 // (2) --email, or (3) --linkedin. --phone and --email-only are mutually exclusive.
 // Pure function over the flag values — no network, trivially testable.
 func validateLushaIdentity() error {
 	if flagLushaPhone && flagLushaEmailOnly {
 		return fmt.Errorf("--phone and --email-only are mutually exclusive")
+	}
+
+	// Roster mode: only --domain set → valid whole-company enumeration.
+	if isLushaRosterMode() {
+		return nil
 	}
 
 	hasName := flagLushaFirstName != "" || flagLushaLastName != "" ||

--- a/cmd/brutus/cmd_enum_lusha_output.go
+++ b/cmd/brutus/cmd_enum_lusha_output.go
@@ -97,41 +97,46 @@ func outputLushaHuman(w io.Writer, c *lusha.Contact, useColor bool) {
 	_, _ = fmt.Fprintln(w)
 }
 
-// outputLushaJSONL writes the contact as a single JSON line.
-// encoding/json already escapes control characters, so no sanitization needed.
-// The per-phone do_not_call bool is always emitted to surface DNC (P0-DNC).
-func outputLushaJSONL(w io.Writer, c *lusha.Contact) {
-	type emailJSON struct {
-		Address    string `json:"address"`
-		Type       string `json:"type,omitempty"`
-		Confidence string `json:"confidence,omitempty"`
-	}
-	type phoneJSON struct {
-		Number    string `json:"number"`
-		Type      string `json:"type,omitempty"`
-		DoNotCall bool   `json:"do_not_call"`
-	}
-	type employmentJSON struct {
-		Organization string `json:"organization,omitempty"`
-		Title        string `json:"title,omitempty"`
-		Current      bool   `json:"current"`
-	}
-	type contactJSON struct {
-		Type          string           `json:"type"`
-		Name          string           `json:"name,omitempty"`
-		JobTitle      string           `json:"job_title,omitempty"`
-		Company       string           `json:"company,omitempty"`
-		CompanyDomain string           `json:"company_domain,omitempty"`
-		LinkedIn      string           `json:"linkedin,omitempty"`
-		Departments   []string         `json:"departments,omitempty"`
-		Seniority     string           `json:"seniority,omitempty"`
-		Location      string           `json:"location,omitempty"`
-		Emails        []emailJSON      `json:"emails,omitempty"`
-		Phones        []phoneJSON      `json:"phones,omitempty"`
-		Employment    []employmentJSON `json:"employment,omitempty"`
-	}
+// JSON shapes for a single Lusha contact, shared by single-identity and roster
+// (domain) JSONL output (DRY). encoding/json escapes control chars, so no
+// sanitization is needed. The per-phone do_not_call bool is always emitted to
+// surface DNC (P0-DNC). These carry no credential fields beyond email/phone.
+type lushaEmailJSON struct {
+	Address    string `json:"address"`
+	Type       string `json:"type,omitempty"`
+	Confidence string `json:"confidence,omitempty"`
+}
 
-	jr := contactJSON{
+type lushaPhoneJSON struct {
+	Number    string `json:"number"`
+	Type      string `json:"type,omitempty"`
+	DoNotCall bool   `json:"do_not_call"`
+}
+
+type lushaEmploymentJSON struct {
+	Organization string `json:"organization,omitempty"`
+	Title        string `json:"title,omitempty"`
+	Current      bool   `json:"current"`
+}
+
+type lushaContactJSON struct {
+	Type          string                `json:"type"`
+	Name          string                `json:"name,omitempty"`
+	JobTitle      string                `json:"job_title,omitempty"`
+	Company       string                `json:"company,omitempty"`
+	CompanyDomain string                `json:"company_domain,omitempty"`
+	LinkedIn      string                `json:"linkedin,omitempty"`
+	Departments   []string              `json:"departments,omitempty"`
+	Seniority     string                `json:"seniority,omitempty"`
+	Location      string                `json:"location,omitempty"`
+	Emails        []lushaEmailJSON      `json:"emails,omitempty"`
+	Phones        []lushaPhoneJSON      `json:"phones,omitempty"`
+	Employment    []lushaEmploymentJSON `json:"employment,omitempty"`
+}
+
+// toLushaContactJSON maps a public Contact to its JSONL shape (type:"lusha").
+func toLushaContactJSON(c *lusha.Contact) lushaContactJSON {
+	jr := lushaContactJSON{
 		Type:          "lusha",
 		Name:          c.Name,
 		JobTitle:      c.JobTitle,
@@ -144,7 +149,7 @@ func outputLushaJSONL(w io.Writer, c *lusha.Contact) {
 	}
 	for i := range c.Emails {
 		e := &c.Emails[i]
-		jr.Emails = append(jr.Emails, emailJSON{
+		jr.Emails = append(jr.Emails, lushaEmailJSON{
 			Address:    e.Address,
 			Type:       e.Type,
 			Confidence: e.Confidence,
@@ -152,7 +157,7 @@ func outputLushaJSONL(w io.Writer, c *lusha.Contact) {
 	}
 	for i := range c.Phones {
 		p := &c.Phones[i]
-		jr.Phones = append(jr.Phones, phoneJSON{
+		jr.Phones = append(jr.Phones, lushaPhoneJSON{
 			Number:    p.Number,
 			Type:      p.Type,
 			DoNotCall: p.DoNotCall,
@@ -160,16 +165,78 @@ func outputLushaJSONL(w io.Writer, c *lusha.Contact) {
 	}
 	for i := range c.Employment {
 		em := &c.Employment[i]
-		jr.Employment = append(jr.Employment, employmentJSON{
+		jr.Employment = append(jr.Employment, lushaEmploymentJSON{
 			Organization: em.Organization,
 			Title:        em.Title,
 			Current:      em.Current,
 		})
 	}
+	return jr
+}
 
+// outputLushaJSONL writes the contact as a single JSON line.
+func outputLushaJSONL(w io.Writer, c *lusha.Contact) {
 	enc := json.NewEncoder(w)
-	if err := enc.Encode(jr); err != nil {
+	if err := enc.Encode(toLushaContactJSON(c)); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Error encoding lusha JSON: %v\n", err)
+	}
+}
+
+// outputLushaDomainHuman renders a Lusha domain roster as an aligned table.
+// All vendor-controlled strings are sanitized via sanitizeTerminal then
+// truncated (P0-4). The per-phone Do-Not-Call flag is surfaced as a DNC marker
+// appended to the phone column so the operator can honor suppression (P0-DNC).
+func outputLushaDomainHuman(w io.Writer, r *lusha.DomainResult, useColor bool) {
+	_, _ = fmt.Fprintf(w, "\n%s %s\n", dim(useColor, SymbolInfo),
+		heading(useColor, "Lusha: "+truncate(sanitizeTerminal(r.Domain), 80)))
+	_, _ = fmt.Fprintf(w, "  Contacts: %d of %d · credits charged: %d\n",
+		len(r.Contacts), r.Total, r.CreditsCharged)
+
+	if len(r.Contacts) == 0 {
+		_, _ = fmt.Fprintf(w, "\n  %s No contacts returned\n\n", dim(useColor, SymbolInfo))
+		return
+	}
+
+	_, _ = fmt.Fprintf(w, "\n  %s%-24s %-24s %-32s %-20s %-30s %-18s%s\n",
+		colorIf(useColor, ColorBold),
+		"Name", "Title", "Email", "Phone", "LinkedIn", "Dept",
+		colorIf(useColor, ColorReset))
+
+	for i := range r.Contacts {
+		c := &r.Contacts[i]
+		email := ""
+		if len(c.Emails) > 0 {
+			email = c.Emails[0].Address
+		}
+		phone := ""
+		if len(c.Phones) > 0 {
+			phone = c.Phones[0].Number
+			if c.Phones[0].DoNotCall {
+				phone += " [DNC]"
+			}
+		}
+		_, _ = fmt.Fprintf(w, "  %-24s %-24s %s%-32s%s %-20s %-30s %-18s\n",
+			truncate(sanitizeTerminal(c.Name), 24),
+			truncate(sanitizeTerminal(c.JobTitle), 24),
+			colorIf(useColor, ColorGreen),
+			truncate(sanitizeTerminal(email), 32),
+			colorIf(useColor, ColorReset),
+			truncate(sanitizeTerminal(phone), 20),
+			truncate(sanitizeTerminal(c.LinkedIn), 30),
+			truncate(sanitizeTerminal(strings.Join(c.Departments, ", ")), 18))
+	}
+	_, _ = fmt.Fprintln(w)
+}
+
+// outputLushaDomainJSONL writes one JSON object per roster contact, reusing the
+// single-identity per-contact rendering (DRY). No envelope object is emitted;
+// each line is a standalone type:"lusha" contact.
+func outputLushaDomainJSONL(w io.Writer, r *lusha.DomainResult) {
+	enc := json.NewEncoder(w)
+	for i := range r.Contacts {
+		if err := enc.Encode(toLushaContactJSON(&r.Contacts[i])); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "Error encoding lusha JSON: %v\n", err)
+		}
 	}
 }
 

--- a/cmd/brutus/cmd_enum_lusha_test.go
+++ b/cmd/brutus/cmd_enum_lusha_test.go
@@ -255,6 +255,32 @@ func TestValidateLushaIdentity(t *testing.T) {
 			wantErr:     true,
 			errContains: "mutually exclusive",
 		},
+		// Roster-mode cases (new: domain-only is valid roster mode).
+		{
+			name: "ROSTER: domain only → valid",
+			setup: func() {
+				flagLushaDomain = "fox.com"
+			},
+			wantErr: false,
+		},
+		{
+			name: "ROSTER+NAME: domain + name pair → single-contact valid (not roster)",
+			setup: func() {
+				flagLushaDomain = "fox.com"
+				flagLushaFirstName = "Ada"
+				flagLushaLastName = "Lovelace"
+			},
+			wantErr: false,
+		},
+		{
+			name: "ERROR ROSTER+EMAIL: domain + email → ambiguous (not roster, two groups)",
+			setup: func() {
+				flagLushaDomain = "fox.com"
+				flagLushaEmail = "ada@fox.com"
+			},
+			wantErr:     true,
+			errContains: "exactly one identity",
+		},
 	}
 
 	for _, tc := range tests {
@@ -382,6 +408,139 @@ func TestClassifyLushaError_NetworkWrap(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// T107: outputLushaDomainJSONL + outputLushaDomainHuman
+// ---------------------------------------------------------------------------
+
+func TestOutputLushaDomainJSONL(t *testing.T) {
+	t.Run("one JSON object per contact, type lusha, DNC preserved", func(t *testing.T) {
+		r := &lusha.DomainResult{
+			Domain: "fox.com",
+			Total:  2,
+			Contacts: []lusha.Contact{
+				{
+					Name:     "Bruna White",
+					JobTitle: "Assistant Director",
+					Company:  "Fox",
+					Emails: []lusha.EmailEntry{
+						{Address: "bruna.white@fox.com", Type: "work", Confidence: "A+"},
+					},
+					Phones: []lusha.PhoneEntry{
+						{Number: "+1 818", Type: "phone", DoNotCall: true},
+					},
+				},
+				{
+					Name:     "Steve R",
+					JobTitle: "Director",
+					Company:  "Fox",
+				},
+			},
+			CreditsCharged: 3,
+		}
+
+		var buf bytes.Buffer
+		outputLushaDomainJSONL(&buf, r)
+
+		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+		require.Len(t, lines, 2, "must emit exactly one JSON object per contact")
+
+		var obj0 map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[0]), &obj0))
+		assert.Equal(t, "lusha", obj0["type"], "type must be 'lusha'")
+		assert.Equal(t, "Bruna White", obj0["name"])
+
+		phones, ok := obj0["phones"].([]interface{})
+		require.True(t, ok, "phones must be a JSON array")
+		require.Len(t, phones, 1)
+		phone := phones[0].(map[string]interface{})
+		doNotCall, exists := phone["do_not_call"]
+		require.True(t, exists, "do_not_call field must always be present (P0-DNC)")
+		assert.Equal(t, true, doNotCall, "DNC flag must be true")
+
+		var obj1 map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[1]), &obj1))
+		assert.Equal(t, "lusha", obj1["type"])
+		assert.Equal(t, "Steve R", obj1["name"])
+
+		// No password or credential keys must appear.
+		for _, line := range lines {
+			assert.NotContains(t, line, "password",
+				"JSONL output must not contain password keys")
+			assert.NotContains(t, line, "api_key",
+				"JSONL output must not contain api_key")
+		}
+	})
+
+	t.Run("empty roster emits no lines", func(t *testing.T) {
+		r := &lusha.DomainResult{Domain: "empty.com"}
+		var buf bytes.Buffer
+		outputLushaDomainJSONL(&buf, r)
+		assert.Empty(t, strings.TrimSpace(buf.String()),
+			"empty roster must produce no JSONL output")
+	})
+}
+
+func TestOutputLushaDomainHuman(t *testing.T) {
+	t.Run("header shows N of Total and credits charged", func(t *testing.T) {
+		r := &lusha.DomainResult{
+			Domain: "fox.com",
+			Total:  10,
+			Contacts: []lusha.Contact{
+				{
+					Name:     "Bruna White",
+					JobTitle: "Assistant Director",
+					Company:  "Fox",
+					Emails: []lusha.EmailEntry{
+						{Address: "bruna.white@fox.com", Type: "work", Confidence: "A+"},
+					},
+				},
+			},
+			CreditsCharged: 3,
+		}
+		var buf bytes.Buffer
+		outputLushaDomainHuman(&buf, r, false)
+		out := buf.String()
+
+		// Header: "1 of 10 · credits charged: 3"
+		assert.Contains(t, out, "1", "header must show contact count")
+		assert.Contains(t, out, "10", "header must show total")
+		assert.Contains(t, out, "3", "header must show credits charged")
+		// Table row
+		assert.Contains(t, out, "Bruna White")
+		assert.Contains(t, out, "bruna.white@fox.com")
+	})
+
+	t.Run("DNC phone shows [DNC] marker in table row", func(t *testing.T) {
+		r := &lusha.DomainResult{
+			Domain: "fox.com",
+			Total:  1,
+			Contacts: []lusha.Contact{
+				{
+					Name: "Eve Example",
+					Phones: []lusha.PhoneEntry{
+						{Number: "+1 818", Type: "phone", DoNotCall: true},
+					},
+				},
+			},
+			CreditsCharged: 1,
+		}
+		var buf bytes.Buffer
+		outputLushaDomainHuman(&buf, r, false)
+		out := buf.String()
+		assert.Contains(t, out, "[DNC]", "DNC phone must show [DNC] marker")
+		assert.Contains(t, out, "+1 818")
+	})
+
+	t.Run("empty roster shows graceful no-contacts message", func(t *testing.T) {
+		r := &lusha.DomainResult{Domain: "empty.com", Total: 0}
+		var buf bytes.Buffer
+		outputLushaDomainHuman(&buf, r, false)
+		out := buf.String()
+		assert.Contains(t, out, "No contacts returned",
+			"empty roster must show graceful message")
+	})
+}
+
+// ---------------------------------------------------------------------------
 // T105: Command registration
 // ---------------------------------------------------------------------------
 
@@ -406,14 +565,19 @@ func TestEnumLushaRegistered(t *testing.T) {
 	}
 	require.NotNil(t, canonicalLusha, `"lusha" must be a subcommand of enumPassiveCmd`)
 
-	// Verify expected flags on the canonical command.
+	// Verify expected flags on the canonical command (includes --limit for roster mode).
 	for _, name := range []string{
 		"first-name", "last-name", "company", "domain",
-		"email", "linkedin", "phone", "email-only", "api-key",
+		"email", "linkedin", "phone", "email-only", "api-key", "limit",
 	} {
 		require.NotNilf(t, canonicalLusha.Flags().Lookup(name),
 			"--%s flag must exist on canonical lusha", name)
 	}
+
+	// --limit default must be 0 (collect all).
+	limitFlag := canonicalLusha.Flags().Lookup("limit")
+	require.NotNil(t, limitFlag, "--limit flag must exist")
+	assert.Equal(t, "0", limitFlag.DefValue, "--limit default must be 0 (collect all)")
 
 	// --domain must NOT be marked required (identity validated in RunE).
 	domainFlag := canonicalLusha.Flags().Lookup("domain")

--- a/pkg/enum/lusha/lusha.go
+++ b/pkg/enum/lusha/lusha.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/praetorian-inc/brutus/pkg/enum"
@@ -41,6 +42,23 @@ var (
 const (
 	defaultBaseURL = "https://api.lusha.com"
 	enrichPath     = "/v3/contacts/search-and-enrich"
+	// prospectSearchPath / prospectEnrichPath are the prospecting (roster) API
+	// endpoints. Their request/response shapes DIFFER from the single-identity
+	// search-and-enrich path above (different field names), so they have their
+	// own request/response structs below.
+	prospectSearchPath = "/prospecting/contact/search"
+	prospectEnrichPath = "/prospecting/contact/enrich"
+	// prospectPageSize is the per-page result count for prospecting search
+	// (API accepts 10-50; we use the max to minimize search-page credits).
+	prospectPageSize = 50
+	// prospectMinPageSize is the API's minimum search page size; requesting
+	// fewer is rejected ("pages.size must not be less than 10"). A small --limit
+	// still over-fetches the search page to this floor (search is ~1 credit/page
+	// regardless), but only the needed contactIds are enriched.
+	prospectMinPageSize = 10
+	// prospectMaxPages bounds collect-all (limit<=0) so a huge org cannot spin
+	// indefinitely; 40 pages * 50 = up to 2000 contacts.
+	prospectMaxPages = 40
 	// headerAPIKey is the Lusha auth header name. UNVERIFIED against a live key
 	// (discovery §3 / architecture §11) — isolated here for a single-edit fix.
 	headerAPIKey = "api_key"
@@ -104,6 +122,17 @@ type Contact struct {
 	Emails        []EmailEntry
 	Phones        []PhoneEntry
 	Employment    []EmploymentEntry
+}
+
+// DomainResult is the roster returned by SearchDomain for one company domain.
+// Total is the company-wide match count reported by the search API (may exceed
+// len(Contacts) when a limit was applied or the page cap was hit). CreditsCharged
+// is the accumulated credit cost across every search and enrich call.
+type DomainResult struct {
+	Domain         string
+	Contacts       []Contact
+	Total          int
+	CreditsCharged int
 }
 
 // APIError is returned for any non-2xx HTTP status from Lusha.
@@ -175,6 +204,81 @@ func (c *Client) Enrich(ctx context.Context, q ContactQuery, r RevealOptions) (*
 		return nil, fmt.Errorf("decoding lusha response: %w", err)
 	}
 	return toContact(&resp), nil
+}
+
+// SearchDomain enumerates a company roster by domain via the prospecting API.
+// It paginates POST /prospecting/contact/search (company-domain filter), then
+// enriches each search page's contacts via POST /prospecting/contact/enrich
+// using that page's requestId. Set limit>0 to bound the roster (and credit
+// spend); limit<=0 collects ALL matches, bounded by prospectMaxPages.
+//
+// Total is taken from the first page's totalResults. CreditsCharged accumulates
+// every search and enrich call's billing.creditsCharged. ctx is honored between
+// pages. NO printing — all data and cost are returned as values.
+func (c *Client) SearchDomain(ctx context.Context, domain string, limit int) (*DomainResult, error) {
+	result := &DomainResult{Domain: domain}
+
+	for page := 0; page < prospectMaxPages; page++ {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		remaining := 0
+		size := prospectPageSize
+		if limit > 0 {
+			remaining = limit - len(result.Contacts)
+			if remaining <= 0 {
+				break
+			}
+			// Shrink the page toward the limit, but never below the API minimum
+			// (a sub-minimum size is rejected with HTTP 400).
+			if remaining < size {
+				size = remaining
+				if size < prospectMinPageSize {
+					size = prospectMinPageSize
+				}
+			}
+		}
+
+		search, err := c.searchProspectPage(ctx, domain, page, size)
+		if err != nil {
+			return nil, err
+		}
+		result.CreditsCharged += search.Billing.CreditsCharged
+		if page == 0 {
+			result.Total = search.TotalResults
+		}
+		if len(search.Data) == 0 {
+			break
+		}
+
+		// Enrich only as many contacts as we still need, so a small --limit does
+		// not pay enrich credits for the over-fetched page tail.
+		entries := search.Data
+		if limit > 0 && remaining < len(entries) {
+			entries = entries[:remaining]
+		}
+		ids := make([]string, 0, len(entries))
+		for _, d := range entries {
+			ids = append(ids, d.ContactID)
+		}
+
+		enriched, credits, err := c.enrichProspectPage(ctx, search.RequestID, ids)
+		if err != nil {
+			return nil, err
+		}
+		result.CreditsCharged += credits
+		result.Contacts = append(result.Contacts, enriched...)
+
+		if limit > 0 && len(result.Contacts) >= limit {
+			break
+		}
+		if result.Total > 0 && len(result.Contacts) >= result.Total {
+			break
+		}
+	}
+
+	return result, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -313,6 +417,110 @@ func toContact(resp *lushaEnrichResponse) *Contact {
 	return c
 }
 
+// searchProspectPage requests one prospecting search page filtered by company
+// domain and decodes the response.
+func (c *Client) searchProspectPage(ctx context.Context, domain string, page, size int) (*prospectSearchResponse, error) {
+	body := prospectSearchRequest{}
+	body.Pages.Page = page
+	body.Pages.Size = size
+	body.Filters.Companies.Include.Domains = []string{domain}
+
+	raw, err := c.do(ctx, http.MethodPost, prospectSearchPath, body)
+	if err != nil {
+		return nil, err
+	}
+	var resp prospectSearchResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, fmt.Errorf("decoding lusha prospecting search response: %w", err)
+	}
+	return &resp, nil
+}
+
+// enrichProspectPage enriches one search page's contactIds (tied to its
+// requestId) and maps each successful result to a public Contact. It returns
+// the contacts and the credits charged for the call.
+func (c *Client) enrichProspectPage(ctx context.Context, requestID string, ids []string) ([]Contact, int, error) {
+	if len(ids) == 0 {
+		return nil, 0, nil
+	}
+
+	raw, err := c.do(ctx, http.MethodPost, prospectEnrichPath, prospectEnrichRequest{
+		RequestID:  requestID,
+		ContactIDs: ids,
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	var resp prospectEnrichResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, 0, fmt.Errorf("decoding lusha prospecting enrich response: %w", err)
+	}
+
+	contacts := make([]Contact, 0, len(resp.Contacts))
+	for i := range resp.Contacts {
+		ec := &resp.Contacts[i]
+		if !ec.IsSuccess {
+			continue
+		}
+		contacts = append(contacts, toProspectContact(&ec.Data))
+	}
+	return contacts, resp.CreditsCharged, nil
+}
+
+// toProspectContact maps one enriched prospecting contact to the public Contact
+// type. Field names differ from the single-identity path (e.g. emailAddresses,
+// phoneNumbers, seniority[].value), so the mapping is explicit. DoNotCall is
+// preserved per phone (P0-DNC).
+func toProspectContact(d *prospectEnrichData) Contact {
+	name := d.FullName
+	if name == "" {
+		name = d.FirstName
+		if d.LastName != "" {
+			if name != "" {
+				name += " "
+			}
+			name += d.LastName
+		}
+	}
+
+	seniority := make([]string, 0, len(d.Seniority))
+	for _, s := range d.Seniority {
+		if s.Value != "" {
+			seniority = append(seniority, s.Value)
+		}
+	}
+
+	c := Contact{
+		Name:        name,
+		JobTitle:    d.JobTitle,
+		Company:     d.CompanyName,
+		LinkedIn:    d.SocialLinks.Linkedin,
+		Departments: d.Departments,
+		Seniority:   strings.Join(seniority, ", "),
+		Location:    d.Location.Country,
+	}
+	for _, e := range d.EmailAddresses {
+		c.Emails = append(c.Emails, EmailEntry{
+			Address:    e.Email,
+			Type:       e.EmailType,
+			Confidence: e.EmailConfidence,
+		})
+	}
+	for _, p := range d.PhoneNumbers {
+		c.Phones = append(c.Phones, PhoneEntry{
+			Number:    p.Number,
+			Type:      p.PhoneType,
+			DoNotCall: p.DoNotCall,
+		})
+	}
+	c.Employment = append(c.Employment, EmploymentEntry{
+		Organization: d.CompanyName,
+		Title:        d.JobTitle,
+		Current:      true,
+	})
+	return c
+}
+
 // ---------------------------------------------------------------------------
 // JSON-mapping structs (unexported) — verified against live API 2026-06-26.
 // Architecture §11: isolated here so a single edit corrects a live mismatch
@@ -414,4 +622,99 @@ type lushaPhone struct {
 // Message is surfaced as APIError.Details (never the key or request body).
 type lushaErrorEnvelope struct {
 	Message string `json:"message"`
+}
+
+// ---------------------------------------------------------------------------
+// Prospecting (roster) JSON-mapping structs — field names DIFFER from the
+// single-identity search-and-enrich structs above. Verified live 2026-06-26.
+// ---------------------------------------------------------------------------
+
+// prospectSearchRequest filters prospecting search by company domain.
+type prospectSearchRequest struct {
+	Pages struct {
+		Page int `json:"page"`
+		Size int `json:"size"`
+	} `json:"pages"`
+	Filters struct {
+		Companies struct {
+			Include struct {
+				Domains []string `json:"domains"`
+			} `json:"include"`
+		} `json:"companies"`
+	} `json:"filters"`
+}
+
+// prospectSearchResponse is one prospecting search page. requestId ties this
+// page's contactIds to a subsequent enrich call.
+type prospectSearchResponse struct {
+	RequestID    string                `json:"requestId"`
+	CurrentPage  int                   `json:"currentPage"`
+	TotalResults int                   `json:"totalResults"`
+	Data         []prospectSearchEntry `json:"data"`
+	Billing      prospectSearchBilling `json:"billing"`
+}
+
+// prospectSearchEntry is one contact stub from a search page; only contactId is
+// needed to enrich (full data comes from the enrich call).
+type prospectSearchEntry struct {
+	ContactID string `json:"contactId"`
+}
+
+type prospectSearchBilling struct {
+	CreditsCharged  int `json:"creditsCharged"`
+	ResultsReturned int `json:"resultsReturned"`
+}
+
+// prospectEnrichRequest enriches contactIds tied to a search page's requestId.
+type prospectEnrichRequest struct {
+	RequestID  string   `json:"requestId"`
+	ContactIDs []string `json:"contactIds"`
+}
+
+// prospectEnrichResponse is the enrich result batch plus the credits charged.
+type prospectEnrichResponse struct {
+	RequestID      string                  `json:"requestId"`
+	Contacts       []prospectEnrichContact `json:"contacts"`
+	CreditsCharged int                     `json:"creditsCharged"`
+}
+
+// prospectEnrichContact wraps one enriched contact; data is only valid when
+// isSuccess is true.
+type prospectEnrichContact struct {
+	ID        string             `json:"id"`
+	IsSuccess bool               `json:"isSuccess"`
+	Data      prospectEnrichData `json:"data"`
+}
+
+// prospectEnrichData is the enriched payload. Field names (emailAddresses,
+// phoneNumbers, seniority[].value) differ from the single-identity result.
+type prospectEnrichData struct {
+	FirstName   string `json:"firstName"`
+	LastName    string `json:"lastName"`
+	FullName    string `json:"fullName"`
+	JobTitle    string `json:"jobTitle"`
+	CompanyName string `json:"companyName"`
+	Location    struct {
+		Country   string `json:"country"`
+		Continent string `json:"continent"`
+	} `json:"location"`
+	EmailAddresses []struct {
+		Email           string `json:"email"`
+		EmailType       string `json:"emailType"`
+		EmailConfidence string `json:"emailConfidence"`
+	} `json:"emailAddresses"`
+	PhoneNumbers []struct {
+		Number    string `json:"number"`
+		PhoneType string `json:"phoneType"`
+		DoNotCall bool   `json:"doNotCall"`
+	} `json:"phoneNumbers"`
+	SocialLinks struct {
+		Linkedin string `json:"linkedin"`
+		XURL     string `json:"xUrl"`
+	} `json:"socialLinks"`
+	Departments []string `json:"departments"`
+	Seniority   []struct {
+		ID    int    `json:"id"`
+		Value string `json:"value"`
+	} `json:"seniority"`
 }

--- a/pkg/enum/lusha/lusha_test.go
+++ b/pkg/enum/lusha/lusha_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -401,4 +402,362 @@ func TestEnrich_ContextCancellation(t *testing.T) {
 
 	_, err := c.Enrich(ctx, ContactQuery{Email: "a@b.com"}, RevealOptions{Email: true})
 	require.Error(t, err, "context cancellation must produce an error")
+}
+
+// ---------------------------------------------------------------------------
+// T106: SearchDomain — prospecting search + enrich pagination
+// ---------------------------------------------------------------------------
+
+// prospectSearchBody mirrors the fields our handler needs to inspect.
+type prospectSearchBody struct {
+	Pages struct {
+		Page int `json:"page"`
+		Size int `json:"size"`
+	} `json:"pages"`
+	Filters struct {
+		Companies struct {
+			Include struct {
+				Domains []string `json:"domains"`
+			} `json:"include"`
+		} `json:"companies"`
+	} `json:"filters"`
+}
+
+type prospectEnrichBody struct {
+	RequestID  string   `json:"requestId"`
+	ContactIDs []string `json:"contactIds"`
+}
+
+// newProspectServer builds an httptest.Server that handles the two prospecting
+// endpoints via a router. The search handler is called once (page 0); the enrich
+// handler is called once with the page's requestId + contactIds.
+func newProspectServer(t *testing.T, searchResp, enrichResp interface{}, captureSearch, captureEnrich *[]byte) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		switch r.URL.Path {
+		case prospectSearchPath:
+			if captureSearch != nil {
+				*captureSearch = body
+			}
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(searchResp))
+		case prospectEnrichPath:
+			if captureEnrich != nil {
+				*captureEnrich = body
+			}
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(enrichResp))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func TestSearchDomain_Success(t *testing.T) {
+	var capturedSearch, capturedEnrich []byte
+	var capturedAPIKey string
+
+	searchResp := map[string]interface{}{
+		"requestId":    "r1",
+		"currentPage":  0,
+		"pageLength":   2,
+		"totalResults": 2,
+		"data": []map[string]interface{}{
+			{"contactId": "c1"},
+			{"contactId": "c2"},
+		},
+		"billing": map[string]interface{}{
+			"creditsCharged":  1,
+			"resultsReturned": 2,
+		},
+	}
+	enrichResp := map[string]interface{}{
+		"requestId": "r1",
+		"contacts": []map[string]interface{}{
+			{
+				"id":        "c1",
+				"isSuccess": true,
+				"data": map[string]interface{}{
+					"fullName":    "Bruna White",
+					"jobTitle":    "Assistant Director",
+					"companyName": "Fox",
+					"location":    map[string]interface{}{"country": "United States"},
+					"emailAddresses": []map[string]interface{}{
+						{"email": "bruna.white@fox.com", "emailType": "work", "emailConfidence": "A+"},
+					},
+					"phoneNumbers": []map[string]interface{}{
+						{"number": "+1 818", "phoneType": "phone", "doNotCall": true},
+					},
+					"socialLinks": map[string]interface{}{
+						"linkedin": "https://linkedin.com/in/bw",
+					},
+					"departments": []string{"Other"},
+					"seniority": []map[string]interface{}{
+						{"id": 6, "value": "director"},
+					},
+				},
+			},
+			{
+				"id":        "c2",
+				"isSuccess": true,
+				"data": map[string]interface{}{
+					"fullName":       "Steve R",
+					"jobTitle":       "Director",
+					"companyName":    "Fox",
+					"emailAddresses": []interface{}{},
+					"phoneNumbers":   []interface{}{},
+					"departments":    []string{},
+					"seniority":      []interface{}{},
+				},
+			},
+		},
+		"creditsCharged": 2,
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedAPIKey = r.Header.Get(headerAPIKey)
+		// api_key must NOT appear in the URL query string (P0-1).
+		assert.NotContains(t, r.URL.RawQuery, "api_key",
+			"api_key must not appear in URL")
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		switch r.URL.Path {
+		case prospectSearchPath:
+			capturedSearch = body
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(searchResp))
+		case prospectEnrichPath:
+			capturedEnrich = body
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(enrichResp))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	result, err := c.SearchDomain(context.Background(), "fox.com", 0)
+	require.NoError(t, err)
+
+	// ---- result shape ----
+	assert.Equal(t, 2, result.Total, "Total must equal totalResults from search page")
+	require.Len(t, result.Contacts, 2)
+
+	// Credits: 1 (search) + 2 (enrich) = 3
+	assert.Equal(t, 3, result.CreditsCharged, "CreditsCharged must sum search+enrich billing")
+
+	// ---- Bruna White (first contact) ----
+	bruna := result.Contacts[0]
+	assert.Equal(t, "Bruna White", bruna.Name)
+	assert.Equal(t, "Assistant Director", bruna.JobTitle)
+	assert.Equal(t, "Fox", bruna.Company)
+	assert.Equal(t, "United States", bruna.Location)
+	assert.Equal(t, "https://linkedin.com/in/bw", bruna.LinkedIn)
+	assert.Equal(t, []string{"Other"}, bruna.Departments)
+	assert.Equal(t, "director", bruna.Seniority)
+
+	require.Len(t, bruna.Emails, 1, "Bruna must have 1 email")
+	assert.Equal(t, "bruna.white@fox.com", bruna.Emails[0].Address)
+	assert.Equal(t, "A+", bruna.Emails[0].Confidence)
+
+	require.Len(t, bruna.Phones, 1, "Bruna must have 1 phone")
+	assert.True(t, bruna.Phones[0].DoNotCall, "DoNotCall flag must be preserved (P0-DNC)")
+
+	// ---- api_key header ----
+	assert.Equal(t, "testkey", capturedAPIKey, "api_key header must be sent")
+
+	// ---- search request body carries domain filter ----
+	var sb prospectSearchBody
+	require.NoError(t, json.Unmarshal(capturedSearch, &sb))
+	require.Contains(t, sb.Filters.Companies.Include.Domains, "fox.com",
+		"search request must carry the domain filter")
+
+	// ---- enrich request carries correct requestId + contactIds ----
+	var eb prospectEnrichBody
+	require.NoError(t, json.Unmarshal(capturedEnrich, &eb))
+	assert.Equal(t, "r1", eb.RequestID,
+		"enrich request must use the page's requestId")
+	assert.ElementsMatch(t, []string{"c1", "c2"}, eb.ContactIDs,
+		"enrich request must carry the page's contactIds")
+}
+
+func TestSearchDomain_Pagination(t *testing.T) {
+	// newPaginationServer builds a fresh httptest.Server for each subtest so
+	// call-count state does not bleed between subtests.
+	makeEnrich := func(reqID string, names []string) map[string]interface{} {
+		contacts := make([]map[string]interface{}, 0, len(names))
+		for _, name := range names {
+			contacts = append(contacts, map[string]interface{}{
+				"id":        strings.ToLower(strings.ReplaceAll(name, " ", "")),
+				"isSuccess": true,
+				"data": map[string]interface{}{
+					"fullName":       name,
+					"emailAddresses": []interface{}{},
+					"phoneNumbers":   []interface{}{},
+					"departments":    []string{},
+					"seniority":      []interface{}{},
+				},
+			})
+		}
+		return map[string]interface{}{
+			"requestId":      reqID,
+			"contacts":       contacts,
+			"creditsCharged": len(names),
+		}
+	}
+
+	newPaginationServer := func(t *testing.T) *httptest.Server {
+		t.Helper()
+		searchCallCount := 0
+		page0Search := map[string]interface{}{
+			"requestId":    "page0-req",
+			"currentPage":  0,
+			"totalResults": 3,
+			"data": []map[string]interface{}{
+				{"contactId": "p0c1"},
+				{"contactId": "p0c2"},
+			},
+			"billing": map[string]interface{}{"creditsCharged": 1, "resultsReturned": 2},
+		}
+		page1Search := map[string]interface{}{
+			"requestId":    "page1-req",
+			"currentPage":  1,
+			"totalResults": 3,
+			"data": []map[string]interface{}{
+				{"contactId": "p1c1"},
+			},
+			"billing": map[string]interface{}{"creditsCharged": 1, "resultsReturned": 1},
+		}
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			switch r.URL.Path {
+			case prospectSearchPath:
+				w.Header().Set("Content-Type", "application/json")
+				if searchCallCount == 0 {
+					require.NoError(t, json.NewEncoder(w).Encode(page0Search))
+				} else {
+					require.NoError(t, json.NewEncoder(w).Encode(page1Search))
+				}
+				searchCallCount++
+			case prospectEnrichPath:
+				var eb prospectEnrichBody
+				require.NoError(t, json.Unmarshal(body, &eb))
+				w.Header().Set("Content-Type", "application/json")
+				// Mirror a real API: only return contacts for the requested ids.
+				allNames := map[string][]string{
+					"page0-req": {"Alice P", "Bob P"},
+					"page1-req": {"Carol P"},
+				}
+				names, ok := allNames[eb.RequestID]
+				if !ok {
+					http.Error(w, "unknown requestId", http.StatusBadRequest)
+					return
+				}
+				// Truncate names to however many ids were actually requested.
+				if len(eb.ContactIDs) < len(names) {
+					names = names[:len(eb.ContactIDs)]
+				}
+				require.NoError(t, json.NewEncoder(w).Encode(makeEnrich(eb.RequestID, names)))
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+	}
+
+	t.Run("collect_all fetches both pages and accumulates contacts and credits", func(t *testing.T) {
+		srv := newPaginationServer(t)
+		defer srv.Close()
+		c := newTestClient(srv.URL)
+		result, err := c.SearchDomain(context.Background(), "example.com", 0)
+		require.NoError(t, err)
+		assert.Equal(t, 3, result.Total)
+		require.Len(t, result.Contacts, 3, "must collect all 3 contacts across 2 pages")
+		// Credits: page0 search(1) + page0 enrich(2) + page1 search(1) + page1 enrich(1) = 5
+		assert.Equal(t, 5, result.CreditsCharged, "credits must be summed across all search and enrich calls")
+	})
+
+	t.Run("limit=1 truncates to 1 enriched contact", func(t *testing.T) {
+		srv := newPaginationServer(t)
+		defer srv.Close()
+		c := newTestClient(srv.URL)
+		result, err := c.SearchDomain(context.Background(), "example.com", 1)
+		require.NoError(t, err)
+		// Even though 3 results exist, limit=1 stops after enriching 1 contact.
+		assert.LessOrEqual(t, len(result.Contacts), 1,
+			"limit=1 must produce at most 1 contact")
+	})
+}
+
+func TestSearchDomain_ContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Slow server: sleeps longer than the ctx deadline.
+		time.Sleep(300 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := c.SearchDomain(ctx, "example.com", 0)
+	require.Error(t, err, "context cancellation must produce an error")
+}
+
+// TestToProspectContact verifies the prospecting-specific field mapping
+// (emailAddresses, phoneNumbers, seniority[].value differ from single-identity).
+func TestToProspectContact(t *testing.T) {
+	d := &prospectEnrichData{
+		FullName:    "Bruna White",
+		JobTitle:    "Assistant Director",
+		CompanyName: "Fox",
+	}
+	d.Location.Country = "United States"
+	d.EmailAddresses = []struct {
+		Email           string `json:"email"`
+		EmailType       string `json:"emailType"`
+		EmailConfidence string `json:"emailConfidence"`
+	}{
+		{Email: "bruna.white@fox.com", EmailType: "work", EmailConfidence: "A+"},
+	}
+	d.PhoneNumbers = []struct {
+		Number    string `json:"number"`
+		PhoneType string `json:"phoneType"`
+		DoNotCall bool   `json:"doNotCall"`
+	}{
+		{Number: "+1 818", PhoneType: "phone", DoNotCall: true},
+	}
+	d.SocialLinks.Linkedin = "https://linkedin.com/in/bw"
+	d.Departments = []string{"Other"}
+	d.Seniority = []struct {
+		ID    int    `json:"id"`
+		Value string `json:"value"`
+	}{
+		{ID: 6, Value: "director"},
+	}
+
+	got := toProspectContact(d)
+	assert.Equal(t, "Bruna White", got.Name)
+	assert.Equal(t, "Assistant Director", got.JobTitle)
+	assert.Equal(t, "Fox", got.Company)
+	assert.Equal(t, "United States", got.Location)
+	assert.Equal(t, "https://linkedin.com/in/bw", got.LinkedIn)
+	assert.Equal(t, []string{"Other"}, got.Departments)
+	assert.Equal(t, "director", got.Seniority)
+
+	require.Len(t, got.Emails, 1)
+	assert.Equal(t, "bruna.white@fox.com", got.Emails[0].Address)
+	assert.Equal(t, "work", got.Emails[0].Type)
+	assert.Equal(t, "A+", got.Emails[0].Confidence)
+
+	require.Len(t, got.Phones, 1)
+	assert.True(t, got.Phones[0].DoNotCall, "DoNotCall must be preserved (P0-DNC)")
+	assert.Equal(t, "+1 818", got.Phones[0].Number)
 }


### PR DESCRIPTION
## Summary

Adds **domain-based roster enumeration** to Lusha — `brutus enum passive lusha --domain example.com` now enumerates an *entire company* (was single-contact only), mirroring the Apollo domain flow. Built for the SaaS-library use case + maximal collection.

### Flow (verified live against fox.com)
Lusha **prospecting** API (separate from the single-identity `search-and-enrich`):
1. `POST /prospecting/contact/search` — `filters.companies.include.domains: [domain]`, paginated → contactIds + names/titles (222 contacts at fox.com).
2. `POST /prospecting/contact/enrich` — each page's contactIds → emails, phones, LinkedIn, departments, seniority, location.

### UX
- **`--domain` alone** (no name/email/linkedin) → roster mode (new).
- **`--domain` *with* a name** → the existing single-contact lookup (unchanged).
- `--limit N` bounds the roster (and credit spend); **`--limit 0` = collect all** (default — maximize).

### Library-clean (SaaS import)
`pkg/enum/lusha` **prints nothing**. `SearchDomain(ctx, domain, limit) (*DomainResult, error)` returns `DomainResult{Domain, Contacts, Total, CreditsCharged}` — the platform tracks spend programmatically. Cost notices live only in the CLI (stderr, `--quiet`/`--json` suppress). The prospecting API uses *different* response field names than the single-identity endpoint, so it has its own mapping structs; the single-identity `Enrich` path is untouched.

### Cost
~1 credit per page searched + ~1 per fresh contact enriched (already-revealed re-enrich free). `DomainResult.CreditsCharged` reports the actual total (e.g. 13 for a 5-contact sample).

Coverage 88.3%, race-clean. Live sample (fox.com `--limit 5`) returned 5 enriched people with emails/phones/LinkedIn + DNC markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)