### PR TITLE
feat(enum): estimate contact tenure across HUMINT/breach sources

### DIFF
--- a/cmd/brutus/cmd_enum_apollo_output.go
+++ b/cmd/brutus/cmd_enum_apollo_output.go
@@ -49,9 +49,9 @@ func outputApolloHuman(w io.Writer, result *apollo.DomainResult, useColor bool) 
 	}
 
 	if result.Revealed {
-		_, _ = fmt.Fprintf(w, "\n  %s%-28s %-22s %-12s %-22s %-32s %-10s %-32s %-7s%s\n",
+		_, _ = fmt.Fprintf(w, "\n  %s%-28s %-22s %-12s %-22s %-32s %-10s %-32s %-7s %-28s%s\n",
 			colorIf(useColor, ColorBold),
-			"Name", "Title", "Dept", "Org", "Email", "Status", "LinkedIn", "Phone?",
+			"Name", "Title", "Dept", "Org", "Email", "Status", "LinkedIn", "Phone?", "Tenure",
 			colorIf(useColor, ColorReset))
 	} else {
 		_, _ = fmt.Fprintf(w, "\n  %s%-28s %-22s %-12s %-22s %-7s %-7s%s\n",
@@ -64,7 +64,7 @@ func outputApolloHuman(w io.Writer, result *apollo.DomainResult, useColor bool) 
 		p := &result.People[i]
 		name := personName(p)
 		if result.Revealed {
-			_, _ = fmt.Fprintf(w, "  %-28s %-22s %-12s %-22s %s%-32s%s %-10s %-32s %-7s\n",
+			_, _ = fmt.Fprintf(w, "  %-28s %-22s %-12s %-22s %s%-32s%s %-10s %-32s %-7s %-28s\n",
 				truncate(name, 28),
 				truncate(sanitizeTerminal(p.Title), 22),
 				truncate(sanitizeTerminal(p.Department), 12),
@@ -74,7 +74,8 @@ func outputApolloHuman(w io.Writer, result *apollo.DomainResult, useColor bool) 
 				colorIf(useColor, ColorReset),
 				truncate(sanitizeTerminal(p.EmailStatus), 10),
 				truncate(sanitizeTerminal(p.LinkedinURL), 32),
-				availabilityMark(p.HasPhone))
+				availabilityMark(p.HasPhone),
+				truncate(sanitizeTerminal(p.Tenure.String()), 28))
 		} else {
 			_, _ = fmt.Fprintf(w, "  %-28s %-22s %-12s %-22s %-7s %-7s\n",
 				truncate(name, 28),
@@ -137,6 +138,7 @@ func outputApolloJSONL(w io.Writer, result *apollo.DomainResult) {
 		State        string           `json:"state,omitempty"`
 		Country      string           `json:"country,omitempty"`
 		Employment   []employmentJSON `json:"employment,omitempty"`
+		Tenure       tenureJSON       `json:"tenure"`
 	}
 
 	enc := json.NewEncoder(w)
@@ -176,6 +178,7 @@ func outputApolloJSONL(w io.Writer, result *apollo.DomainResult) {
 			State:        p.State,
 			Country:      p.Country,
 			Employment:   employment,
+			Tenure:       toTenureJSON(p.Tenure),
 		}
 		if err := enc.Encode(jr); err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "Error encoding apollo JSON: %v\n", err)

--- a/cmd/brutus/cmd_enum_dehashed_output.go
+++ b/cmd/brutus/cmd_enum_dehashed_output.go
@@ -52,21 +52,21 @@ func outputDehashedHuman(w io.Writer, domain string, rawFetched, total, balance 
 
 	// Header row. The Password(s) column is only present with showCredentials.
 	if showCredentials {
-		_, _ = fmt.Fprintf(w, "\n  %s%-32s %-22s %-22s %-18s %-20s %-24s%s\n",
+		_, _ = fmt.Fprintf(w, "\n  %s%-32s %-22s %-22s %-18s %-20s %-24s %-28s%s\n",
 			colorIf(useColor, ColorBold),
-			"Email", "Name", "Username", "Phone", "Sources", "Password(s)",
+			"Email", "Name", "Username", "Phone", "Sources", "Password(s)", "Tenure",
 			colorIf(useColor, ColorReset))
 	} else {
-		_, _ = fmt.Fprintf(w, "\n  %s%-32s %-22s %-22s %-18s %-20s%s\n",
+		_, _ = fmt.Fprintf(w, "\n  %s%-32s %-22s %-22s %-18s %-20s %-28s%s\n",
 			colorIf(useColor, ColorBold),
-			"Email", "Name", "Username", "Phone", "Sources",
+			"Email", "Name", "Username", "Phone", "Sources", "Tenure",
 			colorIf(useColor, ColorReset))
 	}
 
 	for i := range entries {
 		e := &entries[i]
 		if showCredentials {
-			_, _ = fmt.Fprintf(w, "  %s%-32s%s %-22s %-22s %-18s %-20s %-24s\n",
+			_, _ = fmt.Fprintf(w, "  %s%-32s%s %-22s %-22s %-18s %-20s %-24s %-28s\n",
 				colorIf(useColor, ColorGreen),
 				truncate(sanitizeTerminal(e.Email), 32),
 				colorIf(useColor, ColorReset),
@@ -74,17 +74,19 @@ func outputDehashedHuman(w io.Writer, domain string, rawFetched, total, balance 
 				truncate(sanitizeTerminal(joinField(e.Usernames)), 22),
 				truncate(sanitizeTerminal(joinField(e.Phones)), 18),
 				truncate(sanitizeTerminal(joinSources(e.Databases)), 20),
-				truncate(sanitizeTerminal(joinField(e.Passwords)), 24))
+				truncate(sanitizeTerminal(joinField(e.Passwords)), 24),
+				truncate(sanitizeTerminal(e.Tenure.String()), 28))
 			continue
 		}
-		_, _ = fmt.Fprintf(w, "  %s%-32s%s %-22s %-22s %-18s %-20s\n",
+		_, _ = fmt.Fprintf(w, "  %s%-32s%s %-22s %-22s %-18s %-20s %-28s\n",
 			colorIf(useColor, ColorGreen),
 			truncate(sanitizeTerminal(e.Email), 32),
 			colorIf(useColor, ColorReset),
 			truncate(sanitizeTerminal(joinField(e.Names)), 22),
 			truncate(sanitizeTerminal(joinField(e.Usernames)), 22),
 			truncate(sanitizeTerminal(joinField(e.Phones)), 18),
-			truncate(sanitizeTerminal(joinSources(e.Databases)), 20))
+			truncate(sanitizeTerminal(joinSources(e.Databases)), 20),
+			truncate(sanitizeTerminal(e.Tenure.String()), 28))
 	}
 	_, _ = fmt.Fprintln(w)
 }
@@ -110,14 +112,15 @@ func joinSources(databases []string) string {
 // control characters, so no sanitization is needed.
 func outputDehashedJSONL(w io.Writer, entries []dehashed.Entry, showCredentials bool) {
 	type dehashedJSON struct {
-		Type      string   `json:"type"`
-		Email     string   `json:"email"`
-		Names     []string `json:"names,omitempty"`
-		Usernames []string `json:"usernames,omitempty"`
-		Phones    []string `json:"phones,omitempty"`
-		Passwords []string `json:"passwords,omitempty"`
-		Databases []string `json:"databases"`
-		Count     int      `json:"count"`
+		Type      string     `json:"type"`
+		Email     string     `json:"email"`
+		Names     []string   `json:"names,omitempty"`
+		Usernames []string   `json:"usernames,omitempty"`
+		Phones    []string   `json:"phones,omitempty"`
+		Passwords []string   `json:"passwords,omitempty"`
+		Databases []string   `json:"databases"`
+		Count     int        `json:"count"`
+		Tenure    tenureJSON `json:"tenure"`
 	}
 
 	enc := json.NewEncoder(w)
@@ -131,6 +134,7 @@ func outputDehashedJSONL(w io.Writer, entries []dehashed.Entry, showCredentials 
 			Phones:    e.Phones,
 			Databases: e.Databases,
 			Count:     e.Count,
+			Tenure:    toTenureJSON(e.Tenure),
 		}
 		if showCredentials {
 			jr.Passwords = e.Passwords

--- a/cmd/brutus/cmd_enum_lusha_output.go
+++ b/cmd/brutus/cmd_enum_lusha_output.go
@@ -54,6 +54,7 @@ func outputLushaHuman(w io.Writer, c *lusha.Contact, useColor bool) {
 	if line := lushaEmploymentSummary(c); line != "" {
 		_, _ = fmt.Fprintf(w, "  History:  %s\n", line)
 	}
+	_, _ = fmt.Fprintf(w, "  Tenure:   %s\n", sanitizeTerminal(c.Tenure.String()))
 
 	if len(c.Emails) == 0 && len(c.Phones) == 0 {
 		_, _ = fmt.Fprintf(w, "\n  %s No contact data returned\n", dim(useColor, SymbolInfo))
@@ -132,6 +133,7 @@ type lushaContactJSON struct {
 	Emails        []lushaEmailJSON      `json:"emails,omitempty"`
 	Phones        []lushaPhoneJSON      `json:"phones,omitempty"`
 	Employment    []lushaEmploymentJSON `json:"employment,omitempty"`
+	Tenure        tenureJSON            `json:"tenure"`
 }
 
 // toLushaContactJSON maps a public Contact to its JSONL shape (type:"lusha").
@@ -146,6 +148,7 @@ func toLushaContactJSON(c *lusha.Contact) lushaContactJSON {
 		Departments:   c.Departments,
 		Seniority:     c.Seniority,
 		Location:      c.Location,
+		Tenure:        toTenureJSON(c.Tenure),
 	}
 	for i := range c.Emails {
 		e := &c.Emails[i]
@@ -200,9 +203,9 @@ func outputLushaDomainHuman(w io.Writer, r *lusha.DomainResult, useColor bool) {
 	// Phone column is 26 wide. When DNC is set the number is truncated to 20
 	// runes before the " [DNC]" suffix (6 runes) is appended, so the marker is
 	// always fully visible and never truncated mid-marker.
-	_, _ = fmt.Fprintf(w, "\n  %s%-24s %-24s %-32s %-26s %-30s %-18s%s\n",
+	_, _ = fmt.Fprintf(w, "\n  %s%-24s %-24s %-32s %-26s %-30s %-18s %-28s%s\n",
 		colorIf(useColor, ColorBold),
-		"Name", "Title", "Email", "Phone", "LinkedIn", "Dept",
+		"Name", "Title", "Email", "Phone", "LinkedIn", "Dept", "Tenure",
 		colorIf(useColor, ColorReset))
 
 	for i := range r.Contacts {
@@ -222,7 +225,7 @@ func outputLushaDomainHuman(w io.Writer, r *lusha.DomainResult, useColor bool) {
 				phone = truncate(sanitizeTerminal(c.Phones[0].Number), 26)
 			}
 		}
-		_, _ = fmt.Fprintf(w, "  %-24s %-24s %s%-32s%s %-26s %-30s %-18s\n",
+		_, _ = fmt.Fprintf(w, "  %-24s %-24s %s%-32s%s %-26s %-30s %-18s %-28s\n",
 			truncate(sanitizeTerminal(c.Name), 24),
 			truncate(sanitizeTerminal(c.JobTitle), 24),
 			colorIf(useColor, ColorGreen),
@@ -230,7 +233,8 @@ func outputLushaDomainHuman(w io.Writer, r *lusha.DomainResult, useColor bool) {
 			colorIf(useColor, ColorReset),
 			phone,
 			truncate(sanitizeTerminal(c.LinkedIn), 30),
-			truncate(sanitizeTerminal(strings.Join(c.Departments, ", ")), 18))
+			truncate(sanitizeTerminal(strings.Join(c.Departments, ", ")), 18),
+			truncate(sanitizeTerminal(c.Tenure.String()), 28))
 	}
 	_, _ = fmt.Fprintln(w)
 }

--- a/cmd/brutus/cmd_enum_output.go
+++ b/cmd/brutus/cmd_enum_output.go
@@ -380,6 +380,31 @@ func truncate(s string, n int) string {
 	return string(r[:n-1]) + "\u2026"
 }
 
+// tenureJSON is the shared JSONL shape for a derived enum.Tenure, used by every
+// enum integration's JSONL output so the structured tenure object is identical
+// across sources. It carries provenance (source) and date granularity
+// (precision) rather than a confidence rollup, and a reason when unavailable.
+type tenureJSON struct {
+	Available bool   `json:"available"`
+	Months    int    `json:"months"`
+	Current   bool   `json:"current"`
+	Source    string `json:"source,omitempty"`
+	Precision string `json:"precision,omitempty"`
+	Reason    string `json:"reason,omitempty"`
+}
+
+// toTenureJSON maps a library enum.Tenure to its JSONL shape.
+func toTenureJSON(t enum.Tenure) tenureJSON {
+	return tenureJSON{
+		Available: t.Available,
+		Months:    t.Months,
+		Current:   t.Current,
+		Source:    t.Source,
+		Precision: t.Precision,
+		Reason:    t.Reason,
+	}
+}
+
 // outputHunterHuman renders Hunter.io domain search results as an aligned table.
 // All attacker-controlled strings are sanitized via sanitizeTerminal (P0-4).
 func outputHunterHuman(w io.Writer, result *hunter.DomainResult, useColor bool) {
@@ -397,15 +422,15 @@ func outputHunterHuman(w io.Writer, result *hunter.DomainResult, useColor bool) 
 	}
 
 	// Header row.
-	_, _ = fmt.Fprintf(w, "\n  %s%-32s %-22s %-18s %-14s %-12s %-20s %-5s%s\n",
+	_, _ = fmt.Fprintf(w, "\n  %s%-32s %-22s %-18s %-14s %-12s %-20s %-5s %-28s%s\n",
 		colorIf(useColor, ColorBold),
-		"Email", "Name", "Title", "Phone", "Dept", "LinkedIn", "Conf",
+		"Email", "Name", "Title", "Phone", "Dept", "LinkedIn", "Conf", "Tenure",
 		colorIf(useColor, ColorReset))
 
 	for i := range result.People {
 		p := &result.People[i]
 		name := strings.TrimSpace(sanitizeTerminal(p.FirstName) + " " + sanitizeTerminal(p.LastName))
-		_, _ = fmt.Fprintf(w, "  %s%-32s%s %-22s %-18s %-14s %-12s %-20s %s%3d%s\n",
+		_, _ = fmt.Fprintf(w, "  %s%-32s%s %-22s %-18s %-14s %-12s %-20s %s%3d%s %-28s\n",
 			colorIf(useColor, ColorGreen),
 			truncate(sanitizeTerminal(p.Email), 32),
 			colorIf(useColor, ColorReset),
@@ -414,7 +439,8 @@ func outputHunterHuman(w io.Writer, result *hunter.DomainResult, useColor bool) 
 			truncate(sanitizeTerminal(p.Phone), 14),
 			truncate(sanitizeTerminal(p.Department), 12),
 			truncate(sanitizeTerminal(p.LinkedIn), 20),
-			colorIf(useColor, ColorCyan), p.Confidence, colorIf(useColor, ColorReset))
+			colorIf(useColor, ColorCyan), p.Confidence, colorIf(useColor, ColorReset),
+			truncate(sanitizeTerminal(p.Tenure.String()), 28))
 	}
 	_, _ = fmt.Fprintln(w)
 }
@@ -423,21 +449,22 @@ func outputHunterHuman(w io.Writer, result *hunter.DomainResult, useColor bool) 
 // encoding/json already escapes control characters, so no sanitization needed.
 func outputHunterJSONL(w io.Writer, result *hunter.DomainResult) {
 	type hunterJSON struct {
-		Type         string   `json:"type"`
-		Domain       string   `json:"domain"`
-		Organization string   `json:"organization,omitempty"`
-		Email        string   `json:"email"`
-		FirstName    string   `json:"first_name,omitempty"`
-		LastName     string   `json:"last_name,omitempty"`
-		Position     string   `json:"position,omitempty"`
-		Seniority    string   `json:"seniority,omitempty"`
-		Department   string   `json:"department,omitempty"`
-		Phone        string   `json:"phone_number,omitempty"`
-		LinkedIn     string   `json:"linkedin,omitempty"`
-		Twitter      string   `json:"twitter,omitempty"`
-		Confidence   int      `json:"confidence"`
-		EmailType    string   `json:"email_type,omitempty"`
-		Sources      []string `json:"sources,omitempty"`
+		Type         string     `json:"type"`
+		Domain       string     `json:"domain"`
+		Organization string     `json:"organization,omitempty"`
+		Email        string     `json:"email"`
+		FirstName    string     `json:"first_name,omitempty"`
+		LastName     string     `json:"last_name,omitempty"`
+		Position     string     `json:"position,omitempty"`
+		Seniority    string     `json:"seniority,omitempty"`
+		Department   string     `json:"department,omitempty"`
+		Phone        string     `json:"phone_number,omitempty"`
+		LinkedIn     string     `json:"linkedin,omitempty"`
+		Twitter      string     `json:"twitter,omitempty"`
+		Confidence   int        `json:"confidence"`
+		EmailType    string     `json:"email_type,omitempty"`
+		Sources      []string   `json:"sources,omitempty"`
+		Tenure       tenureJSON `json:"tenure"`
 	}
 
 	enc := json.NewEncoder(w)
@@ -459,6 +486,7 @@ func outputHunterJSONL(w io.Writer, result *hunter.DomainResult) {
 			Confidence:   p.Confidence,
 			EmailType:    p.Type,
 			Sources:      p.Sources,
+			Tenure:       toTenureJSON(p.Tenure),
 		}
 		if err := enc.Encode(jr); err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "Error encoding hunter JSON: %v\n", err)

--- a/cmd/brutus/cmd_enum_output_tenure_test.go
+++ b/cmd/brutus/cmd_enum_output_tenure_test.go
@@ -1,0 +1,349 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/brutus/pkg/enum"
+	"github.com/praetorian-inc/brutus/pkg/enum/apollo"
+	"github.com/praetorian-inc/brutus/pkg/enum/dehashed"
+	"github.com/praetorian-inc/brutus/pkg/enum/hunter"
+	"github.com/praetorian-inc/brutus/pkg/enum/lusha"
+)
+
+// ---------------------------------------------------------------------------
+// Apollo: tenure in both human and JSONL output
+// ---------------------------------------------------------------------------
+
+// TestOutputApolloHuman_TenureAvailable verifies that the enriched human output
+// includes the tenure string rendered by Tenure.String() for a person with an
+// available current tenure.
+func TestOutputApolloHuman_TenureAvailable(t *testing.T) {
+	result := &apollo.DomainResult{
+		Domain:   "example.com",
+		Revealed: true,
+		People: []apollo.Person{
+			{
+				ID:       "p1",
+				Name:     "Alice Smith",
+				Email:    "alice@example.com",
+				Revealed: true,
+				Tenure: enum.Tenure{
+					Available: true,
+					Months:    38, // 3y 2m
+					Current:   true,
+					Source:    "apollo:employment_history",
+					Precision: "day",
+				},
+			},
+		},
+		Total: 1,
+	}
+	var buf bytes.Buffer
+	outputApolloHuman(&buf, result, false)
+	out := buf.String()
+
+	assert.Contains(t, out, "Tenure", "human output must include a Tenure column header")
+	assert.Contains(t, out, "3y 2m (current)", "human output must include the rendered tenure string")
+}
+
+// TestOutputApolloHuman_TenureUnavailable verifies that the discovery-mode human
+// output does NOT render a Tenure column (tenure is only shown in enriched mode).
+func TestOutputApolloHuman_TenureUnavailable(t *testing.T) {
+	result := &apollo.DomainResult{
+		Domain:   "example.com",
+		Revealed: false,
+		People: []apollo.Person{
+			{
+				ID:   "p1",
+				Name: "Alice Smith",
+				Tenure: enum.Tenure{
+					Available: false,
+					Source:    "apollo:employment_history",
+					Reason:    "employment history not revealed",
+				},
+			},
+		},
+		Total: 1,
+	}
+	var buf bytes.Buffer
+	outputApolloHuman(&buf, result, false)
+	out := buf.String()
+
+	// In discovery mode the Tenure column is not rendered (no enrichment happened).
+	assert.NotContains(t, out, "Tenure", "discovery-mode output must not include Tenure column")
+}
+
+// TestOutputApolloJSONL_TenureAvailable verifies that the enriched JSONL output
+// includes a "tenure" key with available=true and the correct fields for a
+// person with a derivable current role.
+func TestOutputApolloJSONL_TenureAvailable(t *testing.T) {
+	result := &apollo.DomainResult{
+		Domain:   "example.com",
+		Revealed: true,
+		People: []apollo.Person{
+			{
+				ID:       "p1",
+				Name:     "Alice Smith",
+				Email:    "alice@example.com",
+				Revealed: true,
+				Tenure: enum.Tenure{
+					Available: true,
+					Months:    24,
+					Current:   true,
+					Source:    "apollo:employment_history",
+					Precision: "month",
+				},
+			},
+		},
+		Total: 1,
+	}
+	var buf bytes.Buffer
+	outputApolloJSONL(&buf, result)
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t, lines, 1)
+
+	var obj map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(lines[0]), &obj))
+
+	tenureRaw, hasTenure := obj["tenure"]
+	require.True(t, hasTenure, "enriched JSONL must include a 'tenure' key")
+
+	tenureMap, ok := tenureRaw.(map[string]interface{})
+	require.True(t, ok, "tenure must be a JSON object")
+
+	assert.Equal(t, true, tenureMap["available"], "tenure.available must be true")
+	assert.Equal(t, float64(24), tenureMap["months"], "tenure.months must match")
+	assert.Equal(t, true, tenureMap["current"], "tenure.current must be true")
+	assert.Equal(t, "apollo:employment_history", tenureMap["source"])
+	assert.Equal(t, "month", tenureMap["precision"])
+}
+
+// TestOutputApolloJSONL_TenureUnavailable verifies that the enriched JSONL
+// output for a person with no derivable tenure carries available=false and the
+// correct reason string.
+func TestOutputApolloJSONL_TenureUnavailable(t *testing.T) {
+	result := &apollo.DomainResult{
+		Domain:   "example.com",
+		Revealed: true,
+		People: []apollo.Person{
+			{
+				ID:       "p1",
+				Name:     "Alice Smith",
+				Email:    "alice@example.com",
+				Revealed: true,
+				Tenure: enum.Tenure{
+					Available: false,
+					Source:    "apollo:employment_history",
+					Reason:    "employment history not revealed",
+				},
+			},
+		},
+		Total: 1,
+	}
+	var buf bytes.Buffer
+	outputApolloJSONL(&buf, result)
+
+	var obj map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &obj))
+
+	tenureMap, ok := obj["tenure"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, false, tenureMap["available"])
+	assert.Equal(t, "apollo:employment_history", tenureMap["source"])
+	assert.Equal(t, "employment history not revealed", tenureMap["reason"])
+}
+
+// ---------------------------------------------------------------------------
+// Lusha: tenure in both human and JSONL output
+// ---------------------------------------------------------------------------
+
+// TestOutputLushaHuman_TenureUnavailable verifies that the Lusha human output
+// includes the tenure line with the unavailable rendering.
+func TestOutputLushaHuman_TenureUnavailable(t *testing.T) {
+	c := &lusha.Contact{
+		Name:    "Bob Jones",
+		Company: "ACME",
+		Tenure: enum.Tenure{
+			Available: false,
+			Source:    "lusha",
+			Reason:    "no employment dates from source",
+		},
+	}
+	var buf bytes.Buffer
+	outputLushaHuman(&buf, c, false)
+	out := buf.String()
+
+	assert.Contains(t, out, "Tenure:", "human output must include Tenure: line")
+	assert.Contains(t, out, "unavailable — no employment dates from source",
+		"Lusha human output must render the unavailable reason")
+}
+
+// TestOutputLushaJSONL_TenureUnavailable verifies that Lusha JSONL includes a
+// "tenure" key with available=false and the correct lusha source/reason.
+func TestOutputLushaJSONL_TenureUnavailable(t *testing.T) {
+	c := &lusha.Contact{
+		Name: "Bob Jones",
+		Tenure: enum.Tenure{
+			Available: false,
+			Source:    "lusha",
+			Reason:    "no employment dates from source",
+		},
+	}
+	var buf bytes.Buffer
+	outputLushaJSONL(&buf, c)
+
+	var obj map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &obj))
+
+	tenureMap, ok := obj["tenure"].(map[string]interface{})
+	require.True(t, ok, "lusha JSONL must include a 'tenure' object")
+	assert.Equal(t, false, tenureMap["available"])
+	assert.Equal(t, "lusha", tenureMap["source"])
+	assert.Equal(t, "no employment dates from source", tenureMap["reason"])
+}
+
+// ---------------------------------------------------------------------------
+// DeHashed: tenure in both human and JSONL output
+// ---------------------------------------------------------------------------
+
+// TestOutputDehashedHuman_TenureUnavailable verifies that the DeHashed human
+// output renders the tenure column with the unavailable string.
+func TestOutputDehashedHuman_TenureUnavailable(t *testing.T) {
+	entries := []dehashed.Entry{
+		{
+			Email:     "carol@example.com",
+			Databases: []string{"breach-db"},
+			Count:     1,
+			Tenure: enum.Tenure{
+				Available: false,
+				Source:    "dehashed",
+				Reason:    "breach data, no employment dates",
+			},
+		},
+	}
+	var buf bytes.Buffer
+	outputDehashedHuman(&buf, "example.com", 1, 1, 0, entries, false, false)
+	out := buf.String()
+
+	assert.Contains(t, out, "Tenure", "dehashed human output must include Tenure column header")
+	assert.Contains(t, out, "unavailable", "dehashed human output must render unavailable tenure")
+}
+
+// TestOutputDehashedJSONL_TenureUnavailable verifies that DeHashed JSONL includes
+// a "tenure" key with available=false and the correct source/reason for each entry.
+func TestOutputDehashedJSONL_TenureUnavailable(t *testing.T) {
+	entries := []dehashed.Entry{
+		{
+			Email:     "carol@example.com",
+			Databases: []string{"breach-db"},
+			Count:     1,
+			Tenure: enum.Tenure{
+				Available: false,
+				Source:    "dehashed",
+				Reason:    "breach data, no employment dates",
+			},
+		},
+	}
+	var buf bytes.Buffer
+	outputDehashedJSONL(&buf, entries, false)
+
+	var obj map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &obj))
+
+	tenureMap, ok := obj["tenure"].(map[string]interface{})
+	require.True(t, ok, "dehashed JSONL must include a 'tenure' object")
+	assert.Equal(t, false, tenureMap["available"])
+	assert.Equal(t, "dehashed", tenureMap["source"])
+	assert.Equal(t, "breach data, no employment dates", tenureMap["reason"])
+}
+
+// ---------------------------------------------------------------------------
+// Hunter: tenure in JSONL output
+// ---------------------------------------------------------------------------
+
+// TestOutputHunterJSONL_TenureUnavailable verifies that Hunter JSONL includes
+// a "tenure" key with available=false and the correct source/reason.
+func TestOutputHunterJSONL_TenureUnavailable(t *testing.T) {
+	result := &hunter.DomainResult{
+		Domain:       "example.com",
+		Organization: "Example Inc",
+		People: []hunter.Person{
+			{
+				Email:      "dave@example.com",
+				FirstName:  "Dave",
+				LastName:   "Smith",
+				Confidence: 80,
+				Tenure: enum.Tenure{
+					Available: false,
+					Source:    "hunter",
+					Reason:    "no employment dates from source",
+				},
+			},
+		},
+		Total: 1,
+	}
+	var buf bytes.Buffer
+	outputHunterJSONL(&buf, result)
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t, lines, 1)
+
+	var obj map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(lines[0]), &obj))
+
+	tenureMap, ok := obj["tenure"].(map[string]interface{})
+	require.True(t, ok, "hunter JSONL must include a 'tenure' object")
+	assert.Equal(t, false, tenureMap["available"])
+	assert.Equal(t, "hunter", tenureMap["source"])
+	assert.Equal(t, "no employment dates from source", tenureMap["reason"])
+}
+
+// TestOutputHunterHuman_TenureUnavailable verifies that the Hunter human output
+// includes the Tenure column header and renders the unavailable reason.
+func TestOutputHunterHuman_TenureUnavailable(t *testing.T) {
+	result := &hunter.DomainResult{
+		Domain:       "example.com",
+		Organization: "Example Inc",
+		People: []hunter.Person{
+			{
+				Email:      "dave@example.com",
+				FirstName:  "Dave",
+				LastName:   "Smith",
+				Confidence: 80,
+				Tenure: enum.Tenure{
+					Available: false,
+					Source:    "hunter",
+					Reason:    "no employment dates from source",
+				},
+			},
+		},
+		Total: 1,
+	}
+	var buf bytes.Buffer
+	outputHunterHuman(&buf, result, false)
+	out := buf.String()
+
+	assert.Contains(t, out, "Tenure", "hunter human output must include Tenure column header")
+	assert.Contains(t, out, "unavailable", "hunter human output must render unavailable tenure reason")
+}

--- a/pkg/enum/apollo/apollo.go
+++ b/pkg/enum/apollo/apollo.go
@@ -82,7 +82,11 @@ type Person struct {
 	State       string
 	Country     string
 	Employment  []EmploymentEntry
-	Revealed    bool
+	// Tenure is the derived length of the person's CURRENT role, computed from
+	// the employment_history start dates. It is Available only after a reveal
+	// (the dates are populated by people/match); pre-reveal it is unavailable.
+	Tenure   enum.Tenure
+	Revealed bool
 }
 
 // EmploymentEntry is one raw entry from a person's employment_history. Raw
@@ -420,6 +424,57 @@ func (p apolloPerson) toPerson() Person {
 		State:        p.State,
 		Country:      p.Country,
 		Employment:   employment,
+		Tenure:       computeTenure(employment, time.Now()),
+	}
+}
+
+// computeTenure derives the current-role tenure from a person's employment
+// history. It selects the entry with Current==true (the one with the latest
+// parseable StartDate when several are current) and measures from its StartDate
+// to now (the current role has an open EndDate). When there is no usable data it
+// returns an unavailable Tenure with a reason — it never fabricates dates.
+func computeTenure(employment []EmploymentEntry, now time.Time) enum.Tenure {
+	const source = "apollo:employment_history"
+
+	if len(employment) == 0 {
+		return enum.UnavailableTenure(source, "employment history not revealed")
+	}
+
+	var current *EmploymentEntry
+	var currentStart time.Time
+	for i := range employment {
+		e := &employment[i]
+		if !e.Current {
+			continue
+		}
+		start, _, ok := enum.ParseFlexibleDate(e.StartDate)
+		switch {
+		case current == nil:
+			current = e
+			if ok {
+				currentStart = start
+			}
+		case ok && (currentStart.IsZero() || start.After(currentStart)):
+			current = e
+			currentStart = start
+		}
+	}
+
+	if current == nil {
+		return enum.UnavailableTenure(source, "no current role with dates")
+	}
+
+	start, precision, ok := enum.ParseFlexibleDate(current.StartDate)
+	if !ok {
+		return enum.UnavailableTenure(source, "current role has no start date")
+	}
+
+	return enum.Tenure{
+		Available: true,
+		Months:    enum.MonthsBetween(start, now),
+		Current:   true,
+		Source:    source,
+		Precision: precision,
 	}
 }
 
