### PR TITLE
feat(enum/apollo): discover→enrich split (stop auto-revealing the whole org)

### DIFF
--- a/cmd/brutus/cmd_enum_apollo.go
+++ b/cmd/brutus/cmd_enum_apollo.go
@@ -30,11 +30,11 @@ import (
 // File-local flag variables for the apollo subcommand.
 // Separate from flagEnumDomain to avoid cross-command state bleed.
 var (
-	flagApolloDomain   string
-	flagApolloTitles   []string
-	flagApolloNoReveal bool
-	flagApolloLimit    int
-	flagApolloAPIKey   string
+	flagApolloDomain string
+	flagApolloTitles []string
+	flagApolloEnrich bool
+	flagApolloLimit  int
+	flagApolloAPIKey string
 )
 
 // newEnumApolloCmd builds the "apollo" command. A fresh instance is constructed
@@ -45,13 +45,20 @@ var (
 func newEnumApolloCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "apollo",
-		Short: "Discover and enrich people for a domain via Apollo.io",
-		Long: `Query the Apollo.io people-search API to discover people associated with a
-company domain, then enrich each with the full matched record. By DEFAULT this
-reveals per person via the people/match API — un-obfuscated last name, email and
-status, LinkedIn/Twitter, seniority, departments, location, and employment
-history — which CONSUMES APOLLO CREDITS, bounded by --limit. Pass --no-reveal for
-free discovery only (thin records: id, first name, title, organization; no PII).
+		Short: "Discover people for a domain via Apollo.io (free; --enrich reveals emails)",
+		Long: `Query the Apollo.io people-search API to DISCOVER people associated with a
+company domain. By DEFAULT this is FREE and consumes NO credits: it returns thin
+records (id, first name, title, organization) plus per-person AVAILABILITY flags
+(whether a verified email / direct phone could be revealed) — no actual emails or
+phone numbers.
+
+Pass --enrich to reveal the full matched record for every discovered person via
+the people/match API — un-obfuscated last name, verified email and status,
+LinkedIn/Twitter, seniority, departments, location, and employment history. This
+CONSUMES APOLLO CREDITS (one per person), bounded by --limit.
+
+The SaaS UI performs SELECTIVE per-person enrichment (the operator picks who to
+reveal) directly via the library; this CLI's --enrich is the manual full-pull.
 Standalone — does not feed the saas enumeration pipeline.
 
 Authorized use only: respect Apollo.io's Terms of Service and only enumerate
@@ -59,14 +66,14 @@ domains you are authorized to assess.
 
 Requires an Apollo.io API key via the APOLLO_API_KEY environment variable
 (or the --api-key flag).`,
-		Example: `  # Discover AND enrich people (DEFAULT — CONSUMES CREDITS, bounded by --limit)
+		Example: `  # Discover people (DEFAULT — FREE, no credits; shows email/phone availability)
   brutus enum passive apollo --domain example.com
 
   # Filter by job titles
   brutus enum passive apollo -d example.com --titles "VP Engineering" --titles "CTO"
 
-  # Free discovery only — thin records, no emails, no credits
-  brutus enum passive apollo -d example.com --no-reveal
+  # Enrich all discovered people (CONSUMES CREDITS, bounded by --limit)
+  brutus enum passive apollo -d example.com --enrich --limit 50
 
   # Provide the key explicitly (note: visible in process list / shell history)
   brutus enum passive apollo -d example.com --api-key abc123`,
@@ -76,8 +83,8 @@ Requires an Apollo.io API key via the APOLLO_API_KEY environment variable
 	f := cmd.Flags()
 	f.StringVarP(&flagApolloDomain, "domain", "d", "", "Company domain to discover people for (required)")
 	f.StringSliceVar(&flagApolloTitles, "titles", nil, "Optional job-title filter (repeatable or comma-separated)")
-	f.BoolVar(&flagApolloNoReveal, "no-reveal", false, "Free discovery only — skip people/match enrichment (no PII, no credits)")
-	f.IntVar(&flagApolloLimit, "limit", 100, "Max people to return AND max to reveal (bounds credit spend; 0 = no cap, requires --no-reveal)")
+	f.BoolVar(&flagApolloEnrich, "enrich", false, "Reveal emails for all discovered people via people/match (CONSUMES CREDITS; bounded by --limit)")
+	f.IntVar(&flagApolloLimit, "limit", 0, "Max people to discover AND (with --enrich) to reveal (bounds credit spend; 0 = no cap)")
 	f.StringVar(&flagApolloAPIKey, "api-key", "",
 		"Apollo.io API key (overrides APOLLO_API_KEY; WARNING: visible in process list and shell history — prefer APOLLO_API_KEY)")
 	_ = cmd.MarkFlagRequired("domain")
@@ -93,17 +100,14 @@ func runEnumApollo(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--domain/-d is required")
 	}
 
-	// Reveal is the default; --no-reveal opts out to free discovery only.
-	reveal := !flagApolloNoReveal
+	// DISCOVER is the default (free, no credits). --enrich opts in to revealing
+	// emails for every discovered person (consumes credits, bounded by --limit).
+	enrich := flagApolloEnrich
 
-	// Bound credit spend: reject a negative cap outright, and reject an unbounded
-	// cap (0 = no cap) while revealing (the default) since reveal spends credits
-	// per person. An unbounded cap is only allowed with --no-reveal.
+	// --limit bounds discovery breadth and (with --enrich) enrich spend.
+	// 0 = no cap. Reject a negative cap outright.
 	if flagApolloLimit < 0 {
 		return fmt.Errorf("--limit must be >= 0")
-	}
-	if reveal && flagApolloLimit == 0 {
-		return fmt.Errorf("revealing (the default) requires a positive --limit to bound credit spend; pass --no-reveal for unbounded free discovery")
 	}
 
 	apiKey, err := resolveApolloAPIKey(flagApolloAPIKey)
@@ -143,9 +147,9 @@ func runEnumApollo(cmd *cobra.Command, args []string) error {
 	}
 
 	client := apollo.NewClient(apiKey, flagTimeout, pageSizeForLimit(flagApolloLimit))
-	result, err := client.SearchPeople(ctx, flagApolloDomain, flagApolloTitles, flagApolloLimit)
+	result, err := client.Discover(ctx, flagApolloDomain, flagApolloTitles, flagApolloLimit)
 	if err != nil {
-		// Output any partial discovery (SearchPeople returns partial + err) before
+		// Output any partial discovery (Discover returns partial + err) before
 		// surfacing the classified, nonzero-exit error — discovered contacts are free.
 		if result != nil && len(result.People) > 0 {
 			emitResult(result)
@@ -153,10 +157,12 @@ func runEnumApollo(cmd *cobra.Command, args []string) error {
 		return classifyApolloError(err)
 	}
 
-	if reveal {
+	if enrich {
+		// Discovery is free, so the only credit-spending action is --enrich. Warn
+		// once, on stderr, with the exact count that will be charged.
 		if !flagQuiet && !flagJSON && len(result.People) > 0 {
-			fmt.Fprintf(os.Stderr, "%s revealing will consume Apollo credits for %d people (pass --no-reveal to skip)\n",
-				dim(useColor, SymbolInfo), len(result.People))
+			fmt.Fprintf(os.Stderr, "%s --enrich will reveal emails for %d people (consumes ~%d Apollo credits)\n",
+				dim(useColor, SymbolInfo), len(result.People), len(result.People))
 		}
 		if err := client.RevealEmails(ctx, result); err != nil {
 			// Output the partial result (emails merged so far are paid for) before

--- a/cmd/brutus/cmd_enum_apollo.go
+++ b/cmd/brutus/cmd_enum_apollo.go
@@ -110,6 +110,15 @@ func runEnumApollo(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--limit must be >= 0")
 	}
 
+	// --enrich consumes one Apollo credit per discovered person, so it must be
+	// bounded. Without a positive --limit, "--enrich" against a large org would
+	// reveal the entire directory and silently burn ~one credit/person — the exact
+	// cost blowout this discover→enrich split exists to prevent. Free discovery may
+	// still run uncapped (--limit 0); only credit-spending enrichment requires a cap.
+	if enrich && flagApolloLimit <= 0 {
+		return fmt.Errorf("--enrich requires a positive --limit to bound credit spend (e.g. --limit 50)")
+	}
+
 	apiKey, err := resolveApolloAPIKey(flagApolloAPIKey)
 	if err != nil {
 		return err
@@ -160,7 +169,10 @@ func runEnumApollo(cmd *cobra.Command, args []string) error {
 	if enrich {
 		// Discovery is free, so the only credit-spending action is --enrich. Warn
 		// once, on stderr, with the exact count that will be charged.
-		if !flagQuiet && !flagJSON && len(result.People) > 0 {
+		// Emit the credit-spend notice on stderr regardless of --json: stderr does
+		// not corrupt stdout JSON, and --enrich is the only credit-spending path, so
+		// the operator must always see the spend (unless they explicitly --quiet).
+		if !flagQuiet && len(result.People) > 0 {
 			fmt.Fprintf(os.Stderr, "%s --enrich will reveal emails for %d people (consumes ~%d Apollo credits)\n",
 				dim(useColor, SymbolInfo), len(result.People), len(result.People))
 		}

--- a/cmd/brutus/cmd_enum_apollo_output.go
+++ b/cmd/brutus/cmd_enum_apollo_output.go
@@ -24,18 +24,21 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/enum/apollo"
 )
 
-// outputApolloHuman renders Apollo people-search results as an aligned table.
+// outputApolloHuman renders Apollo people results as an aligned table.
 // All attacker-controlled strings are sanitized via sanitizeTerminal (P0-4).
-// Columns adapt: preview (no emails) shows Name|Title|Dept|Org; revealed adds
-// Email|Status.
+// Columns adapt on result.Revealed: discovery (free) shows
+// Name|Title|Dept|Org|Email?|Phone? where Email?/Phone? render AVAILABILITY
+// (✓/–) — not actual values; enriched adds Email|Status|LinkedIn.
 func outputApolloHuman(w io.Writer, result *apollo.DomainResult, useColor bool) {
 	_, _ = fmt.Fprintf(w, "\n%s %s\n", dim(useColor, SymbolInfo),
 		heading(useColor, "Apollo: "+sanitizeTerminal(result.Domain)))
-	_, _ = fmt.Fprintf(w, "  People found: %d (total: %d)\n", len(result.People), result.Total)
-
-	if !result.Revealed {
+	if result.Revealed {
+		_, _ = fmt.Fprintf(w, "  People found: %d (total: %d) · credits charged: %d\n",
+			len(result.People), result.Total, result.CreditsCharged)
+	} else {
+		_, _ = fmt.Fprintf(w, "  People found: %d (total: %d)\n", len(result.People), result.Total)
 		_, _ = fmt.Fprintf(w, "  %s\n",
-			dim(useColor, "(preview — run with --reveal for emails; consumes credits)"))
+			dim(useColor, "(discovery — Email?/Phone? show availability; run with --enrich to reveal emails, consumes credits)"))
 	}
 
 	if len(result.People) == 0 {
@@ -50,9 +53,9 @@ func outputApolloHuman(w io.Writer, result *apollo.DomainResult, useColor bool) 
 			"Name", "Title", "Dept", "Org", "Email", "Status", "LinkedIn",
 			colorIf(useColor, ColorReset))
 	} else {
-		_, _ = fmt.Fprintf(w, "\n  %s%-28s %-22s %-12s %-22s%s\n",
+		_, _ = fmt.Fprintf(w, "\n  %s%-28s %-22s %-12s %-22s %-7s %-7s%s\n",
 			colorIf(useColor, ColorBold),
-			"Name", "Title", "Dept", "Org",
+			"Name", "Title", "Dept", "Org", "Email?", "Phone?",
 			colorIf(useColor, ColorReset))
 	}
 
@@ -71,21 +74,37 @@ func outputApolloHuman(w io.Writer, result *apollo.DomainResult, useColor bool) 
 				truncate(sanitizeTerminal(p.EmailStatus), 10),
 				truncate(sanitizeTerminal(p.LinkedinURL), 32))
 		} else {
-			_, _ = fmt.Fprintf(w, "  %-28s %-22s %-12s %-22s\n",
+			_, _ = fmt.Fprintf(w, "  %-28s %-22s %-12s %-22s %-7s %-7s\n",
 				truncate(name, 28),
 				truncate(sanitizeTerminal(p.Title), 22),
 				truncate(sanitizeTerminal(p.Department), 12),
-				truncate(sanitizeTerminal(p.Organization), 22))
+				truncate(sanitizeTerminal(p.Organization), 22),
+				availabilityMark(p.HasEmail),
+				availabilityMark(p.HasPhone))
 		}
 	}
 	_, _ = fmt.Fprintln(w)
 }
 
-// outputApolloJSONL writes one JSON object per discovered person.
-// encoding/json already escapes control characters, so no sanitization needed.
-// Preview (un-revealed) people omit email/email_status via omitempty so a
-// consumer never misreads a blank email as confirmed-absent.
+// availabilityMark renders a discovery-tier availability flag as a check or dash.
+// These reflect whether enrichment COULD reveal a value — never an actual value.
+func availabilityMark(available bool) string {
+	if available {
+		return "✓"
+	}
+	return "–"
+}
+
+// outputApolloJSONL writes one JSON object per person. encoding/json already
+// escapes control characters, so no sanitization needed. It branches on
+// result.Revealed: discovery emits slim candidate objects carrying only the free
+// fields plus has_email/has_phone availability (NO email/phone values); enriched
+// emits the full record including the revealed fields.
 func outputApolloJSONL(w io.Writer, result *apollo.DomainResult) {
+	if !result.Revealed {
+		outputApolloDiscoverJSONL(w, result)
+		return
+	}
 	type employmentJSON struct {
 		Organization string `json:"organization,omitempty"`
 		Title        string `json:"title,omitempty"`
@@ -151,6 +170,45 @@ func outputApolloJSONL(w io.Writer, result *apollo.DomainResult) {
 			State:        p.State,
 			Country:      p.Country,
 			Employment:   employment,
+		}
+		if err := enc.Encode(jr); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "Error encoding apollo JSON: %v\n", err)
+		}
+	}
+}
+
+// outputApolloDiscoverJSONL writes one slim candidate object per discovered
+// person for the FREE discovery tier: identity fields plus has_email/has_phone
+// availability (always present so a consumer can read availability=false), and
+// deliberately NO email/phone values (none were revealed). type is "apollo".
+func outputApolloDiscoverJSONL(w io.Writer, result *apollo.DomainResult) {
+	type apolloCandidateJSON struct {
+		Type         string `json:"type"`
+		Domain       string `json:"domain"`
+		Revealed     bool   `json:"revealed"`
+		ID           string `json:"id"`
+		Name         string `json:"name,omitempty"`
+		FirstName    string `json:"first_name,omitempty"`
+		Title        string `json:"title,omitempty"`
+		Organization string `json:"organization,omitempty"`
+		HasEmail     bool   `json:"has_email"`
+		HasPhone     bool   `json:"has_phone"`
+	}
+
+	enc := json.NewEncoder(w)
+	for i := range result.People {
+		p := &result.People[i]
+		jr := apolloCandidateJSON{
+			Type:         "apollo",
+			Domain:       result.Domain,
+			Revealed:     false,
+			ID:           p.ID,
+			Name:         p.Name,
+			FirstName:    p.FirstName,
+			Title:        p.Title,
+			Organization: p.Organization,
+			HasEmail:     p.HasEmail,
+			HasPhone:     p.HasPhone,
 		}
 		if err := enc.Encode(jr); err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "Error encoding apollo JSON: %v\n", err)

--- a/cmd/brutus/cmd_enum_apollo_output.go
+++ b/cmd/brutus/cmd_enum_apollo_output.go
@@ -28,7 +28,8 @@ import (
 // All attacker-controlled strings are sanitized via sanitizeTerminal (P0-4).
 // Columns adapt on result.Revealed: discovery (free) shows
 // Name|Title|Dept|Org|Email?|Phone? where Email?/Phone? render AVAILABILITY
-// (✓/–) — not actual values; enriched adds Email|Status|LinkedIn.
+// (✓/–) — not actual values; enriched shows Email|Status|LinkedIn and keeps a
+// trailing Phone? AVAILABILITY column (✓/–), since phone is never revealed.
 func outputApolloHuman(w io.Writer, result *apollo.DomainResult, useColor bool) {
 	_, _ = fmt.Fprintf(w, "\n%s %s\n", dim(useColor, SymbolInfo),
 		heading(useColor, "Apollo: "+sanitizeTerminal(result.Domain)))
@@ -48,9 +49,9 @@ func outputApolloHuman(w io.Writer, result *apollo.DomainResult, useColor bool) 
 	}
 
 	if result.Revealed {
-		_, _ = fmt.Fprintf(w, "\n  %s%-28s %-22s %-12s %-22s %-32s %-10s %-32s%s\n",
+		_, _ = fmt.Fprintf(w, "\n  %s%-28s %-22s %-12s %-22s %-32s %-10s %-32s %-7s%s\n",
 			colorIf(useColor, ColorBold),
-			"Name", "Title", "Dept", "Org", "Email", "Status", "LinkedIn",
+			"Name", "Title", "Dept", "Org", "Email", "Status", "LinkedIn", "Phone?",
 			colorIf(useColor, ColorReset))
 	} else {
 		_, _ = fmt.Fprintf(w, "\n  %s%-28s %-22s %-12s %-22s %-7s %-7s%s\n",
@@ -63,7 +64,7 @@ func outputApolloHuman(w io.Writer, result *apollo.DomainResult, useColor bool) 
 		p := &result.People[i]
 		name := personName(p)
 		if result.Revealed {
-			_, _ = fmt.Fprintf(w, "  %-28s %-22s %-12s %-22s %s%-32s%s %-10s %-32s\n",
+			_, _ = fmt.Fprintf(w, "  %-28s %-22s %-12s %-22s %s%-32s%s %-10s %-32s %-7s\n",
 				truncate(name, 28),
 				truncate(sanitizeTerminal(p.Title), 22),
 				truncate(sanitizeTerminal(p.Department), 12),
@@ -72,7 +73,8 @@ func outputApolloHuman(w io.Writer, result *apollo.DomainResult, useColor bool) 
 				truncate(sanitizeTerminal(p.Email), 32),
 				colorIf(useColor, ColorReset),
 				truncate(sanitizeTerminal(p.EmailStatus), 10),
-				truncate(sanitizeTerminal(p.LinkedinURL), 32))
+				truncate(sanitizeTerminal(p.LinkedinURL), 32),
+				availabilityMark(p.HasPhone))
 		} else {
 			_, _ = fmt.Fprintf(w, "  %-28s %-22s %-12s %-22s %-7s %-7s\n",
 				truncate(name, 28),
@@ -116,6 +118,8 @@ func outputApolloJSONL(w io.Writer, result *apollo.DomainResult) {
 		Type         string           `json:"type"`
 		Domain       string           `json:"domain"`
 		Revealed     bool             `json:"revealed"`
+		HasEmail     bool             `json:"has_email"`
+		HasPhone     bool             `json:"has_phone"`
 		ID           string           `json:"id"`
 		Name         string           `json:"name,omitempty"`
 		FirstName    string           `json:"first_name,omitempty"`
@@ -153,6 +157,8 @@ func outputApolloJSONL(w io.Writer, result *apollo.DomainResult) {
 			Type:         "apollo",
 			Domain:       result.Domain,
 			Revealed:     p.Revealed,
+			HasEmail:     p.HasEmail,
+			HasPhone:     p.HasPhone,
 			ID:           p.ID,
 			Name:         p.Name,
 			FirstName:    p.FirstName,

--- a/cmd/brutus/cmd_enum_apollo_test.go
+++ b/cmd/brutus/cmd_enum_apollo_test.go
@@ -183,6 +183,40 @@ func TestRunEnumApollo_DiscoverWithZeroLimitAllowed(t *testing.T) {
 		"discover with --limit 0 must not be rejected")
 }
 
+// TestRunEnumApollo_EnrichWithZeroLimitRejected asserts that --enrich with the
+// default/unbounded --limit 0 is rejected up front: enrichment spends one credit
+// per person, so an unbounded reveal must be refused before any network call.
+func TestRunEnumApollo_EnrichWithZeroLimitRejected(t *testing.T) {
+	resetApolloFlags()
+	flagApolloEnrich = true
+	flagApolloLimit = 0
+
+	t.Setenv("APOLLO_API_KEY", "test-key")
+	err := runEnumApollo(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--enrich",
+		"error must mention --enrich")
+	assert.Contains(t, err.Error(), "--limit",
+		"error must tell the operator to set a positive --limit")
+}
+
+// TestRunEnumApollo_EnrichWithPositiveLimitPassesGuard asserts that --enrich with
+// a positive --limit clears the credit-bound guard (it then fails later on the
+// missing API key, NOT on the limit guard).
+func TestRunEnumApollo_EnrichWithPositiveLimitPassesGuard(t *testing.T) {
+	resetApolloFlags()
+	flagApolloEnrich = true
+	flagApolloLimit = 50
+
+	t.Setenv("APOLLO_API_KEY", "")
+	err := runEnumApollo(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "APOLLO_API_KEY",
+		"with a positive --limit the guard must pass; failure should be the missing key")
+	assert.NotContains(t, err.Error(), "--enrich requires",
+		"positive --limit must clear the --enrich credit guard")
+}
+
 // ---------------------------------------------------------------------------
 // T003 cmd: outputApolloJSONL + outputApolloHuman
 // ---------------------------------------------------------------------------
@@ -258,6 +292,31 @@ func TestOutputApolloJSONL(t *testing.T) {
 		assert.Equal(t, true, obj["revealed"])
 	})
 
+	t.Run("revealed person retains has_email/has_phone availability", func(t *testing.T) {
+		result := &apollo.DomainResult{
+			Domain:   "example.com",
+			Revealed: true,
+			People: []apollo.Person{
+				{
+					ID:       "p1",
+					Name:     "Alice Smith",
+					Email:    "alice@example.com",
+					HasEmail: true,
+					HasPhone: true,
+					Revealed: true,
+				},
+			},
+			Total: 1,
+		}
+		var buf bytes.Buffer
+		outputApolloJSONL(&buf, result)
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &obj))
+		assert.Equal(t, true, obj["has_email"], "enriched JSONL must retain has_email availability")
+		assert.Equal(t, true, obj["has_phone"], "enriched JSONL must retain has_phone availability (phone is never revealed)")
+	})
+
 	t.Run("empty result emits zero lines", func(t *testing.T) {
 		result := &apollo.DomainResult{Domain: "empty.com"}
 		var buf bytes.Buffer
@@ -310,6 +369,7 @@ func TestOutputApolloHuman(t *testing.T) {
 					Name:        "Alice Smith",
 					Email:       "alice@example.com",
 					EmailStatus: "verified",
+					HasPhone:    true,
 					Revealed:    true,
 				},
 			},
@@ -324,6 +384,7 @@ func TestOutputApolloHuman(t *testing.T) {
 		assert.Contains(t, out, "verified")
 		// Enriched output must report credits charged.
 		assert.Contains(t, out, "credits charged", "enriched output must mention credits charged")
+		assert.Contains(t, out, "Phone?", "enriched table must retain Phone? availability column (phone is not revealed)")
 	})
 
 	t.Run("empty result shows no-people message", func(t *testing.T) {

--- a/cmd/brutus/cmd_enum_apollo_test.go
+++ b/cmd/brutus/cmd_enum_apollo_test.go
@@ -143,11 +143,11 @@ func TestClassifyApolloError_NetworkWrap(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // resetApolloFlags resets the package-level apollo flag vars to safe defaults.
-// Reveal is DEFAULT-ON: flagApolloNoReveal=false means reveal is active.
+// Discover is the default (flagApolloEnrich=false). --enrich opts in to enrichment.
 func resetApolloFlags() {
 	flagApolloDomain = "example.com"
 	flagApolloTitles = nil
-	flagApolloNoReveal = false
+	flagApolloEnrich = false
 	flagApolloLimit = 100
 	flagApolloAPIKey = ""
 }
@@ -164,37 +164,23 @@ func TestRunEnumApollo_RejectsNegativeLimit(t *testing.T) {
 		"error must mention --limit so the operator knows what to fix")
 }
 
-// TestRunEnumApollo_RejectsRevealWithZeroLimit asserts that reveal (the DEFAULT)
-// combined with --limit 0 (unbounded) is rejected to prevent unbounded credit
-// spend. With reveal as default, --limit 0 alone must be rejected; passing
-// --no-reveal (flagApolloNoReveal=true) with --limit 0 is allowed.
-func TestRunEnumApollo_RejectsRevealWithZeroLimit(t *testing.T) {
+// TestRunEnumApollo_DiscoverWithZeroLimitAllowed asserts that discover-only
+// (default, flagApolloEnrich=false) with --limit 0 (unbounded) is accepted.
+// Free discovery is safe to run without a limit cap.
+func TestRunEnumApollo_DiscoverWithZeroLimitAllowed(t *testing.T) {
 	resetApolloFlags()
-	// reveal is default (flagApolloNoReveal=false), so --limit 0 alone must fail.
-	flagApolloLimit = 0
-
-	err := runEnumApollo(nil, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "--limit",
-		"error must mention --limit so the operator knows how to fix it")
-}
-
-// TestRunEnumApollo_AllowsNoRevealWithZeroLimit asserts that --no-reveal with
-// --limit 0 (unbounded free discovery) is accepted.
-func TestRunEnumApollo_AllowsNoRevealWithZeroLimit(t *testing.T) {
-	resetApolloFlags()
-	flagApolloNoReveal = true
+	flagApolloEnrich = false
 	flagApolloLimit = 0
 
 	// No API key set — runEnumApollo will fail on resolveApolloAPIKey, which is
-	// expected; the important thing is it does NOT fail on the limit guard.
+	// expected; the important thing is it does NOT fail on a limit guard.
 	t.Setenv("APOLLO_API_KEY", "")
 	err := runEnumApollo(nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "APOLLO_API_KEY",
-		"error must be about missing API key, not the limit guard")
+		"error must be about missing API key, not a limit guard")
 	assert.NotContains(t, err.Error(), "--limit",
-		"--no-reveal with --limit 0 must not be rejected by the limit guard")
+		"discover with --limit 0 must not be rejected")
 }
 
 // ---------------------------------------------------------------------------
@@ -202,7 +188,7 @@ func TestRunEnumApollo_AllowsNoRevealWithZeroLimit(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestOutputApolloJSONL(t *testing.T) {
-	t.Run("preview person omits email field", func(t *testing.T) {
+	t.Run("discovery person emits has_email/has_phone availability, no email values", func(t *testing.T) {
 		result := &apollo.DomainResult{
 			Domain:   "example.com",
 			Revealed: false,
@@ -211,12 +197,11 @@ func TestOutputApolloJSONL(t *testing.T) {
 					ID:           "p1",
 					Name:         "Alice Smith",
 					FirstName:    "Alice",
-					LastName:     "Smith",
 					Title:        "Engineer",
-					Seniority:    "senior",
-					Department:   "Engineering",
 					Organization: "ACME Corp",
-					// Email is empty — preview mode (no --reveal)
+					HasEmail:     true,
+					HasPhone:     false,
+					// Email is empty — discovery mode (no --enrich)
 					Revealed: false,
 				},
 			},
@@ -236,11 +221,15 @@ func TestOutputApolloJSONL(t *testing.T) {
 		assert.Equal(t, "p1", obj["id"])
 		assert.Equal(t, false, obj["revealed"])
 
-		// Preview mode: email must be omitted (omitempty) — not present as empty string.
+		// Discovery mode: availability flags must be present.
+		assert.Equal(t, true, obj["has_email"], "has_email must be present in discovery JSONL")
+		assert.Equal(t, false, obj["has_phone"], "has_phone must be present in discovery JSONL")
+
+		// Discovery mode: email must be omitted (omitempty) — no PII revealed.
 		_, hasEmail := obj["email"]
-		assert.False(t, hasEmail, "email must be omitted in preview JSONL (omitempty)")
+		assert.False(t, hasEmail, "email must be omitted in discovery JSONL (no PII)")
 		_, hasEmailStatus := obj["email_status"]
-		assert.False(t, hasEmailStatus, "email_status must be omitted in preview JSONL (omitempty)")
+		assert.False(t, hasEmailStatus, "email_status must be omitted in discovery JSONL")
 	})
 
 	t.Run("revealed person includes email", func(t *testing.T) {
@@ -278,7 +267,7 @@ func TestOutputApolloJSONL(t *testing.T) {
 }
 
 func TestOutputApolloHuman(t *testing.T) {
-	t.Run("renders header and person row in preview mode", func(t *testing.T) {
+	t.Run("renders header and person row in discovery mode", func(t *testing.T) {
 		result := &apollo.DomainResult{
 			Domain:   "example.com",
 			Revealed: false,
@@ -289,6 +278,8 @@ func TestOutputApolloHuman(t *testing.T) {
 					Title:        "VP Engineering",
 					Department:   "Engineering",
 					Organization: "ACME Corp",
+					HasEmail:     true,
+					HasPhone:     false,
 				},
 			},
 			Total: 1,
@@ -301,14 +292,18 @@ func TestOutputApolloHuman(t *testing.T) {
 		assert.Contains(t, out, "example.com")
 		assert.Contains(t, out, "Alice Smith")
 		assert.Contains(t, out, "VP Engineering")
-		// Preview note must appear when not revealed.
-		assert.Contains(t, out, "--reveal", "preview note must mention --reveal")
+		// Discovery table must show availability columns, not email values.
+		assert.Contains(t, out, "Email?", "discovery header must show Email? availability column")
+		assert.Contains(t, out, "Phone?", "discovery header must show Phone? availability column")
+		// Discovery note must mention --enrich (not --reveal).
+		assert.Contains(t, out, "--enrich", "discovery note must mention --enrich")
 	})
 
-	t.Run("revealed shows Email column and values", func(t *testing.T) {
+	t.Run("enriched shows Email column, values, and credits charged", func(t *testing.T) {
 		result := &apollo.DomainResult{
-			Domain:   "example.com",
-			Revealed: true,
+			Domain:         "example.com",
+			Revealed:       true,
+			CreditsCharged: 1,
 			People: []apollo.Person{
 				{
 					ID:          "p1",
@@ -327,6 +322,8 @@ func TestOutputApolloHuman(t *testing.T) {
 		assert.Contains(t, out, "Email")
 		assert.Contains(t, out, "alice@example.com")
 		assert.Contains(t, out, "verified")
+		// Enriched output must report credits charged.
+		assert.Contains(t, out, "credits charged", "enriched output must mention credits charged")
 	})
 
 	t.Run("empty result shows no-people message", func(t *testing.T) {
@@ -363,11 +360,15 @@ func TestEnumApolloRegistered(t *testing.T) {
 	}
 	require.NotNil(t, canonicalApollo, `"apollo" must be a subcommand of enumPassiveCmd`)
 
-	// Verify expected flags on the canonical command.
-	for _, flagName := range []string{"domain", "titles", "no-reveal", "limit", "api-key"} {
+	// Verify expected flags on the canonical command: --enrich replaces --no-reveal.
+	for _, flagName := range []string{"domain", "titles", "enrich", "limit", "api-key"} {
 		require.NotNilf(t, canonicalApollo.Flags().Lookup(flagName),
 			"--%s flag must exist on canonical apollo", flagName)
 	}
+
+	// --no-reveal must NOT exist (it was removed in the discover→enrich split).
+	assert.Nilf(t, canonicalApollo.Flags().Lookup("no-reveal"),
+		"--no-reveal must not exist on the apollo command (replaced by --enrich)")
 
 	domainShort := canonicalApollo.Flags().ShorthandLookup("d")
 	require.NotNil(t, domainShort, "-d shorthand for --domain must exist")

--- a/pkg/enum/apollo/apollo.go
+++ b/pkg/enum/apollo/apollo.go
@@ -52,8 +52,8 @@ const (
 // Public types
 // ---------------------------------------------------------------------------
 
-// Person is one discovered contact for the domain. The reveal-only fields are
-// empty until RevealEmails runs (default-on, consumes credits).
+// Person is one discovered contact for the domain. The enrichment-only fields
+// are empty until EnrichByIDs/RevealEmails runs (consumes credits).
 type Person struct {
 	// From people-search (FREE, thin — last_name is obfuscated/empty here).
 	ID           string
@@ -65,7 +65,14 @@ type Person struct {
 	Department   string
 	Organization string
 
-	// From people/match (CREDITS, PII) — empty unless reveal ran.
+	// Availability signals from people-search (FREE, no credits): whether a
+	// verified email / direct phone could be revealed by enrichment. HasPhone is
+	// true only when the search tier reports a definite "Yes" (a "Maybe" requires
+	// a separate bulk_match request and is treated as not-available here).
+	HasEmail bool
+	HasPhone bool
+
+	// From people/match (CREDITS, PII) — empty unless enrichment ran.
 	Email       string
 	EmailStatus string
 	LinkedinURL string
@@ -90,10 +97,11 @@ type EmploymentEntry struct {
 
 // DomainResult is the aggregated, de-paginated result for a domain.
 type DomainResult struct {
-	Domain   string
-	People   []Person
-	Total    int  // pagination.total_entries
-	Revealed bool // true if RevealEmails ran (any credits spent)
+	Domain         string
+	People         []Person
+	Total          int  // pagination.total_entries
+	Revealed       bool // true if enrichment ran (any credits spent)
+	CreditsCharged int  // count of people enriched = Apollo credits spent
 }
 
 // APIError is returned for any non-2xx HTTP status from Apollo.
@@ -154,10 +162,11 @@ func NewClient(apiKey string, timeout time.Duration, pageSize int) *Client {
 	}
 }
 
-// SearchPeople paginates people-search for domain (optionally filtered by
-// titles), accumulating up to limit people. Phase 1 is FREE and returns no PII.
-// Honors ctx cancellation between pages.
-func (c *Client) SearchPeople(ctx context.Context, domain string, titles []string, limit int) (*DomainResult, error) {
+// Discover paginates people-search for domain (optionally filtered by titles),
+// accumulating up to limit people. This is the cheap discovery step: it is FREE,
+// returns no PII (only availability flags HasEmail/HasPhone), and consumes no
+// credits. Honors ctx cancellation between pages.
+func (c *Client) Discover(ctx context.Context, domain string, titles []string, limit int) (*DomainResult, error) {
 	result := &DomainResult{Domain: domain}
 	page := 1
 
@@ -200,37 +209,71 @@ func (c *Client) SearchPeople(ctx context.Context, domain string, titles []strin
 	return result, nil
 }
 
-// RevealEmails enriches the already-discovered people in result with the full
-// matched record via people/match, in place, serially. Consumes credits. Skips
-// people without an id. Merges the enriched fields (un-obfuscated last name,
-// email/status, LinkedIn/Twitter, seniority, departments, location, employment
-// history) onto each person and sets Revealed=true (even when the returned
-// email is empty — partial-result honesty), and sets result.Revealed=true on
-// the FIRST successful match so spent credits are reflected even if a later
-// match fails. Surfaces the first error (no partial swallow), leaving
-// already-merged records intact.
-func (c *Client) RevealEmails(ctx context.Context, result *DomainResult) error {
-	for i := range result.People {
-		p := &result.People[i]
-		if p.ID == "" { // can't match without an id
+// EnrichByIDs is the selective enrichment step: it reveals the full matched
+// record (linkedin_url, verified email, departments, seniority, employment,
+// etc.) for each given Apollo person id via people/match, serially. This is what
+// the SaaS UI calls on the operator's per-person selection. CONSUMES CREDITS —
+// one per id. Skips empty ids. Returns the enriched Person records (each with
+// Revealed=true) in id order, omitting any skipped (empty) ids. Surfaces the
+// first match error, returning the records enriched so far alongside it so the
+// caller still has — and is accountable for — the credits already spent. Honors
+// ctx cancellation between matches.
+func (c *Client) EnrichByIDs(ctx context.Context, ids []string) ([]Person, error) {
+	enriched := make([]Person, 0, len(ids))
+	for _, id := range ids {
+		if id == "" { // can't match without an id
 			continue
 		}
-		matched, err := c.matchPerson(ctx, p.ID)
+		matched, err := c.matchPerson(ctx, id)
 		if err != nil {
-			// On error, return it but leave the records merged so far intact;
-			// result.Revealed is already true if any earlier reveal succeeded.
-			return err
+			// Return the records enriched so far alongside the error — those
+			// credits are already spent, so the caller must still see them.
+			return enriched, err
 		}
-		mergeReveal(p, matched)
-		// Mark the aggregate as revealed on the FIRST successful match — credits
-		// have been spent, so the partial result must reflect that even if a
-		// later match fails.
-		result.Revealed = true
+		matched.ID = id // preserve the requested id (match echo may differ/omit)
+		matched.Revealed = true
+		enriched = append(enriched, matched)
 		if err := ctx.Err(); err != nil {
-			return err
+			return enriched, err
 		}
 	}
-	return nil
+	return enriched, nil
+}
+
+// RevealEmails is a convenience that enriches ALL discovered people in result,
+// in place. It is the CLI --enrich (manual full-pull) path, NOT the default. It
+// delegates to EnrichByIDs over the result's ids and merges the enriched fields
+// (un-obfuscated last name, email/status, LinkedIn/Twitter, seniority,
+// departments, location, employment history) back onto each person by id.
+// CONSUMES CREDITS — one per enriched person, recorded in result.CreditsCharged.
+// Sets result.Revealed=true if any person was enriched (so spent credits are
+// reflected even if a later match fails). Surfaces the first error (no partial
+// swallow), leaving already-merged records intact.
+func (c *Client) RevealEmails(ctx context.Context, result *DomainResult) error {
+	ids := make([]string, len(result.People))
+	for i := range result.People {
+		ids[i] = result.People[i].ID
+	}
+
+	enriched, err := c.EnrichByIDs(ctx, ids)
+
+	// Merge whatever was enriched (even on partial error) back by id, and record
+	// the credits spent so the partial result stays honest.
+	byID := make(map[string]*Person, len(enriched))
+	for i := range enriched {
+		byID[enriched[i].ID] = &enriched[i]
+	}
+	for i := range result.People {
+		if m, ok := byID[result.People[i].ID]; ok {
+			mergeReveal(&result.People[i], *m)
+		}
+	}
+	result.CreditsCharged = len(enriched)
+	if len(enriched) > 0 {
+		result.Revealed = true
+	}
+
+	return err
 }
 
 // ---------------------------------------------------------------------------
@@ -352,6 +395,8 @@ func (p apolloPerson) toPerson() Person {
 		Seniority:    p.Seniority,
 		Department:   dept,
 		Organization: p.Organization.Name,
+		HasEmail:     p.HasEmail,
+		HasPhone:     p.HasDirectPhone == "Yes",
 		Email:        p.Email,
 		EmailStatus:  p.EmailStatus,
 		LinkedinURL:  p.LinkedinURL,
@@ -417,14 +462,19 @@ type apolloMatchResponse struct {
 }
 
 type apolloPerson struct {
-	ID                string                  `json:"id"`
-	FirstName         string                  `json:"first_name"`
-	LastName          string                  `json:"last_name"`
-	Name              string                  `json:"name"`
-	Title             string                  `json:"title"`
-	Seniority         string                  `json:"seniority"`
-	Departments       []string                `json:"departments"`
-	Organization      apolloOrganization      `json:"organization"`
+	ID           string             `json:"id"`
+	FirstName    string             `json:"first_name"`
+	LastName     string             `json:"last_name"`
+	Name         string             `json:"name"`
+	Title        string             `json:"title"`
+	Seniority    string             `json:"seniority"`
+	Departments  []string           `json:"departments"`
+	Organization apolloOrganization `json:"organization"`
+	// Availability flags from people-search (no credits). has_email is a bool;
+	// has_direct_phone is a STRING ("Yes" / "Maybe: ...") — verified live
+	// 2026-06-26, hence the string type and the =="Yes" mapping in toPerson.
+	HasEmail          bool                    `json:"has_email"`
+	HasDirectPhone    string                  `json:"has_direct_phone"`
 	Email             string                  `json:"email"`
 	EmailStatus       string                  `json:"email_status"`
 	LinkedinURL       string                  `json:"linkedin_url"`

--- a/pkg/enum/apollo/apollo.go
+++ b/pkg/enum/apollo/apollo.go
@@ -250,9 +250,23 @@ func (c *Client) EnrichByIDs(ctx context.Context, ids []string) ([]Person, error
 // reflected even if a later match fails). Surfaces the first error (no partial
 // swallow), leaving already-merged records intact.
 func (c *Client) RevealEmails(ctx context.Context, result *DomainResult) error {
-	ids := make([]string, len(result.People))
+	// Deduplicate ids before enriching: pagination can surface the same person
+	// twice, and EnrichByIDs spends one credit per id — enriching a duplicate would
+	// burn a credit for a record already revealed. Empty ids are dropped here too
+	// (EnrichByIDs also skips them). The merge-by-id loop below still fans a single
+	// enriched record back onto every row sharing that id.
+	ids := make([]string, 0, len(result.People))
+	seen := make(map[string]struct{}, len(result.People))
 	for i := range result.People {
-		ids[i] = result.People[i].ID
+		id := result.People[i].ID
+		if id == "" {
+			continue
+		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
 	}
 
 	enriched, err := c.EnrichByIDs(ctx, ids)

--- a/pkg/enum/apollo/apollo_test.go
+++ b/pkg/enum/apollo/apollo_test.go
@@ -299,17 +299,26 @@ func TestDo_SetsAuthHeader(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// T003: SearchPeople pagination + RevealEmails
+// T003: Discover pagination (was SearchPeople) + EnrichByIDs + RevealEmails
 // ---------------------------------------------------------------------------
 
 // pagedSearchServer returns an httptest.Server that serves paginated Apollo
 // search results (page-based, not offset-based). Each request must include a
 // `page` field in the JSON body. midErrPage triggers a 429 when page >= midErrPage.
-func pagedSearchServer(t *testing.T, allPeople []apolloPerson, total, pageSize, midErrPage int) (*httptest.Server, *atomic.Int32) {
+// matchFail, when true, causes the server to fail the test immediately if the
+// /people/match path is called — used to assert Discover never spends credits.
+func pagedSearchServer(t *testing.T, allPeople []apolloPerson, total, pageSize, midErrPage int, matchFail bool) (*httptest.Server, *atomic.Int32) {
 	t.Helper()
 	var requestCount atomic.Int32
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Discover must NEVER call /people/match — that spends credits.
+		if matchFail && r.URL.Path == matchPath {
+			t.Errorf("Discover must not call /people/match (credits would be charged), but got request to %s", r.URL.Path)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
 		requestCount.Add(1)
 
 		var req apolloSearchRequest
@@ -351,7 +360,21 @@ func makePerson(id string) apolloPerson {
 	}
 }
 
-func TestSearchPeople_Pagination(t *testing.T) {
+// makePersonWithAvailability creates an apolloPerson with known availability flags.
+// hasDirectPhone follows the live Apollo API: "Yes" means available, any other
+// string (e.g. "Maybe: ...") means not available.
+func makePersonWithAvailability(id string, hasEmail bool, hasDirectPhone string) apolloPerson {
+	return apolloPerson{
+		ID:             id,
+		Name:           "Person " + id,
+		Title:          "Engineer",
+		Organization:   apolloOrganization{Name: "Corp"},
+		HasEmail:       hasEmail,
+		HasDirectPhone: hasDirectPhone,
+	}
+}
+
+func TestDiscover_Pagination(t *testing.T) {
 	tests := []struct {
 		name         string
 		allPeople    []apolloPerson
@@ -424,18 +447,19 @@ func TestSearchPeople_Pagination(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			srv, reqCount := pagedSearchServer(t, tc.allPeople, tc.total, tc.pageSize, tc.midErrPage)
+			// matchFail=true: Discover must never call /people/match.
+			srv, reqCount := pagedSearchServer(t, tc.allPeople, tc.total, tc.pageSize, tc.midErrPage, true)
 			defer srv.Close()
 
 			c := newTestClient(srv.URL)
 			c.pageSize = tc.pageSize
 
-			result, err := c.SearchPeople(context.Background(), "example.com", nil, tc.limit)
+			result, err := c.Discover(context.Background(), "example.com", nil, tc.limit)
 
 			if tc.wantErr != nil {
 				require.Error(t, err)
 				assert.True(t, errors.Is(err, tc.wantErr), "expected %v, got %v", tc.wantErr, err)
-				// SearchPeople returns a non-nil partial result even on mid-pagination error.
+				// Discover returns a non-nil partial result even on mid-pagination error.
 				require.NotNil(t, result, "partial result must be non-nil on mid-pagination error")
 				assert.Equal(t, tc.wantPeople, len(result.People),
 					"partial result must contain pages fetched before error")
@@ -449,7 +473,76 @@ func TestSearchPeople_Pagination(t *testing.T) {
 	}
 }
 
-func TestSearchPeople_ContextCancellation(t *testing.T) {
+// TestDiscover_NoMatchCalls asserts that Discover (the free tier) never calls
+// /people/match regardless of the number of people returned. Calling match would
+// silently spend Apollo credits.
+func TestDiscover_NoMatchCalls(t *testing.T) {
+	people := []apolloPerson{
+		makePersonWithAvailability("p1", true, "Yes"),
+		makePersonWithAvailability("p2", false, "Maybe: could be work email"),
+		makePersonWithAvailability("p3", true, ""),
+	}
+	// matchFail=true: any call to /people/match causes the test to fail.
+	srv, _ := pagedSearchServer(t, people, 3, 10, 0, true)
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	result, err := c.Discover(context.Background(), "example.com", nil, 0)
+	require.NoError(t, err)
+	require.Len(t, result.People, 3)
+
+	// Discovery sets no emails — the free search tier never reveals PII.
+	for i, p := range result.People {
+		assert.Empty(t, p.Email, "person[%d] Email must be empty from Discover (free tier)", i)
+		assert.False(t, p.Revealed, "person[%d] Revealed must be false after Discover", i)
+	}
+	// result.Revealed is never set by Discover — credits were NOT spent.
+	assert.False(t, result.Revealed, "DomainResult.Revealed must be false after Discover-only")
+	assert.Zero(t, result.CreditsCharged, "CreditsCharged must be 0 after Discover-only")
+}
+
+// TestDiscover_HasEmailHasPhoneMapping verifies that HasEmail and HasPhone are
+// mapped correctly from the search-tier JSON. The key case: has_direct_phone is
+// a STRING in Apollo's API — "Yes" maps to HasPhone=true, anything else
+// (including "Maybe: ...", empty string, or any vendor-defined variation) maps
+// to HasPhone=false.
+func TestDiscover_HasEmailHasPhoneMapping(t *testing.T) {
+	people := []apolloPerson{
+		// has_email:true, has_direct_phone:"Yes" → both true
+		makePersonWithAvailability("p1", true, "Yes"),
+		// has_email:false, has_direct_phone:"Maybe: could be work" → phone false
+		makePersonWithAvailability("p2", false, "Maybe: could be work email"),
+		// has_email:true, has_direct_phone:"" → phone false (empty string)
+		makePersonWithAvailability("p3", true, ""),
+		// has_email:false, has_direct_phone:"No" → both false
+		makePersonWithAvailability("p4", false, "No"),
+	}
+	srv, _ := pagedSearchServer(t, people, 4, 10, 0, true)
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	result, err := c.Discover(context.Background(), "example.com", nil, 0)
+	require.NoError(t, err)
+	require.Len(t, result.People, 4)
+
+	// p1: has_email=true, has_direct_phone="Yes" → both flags true
+	assert.True(t, result.People[0].HasEmail, "p1: has_email:true must map to HasEmail=true")
+	assert.True(t, result.People[0].HasPhone, `p1: has_direct_phone:"Yes" must map to HasPhone=true`)
+
+	// p2: has_email=false, has_direct_phone="Maybe: ..." → phone false (non-"Yes" string)
+	assert.False(t, result.People[1].HasEmail, "p2: has_email:false must map to HasEmail=false")
+	assert.False(t, result.People[1].HasPhone, `p2: has_direct_phone:"Maybe:..." must map to HasPhone=false (non-"Yes" string)`)
+
+	// p3: has_email=true, has_direct_phone="" → phone false (empty string != "Yes")
+	assert.True(t, result.People[2].HasEmail, "p3: has_email:true must map to HasEmail=true")
+	assert.False(t, result.People[2].HasPhone, `p3: has_direct_phone:"" must map to HasPhone=false`)
+
+	// p4: has_email=false, has_direct_phone="No" → both false
+	assert.False(t, result.People[3].HasEmail, "p4: has_email:false must map to HasEmail=false")
+	assert.False(t, result.People[3].HasPhone, `p4: has_direct_phone:"No" must map to HasPhone=false`)
+}
+
+func TestDiscover_ContextCancellation(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Simulate a slow server that outlasts the context timeout.
 		time.Sleep(200 * time.Millisecond)
@@ -464,8 +557,113 @@ func TestSearchPeople_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 
-	_, err := c.SearchPeople(ctx, "example.com", nil, 0)
+	_, err := c.Discover(ctx, "example.com", nil, 0)
 	require.Error(t, err, "expected error due to context cancellation")
+}
+
+// ---------------------------------------------------------------------------
+// T003b: EnrichByIDs — selective per-id enrichment
+// ---------------------------------------------------------------------------
+
+// makeMatchResponseForID returns a full apolloMatchResponse JSON payload for the
+// given Apollo person id. The email is derived from the id so each person gets a
+// distinct email, making assertions straightforward.
+func makeMatchResponseForID(id string) []byte {
+	resp := apolloMatchResponse{
+		Person: apolloPerson{
+			ID:          id,
+			FirstName:   "Person",
+			LastName:    id,
+			Name:        "Person " + id,
+			Email:       id + "@example.com",
+			EmailStatus: "verified",
+			LinkedinURL: "https://linkedin.com/in/" + id,
+		},
+	}
+	b, _ := json.Marshal(resp)
+	return b
+}
+
+func TestEnrichByIDs_ReturnsEnrichedPersons(t *testing.T) {
+	var matchCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, matchPath, r.URL.Path, "EnrichByIDs must call /people/match")
+		matchCount.Add(1)
+		var req apolloMatchRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(makeMatchResponseForID(req.ID))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	ids := []string{"p1", "p2", "p3"}
+
+	enriched, err := c.EnrichByIDs(context.Background(), ids)
+	require.NoError(t, err)
+	require.Len(t, enriched, 3, "EnrichByIDs must return one Person per id")
+
+	// One /people/match call per id.
+	assert.Equal(t, int32(3), matchCount.Load(), "must call /people/match once per id")
+
+	// Each enriched person has the correct id, email (set from id), and Revealed=true.
+	for i, id := range ids {
+		assert.Equal(t, id, enriched[i].ID, "person[%d] ID must match requested id", i)
+		assert.Equal(t, id+"@example.com", enriched[i].Email, "person[%d] Email must be populated", i)
+		assert.Equal(t, "verified", enriched[i].EmailStatus)
+		assert.Equal(t, "https://linkedin.com/in/"+id, enriched[i].LinkedinURL)
+		assert.True(t, enriched[i].Revealed, "person[%d] Revealed must be true after EnrichByIDs", i)
+	}
+}
+
+func TestEnrichByIDs_SkipsEmptyIDs(t *testing.T) {
+	var matchCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		matchCount.Add(1)
+		var req apolloMatchRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(makeMatchResponseForID(req.ID))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	ids := []string{"", "p2", ""}
+
+	enriched, err := c.EnrichByIDs(context.Background(), ids)
+	require.NoError(t, err)
+	require.Len(t, enriched, 1, "empty ids must be skipped")
+	assert.Equal(t, int32(1), matchCount.Load(), "only one match call for the non-empty id")
+	assert.Equal(t, "p2", enriched[0].ID)
+}
+
+func TestEnrichByIDs_SurfacesFirstError(t *testing.T) {
+	var callCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := callCount.Add(1)
+		if n == 1 {
+			var req apolloMatchRequest
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(makeMatchResponseForID(req.ID))
+			return
+		}
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":"rate limit exceeded"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	enriched, err := c.EnrichByIDs(context.Background(), []string{"p1", "p2", "p3"})
+
+	// Error from the second call is surfaced.
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrRateLimited))
+
+	// Records enriched before the error are still returned (credits already spent).
+	require.Len(t, enriched, 1, "must return records enriched before the error")
+	assert.Equal(t, "p1", enriched[0].ID)
+	assert.True(t, enriched[0].Revealed)
 }
 
 // ---------------------------------------------------------------------------
@@ -534,6 +732,8 @@ func TestRevealEmails_Merge(t *testing.T) {
 
 	// result.Revealed is set when there were people to reveal.
 	assert.True(t, result.Revealed)
+	// CreditsCharged == number of people enriched (all 3, including the one with no email).
+	assert.Equal(t, 3, result.CreditsCharged, "CreditsCharged must equal number of people enriched")
 }
 
 func TestRevealEmails_SkipsEmptyID(t *testing.T) {
@@ -587,6 +787,9 @@ func TestRevealEmails_SerialCount(t *testing.T) {
 	err := c.RevealEmails(context.Background(), result)
 	require.NoError(t, err)
 	assert.Equal(t, int32(5), requestCount.Load(), "exactly 5 match requests for 5 people")
+	// CreditsCharged reflects the number of enriched people — one per match call.
+	assert.Equal(t, 5, result.CreditsCharged, "CreditsCharged must equal 5 (one per person)")
+	assert.True(t, result.Revealed, "result.Revealed must be true after successful enrichment")
 }
 
 // TestRevealEmails_ResultRevealedOnFirstSuccess asserts that result.Revealed is

--- a/pkg/enum/apollo/apollo_test.go
+++ b/pkg/enum/apollo/apollo_test.go
@@ -766,6 +766,42 @@ func TestRevealEmails_SkipsEmptyID(t *testing.T) {
 	assert.False(t, result.People[2].Revealed, "empty-ID person should not be revealed")
 }
 
+// TestRevealEmails_DeduplicatesIDs asserts that a duplicate person id (which
+// pagination can surface) triggers only ONE /people/match call — enriching the
+// same id twice would burn a credit for an already-revealed record.
+func TestRevealEmails_DeduplicatesIDs(t *testing.T) {
+	var requestCount atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(makeMatchResponse("alice@example.com", "verified"))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	result := &DomainResult{
+		Domain: "example.com",
+		People: []Person{
+			{ID: "p1"},
+			{ID: "p1"}, // duplicate — must NOT trigger a second match call
+			{ID: "p2"},
+		},
+	}
+
+	err := c.RevealEmails(context.Background(), result)
+	require.NoError(t, err)
+
+	// Two unique ids -> exactly two match calls (not three).
+	assert.Equal(t, int32(2), requestCount.Load(), "duplicate id must not trigger a second match call")
+	// CreditsCharged counts unique enriched ids, not raw rows.
+	assert.Equal(t, 2, result.CreditsCharged, "CreditsCharged must count unique ids only")
+	// Both duplicate rows still get the merged email.
+	assert.Equal(t, "alice@example.com", result.People[0].Email)
+	assert.Equal(t, "alice@example.com", result.People[1].Email)
+	assert.Equal(t, "alice@example.com", result.People[2].Email)
+}
+
 func TestRevealEmails_SerialCount(t *testing.T) {
 	var requestCount atomic.Int32
 


### PR DESCRIPTION
## Summary

Stops Apollo from auto-revealing the entire org by default (which cost ~1 credit/person × the whole company — ~2,376 for Fox). New model: **cheap discovery by default; enrichment is selective**, driven by the SaaS UI.

### Library (`pkg/enum/apollo`)
- `SearchPeople` → **`Discover`** — the free `api_search` step; now surfaces availability via `Person.HasEmail`/`HasPhone` (from `has_email` / `has_direct_phone`) with **no reveal credits**.
- **`EnrichByIDs(ids)`** — NEW selective enrichment (`/people/match` per id); the UI calls this on the operator's selection.
- `RevealEmails(result)` now delegates to `EnrichByIDs` over the result's ids (the `--enrich` full-pull convenience).
- `DomainResult.CreditsCharged` reports spend. Library prints nothing.

### CLI
- **Default = discover only** (no credits). `--no-reveal` removed; **`--enrich`** added (reveal all discovered, bounded by `--limit`, with a stderr cost notice). Negative `--limit` rejected.

### Output
Branches on `Revealed`: discovery shows `Email?`/`Phone?` availability (no values) + slim JSONL (`has_email`/`has_phone`, no email); `--enrich` shows full records + `credits charged`.

### Notes
- `has_direct_phone` is a **string** (`"Yes"` / `"Maybe: …"`), not a bool — `HasPhone` is true only when `== "Yes"` (live-verified).
- This reverses #188's reveal-default-on, per the cost-control direction (selective enrichment is a manual UI flow now).
- 92.9% coverage, race-clean; a test asserts Discover makes **zero** `/people/match` calls.

Verified live (fox.com): discover → 5 people w/ availability, no emails, no notice; `--enrich` → real verified emails + cost notice. The Lusha equivalent follows (after #194 merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)