### PR TITLE
fix(release): make credential-store write build on Windows

### DIFF
--- a/cmd/brutus/teams_credstore.go
+++ b/cmd/brutus/teams_credstore.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"syscall"
 	"time"
 
 	"github.com/praetorian-inc/brutus/pkg/enum/teams"
@@ -79,10 +78,12 @@ func saveTeamsTokenFile(path string, tok *teams.TokenSet) error {
 		return fmt.Errorf("encoding token for %q: %w", path, err)
 	}
 
-	// Open with O_NOFOLLOW so a pre-existing symlink at path is not followed
-	// (an attacker could otherwise redirect the token write elsewhere). Token
+	// Open via the platform-specific helper (teams_credstore_unix.go /
+	// teams_credstore_windows.go). On Unix it passes O_NOFOLLOW so a
+	// pre-existing symlink at path is not followed (an attacker could otherwise
+	// redirect the token write elsewhere); Windows lacks O_NOFOLLOW. Token
 	// values are never included in returned errors; only path may appear (P0-1).
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC|syscall.O_NOFOLLOW, 0o600)
+	f, err := openCredStoreFile(path, 0o600)
 	if err != nil {
 		return fmt.Errorf("opening credential store %q: %w", path, err)
 	}

--- a/cmd/brutus/teams_credstore_unix.go
+++ b/cmd/brutus/teams_credstore_unix.go
@@ -1,0 +1,30 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+// openCredStoreFile opens the credential store for writing on Unix platforms
+// (linux/darwin/freebsd). It passes O_NOFOLLOW so a pre-existing symlink at
+// path is not followed: an attacker could otherwise plant a symlink to redirect
+// the token write elsewhere (P0-1).
+func openCredStoreFile(path string, perm os.FileMode) (*os.File, error) {
+	return os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC|syscall.O_NOFOLLOW, perm)
+}

--- a/cmd/brutus/teams_credstore_windows.go
+++ b/cmd/brutus/teams_credstore_windows.go
@@ -1,0 +1,28 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package main
+
+import "os"
+
+// openCredStoreFile opens the credential store for writing on Windows. Windows
+// has no O_NOFOLLOW flag, so it is omitted here; this is acceptable because
+// creating symlinks on Windows requires elevated privileges, so the symlink
+// redirection that O_NOFOLLOW guards against on Unix (P0-1) is not reachable by
+// an unprivileged attacker.
+func openCredStoreFile(path string, perm os.FileMode) (*os.File, error) {
+	return os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, perm)
+}


### PR DESCRIPTION
## Problem

The **v1.6.0 release failed to build** ([run 28167250508](https://github.com/praetorian-inc/brutus/actions/runs/28167250508)). The `Test` job passed, but GoReleaser aborted while cross-compiling `cmd/brutus` to the Windows targets:

```
build failed: exit status 1: # github.com/praetorian-inc/brutus/cmd/brutus
cmd/brutus/teams_credstore.go:85:73: undefined: syscall.O_NOFOLLOW
target=windows_amd64_v1
```

`syscall.O_NOFOLLOW` exists on Linux/Darwin/FreeBSD but **not on Windows**, so any release that builds the `windows_amd64/arm64/386` targets fails. This is still broken on `main`, so the next tag would fail identically.

## Fix

Standard Go portability split — the credential-store open moves into a platform-specific `openCredStoreFile()` helper behind build tags:

- `teams_credstore.go` — drops the `syscall` import, calls the helper
- `teams_credstore_unix.go` (`//go:build !windows`) — **keeps `O_NOFOLLOW`**, preserving the P0-1 protection against following a pre-existing symlink at the token path
- `teams_credstore_windows.go` (`//go:build windows`) — omits the flag (Windows has no `O_NOFOLLOW`; planting a symlink there requires elevation, so the redirect it guards against isn't reachable by an unprivileged attacker)

No behavior change on Unix.

## Verification

- `gofmt -l` clean, `go vet ./cmd/brutus/` clean
- `go test ./cmd/brutus/ -run TestSaveTeamsTokenFile` passes
- All **11 goreleaser targets** cross-compile: linux (amd64/arm64/386/arm7), darwin (amd64/arm64), windows (amd64/arm64/386), freebsd (amd64/arm64)

## Follow-up (not in this PR)

CI's `Test` job is host-only, so it never exercised a Windows build — this only surfaced at release time. Worth adding a `GOOS=windows go build` smoke step to the CI workflow to catch this class of break on PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)