@@ -439,6 +494,7 @@ func mergeReveal(p *Person, m Person) {
 	p.State = m.State
 	p.Country = m.Country
 	p.Employment = m.Employment
+	p.Tenure = m.Tenure
 	p.Revealed = true
 }
 

--- a/pkg/enum/apollo/apollo_tenure_test.go
+++ b/pkg/enum/apollo/apollo_tenure_test.go
@@ -1,0 +1,239 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apollo
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/brutus/pkg/enum"
+)
+
+// fixedNow is a stable "current time" used by all computeTenure tests so that
+// expected month counts are deterministic regardless of when the suite runs.
+var fixedNow = time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+
+// ---------------------------------------------------------------------------
+// computeTenure: table-driven tests with a fixed "now"
+// ---------------------------------------------------------------------------
+
+func TestComputeTenure(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		employment []EmploymentEntry
+		wantAvail  bool
+		wantCurr   bool
+		wantMonths int
+		wantPrec   string
+		wantSrc    string
+		wantReason string
+	}{
+		{
+			name: "current role with day-precision StartDate",
+			// Start 2021-06-01 → fixedNow 2024-06-01 = 36 months exactly.
+			employment: []EmploymentEntry{
+				{Organization: "ACME", Title: "Engineer", StartDate: "2021-06-01", Current: true},
+			},
+			wantAvail:  true,
+			wantCurr:   true,
+			wantMonths: 36,
+			wantPrec:   "day",
+			wantSrc:    "apollo:employment_history",
+		},
+		{
+			name: "year-only StartDate — precision is year",
+			// Start 2020 (Jan 1) → fixedNow 2024-06-01 = 53 months.
+			employment: []EmploymentEntry{
+				{Organization: "ACME", Title: "Engineer", StartDate: "2020", Current: true},
+			},
+			wantAvail:  true,
+			wantCurr:   true,
+			wantMonths: 53,
+			wantPrec:   "year",
+			wantSrc:    "apollo:employment_history",
+		},
+		{
+			name:       "empty employment slice — unavailable",
+			employment: []EmploymentEntry{},
+			wantAvail:  false,
+			wantReason: "employment history not revealed",
+			wantSrc:    "apollo:employment_history",
+		},
+		{
+			name: "no entry with Current==true — unavailable",
+			employment: []EmploymentEntry{
+				{Organization: "Old Corp", Title: "Analyst", StartDate: "2018-01", Current: false},
+				{Organization: "Another Co", Title: "Senior", StartDate: "2015-06-01", Current: false},
+			},
+			wantAvail:  false,
+			wantReason: "no current role with dates",
+			wantSrc:    "apollo:employment_history",
+		},
+		{
+			name: "current role with empty StartDate — unavailable",
+			employment: []EmploymentEntry{
+				{Organization: "ACME", Title: "Engineer", StartDate: "", Current: true},
+			},
+			wantAvail:  false,
+			wantReason: "current role has no start date",
+			wantSrc:    "apollo:employment_history",
+		},
+		{
+			name: "current role with unparseable StartDate — unavailable",
+			employment: []EmploymentEntry{
+				{Organization: "ACME", Title: "Engineer", StartDate: "not-a-date", Current: true},
+			},
+			wantAvail:  false,
+			wantReason: "current role has no start date",
+			wantSrc:    "apollo:employment_history",
+		},
+		{
+			name: "multiple current entries — picks latest parseable StartDate",
+			// earliest: 2019-01, latest: 2022-03-15 → fixedNow 2024-06-01 = 26 months
+			employment: []EmploymentEntry{
+				{Organization: "Early Corp", Title: "A", StartDate: "2019-01", Current: true},
+				{Organization: "Latest Corp", Title: "B", StartDate: "2022-03-15", Current: true},
+				{Organization: "Mid Corp", Title: "C", StartDate: "2021-06", Current: true},
+			},
+			wantAvail:  true,
+			wantCurr:   true,
+			wantMonths: 26,
+			wantPrec:   "day",
+			wantSrc:    "apollo:employment_history",
+		},
+		{
+			name: "month-precision StartDate",
+			// Start 2022-06 (June 1) → fixedNow 2024-06-01 = 24 months.
+			employment: []EmploymentEntry{
+				{Organization: "ACME", Title: "Engineer", StartDate: "2022-06", Current: true},
+			},
+			wantAvail:  true,
+			wantCurr:   true,
+			wantMonths: 24,
+			wantPrec:   "month",
+			wantSrc:    "apollo:employment_history",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := computeTenure(tc.employment, fixedNow)
+
+			require.Equal(t, tc.wantAvail, got.Available, "Available mismatch")
+			assert.Equal(t, tc.wantSrc, got.Source, "Source must always be apollo:employment_history")
+
+			if !tc.wantAvail {
+				assert.Equal(t, tc.wantReason, got.Reason, "Reason mismatch for unavailable tenure")
+				assert.Equal(t, 0, got.Months, "Months must be zero for unavailable tenure")
+				return
+			}
+
+			assert.True(t, got.Current, "Current must be true for available tenure")
+			assert.Equal(t, tc.wantMonths, got.Months, "Months mismatch")
+			assert.Equal(t, tc.wantPrec, got.Precision, "Precision mismatch")
+			assert.Empty(t, got.Reason, "Reason must be empty for available tenure")
+		})
+	}
+}
+
+// TestComputeTenure_MultipleCurrentNilStart verifies that when one Current entry
+// has an unparseable StartDate and another has a parseable one, we select the
+// parseable entry (not the nil-start one). This exercises the case==nil branch
+// inside the "later parseable" pick logic.
+func TestComputeTenure_MultipleCurrentFirstUnparseable(t *testing.T) {
+	t.Parallel()
+	employment := []EmploymentEntry{
+		{Organization: "Bad Corp", Title: "X", StartDate: "???", Current: true},
+		{Organization: "Good Corp", Title: "Y", StartDate: "2023-01-01", Current: true},
+	}
+	// 2023-01-01 → fixedNow 2024-06-01 = 17 months
+	got := computeTenure(employment, fixedNow)
+	require.True(t, got.Available)
+	assert.Equal(t, 17, got.Months)
+	assert.Equal(t, "day", got.Precision)
+}
+
+// TestToPerson_TenurePopulated verifies that toPerson correctly populates Tenure
+// from an apolloPerson that has employment_history with a current role. This is
+// the integration point: computeTenure is called inside toPerson.
+func TestToPerson_TenurePopulated(t *testing.T) {
+	t.Parallel()
+	src := apolloPerson{
+		ID:        "p1",
+		FirstName: "Alice",
+		LastName:  "Smith",
+		EmploymentHistory: []apolloEmploymentEntry{
+			{
+				OrganizationName: "ACME",
+				Title:            "Engineer",
+				StartDate:        "2021-01-15",
+				Current:          true,
+			},
+		},
+	}
+	got := src.toPerson()
+
+	// Tenure must be available and current (time.Now is used inside toPerson, so
+	// we only assert the structural invariants, not the exact month count).
+	require.True(t, got.Tenure.Available, "Tenure must be available when current role has start date")
+	assert.True(t, got.Tenure.Current)
+	assert.Equal(t, "apollo:employment_history", got.Tenure.Source)
+	assert.Equal(t, "day", got.Tenure.Precision)
+	assert.Greater(t, got.Tenure.Months, 0, "Months must be positive (start date is in the past)")
+}
+
+// TestToPerson_TenureUnavailableNoHistory verifies that toPerson returns an
+// unavailable tenure when the person has no employment history (pre-reveal thin
+// record from the search tier).
+func TestToPerson_TenureUnavailableNoHistory(t *testing.T) {
+	t.Parallel()
+	src := apolloPerson{
+		ID:        "p2",
+		FirstName: "Bob",
+		LastName:  "Jones",
+		// EmploymentHistory is nil/empty — pre-reveal discovery record.
+	}
+	got := src.toPerson()
+
+	assert.False(t, got.Tenure.Available, "pre-reveal person must have unavailable tenure")
+	assert.Equal(t, "apollo:employment_history", got.Tenure.Source)
+	assert.NotEmpty(t, got.Tenure.Reason)
+	assert.Equal(t, 0, got.Tenure.Months)
+}
+
+// TestMergeReveal_TenureCarriedOver verifies that mergeReveal copies the tenure
+// from the enriched record onto the discovered person, ensuring that after
+// RevealEmails the discovered person carries the tenure from enrichment.
+func TestMergeReveal_TenureCarriedOver(t *testing.T) {
+	t.Parallel()
+	discovered := Person{ID: "p1", FirstName: "Alice"}
+	enriched := Person{
+		ID: "p1",
+		Tenure: enum.Tenure{
+			Available: true,
+			Months:    18,
+			Current:   true,
+			Source:    "apollo:employment_history",
+			Precision: "month",
+		},
+	}
+	mergeReveal(&discovered, enriched)
+	assert.Equal(t, enriched.Tenure, discovered.Tenure, "mergeReveal must copy tenure from enriched person")
+}

--- a/pkg/enum/dehashed/dehashed.go
+++ b/pkg/enum/dehashed/dehashed.go
@@ -68,6 +68,9 @@ type Record struct {
 	Passwords    []string
 	Database     string
 	ObtainedDate string
+	// Tenure is always unavailable for DeHashed: breach data carries no
+	// employment dates, so current-role tenure cannot be derived (no fabrication).
+	Tenure enum.Tenure
 }
 
 // DomainResult is the aggregated, de-paginated result for a domain.
@@ -97,6 +100,9 @@ type Entry struct {
 	Passwords []string // breach-exposed plaintext passwords for this entry
 	Databases []string // distinct source DBs contributing to this entry
 	Count     int      // number of raw breach records merged into this entry
+	// Tenure is always unavailable for DeHashed: breach data carries no
+	// employment dates, so current-role tenure cannot be derived (no fabrication).
+	Tenure enum.Tenure
 }
 
 // Refine applies the filtering/merging pipeline to raw breach records and
@@ -142,6 +148,7 @@ func Refine(records []Record, opts RefineOptions) []Entry {
 			Passwords: dedupStrings(r.Passwords),
 			Databases: dedupStrings([]string{r.Database}),
 			Count:     1,
+			Tenure:    unavailableTenure(),
 		})
 	}
 
@@ -345,7 +352,7 @@ func mergeEntry(entries *[]Entry, indexByEmail map[string]int, email string, r *
 	key := strings.ToLower(email)
 	idx, seen := indexByEmail[key]
 	if !seen {
-		*entries = append(*entries, Entry{Email: email})
+		*entries = append(*entries, Entry{Email: email, Tenure: unavailableTenure()})
 		idx = len(*entries) - 1
 		indexByEmail[key] = idx
 	}
@@ -392,7 +399,15 @@ func toRecord(e *apiEntry) Record {
 		Passwords:    e.Password,
 		Database:     e.Database,
 		ObtainedDate: e.ObtainedDate,
+		Tenure:       unavailableTenure(),
 	}
+}
+
+// unavailableTenure is the single source of the DeHashed tenure provenance and
+// reason, shared by Record construction and Entry building (breach data carries
+// no employment dates).
+func unavailableTenure() enum.Tenure {
+	return enum.UnavailableTenure("dehashed", "breach data, no employment dates")
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/enum/dehashed/dehashed_tenure_test.go
+++ b/pkg/enum/dehashed/dehashed_tenure_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dehashed
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Tenure: DeHashed always returns unavailable (breach data, no employment dates)
+// ---------------------------------------------------------------------------
+
+const (
+	dehashedTenureSource = "dehashed"
+	dehashedTenureReason = "breach data, no employment dates"
+)
+
+// TestToRecord_TenureUnavailable verifies that a Record built from a raw API
+// entry always carries an unavailable tenure with the correct source/reason.
+// Breach data carries no employment dates so no derivation is possible.
+func TestToRecord_TenureUnavailable(t *testing.T) {
+	t.Parallel()
+	entry := &apiEntry{
+		ID:       "rec-1",
+		Email:    []string{"alice@example.com"},
+		Database: "breach-db",
+	}
+	got := toRecord(entry)
+
+	assert.False(t, got.Tenure.Available, "Record tenure must always be unavailable for DeHashed")
+	assert.Equal(t, dehashedTenureSource, got.Tenure.Source)
+	assert.Equal(t, dehashedTenureReason, got.Tenure.Reason)
+	assert.Equal(t, 0, got.Tenure.Months)
+	assert.False(t, got.Tenure.Current)
+	assert.Empty(t, got.Tenure.Precision)
+}
+
+// TestRefine_TenureUnavailableOnEntry verifies that the Refine pipeline
+// propagates unavailable tenure onto each Entry. This covers the no-dedup path
+// (one Entry per surviving record).
+func TestRefine_TenureUnavailableOnEntry(t *testing.T) {
+	t.Parallel()
+	records := []Record{
+		{
+			Email:    []string{"alice@example.com"},
+			Database: "breach-db",
+			Tenure:   unavailableTenure(),
+		},
+		{
+			Email:    []string{"bob@example.com"},
+			Database: "breach-db2",
+			Tenure:   unavailableTenure(),
+		},
+	}
+	entries := Refine(records, RefineOptions{})
+	require.Len(t, entries, 2)
+
+	for _, e := range entries {
+		assert.False(t, e.Tenure.Available, "Entry tenure must always be unavailable")
+		assert.Equal(t, dehashedTenureSource, e.Tenure.Source)
+		assert.Equal(t, dehashedTenureReason, e.Tenure.Reason)
+		assert.Equal(t, 0, e.Tenure.Months)
+	}
+}
+
+// TestRefine_TenureUnavailableWithDedup verifies that the dedup/merge path also
+// results in an unavailable tenure on the merged Entry. Multiple records for the
+// same email are merged into a single Entry; tenure must remain unavailable.
+func TestRefine_TenureUnavailableWithDedup(t *testing.T) {
+	t.Parallel()
+	records := []Record{
+		{
+			Email:     []string{"alice@example.com"},
+			Database:  "breach-a",
+			Passwords: []string{"pass1"},
+			Tenure:    unavailableTenure(),
+		},
+		{
+			Email:     []string{"alice@example.com"},
+			Database:  "breach-b",
+			Passwords: []string{"pass2"},
+			Tenure:    unavailableTenure(),
+		},
+	}
+	entries := Refine(records, RefineOptions{Dedup: true})
+	require.Len(t, entries, 1, "dedup must merge two records for the same email into one Entry")
+
+	e := entries[0]
+	assert.Equal(t, "alice@example.com", e.Email)
+	assert.Equal(t, 2, e.Count, "merged Entry must count both records")
+
+	// Tenure must remain unavailable even after merging.
+	assert.False(t, e.Tenure.Available, "merged Entry tenure must be unavailable")
+	assert.Equal(t, dehashedTenureSource, e.Tenure.Source)
+	assert.Equal(t, dehashedTenureReason, e.Tenure.Reason)
+}

--- a/pkg/enum/hunter/hunter.go
+++ b/pkg/enum/hunter/hunter.go
@@ -68,6 +68,9 @@ type Person struct {
 	Confidence int
 	Type       string
 	Sources    []string
+	// Tenure is always unavailable for Hunter: the source carries no employment
+	// dates, so current-role tenure cannot be derived (no fabrication).
+	Tenure enum.Tenure
 }
 
 // DomainResult is the aggregated, de-paginated result for a domain.
@@ -260,6 +263,7 @@ func toPerson(e *apiEmail) Person {
 		Confidence: e.Confidence,
 		Type:       e.Type,
 		Sources:    sources,
+		Tenure:     enum.UnavailableTenure("hunter", "no employment dates from source"),
 	}
 }
 

--- a/pkg/enum/hunter/hunter_tenure_test.go
+++ b/pkg/enum/hunter/hunter_tenure_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hunter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// Tenure: Hunter always returns unavailable (no employment dates in source)
+// ---------------------------------------------------------------------------
+
+// TestToPerson_TenureUnavailable verifies that a Person built from a Hunter API
+// email entry always carries an unavailable tenure — Hunter provides no
+// employment start/end dates so current-role tenure cannot be derived (no
+// fabrication).
+func TestToPerson_TenureUnavailable(t *testing.T) {
+	t.Parallel()
+	src := &apiEmail{
+		Value:      "alice@example.com",
+		FirstName:  "Alice",
+		LastName:   "Smith",
+		Position:   "Engineer",
+		Confidence: 85,
+	}
+	got := toPerson(src)
+
+	assert.False(t, got.Tenure.Available, "Hunter tenure must always be unavailable (no employment dates)")
+	assert.Equal(t, "hunter", got.Tenure.Source, "Source must be 'hunter'")
+	assert.Equal(t, "no employment dates from source", got.Tenure.Reason,
+		"Reason must explain why tenure is unavailable")
+	assert.Equal(t, 0, got.Tenure.Months, "Months must be zero for unavailable tenure")
+	assert.False(t, got.Tenure.Current, "Current must be false for unavailable tenure")
+	assert.Empty(t, got.Tenure.Precision, "Precision must be empty for unavailable tenure")
+}

--- a/pkg/enum/lusha/lusha.go
+++ b/pkg/enum/lusha/lusha.go
@@ -119,6 +119,9 @@ type Contact struct {
 	Emails        []EmailEntry
 	Phones        []PhoneEntry
 	Employment    []EmploymentEntry
+	// Tenure is always unavailable for Lusha: the source carries no employment
+	// start/end dates, so current-role tenure cannot be derived (no fabrication).
+	Tenure enum.Tenure
 }
 
 // DomainResult is the roster returned by SearchDomain for one company domain.
@@ -376,6 +379,7 @@ func toContact(resp *lushaEnrichResponse) *Contact {
 		Departments:   r.JobTitle.Departments,
 		Seniority:     r.JobTitle.Seniority,
 		Location:      r.Location.Country,
+		Tenure:        enum.UnavailableTenure("lusha", "no employment dates from source"),
 	}
 	// Employment = current role (from top-level company/jobTitle) followed by
 	// prior roles. Lusha previousEmployment lacks dates, so Current is the only
@@ -492,6 +496,7 @@ func toProspectContact(d *prospectEnrichData) Contact {
 		Departments: d.Departments,
 		Seniority:   strings.Join(seniority, ", "),
 		Location:    d.Location.Country,
+		Tenure:      enum.UnavailableTenure("lusha", "no employment dates from source"),
 	}
 	for _, e := range d.EmailAddresses {
 		c.Emails = append(c.Emails, EmailEntry{

--- a/pkg/enum/lusha/lusha_tenure_test.go
+++ b/pkg/enum/lusha/lusha_tenure_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lusha
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// Tenure: Lusha always returns unavailable (no employment dates in source)
+// ---------------------------------------------------------------------------
+
+// TestToContact_TenureUnavailable verifies that a contact built from a Lusha
+// v3 enrich result always carries an unavailable tenure — the source provides
+// no employment start/end dates so no derivation is possible (no fabrication).
+func TestToContact_TenureUnavailable(t *testing.T) {
+	t.Parallel()
+	r := lushaResult{}
+	r.FirstName = "Alice"
+	r.LastName = "Smith"
+	r.JobTitle.Title = "Engineer"
+	r.Company.Name = "ACME"
+	r.Company.Domain = "acme.com"
+
+	resp := &lushaEnrichResponse{
+		Results: []lushaResult{r},
+	}
+	got := toContact(resp)
+
+	assert.False(t, got.Tenure.Available, "Lusha tenure must always be unavailable (no employment dates)")
+	assert.Equal(t, "lusha", got.Tenure.Source, "Source must be 'lusha'")
+	assert.Equal(t, "no employment dates from source", got.Tenure.Reason,
+		"Reason must explain why tenure is unavailable")
+	assert.Equal(t, 0, got.Tenure.Months, "Months must be zero for unavailable tenure")
+	assert.False(t, got.Tenure.Current, "Current must be false for unavailable tenure")
+	assert.Empty(t, got.Tenure.Precision, "Precision must be empty for unavailable tenure")
+}
+
+// TestToProspectContact_TenureUnavailable verifies that the prospect-search code
+// path (toProspectContact) also returns an unavailable tenure with the same
+// provenance as the enrich path.
+func TestToProspectContact_TenureUnavailable(t *testing.T) {
+	t.Parallel()
+	d := &prospectEnrichData{
+		FullName:    "Bob Jones",
+		JobTitle:    "Manager",
+		CompanyName: "SomeCorp",
+	}
+
+	got := toProspectContact(d)
+
+	assert.False(t, got.Tenure.Available, "prospect contact tenure must always be unavailable")
+	assert.Equal(t, "lusha", got.Tenure.Source)
+	assert.Equal(t, "no employment dates from source", got.Tenure.Reason)
+	assert.Equal(t, 0, got.Tenure.Months)
+}

--- a/pkg/enum/tenure.go
+++ b/pkg/enum/tenure.go
@@ -1,0 +1,107 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enum
+
+import (
+	"fmt"
+	"time"
+)
+
+// Tenure describes how long a person has held their CURRENT role, derived from
+// real source dates. It carries provenance (Source) and date granularity
+// (Precision) rather than a High/Med/Low rollup — the consuming platform
+// computes any confidence rollup itself. When the source carries no employment
+// dates, Available is false and Reason explains why (no fabrication).
+type Tenure struct {
+	Available bool   // true only when derived from real source dates
+	Months    int    // whole months in the current role
+	Current   bool   // tenure reflects an ongoing role
+	Source    string // provenance, e.g. "apollo:employment_history"
+	Precision string // "day"|"month"|"year" granularity of the dates used
+	Reason    string // when !Available: why (no fabrication)
+}
+
+// ParseFlexibleDate parses an employment date string at whatever granularity the
+// source provides, returning the parsed time (in UTC), the precision of the
+// input ("day", "month", or "year"), and ok=false for empty or unparseable
+// input. Accepted forms: "2006-01-02" (day), "2006-01" (month), "2006" (year).
+func ParseFlexibleDate(s string) (t time.Time, precision string, ok bool) {
+	if s == "" {
+		return time.Time{}, "", false
+	}
+	for _, f := range []struct {
+		layout    string
+		precision string
+	}{
+		{"2006-01-02", "day"},
+		{"2006-01", "month"},
+		{"2006", "year"},
+	} {
+		if parsed, err := time.ParseInLocation(f.layout, s, time.UTC); err == nil {
+			return parsed, f.precision, true
+		}
+	}
+	return time.Time{}, "", false
+}
+
+// MonthsBetween returns the number of whole calendar months elapsed from start
+// to end, floored at 0. A partial trailing month (end's day-of-month not yet
+// reached) does not count.
+func MonthsBetween(start, end time.Time) int {
+	if !end.After(start) {
+		return 0
+	}
+	months := int(end.Year()-start.Year())*12 + int(end.Month()) - int(start.Month())
+	if end.Day() < start.Day() {
+		months--
+	}
+	if months < 0 {
+		return 0
+	}
+	return months
+}
+
+// UnavailableTenure builds a Tenure marked unavailable, carrying the provenance
+// source and the reason no tenure could be derived. It never fabricates dates.
+func UnavailableTenure(source, reason string) Tenure {
+	return Tenure{Available: false, Source: source, Reason: reason}
+}
+
+// String renders a human-readable tenure. Available tenures render as years and
+// months ("3y 2m", or "<n>m" when under a year), with " (current)" appended for
+// ongoing roles. Unavailable tenures render as "unavailable — <reason>".
+func (t Tenure) String() string {
+	if !t.Available {
+		return "unavailable — " + t.Reason
+	}
+
+	years := t.Months / 12
+	months := t.Months % 12
+
+	var span string
+	switch {
+	case years > 0 && months > 0:
+		span = fmt.Sprintf("%dy %dm", years, months)
+	case years > 0:
+		span = fmt.Sprintf("%dy", years)
+	default:
+		span = fmt.Sprintf("%dm", months)
+	}
+
+	if t.Current {
+		return span + " (current)"
+	}
+	return span
+}

--- a/pkg/enum/tenure_test.go
+++ b/pkg/enum/tenure_test.go
@@ -1,0 +1,254 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enum
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// ParseFlexibleDate
+// ---------------------------------------------------------------------------
+
+func TestParseFlexibleDate(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		input     string
+		wantYear  int
+		wantMonth time.Month
+		wantDay   int
+		wantPrec  string
+		wantOK    bool
+	}{
+		{
+			name:      "day precision",
+			input:     "2020-01-15",
+			wantYear:  2020,
+			wantMonth: time.January,
+			wantDay:   15,
+			wantPrec:  "day",
+			wantOK:    true,
+		},
+		{
+			name:      "month precision",
+			input:     "2020-01",
+			wantYear:  2020,
+			wantMonth: time.January,
+			wantDay:   1, // month layout parses to first of the month
+			wantPrec:  "month",
+			wantOK:    true,
+		},
+		{
+			name:      "year precision",
+			input:     "2020",
+			wantYear:  2020,
+			wantMonth: time.January,
+			wantDay:   1, // year layout parses to Jan 1
+			wantPrec:  "year",
+			wantOK:    true,
+		},
+		{name: "empty string", input: "", wantOK: false},
+		{name: "garbage string", input: "garbage", wantOK: false},
+		{name: "invalid month 13", input: "2020-13", wantOK: false},
+		{name: "invalid day 32", input: "2020-01-32", wantOK: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, prec, ok := ParseFlexibleDate(tc.input)
+			require.Equal(t, tc.wantOK, ok, "ok mismatch")
+			if !tc.wantOK {
+				return
+			}
+			// Parsed time must be UTC.
+			assert.Equal(t, time.UTC, got.Location(), "parsed time must be UTC")
+			assert.Equal(t, tc.wantYear, got.Year(), "year mismatch")
+			assert.Equal(t, tc.wantMonth, got.Month(), "month mismatch")
+			assert.Equal(t, tc.wantDay, got.Day(), "day mismatch")
+			assert.Equal(t, tc.wantPrec, prec, "precision mismatch")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// MonthsBetween
+// ---------------------------------------------------------------------------
+
+func TestMonthsBetween(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		start time.Time
+		end   time.Time
+		want  int
+	}{
+		{
+			name:  "same date is zero",
+			start: time.Date(2020, 6, 1, 0, 0, 0, 0, time.UTC),
+			end:   time.Date(2020, 6, 1, 0, 0, 0, 0, time.UTC),
+			want:  0,
+		},
+		{
+			name:  "approximately 3 years is 36 months",
+			start: time.Date(2021, 6, 1, 0, 0, 0, 0, time.UTC),
+			end:   time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC),
+			want:  36,
+		},
+		{
+			name:  "sub-month (10 days) rounds to zero",
+			start: time.Date(2020, 6, 1, 0, 0, 0, 0, time.UTC),
+			end:   time.Date(2020, 6, 11, 0, 0, 0, 0, time.UTC),
+			want:  0,
+		},
+		{
+			name:  "reversed (end before start) is zero (floored)",
+			start: time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC),
+			end:   time.Date(2021, 6, 1, 0, 0, 0, 0, time.UTC),
+			want:  0,
+		},
+		{
+			name: "day-of-month boundary: start day 15, end day 10 — partial month not counted",
+			// start=June 15 → end=July 10: end.Day(10) < start.Day(15) → not yet 1 full month
+			start: time.Date(2020, 6, 15, 0, 0, 0, 0, time.UTC),
+			end:   time.Date(2020, 7, 10, 0, 0, 0, 0, time.UTC),
+			want:  0,
+		},
+		{
+			name:  "day-of-month boundary: start day 15, end day 15 exactly — counts",
+			start: time.Date(2020, 6, 15, 0, 0, 0, 0, time.UTC),
+			end:   time.Date(2020, 7, 15, 0, 0, 0, 0, time.UTC),
+			want:  1,
+		},
+		{
+			name:  "day-of-month boundary: start day 15, end day 16 — counts",
+			start: time.Date(2020, 6, 15, 0, 0, 0, 0, time.UTC),
+			end:   time.Date(2020, 7, 16, 0, 0, 0, 0, time.UTC),
+			want:  1,
+		},
+		{
+			name:  "exact 1 year",
+			start: time.Date(2022, 3, 1, 0, 0, 0, 0, time.UTC),
+			end:   time.Date(2023, 3, 1, 0, 0, 0, 0, time.UTC),
+			want:  12,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := MonthsBetween(tc.start, tc.end)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// UnavailableTenure
+// ---------------------------------------------------------------------------
+
+func TestUnavailableTenure(t *testing.T) {
+	t.Parallel()
+	got := UnavailableTenure("mysource", "some reason")
+	assert.False(t, got.Available, "Available must be false")
+	assert.Equal(t, "mysource", got.Source)
+	assert.Equal(t, "some reason", got.Reason)
+	assert.Equal(t, 0, got.Months, "Months must be zero for unavailable tenure")
+	assert.False(t, got.Current, "Current must be false for unavailable tenure")
+}
+
+// ---------------------------------------------------------------------------
+// Tenure.String
+// ---------------------------------------------------------------------------
+
+func TestTenure_String(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		tenure Tenure
+		want   string
+	}{
+		{
+			name: "available current — years and months",
+			tenure: Tenure{
+				Available: true,
+				Months:    38, // 3y 2m
+				Current:   true,
+			},
+			want: "3y 2m (current)",
+		},
+		{
+			name: "available non-current — years and months, no suffix",
+			tenure: Tenure{
+				Available: true,
+				Months:    38,
+				Current:   false,
+			},
+			want: "3y 2m",
+		},
+		{
+			name: "available sub-year — months only",
+			tenure: Tenure{
+				Available: true,
+				Months:    5,
+				Current:   true,
+			},
+			want: "5m (current)",
+		},
+		{
+			name: "available exact years — no month component",
+			tenure: Tenure{
+				Available: true,
+				Months:    24,
+				Current:   false,
+			},
+			want: "2y",
+		},
+		{
+			name: "unavailable — renders reason",
+			tenure: Tenure{
+				Available: false,
+				Reason:    "employment history not revealed",
+			},
+			want: "unavailable — employment history not revealed",
+		},
+		{
+			name: "unavailable — different reason",
+			tenure: Tenure{
+				Available: false,
+				Reason:    "breach data, no employment dates",
+			},
+			want: "unavailable — breach data, no employment dates",
+		},
+		{
+			name:   "zero months available current",
+			tenure: Tenure{Available: true, Months: 0, Current: true},
+			want:   "0m (current)",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := tc.tenure.String()
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds a tenure signal to every enum integration. A shared `enum.Tenure` type carries the value plus provenance; it is **computed where the source supports it and explicitly marked unavailable (never fabricated) where it does not**.

- **New `pkg/enum/tenure.go`** — `Tenure{Available, Months, Current, Source, Precision, Reason}` + pure, unit-tested helpers (`ParseFlexibleDate`, `MonthsBetween`, `UnavailableTenure`, `String`). Confidence is expressed as **provenance (`Source`) + `Precision`**, not a High/Med/Low rollup — the platform owns rollups.
- **Apollo** — computes **current-role** tenure from `employment_history` start dates. Unavailable pre-reveal (dates arrive on the credit-consuming match), when there's no current role, or when the start date is missing.
- **Lusha / DeHashed / Hunter** — carry the same field, always `Unavailable` with a source-accurate reason (these sources have no employment dates).
- **CLI output** — human column + structured JSONL `tenure` object across all four.

### Why only Apollo computes
Only Apollo carries employment start/end dates. Lusha's `previousEmployment` has no dates; DeHashed is breach data; Hunter has no employment history. Rather than invent numbers, the other three report unavailability — consistent with the library's data-faithfulness contract (the `pkg/enum` library is also consumed by the Guard platform).

## Testing
- 25 new test functions; `go build`, `go vet`, `gofmt`, and `go test -count=1 ./pkg/enum/... ./cmd/brutus/...` all green.
- Coverage: apollo 94%, dehashed 94%, hunter 92%, lusha 88%; tenure helpers 87–100%.
- Code review: APPROVED (no blockers). Security review: PASS (no Critical/High/Med).

## ⚠️ Downstream follow-up (separate repo)
These `pkg/enum` public types feed Guard's `model.Person` via capmodel codegen. The new `Tenure` field requires a **capmodel regeneration in the guard repo** — not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)