### PR TITLE
feat(enum): group active sources under `enum active` + add `enum active github`

### DIFF
--- a/README.md
+++ b/README.md
@@ -820,19 +820,19 @@ Identify which unauthenticated account-existence oracles (microsoft365, google, 
 
 ```bash
 # Discover candidate oracles via DNS and report which ones work
-brutus enum oracles --domain example.com --known-valid admin@example.com
+brutus enum active oracles --domain example.com --known-valid admin@example.com
 
 # Enumerate specific emails against the working oracles
-brutus enum oracles --domain example.com -e user@example.com,admin@example.com --known-valid admin@example.com
+brutus enum active oracles --domain example.com -e user@example.com,admin@example.com --known-valid admin@example.com
 
 # Enumerate emails from file
-brutus enum oracles --domain example.com -E emails.txt --known-valid admin@example.com
+brutus enum active oracles --domain example.com -E emails.txt --known-valid admin@example.com
 
 # Generate emails from embedded name lists and enumerate against working oracles
-brutus enum oracles --domain example.com --generate --format flast --known-valid admin@example.com
+brutus enum active oracles --domain example.com --generate --format flast --known-valid admin@example.com
 
 # Discover working oracles with a known-valid email before large-scale enumeration
-brutus enum oracles discover --domain example.com --known-valid admin@example.com
+brutus enum active oracles discover --domain example.com --known-valid admin@example.com
 ```
 
 ### Kerberos User Enumeration
@@ -841,13 +841,13 @@ Enumerate Active Directory usernames via Kerberos AS-REQ (no passwords sent, no 
 
 ```bash
 # Enumerate specific users
-brutus enum kerberos --dc 10.0.0.1 --domain CORP.LOCAL -u administrator,guest,krbtgt
+brutus enum active kerberos --dc 10.0.0.1 --domain CORP.LOCAL -u administrator,guest,krbtgt
 
 # Enumerate from file
-brutus enum kerberos --dc dc01.corp.local --domain CORP.LOCAL -U users.txt
+brutus enum active kerberos --dc dc01.corp.local --domain CORP.LOCAL -U users.txt
 
 # Generate usernames and pipe to Kerberos enum
-brutus enum generate --format flast | brutus enum kerberos --dc 10.0.0.1 --domain CORP.LOCAL -U -
+brutus enum generate --format flast | brutus enum active kerberos --dc 10.0.0.1 --domain CORP.LOCAL -U -
 ```
 
 ### Email/Username Generation
@@ -896,23 +896,23 @@ Obtain an OAuth2 access token, refresh token, and ID token from Microsoft Entra 
 
 ```bash
 # Authenticate against the common endpoint (any Microsoft tenant)
-brutus enum teams auth
+brutus enum active teams auth
 
 # Authenticate against a specific tenant by domain or GUID
-brutus enum teams auth --tenant contoso.com
-brutus enum teams auth --tenant 00000000-0000-0000-0000-000000000000
+brutus enum active teams auth --tenant contoso.com
+brutus enum active teams auth --tenant 00000000-0000-0000-0000-000000000000
 
 # Request a different resource scope (space-separated). The default targets the
 # Skype/Teams resource (api.spaces.skype.com); the Teams client is NOT
 # authorized for Microsoft Graph (Graph yields AADSTS65002).
-brutus enum teams auth --scope "offline_access https://api.spaces.skype.com/.default"
+brutus enum active teams auth --scope "offline_access https://api.spaces.skype.com/.default"
 
 # Use a custom app registration (your own Azure app client ID)
-brutus enum teams auth --client-id 00000000-0000-0000-0000-000000000000
+brutus enum active teams auth --client-id 00000000-0000-0000-0000-000000000000
 
 # Capture the full token set as JSONL for piping to other tools
-brutus enum teams auth -o tokens.jsonl
-brutus enum teams auth --json
+brutus enum active teams auth -o tokens.jsonl
+brutus enum active teams auth --json
 ```
 
 **How it works:**
@@ -927,7 +927,7 @@ brutus enum teams auth --json
 **Default client ID:** The Microsoft Teams desktop application (`1fec8e78-bce4-4aaf-ab1b-5451cc387264`), a first-party public client that supports device code flow. Override with `--client-id` to use your own app registration.
 
 ```
-$ brutus enum teams auth --tenant contoso.com
+$ brutus enum active teams auth --tenant contoso.com
 [*] Starting Microsoft device code authentication...
 
 [*] Microsoft device code authentication
@@ -955,21 +955,21 @@ accounts are not supported — corporate tenants only.
 
 ```bash
 # Device-code auth inline, then enumerate a couple of emails
-brutus enum teams users -e alice@contoso.com,bob@contoso.com
+brutus enum active teams users -e alice@contoso.com,bob@contoso.com
 
 # Generate candidate emails for a domain and enumerate the most-likely 5000
 # (presence and out-of-office are gathered by default; use --no-presence to skip)
-brutus enum teams users --domain target.com --format first.last --limit 5000
+brutus enum active teams users --domain target.com --format first.last --limit 5000
 
 # Enumerate emails from a file
-brutus enum teams users -E emails.txt
+brutus enum active teams users -E emails.txt
 
 # Reuse a token captured earlier and route through a SOCKS5 proxy
-brutus enum teams auth -o token.jsonl
-brutus enum teams users -E emails.txt --token-file token.jsonl --proxy socks5://127.0.0.1:1080
+brutus enum active teams auth -o token.jsonl
+brutus enum active teams users -E emails.txt --token-file token.jsonl --proxy socks5://127.0.0.1:1080
 
 # Provide an access token directly
-brutus enum teams users -e alice@contoso.com --access-token "$TOKEN"
+brutus enum active teams users -e alice@contoso.com --access-token "$TOKEN"
 ```
 
 When a refresh token is available (via `--token-file` or `--refresh-token`), an
@@ -993,16 +993,16 @@ or `not found`.
 
 ```bash
 # Enumerate a couple of emails
-brutus enum google -e alice@example.com,bob@example.com
+brutus enum active google -e alice@example.com,bob@example.com
 
 # Generate candidate emails for a domain and enumerate the most-likely 5000
-brutus enum google --domain target.com --format first.last --limit 5000
+brutus enum active google --domain target.com --format first.last --limit 5000
 
 # Enumerate emails from a file
-brutus enum google -E emails.txt
+brutus enum active google -E emails.txt
 
 # Route through a SOCKS5 proxy and raise concurrency
-brutus enum google -E emails.txt --proxy socks5://127.0.0.1:1080 --threads 20
+brutus enum active google -E emails.txt --proxy socks5://127.0.0.1:1080 --threads 20
 ```
 
 `--domain` reuses the same frequency-ranked first/last name generator as

--- a/cmd/brutus/cmd_enum.go
+++ b/cmd/brutus/cmd_enum.go
@@ -40,29 +40,28 @@ work for an organization and enumerate emails against them, or enumerate Active
 Directory usernames via Kerberos AS-REQ.
 
 Subcommands:
-  oracles    Enumerate which account-existence oracles work for an organization
-  kerberos   Enumerate Active Directory users via Kerberos AS-REQ
+  active     Active enumeration against live oracles & directories (oracles, google, kerberos, teams, github, custom)
   generate   Generate email addresses or usernames from embedded name lists
-  teams      Authenticate with Microsoft Entra ID via device code flow
   passive    API-key OSINT/HUMINT sources (Hunter, Apollo, Lusha, DeHashed)
 
 See subcommand help for details:
-  brutus enum oracles --help
-  brutus enum kerberos --help
+  brutus enum active --help
   brutus enum generate --help
-  brutus enum teams --help
   brutus enum passive --help`,
 	Example: `  # Account-existence oracle enumeration
-  brutus enum oracles --domain praetorian.com -e test@praetorian.com --known-valid admin@praetorian.com
+  brutus enum active oracles --domain praetorian.com -e test@praetorian.com --known-valid admin@praetorian.com
 
   # Kerberos user enumeration
-  brutus enum kerberos --dc 10.0.0.1 --domain CORP.LOCAL -u administrator
+  brutus enum active kerberos --dc 10.0.0.1 --domain CORP.LOCAL -u administrator
+
+  # Authenticate with Microsoft Entra ID via device code
+  brutus enum active teams auth --tenant contoso.com
+
+  # GitHub account enumeration by email
+  brutus enum active github -e alice@example.com,bob@example.com
 
   # Generate emails for enumeration
   brutus enum generate --domain example.com --format flast
-
-  # Authenticate with Microsoft Entra ID via device code
-  brutus enum teams auth --tenant contoso.com
 
   # API-key OSINT/HUMINT sources (employee email/contact discovery)
   brutus enum passive hunter --domain example.com
@@ -103,7 +102,7 @@ Available formats:
   brutus enum generate --domain example.com --limit 1000
 
   # Pipe the 500 most-likely usernames to Kerberos enum
-  brutus enum generate --format flast --limit 500 | brutus enum kerberos --dc 10.0.0.1 --domain CORP.LOCAL -U -`,
+  brutus enum generate --format flast --limit 500 | brutus enum active kerberos --dc 10.0.0.1 --domain CORP.LOCAL -U -`,
 	RunE: runEnumGenerate,
 }
 
@@ -114,12 +113,17 @@ func init() {
 	f.StringVar(&flagEnumFormat, "format", "first.last", "Username format (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first)")
 	f.IntVar(&flagEnumGenerateLimit, "limit", 0, "Emit only the first N (most-likely) results (0 = no limit, emit all)")
 
-	// Wire direct children of enum (unchanged commands).
+	// generate stays a direct child of enum.
 	enumCmd.AddCommand(enumGenerateCmd)
-	enumCmd.AddCommand(enumOraclesCmd)
-	enumCmd.AddCommand(enumKerberosCmd)
-	enumCmd.AddCommand(enumCustomCmd)
-	enumCmd.AddCommand(enumTeamsCmd)
+
+	// Canonical path: the active enumeration sources live under "active".
+	// (enum active google is wired in cmd_enum_google.go init(); enum active
+	// github in cmd_enum_github.go init().)
+	enumActiveCmd.AddCommand(enumOraclesCmd)
+	enumActiveCmd.AddCommand(enumKerberosCmd)
+	enumActiveCmd.AddCommand(enumCustomCmd)
+	enumActiveCmd.AddCommand(enumTeamsCmd)
+	enumCmd.AddCommand(enumActiveCmd)
 
 	// Canonical path: the passive API-key OSINT/HUMINT sources live under "passive".
 	enumPassiveCmd.AddCommand(newEnumHunterCmd(), newEnumApolloCmd(), newEnumLushaCmd(), newEnumDehashedCmd())

--- a/cmd/brutus/cmd_enum_active.go
+++ b/cmd/brutus/cmd_enum_active.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var enumActiveCmd = &cobra.Command{
+	Use:   "active",
+	Short: "Active account-existence enumeration against live oracles & directories",
+	Long: `Active enumeration probes live services directly (account-existence oracles,
+Google Workspace, GitHub, Active Directory via Kerberos, Microsoft Entra ID).
+Unlike the passive API-key sources, these sources send traffic to the target's
+own infrastructure or to the relevant provider's public endpoints — see the
+per-source help for what each one touches and whether it is authenticated.
+
+Sources:
+  oracles    Enumerate which account-existence oracles work for an organization
+  google     Enumerate Google Workspace accounts (existence + SSO/IdP)
+  kerberos   Enumerate Active Directory users via Kerberos AS-REQ
+  teams      Authenticate with Microsoft Entra ID via device code flow
+  github     Enumerate GitHub accounts by email (existence + username reveal)
+  custom     Enumerate against a user-supplied oracle definition`,
+	Example: `  # Account-existence oracle enumeration
+  brutus enum active oracles --domain example.com --known-valid admin@example.com
+
+  # Google Workspace account enumeration
+  brutus enum active google -e alice@example.com,bob@example.com
+
+  # Kerberos user enumeration
+  brutus enum active kerberos --dc 10.0.0.1 --domain CORP.LOCAL -u administrator
+
+  # Authenticate with Microsoft Entra ID via device code
+  brutus enum active teams auth --tenant contoso.com
+
+  # GitHub account enumeration by email
+  brutus enum active github -e alice@example.com,bob@example.com
+
+  # Enumerate against a custom oracle definition
+  brutus enum active custom -f oracle.json -e jsmith,asmith`,
+}

--- a/cmd/brutus/cmd_enum_custom.go
+++ b/cmd/brutus/cmd_enum_custom.go
@@ -54,16 +54,16 @@ Subjects come from --emails/-e, --email-file/-E, or --generate. Only http/https
 URLs are allowed; placeholder substitution is encoding-aware and redirects are
 not followed.`,
 	Example: `  # Run an oracle against inline subjects
-  brutus enum custom -f oracle.json -e jsmith,asmith
+  brutus enum active custom -f oracle.json -e jsmith,asmith
 
   # Run against a subject file
-  brutus enum custom -f oracle.yaml -E users.txt
+  brutus enum active custom -f oracle.yaml -E users.txt
 
   # Generate usernames and run
-  brutus enum custom -f oracle.json --generate --format flast
+  brutus enum active custom -f oracle.json --generate --format flast
 
   # JSON output to a file
-  brutus enum custom -f oracle.json -e jsmith -o results.jsonl`,
+  brutus enum active custom -f oracle.json -e jsmith -o results.jsonl`,
 	RunE: runEnumCustom,
 }
 
@@ -78,7 +78,7 @@ func init() {
 	_ = enumCustomCmd.MarkFlagRequired("file")
 }
 
-// runEnumCustom implements the "enum custom" subcommand.
+// runEnumCustom implements the "enum active custom" subcommand.
 func runEnumCustom(cmd *cobra.Command, args []string) error {
 	useColor := isColorEnabled(flagNoColor)
 

--- a/cmd/brutus/cmd_enum_custom_test.go
+++ b/cmd/brutus/cmd_enum_custom_test.go
@@ -39,7 +39,7 @@ import (
 // annotation — mirrors cmd_enum_hunter_test.go::TestEnumHunterRegistered.
 func TestEnumCustomRegistered(t *testing.T) {
 	var found bool
-	for _, cmd := range enumCmd.Commands() {
+	for _, cmd := range enumActiveCmd.Commands() {
 		if cmd.Use != "custom" {
 			continue
 		}
@@ -90,7 +90,7 @@ func TestEnumCustomRegistered(t *testing.T) {
 
 		break
 	}
-	require.True(t, found, "custom subcommand must be registered with enumCmd")
+	require.True(t, found, "custom subcommand must be registered with enumActiveCmd")
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/brutus/cmd_enum_github.go
+++ b/cmd/brutus/cmd_enum_github.go
@@ -1,0 +1,312 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"slices"
+	"strings"
+	"syscall"
+
+	"github.com/spf13/cobra"
+
+	"github.com/praetorian-inc/brutus/pkg/enum"
+	githubenum "github.com/praetorian-inc/brutus/pkg/enum/github"
+)
+
+// File-local flag variables for the "enum active github" subcommand. A separate
+// block avoids cross-command flag-state bleed with the other enum subcommands.
+var (
+	flagGithubEnumEmails    string
+	flagGithubEnumEmailFile string
+	flagGithubEnumDomain    string
+	flagGithubEnumFormat    string
+	flagGithubEnumLimit     int
+	flagGithubEnumToken     string
+)
+
+var enumGithubCmd = &cobra.Command{
+	Use:   "github",
+	Short: "Enumerate GitHub accounts by email (existence + username reveal)",
+	Long: `Check whether email addresses correspond to GitHub accounts and, with a
+personal access token, reveal the GitHub username behind each one.
+
+Existence (unauthenticated): the github.com sign-up flow exposes an
+email_validity_checks endpoint that reports whether an address is already in use
+(an account exists) or available (no account). No token or sign-in is required.
+GitHub aggressively rate-limits this endpoint — if you see rate-limit retries,
+lower --threads and/or set --rate-limit to pace requests.
+
+Username reveal (authenticated): when a token is provided (via GITHUB_TOKEN or
+--token) the existing accounts are resolved to their GitHub usernames. This
+requires a PAT with the "repo" and "delete_repo" scopes: a temporary PRIVATE
+repository is created, one commit per existing email is pushed with that email
+as the commit author, GitHub resolves the author's login (even when email
+privacy is enabled), and the temporary repository is then ALWAYS deleted. If the
+cleanup delete ever fails, the repository name is printed so you can remove it
+manually.
+
+Provide targets directly with --emails/-e or --email-file/-E, or pass --domain
+to generate the candidate wordlist internally from a bundled, frequency-ranked
+list of statistically-likely first/last name combinations (the same generator as
+"enum generate") — no piping required. --format selects the username layout and
+--limit caps generation to the first N (most-likely) candidates. --domain may be
+combined with -e/-E.`,
+	Example: `  # Existence-only enumeration (unauthenticated)
+  brutus enum active github -e alice@example.com,bob@example.com
+
+  # Generate candidate emails for a domain and enumerate the 5000 most likely
+  brutus enum active github --domain target.com --format first.last --limit 5000
+
+  # Enumerate emails from a file
+  brutus enum active github -E emails.txt
+
+  # Reveal usernames for existing accounts (requires a PAT with repo+delete_repo)
+  export GITHUB_TOKEN=ghp_...
+  brutus enum active github -E emails.txt
+
+  # Pace requests to avoid GitHub's existence-endpoint rate limiting
+  brutus enum active github -E emails.txt --threads 2 --rate-limit 1`,
+	RunE: runEnumGithub,
+}
+
+func init() {
+	f := enumGithubCmd.Flags()
+	f.StringVarP(&flagGithubEnumEmails, "emails", "e", "", "Comma-separated email addresses to check")
+	f.StringVarP(&flagGithubEnumEmailFile, "email-file", "E", "", "File of email addresses, one per line (\"-\" for stdin)")
+	f.StringVarP(&flagGithubEnumDomain, "domain", "d", "", "Generate candidate emails for this domain (statistically-likely first/last combos)")
+	f.StringVar(&flagGithubEnumFormat, "format", "first.last", "Username format for --domain generation (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first)")
+	f.IntVar(&flagGithubEnumLimit, "limit", 0, "When generating with --domain, cap to the first N (most-likely) candidates (0 = all)")
+	f.StringVar(&flagGithubEnumToken, "token", "", "GitHub PAT for username reveal (overrides GITHUB_TOKEN; visible in process list — prefer the env var)")
+	// NOTE: no -t shorthand: it collides with the global persistent --threads/-t
+	// flag, which cobra merges into this subcommand at execute time.
+	enumActiveCmd.AddCommand(enumGithubCmd)
+}
+
+// runEnumGithub implements the "enum active github" subcommand. Existence runs
+// unauthenticated; when a token is resolved and any accounts exist, it then
+// reveals their GitHub usernames.
+func runEnumGithub(cmd *cobra.Command, args []string) error {
+	useColor := isColorEnabled(flagNoColor)
+
+	jsonWriter, forceJSON, closeOutput, err := setupOutputWriter(flagOutputFile)
+	if err != nil {
+		return err
+	}
+	defer closeOutput()
+	if forceJSON {
+		flagJSON = true
+	}
+
+	emails, err := githubEnumTargets()
+	if err != nil {
+		return err
+	}
+
+	token := resolveGithubToken(flagGithubEnumToken, useColor)
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	enumerator, err := githubenum.NewEnumerator(flagProxy, flagTimeout, token)
+	if err != nil {
+		return fmt.Errorf("github: %w", err)
+	}
+
+	if !flagQuiet && !flagJSON {
+		fmt.Fprintf(os.Stderr, "%s Enumerating %d email(s) against GitHub...\n",
+			dim(useColor, SymbolInfo), len(emails))
+		fmt.Fprintf(os.Stdout, "\n%s %s\n\n", dim(useColor, SymbolInfo), heading(useColor, "GitHub Account Enumeration"))
+	}
+
+	// Stream each completed result live. Human mode prints only EXISTS rows
+	// unless --verbose; JSON mode streams a JSONL line per result. A periodic
+	// progress counter goes to stderr (suppressed under --quiet/--json).
+	total := len(emails)
+	var processed, found int
+	onResult := func(res githubenum.Result) {
+		processed++
+		if res.Exists {
+			found++
+		}
+
+		if flagJSON {
+			// By design, a revealed email yields TWO JSONL records: this initial
+			// existence record (no username yet), then a second, enriched record
+			// emitted after reveal (carrying the resolved username). Consumers
+			// should treat the later record as authoritative — this is not a bug.
+			outputGithubEnumJSONL(jsonWriter, []githubenum.Result{res})
+		} else if res.Exists || flagVerbose {
+			outputGithubEnumResultLine(os.Stdout, res, useColor)
+		}
+
+		if !flagQuiet && !flagJSON && processed%500 == 0 {
+			fmt.Fprintf(os.Stderr, "%s processed %d/%d — %d found\n",
+				dim(useColor, SymbolInfo), processed, total, found)
+		}
+	}
+
+	results := enumerator.EnumerateWith(ctx, emails, flagThreads, flagRateLimit, flagJitter, onResult)
+
+	// Username reveal: only when a token is set and at least one account exists.
+	existing := existingEmails(results)
+	if token != "" && len(existing) > 0 {
+		if !flagQuiet && !flagJSON {
+			fmt.Fprintf(os.Stderr, "%s Revealing usernames for %d existing account(s) via a temporary private repo (deleted afterward)...\n",
+				dim(useColor, SymbolInfo), len(existing))
+		}
+
+		mapping, revErr := enumerator.Reveal(ctx, existing)
+		if revErr != nil {
+			// Reveal failures are non-fatal to existence results; warn and continue.
+			fmt.Fprintf(os.Stderr, "%s github username reveal failed: %v\n",
+				dim(useColor, SymbolInfo), revErr)
+		} else {
+			mergeUsernames(results, mapping)
+			if flagJSON {
+				// Re-emit the now-enriched results so JSONL consumers see usernames.
+				// This is the intentional SECOND record per revealed email (see the
+				// onResult emit above): the first record carries existence only, this
+				// one carries the resolved username. Two records per email is expected.
+				for i := range results {
+					if results[i].Username != "" {
+						outputGithubEnumJSONL(jsonWriter, []githubenum.Result{results[i]})
+					}
+				}
+			} else {
+				outputGithubEnumUsernames(os.Stdout, results, useColor)
+			}
+		}
+	}
+
+	if !flagJSON {
+		outputGithubEnumSummary(os.Stdout, results, useColor)
+	}
+	return nil
+}
+
+// githubEnumTargets parses, trims, and dedups the email targets from --emails
+// and --email-file, plus any --domain-generated candidates. It errors when no
+// targets are supplied.
+func githubEnumTargets() ([]string, error) {
+	var raw []string
+	if flagGithubEnumEmails != "" {
+		raw = append(raw, strings.Split(flagGithubEnumEmails, ",")...)
+	}
+	if flagGithubEnumEmailFile != "" {
+		lines, err := loadLinesFromFile(flagGithubEnumEmailFile)
+		if err != nil {
+			return nil, fmt.Errorf("reading --email-file: %w", err)
+		}
+		raw = append(raw, lines...)
+	}
+
+	if flagGithubEnumDomain != "" {
+		generated, err := githubEnumGenerate()
+		if err != nil {
+			return nil, err
+		}
+		raw = append(raw, generated...)
+	}
+
+	seen := make(map[string]struct{})
+	var emails []string
+	for _, e := range raw {
+		e = strings.TrimSpace(e)
+		if e == "" {
+			continue
+		}
+		if _, ok := seen[e]; ok {
+			continue
+		}
+		seen[e] = struct{}{}
+		emails = append(emails, e)
+	}
+
+	if len(emails) == 0 {
+		return nil, fmt.Errorf("provide --emails/-e, --email-file/-E, or --domain")
+	}
+	return emails, nil
+}
+
+// githubEnumGenerate produces the candidate email wordlist for --domain by
+// reusing the shared, frequency-ranked generator (enum.GenerateEmails) and the
+// shared capResults helper — no duplicated generation logic. The format is
+// validated against enum.ListFormats() first. A status line goes to stderr
+// (never stdout) unless quiet or JSON.
+func githubEnumGenerate() ([]string, error) {
+	if !slices.Contains(enum.ListFormats(), flagGithubEnumFormat) {
+		return nil, fmt.Errorf("invalid --format %q; valid formats: %s",
+			flagGithubEnumFormat, strings.Join(enum.ListFormats(), ", "))
+	}
+
+	generated, err := enum.GenerateEmails(flagGithubEnumFormat, flagGithubEnumDomain)
+	if err != nil {
+		return nil, fmt.Errorf("generating candidate emails: %w", err)
+	}
+	generated = capResults(generated, flagGithubEnumLimit)
+
+	if !flagQuiet && !flagJSON {
+		useColor := isColorEnabled(flagNoColor)
+		fmt.Fprintf(os.Stderr, "%s Generating %s candidates for %s (%d emails)...\n",
+			dim(useColor, SymbolInfo), flagGithubEnumFormat, flagGithubEnumDomain, len(generated))
+		if flagGithubEnumLimit == 0 {
+			fmt.Fprintf(os.Stderr, "%s (no --limit; generating the full ~%d-candidate list — pass --limit to cap)\n",
+				dim(useColor, SymbolInfo), len(generated))
+		}
+	}
+
+	return generated, nil
+}
+
+// resolveGithubToken returns the --token flag value if set, otherwise the
+// GITHUB_TOKEN env var, otherwise "" (existence-only mode). When the flag is
+// used it warns (to stderr) that the token is visible in the process list and
+// shell history. The token is never logged.
+func resolveGithubToken(flagValue string, useColor bool) string {
+	if flagValue != "" {
+		if !flagQuiet {
+			fmt.Fprintf(os.Stderr,
+				"%s --token is visible in the process list and shell history; prefer the GITHUB_TOKEN env var\n",
+				dim(useColor, SymbolInfo))
+		}
+		return flagValue
+	}
+	return os.Getenv("GITHUB_TOKEN")
+}
+
+// existingEmails returns the emails whose existence check confirmed an account.
+func existingEmails(results []githubenum.Result) []string {
+	var existing []string
+	for i := range results {
+		if results[i].Exists {
+			existing = append(existing, results[i].Email)
+		}
+	}
+	return existing
+}
+
+// mergeUsernames writes the resolved usernames from mapping (email -> login)
+// back onto the matching results in place.
+func mergeUsernames(results []githubenum.Result, mapping map[string]string) {
+	for i := range results {
+		if login, ok := mapping[results[i].Email]; ok {
+			results[i].Username = login
+		}
+	}
+}

--- a/cmd/brutus/cmd_enum_github_output.go
+++ b/cmd/brutus/cmd_enum_github_output.go
@@ -1,0 +1,138 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	githubenum "github.com/praetorian-inc/brutus/pkg/enum/github"
+)
+
+// outputGithubEnumResultLine prints ONE GitHub enumeration result row. EXISTS
+// rows show the email and an "[+] EXISTS" label, plus the revealed username (if
+// any) as " (<username>)". Not-found rows render as "[ ] not found". The
+// server-/user-derived email and username are sanitized via sanitizeTerminal
+// (P0-4) before rendering. Callers decide which results to print.
+func outputGithubEnumResultLine(w io.Writer, r githubenum.Result, useColor bool) {
+	email := truncate(sanitizeTerminal(r.Email), 40)
+
+	if !r.Exists {
+		_, _ = fmt.Fprintf(w, "  %-40s %s[ ] not found%s\n",
+			email, colorIf(useColor, ColorDim), colorIf(useColor, ColorReset))
+		return
+	}
+
+	note := ""
+	if r.Username != "" {
+		note = " (" + sanitizeTerminal(r.Username) + ")"
+	}
+
+	_, _ = fmt.Fprintf(w, "  %-40s %s%s EXISTS%s%s\n",
+		email,
+		colorIf(useColor, ColorGreen), SymbolSuccess, colorIf(useColor, ColorReset),
+		dim(useColor, note))
+}
+
+// outputGithubEnumUsernames prints the resolved username:email mappings for
+// results that have a revealed username, under a small heading.
+func outputGithubEnumUsernames(w io.Writer, results []githubenum.Result, useColor bool) {
+	var any bool
+	for i := range results {
+		if results[i].Username != "" {
+			any = true
+			break
+		}
+	}
+	if !any {
+		return
+	}
+
+	_, _ = fmt.Fprintf(w, "\n  %s\n", heading(useColor, "Revealed Usernames"))
+	for i := range results {
+		if results[i].Username == "" {
+			continue
+		}
+		_, _ = fmt.Fprintf(w, "    %s%s%s:%s\n",
+			colorIf(useColor, ColorCyan), sanitizeTerminal(results[i].Username), colorIf(useColor, ColorReset),
+			" "+sanitizeTerminal(results[i].Email))
+	}
+}
+
+// outputGithubEnumSummary prints the counts-by-status summary block: found /
+// revealed / not found / errors / total.
+func outputGithubEnumSummary(w io.Writer, results []githubenum.Result, useColor bool) {
+	var foundCount, revealedCount, notFoundCount, errorCount int
+	for i := range results {
+		switch {
+		case results[i].Error != nil:
+			errorCount++
+		case results[i].Exists:
+			foundCount++
+			if results[i].Username != "" {
+				revealedCount++
+			}
+		default:
+			notFoundCount++
+		}
+	}
+
+	_, _ = fmt.Fprintf(w, "\n  %s\n", heading(useColor, "Summary"))
+	if foundCount > 0 {
+		_, _ = fmt.Fprintf(w, "    %sExists:%s     %d\n", colorIf(useColor, ColorGreen), colorIf(useColor, ColorReset), foundCount)
+	}
+	if revealedCount > 0 {
+		_, _ = fmt.Fprintf(w, "    %sUsernames:%s  %d\n", colorIf(useColor, ColorCyan), colorIf(useColor, ColorReset), revealedCount)
+	}
+	if notFoundCount > 0 {
+		_, _ = fmt.Fprintf(w, "    %sNot found:%s  %d\n", colorIf(useColor, ColorDim), colorIf(useColor, ColorReset), notFoundCount)
+	}
+	if errorCount > 0 {
+		_, _ = fmt.Fprintf(w, "    %sErrors:%s     %d\n", colorIf(useColor, ColorRed), colorIf(useColor, ColorReset), errorCount)
+	}
+	_, _ = fmt.Fprintf(w, "    %sTotal:%s      %d\n", colorIf(useColor, ColorCyan), colorIf(useColor, ColorReset), len(results))
+	_, _ = fmt.Fprintln(w)
+}
+
+// outputGithubEnumJSONL writes one JSON object per result. encoding/json escapes
+// control characters, so no sanitization is needed.
+func outputGithubEnumJSONL(w io.Writer, results []githubenum.Result) {
+	type githubEnumJSON struct {
+		Type     string `json:"type"`
+		Email    string `json:"email"`
+		Exists   bool   `json:"exists"`
+		Username string `json:"username,omitempty"`
+		Error    string `json:"error,omitempty"`
+	}
+
+	enc := json.NewEncoder(w)
+	for i := range results {
+		r := &results[i]
+		jr := githubEnumJSON{
+			Type:     "github_account",
+			Email:    r.Email,
+			Exists:   r.Exists,
+			Username: r.Username,
+		}
+		if r.Error != nil {
+			jr.Error = r.Error.Error()
+		}
+		if err := enc.Encode(jr); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "Error encoding github enum JSON: %v\n", err)
+		}
+	}
+}

--- a/cmd/brutus/cmd_enum_github_test.go
+++ b/cmd/brutus/cmd_enum_github_test.go
@@ -1,0 +1,339 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	githubenum "github.com/praetorian-inc/brutus/pkg/enum/github"
+)
+
+// ---------------------------------------------------------------------------
+// Flag registration
+// ---------------------------------------------------------------------------
+
+// TestEnumGithubCmd_Flags verifies that enumGithubCmd carries the required
+// flags and shorthands, and that no shorthand collides with the global
+// persistent --threads/-t flag.
+func TestEnumGithubCmd_Flags(t *testing.T) {
+	// --emails / -e
+	f := enumGithubCmd.Flags().Lookup("emails")
+	require.NotNil(t, f, "--emails flag must exist on enumGithubCmd")
+	sh := enumGithubCmd.Flags().ShorthandLookup("e")
+	require.NotNil(t, sh, "-e shorthand must exist on enumGithubCmd")
+	assert.Equal(t, "emails", sh.Name, "-e must map to --emails")
+
+	// --email-file / -E
+	f = enumGithubCmd.Flags().Lookup("email-file")
+	require.NotNil(t, f, "--email-file flag must exist on enumGithubCmd")
+	sh = enumGithubCmd.Flags().ShorthandLookup("E")
+	require.NotNil(t, sh, "-E shorthand must exist on enumGithubCmd")
+	assert.Equal(t, "email-file", sh.Name, "-E must map to --email-file")
+
+	// --domain / -d
+	f = enumGithubCmd.Flags().Lookup("domain")
+	require.NotNil(t, f, "--domain flag must exist on enumGithubCmd")
+	sh = enumGithubCmd.Flags().ShorthandLookup("d")
+	require.NotNil(t, sh, "-d shorthand must exist on enumGithubCmd")
+	assert.Equal(t, "domain", sh.Name, "-d must map to --domain")
+
+	// --format (no shorthand; default is first.last)
+	f = enumGithubCmd.Flags().Lookup("format")
+	require.NotNil(t, f, "--format flag must exist on enumGithubCmd")
+	assert.Equal(t, "first.last", f.DefValue, "--format default must be \"first.last\"")
+
+	// --limit (no shorthand)
+	f = enumGithubCmd.Flags().Lookup("limit")
+	require.NotNil(t, f, "--limit flag must exist on enumGithubCmd")
+
+	// --token (no shorthand; -t is taken by global --threads)
+	f = enumGithubCmd.Flags().Lookup("token")
+	require.NotNil(t, f, "--token flag must exist on enumGithubCmd")
+
+	// No -t shorthand: it collides with the global persistent --threads/-t.
+	noT := enumGithubCmd.Flags().ShorthandLookup("t")
+	require.Nil(t, noT,
+		"enumGithubCmd must not define a local -t shorthand (collides with global --threads/-t)")
+}
+
+// ---------------------------------------------------------------------------
+// Command wiring (HARD MOVE assertion)
+// ---------------------------------------------------------------------------
+
+// TestEnumGithubCmd_WiredUnderActiveCmd verifies the cobra tree after the
+// "enum active" hard move:
+//
+//   - enumCmd has a child named "active"
+//   - enumActiveCmd (the "active" child) has github, oracles, google, kerberos,
+//     teams, and custom as children
+//   - enumCmd does NOT directly have google, kerberos, teams, oracles, or custom
+//     as children (they were hard-moved)
+func TestEnumGithubCmd_WiredUnderActiveCmd(t *testing.T) {
+	// 1. enumCmd must have an "active" child.
+	var active *cobra.Command
+	for _, cmd := range enumCmd.Commands() {
+		if cmd.Use == "active" {
+			active = cmd
+			break
+		}
+	}
+	require.NotNil(t, active, `enumCmd must have an "active" subcommand`)
+
+	// 2. "active" must have github, oracles, google, kerberos, teams, and custom.
+	wantActiveChildren := []string{"github", "oracles", "google", "kerberos", "teams", "custom"}
+	for _, name := range wantActiveChildren {
+		var found bool
+		for _, cmd := range active.Commands() {
+			if cmd.Use == name {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "enumActiveCmd must have %q as a subcommand", name)
+	}
+
+	// 3. enumCmd must NOT have google, kerberos, teams, oracles, or custom as
+	//    direct children (hard move — these are now under "active" only).
+	hardMovedNames := []string{"google", "kerberos", "teams", "oracles", "custom"}
+	for _, name := range hardMovedNames {
+		for _, cmd := range enumCmd.Commands() {
+			// Allow hidden/deprecated back-compat aliases (e.g., apollo has one),
+			// but these five never had aliases, so none should appear at all.
+			if cmd.Use == name {
+				assert.True(t, cmd.Hidden || cmd.Deprecated != "",
+					"enumCmd must not have %q as a direct non-deprecated child (hard move)", name)
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// githubEnumTargets
+// ---------------------------------------------------------------------------
+
+// TestGithubEnumTargets_InlineEmails verifies that --emails CSV is parsed,
+// trimmed, and deduplicated.
+func TestGithubEnumTargets_InlineEmails(t *testing.T) {
+	origEmails := flagGithubEnumEmails
+	origEmailFile := flagGithubEnumEmailFile
+	origDomain := flagGithubEnumDomain
+	defer func() {
+		flagGithubEnumEmails = origEmails
+		flagGithubEnumEmailFile = origEmailFile
+		flagGithubEnumDomain = origDomain
+	}()
+
+	flagGithubEnumEmails = "alice@example.com,bob@example.com,alice@example.com"
+	flagGithubEnumEmailFile = ""
+	flagGithubEnumDomain = ""
+
+	emails, err := githubEnumTargets()
+	require.NoError(t, err)
+
+	// Dedup: alice appears twice but must appear once.
+	assert.Len(t, emails, 2, "deduplication must collapse duplicate emails")
+	assert.Contains(t, emails, "alice@example.com")
+	assert.Contains(t, emails, "bob@example.com")
+}
+
+// TestGithubEnumTargets_NoSource verifies that an error is returned (and
+// mentions "provide") when no --emails, --email-file, or --domain is given.
+func TestGithubEnumTargets_NoSource(t *testing.T) {
+	origEmails := flagGithubEnumEmails
+	origEmailFile := flagGithubEnumEmailFile
+	origDomain := flagGithubEnumDomain
+	defer func() {
+		flagGithubEnumEmails = origEmails
+		flagGithubEnumEmailFile = origEmailFile
+		flagGithubEnumDomain = origDomain
+	}()
+
+	flagGithubEnumEmails = ""
+	flagGithubEnumEmailFile = ""
+	flagGithubEnumDomain = ""
+
+	_, err := githubEnumTargets()
+	require.Error(t, err, "githubEnumTargets must fail when no source is supplied")
+	assert.Contains(t, err.Error(), "provide",
+		"error must guide the user to supply a target source")
+}
+
+// ---------------------------------------------------------------------------
+// resolveGithubToken
+// ---------------------------------------------------------------------------
+
+// TestResolveGithubToken verifies the flag-overrides-env, env-fallback, and
+// empty-allowed behaviors. The token is never required (existence-only mode is
+// valid with an empty token).
+func TestResolveGithubToken(t *testing.T) {
+	tests := []struct {
+		name      string
+		flagValue string
+		envValue  string
+		wantToken string
+	}{
+		{
+			name:      "flag value overrides env var",
+			flagValue: "flag-token",
+			envValue:  "env-token",
+			wantToken: "flag-token",
+		},
+		{
+			name:      "env var used when flag is empty",
+			flagValue: "",
+			envValue:  "env-token",
+			wantToken: "env-token",
+		},
+		{
+			name:      "empty token allowed (existence-only mode)",
+			flagValue: "",
+			envValue:  "",
+			wantToken: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("GITHUB_TOKEN", tc.envValue)
+
+			// resolveGithubToken writes a warning to stderr when the flag is
+			// used; suppress that by running in quiet mode.
+			origQuiet := flagQuiet
+			flagQuiet = true
+			defer func() { flagQuiet = origQuiet }()
+
+			got := resolveGithubToken(tc.flagValue, false)
+			assert.Equal(t, tc.wantToken, got)
+		})
+	}
+}
+
+// TestResolveGithubToken_FlagWarns verifies that passing a non-empty flag
+// value emits a warning (does not panic, does not leak the token into the
+// warning text when quiet=false). We can observe the warning indirectly: the
+// function must return the flag value.
+func TestResolveGithubToken_FlagValueReturned(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "env-value")
+	origQuiet := flagQuiet
+	flagQuiet = true
+	defer func() { flagQuiet = origQuiet }()
+
+	got := resolveGithubToken("flag-overrides", false)
+	assert.Equal(t, "flag-overrides", got,
+		"flag value must take precedence over GITHUB_TOKEN env var")
+}
+
+// ---------------------------------------------------------------------------
+// outputGithubEnumJSONL
+// ---------------------------------------------------------------------------
+
+// TestOutputGithubEnumJSONL verifies the JSON structure of each output line:
+// type, email, exists, optional username and error fields.
+func TestOutputGithubEnumJSONL(t *testing.T) {
+	tests := []struct {
+		name         string
+		result       githubenum.Result
+		wantType     string
+		wantExists   bool
+		wantUsername string // empty → key must be absent (omitempty)
+		wantError    string // empty → key must be absent (omitempty)
+	}{
+		{
+			name: "account exists with username revealed",
+			result: githubenum.Result{
+				Email:    "alice@example.com",
+				Exists:   true,
+				Username: "alice-gh",
+			},
+			wantType:     "github_account",
+			wantExists:   true,
+			wantUsername: "alice-gh",
+		},
+		{
+			name: "account exists without username",
+			result: githubenum.Result{
+				Email:  "bob@example.com",
+				Exists: true,
+			},
+			wantType:   "github_account",
+			wantExists: true,
+			// username omitted (omitempty)
+		},
+		{
+			name: "account does not exist",
+			result: githubenum.Result{
+				Email:  "nobody@example.com",
+				Exists: false,
+			},
+			wantType:   "github_account",
+			wantExists: false,
+		},
+		{
+			name: "result with error",
+			result: githubenum.Result{
+				Email: "err@example.com",
+				Error: assert.AnError,
+			},
+			wantType:  "github_account",
+			wantError: assert.AnError.Error(),
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			outputGithubEnumJSONL(&buf, []githubenum.Result{tc.result})
+
+			line := strings.TrimSpace(buf.String())
+			require.NotEmpty(t, line, "outputGithubEnumJSONL must produce a JSONL line")
+
+			var obj map[string]interface{}
+			require.NoError(t, json.Unmarshal([]byte(line), &obj),
+				"JSONL output must be valid JSON: %q", line)
+
+			assert.Equal(t, tc.wantType, obj["type"], "type field must be %q", tc.wantType)
+			assert.Equal(t, tc.result.Email, obj["email"], "email field must match")
+
+			gotExists, _ := obj["exists"].(bool)
+			assert.Equal(t, tc.wantExists, gotExists, "exists field must match")
+
+			// username is omitempty — present only when non-empty.
+			if tc.wantUsername != "" {
+				assert.Equal(t, tc.wantUsername, obj["username"],
+					"username must be %q", tc.wantUsername)
+			} else {
+				assert.NotContains(t, obj, "username",
+					"username key must be absent when empty (omitempty)")
+			}
+
+			// error is omitempty — present only when non-nil.
+			if tc.wantError != "" {
+				assert.Equal(t, tc.wantError, obj["error"],
+					"error field must contain the error text")
+			} else {
+				assert.NotContains(t, obj, "error",
+					"error key must be absent when result.Error is nil")
+			}
+		})
+	}
+}

--- a/cmd/brutus/cmd_enum_google.go
+++ b/cmd/brutus/cmd_enum_google.go
@@ -59,16 +59,16 @@ may be combined with -e/-E.
 This enumeration is unauthenticated: no token, credential store, or sign-in is
 required.`,
 	Example: `  # Enumerate a couple of emails
-  brutus enum google -e alice@example.com,bob@example.com
+  brutus enum active google -e alice@example.com,bob@example.com
 
   # Generate candidate emails for a domain and enumerate the 5000 most likely
-  brutus enum google --domain target.com --format first.last --limit 5000
+  brutus enum active google --domain target.com --format first.last --limit 5000
 
   # Enumerate emails from a file
-  brutus enum google -E emails.txt
+  brutus enum active google -E emails.txt
 
   # Route through a SOCKS5 proxy and raise concurrency
-  brutus enum google -E emails.txt --proxy socks5://127.0.0.1:1080 --threads 20`,
+  brutus enum active google -E emails.txt --proxy socks5://127.0.0.1:1080 --threads 20`,
 	RunE: runEnumGoogle,
 }
 
@@ -81,7 +81,11 @@ func init() {
 	f.IntVar(&flagGoogleEnumLimit, "limit", 0, "When generating with --domain, cap to the first N (most-likely) candidates (0 = all)")
 	// NOTE: no -t shorthand: it collides with the global persistent --threads/-t
 	// flag, which cobra merges into this subcommand at execute time.
-	enumCmd.AddCommand(enumGoogleCmd)
+	//
+	// google lives under "active". init() runs after all package-level command
+	// vars are initialized and AddCommand only needs the vars to exist, so it is
+	// safe to reference enumActiveCmd (defined in cmd_enum_active.go) here.
+	enumActiveCmd.AddCommand(enumGoogleCmd)
 }
 
 // runEnumGoogle implements the "enum google" subcommand.

--- a/cmd/brutus/cmd_enum_google_test.go
+++ b/cmd/brutus/cmd_enum_google_test.go
@@ -75,20 +75,21 @@ func TestEnumGoogleCmd_Flags(t *testing.T) {
 		"enumGoogleCmd must not define a local -s shorthand (reserved)")
 }
 
-// TestEnumGoogleCmd_RegisteredUnderEnumCmd verifies that enumGoogleCmd has
-// Use=="google" and is a child of enumCmd.
-func TestEnumGoogleCmd_RegisteredUnderEnumCmd(t *testing.T) {
+// TestEnumGoogleCmd_RegisteredUnderActiveCmd verifies that enumGoogleCmd has
+// Use=="google" and is a child of enumActiveCmd (hard move — it is no longer
+// a direct child of enumCmd).
+func TestEnumGoogleCmd_RegisteredUnderActiveCmd(t *testing.T) {
 	assert.Equal(t, "google", enumGoogleCmd.Use,
 		"enumGoogleCmd.Use must be \"google\"")
 
 	var found bool
-	for _, cmd := range enumCmd.Commands() {
+	for _, cmd := range enumActiveCmd.Commands() {
 		if cmd.Use == "google" {
 			found = true
 			break
 		}
 	}
-	assert.True(t, found, "enumGoogleCmd must be registered as a subcommand of enumCmd")
+	assert.True(t, found, "enumGoogleCmd must be registered as a subcommand of enumActiveCmd (hard move)")
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/brutus/cmd_enum_kerberos.go
+++ b/cmd/brutus/cmd_enum_kerberos.go
@@ -53,16 +53,16 @@ Detection is based on KDC error codes:
   AS-REP success    → user exists, no preauth required (AS-REP roastable)
   PRINCIPAL_UNKNOWN → user does not exist`,
 	Example: `  # Enumerate specific users
-  brutus enum kerberos --dc 10.0.0.1 --domain CORP.LOCAL -u administrator,guest,krbtgt
+  brutus enum active kerberos --dc 10.0.0.1 --domain CORP.LOCAL -u administrator,guest,krbtgt
 
   # Enumerate from file
-  brutus enum kerberos --dc dc01.corp.local --domain CORP.LOCAL -U users.txt
+  brutus enum active kerberos --dc dc01.corp.local --domain CORP.LOCAL -U users.txt
 
   # Generate usernames and enumerate
-  brutus enum generate --format flast | brutus enum kerberos --dc 10.0.0.1 --domain CORP.LOCAL -U -
+  brutus enum generate --format flast | brutus enum active kerberos --dc 10.0.0.1 --domain CORP.LOCAL -U -
 
   # JSON output
-  brutus enum kerberos --dc 10.0.0.1 --domain CORP.LOCAL -u administrator --json`,
+  brutus enum active kerberos --dc 10.0.0.1 --domain CORP.LOCAL -u administrator --json`,
 	RunE: runEnumKerberos,
 }
 

--- a/cmd/brutus/cmd_enum_oracles.go
+++ b/cmd/brutus/cmd_enum_oracles.go
@@ -54,26 +54,26 @@ against the oracles that confirm it (including the Microsoft Teams oracle when
 applicable).
 
 Modes:
-  Oracle check only:  brutus enum oracles --domain example.com --known-valid admin@example.com
-  Enumerate emails:   brutus enum oracles --domain example.com -e user@example.com --known-valid admin@example.com
-  Generate + enum:    brutus enum oracles --domain example.com --generate --format flast --known-valid admin@example.com`,
+  Oracle check only:  brutus enum active oracles --domain example.com --known-valid admin@example.com
+  Enumerate emails:   brutus enum active oracles --domain example.com -e user@example.com --known-valid admin@example.com
+  Generate + enum:    brutus enum active oracles --domain example.com --generate --format flast --known-valid admin@example.com`,
 	Example: `  # Discover candidate oracles via DNS and report which ones work (validated against --known-valid)
-  brutus enum oracles --domain praetorian.com --known-valid admin@praetorian.com
+  brutus enum active oracles --domain praetorian.com --known-valid admin@praetorian.com
 
   # Enumerate specific emails against the working oracles
-  brutus enum oracles --domain praetorian.com -e test@praetorian.com,admin@praetorian.com --known-valid admin@praetorian.com
+  brutus enum active oracles --domain praetorian.com -e test@praetorian.com,admin@praetorian.com --known-valid admin@praetorian.com
 
   # Enumerate emails from file
-  brutus enum oracles --domain praetorian.com -E emails.txt --known-valid admin@praetorian.com
+  brutus enum active oracles --domain praetorian.com -E emails.txt --known-valid admin@praetorian.com
 
   # Generate emails and enumerate against working oracles
-  brutus enum oracles --domain target.com --generate --format first.last --known-valid admin@target.com
+  brutus enum active oracles --domain target.com --generate --format first.last --known-valid admin@target.com
 
   # Check / enumerate against specific oracles only
-  brutus enum oracles -e user@example.com -s microsoft365,google --known-valid admin@example.com
+  brutus enum active oracles -e user@example.com -s microsoft365,google --known-valid admin@example.com
 
   # JSON output
-  brutus enum oracles --domain praetorian.com -e test@praetorian.com --known-valid admin@praetorian.com --json`,
+  brutus enum active oracles --domain praetorian.com -e test@praetorian.com --known-valid admin@praetorian.com --json`,
 	RunE: runEnumOracles,
 }
 
@@ -86,10 +86,10 @@ to avoid wasting time on broken or rate-limited oracles.
 
 Optionally combine with --domain to auto-discover candidate oracles from DNS TXT records.`,
 	Example: `  # Test oracles for a domain (auto-discovers candidate oracles from DNS)
-  brutus enum oracles discover --domain praetorian.com --known-valid admin@praetorian.com
+  brutus enum active oracles discover --domain praetorian.com --known-valid admin@praetorian.com
 
   # Test specific oracles only
-  brutus enum oracles discover --known-valid admin@example.com -s microsoft365,google`,
+  brutus enum active oracles discover --known-valid admin@example.com -s microsoft365,google`,
 	RunE: runEnumDiscover,
 }
 
@@ -526,7 +526,7 @@ func maybeConfirmTeamsOracle(ctx context.Context, dnsResult *enum.DNSReconResult
 func confirmTeamsOracle(ctx context.Context, knownValid string, useColor bool) string {
 	accessToken, refreshToken, ok := resolveTeamsConfirmToken(useColor)
 	if !ok {
-		return "teams: available (unconfirmed) — run `brutus enum teams auth` then re-run to confirm"
+		return "teams: available (unconfirmed) — run `brutus enum active teams auth` then re-run to confirm"
 	}
 
 	enumerator, err := teams.NewEnumerator(accessToken, refreshToken, flagProxy, flagTimeout, false)

--- a/cmd/brutus/cmd_enum_oracles_teams_test.go
+++ b/cmd/brutus/cmd_enum_oracles_teams_test.go
@@ -405,7 +405,7 @@ func TestConfirmTeamsOracle_NoToken(t *testing.T) {
 	}
 
 	// The returned line must reference how to authenticate (the auth hint).
-	assert.Contains(t, line, "brutus enum teams auth",
+	assert.Contains(t, line, "brutus enum active teams auth",
 		"no-token line must include the auth hint for the user")
 }
 

--- a/cmd/brutus/cmd_enum_oracles_test.go
+++ b/cmd/brutus/cmd_enum_oracles_test.go
@@ -40,7 +40,7 @@ func TestEnumOracles_RequiresKnownValid(t *testing.T) {
 	rootCmd.SetOut(io.Discard)
 	rootCmd.SetErr(io.Discard)
 	// Provide --domain so the only missing required flag is --known-valid.
-	rootCmd.SetArgs([]string{"enum", "oracles", "--domain", "example.com"})
+	rootCmd.SetArgs([]string{"enum", "active", "oracles", "--domain", "example.com"})
 
 	// Restore global rootCmd state after the test.
 	t.Cleanup(func() {

--- a/cmd/brutus/cmd_enum_output.go
+++ b/cmd/brutus/cmd_enum_output.go
@@ -51,7 +51,7 @@ func outputDNSReconHuman(result *enum.DNSReconResult, teamsAvailable, useColor b
 	if teamsAvailable {
 		fmt.Printf("    %s%-16s%s %s\n",
 			colorIf(useColor, ColorGreen), "teams", colorIf(useColor, ColorReset),
-			dim(useColor, "(available: Microsoft 365 tenant — run `brutus enum teams users` / `audit`)"))
+			dim(useColor, "(available: Microsoft 365 tenant — run `brutus enum active teams users` / `audit`)"))
 	}
 	fmt.Println()
 }

--- a/cmd/brutus/cmd_enum_teams.go
+++ b/cmd/brutus/cmd_enum_teams.go
@@ -86,7 +86,7 @@ in. On success it returns an access token (and, when offline_access is in the
 requested scope, a refresh token).
 
 See the auth subcommand for details:
-  brutus enum teams auth --help`,
+  brutus enum active teams auth --help`,
 }
 
 var enumTeamsAuthCmd = &cobra.Command{
@@ -101,20 +101,20 @@ command is interrupted.
 Token values are never written to logs. In human output only a short prefix of
 each token is shown; use --json (or -o) to capture the full token set.`,
 	Example: `  # Authenticate against the default (organizations / work-school) tenant (interactive)
-  brutus enum teams auth
+  brutus enum active teams auth
 
   # Headless / SSH: print the URL and code, don't open a browser
-  brutus enum teams auth --no-browser
+  brutus enum active teams auth --no-browser
 
   # Authenticate against a specific tenant by domain
-  brutus enum teams auth --tenant contoso.com
+  brutus enum active teams auth --tenant contoso.com
 
   # Use a custom app registration and scopes
-  brutus enum teams auth --client-id 00000000-0000-0000-0000-000000000000 \
+  brutus enum active teams auth --client-id 00000000-0000-0000-0000-000000000000 \
     --scope "offline_access https://api.spaces.skype.com/.default"
 
   # Capture the full token set as JSON
-  brutus enum teams auth -o token.jsonl`,
+  brutus enum active teams auth -o token.jsonl`,
 	RunE: runEnumTeamsAuth,
 }
 
@@ -134,7 +134,7 @@ and --limit caps generation to the first N (most-likely) candidates. --domain
 may be combined with -e/-E.
 
 A valid access token is required. Provide it directly with --access-token,
-reuse a token captured by "enum teams auth -o" with --token-file, or omit both
+reuse a token captured by "enum active teams auth -o" with --token-file, or omit both
 to run the interactive device-code flow inline. When a refresh token is
 available, an expired access token is refreshed once automatically; otherwise a
 401 degrades gracefully to an "unknown" result.
@@ -145,26 +145,26 @@ Teams presence (availability and device type) is fetched by default for users
 that exist; presence failures are non-fatal. Pass --no-presence to skip the
 presence lookups (fewer requests).`,
 	Example: `  # Device-code auth inline, then enumerate a few emails
-  brutus enum teams users -e alice@contoso.com,bob@contoso.com
+  brutus enum active teams users -e alice@contoso.com,bob@contoso.com
 
   # Generate candidate emails for a domain and enumerate the 5000 most likely
-  brutus enum teams users --domain target.com --format first.last --limit 5000
+  brutus enum active teams users --domain target.com --format first.last --limit 5000
 
   # Generate first_last candidates (presence is fetched by default for hits)
-  brutus enum teams users --domain target.com --format first_last
+  brutus enum active teams users --domain target.com --format first_last
 
   # Enumerate emails from a file, skipping presence lookups
-  brutus enum teams users -E emails.txt --no-presence
+  brutus enum active teams users -E emails.txt --no-presence
 
-  # Reuse a token captured earlier with "enum teams auth -o"
-  brutus enum teams auth -o token.jsonl
-  brutus enum teams users -E emails.txt --token-file token.jsonl
+  # Reuse a token captured earlier with "enum active teams auth -o"
+  brutus enum active teams auth -o token.jsonl
+  brutus enum active teams users -E emails.txt --token-file token.jsonl
 
   # Provide an access token directly
-  brutus enum teams users -e alice@contoso.com --access-token "$TOKEN"
+  brutus enum active teams users -e alice@contoso.com --access-token "$TOKEN"
 
   # Route through a SOCKS5 proxy and raise concurrency
-  brutus enum teams users -E emails.txt --proxy socks5://127.0.0.1:1080 --threads 20`,
+  brutus enum active teams users -E emails.txt --proxy socks5://127.0.0.1:1080 --threads 20`,
 	RunE: runEnumTeamsUsers,
 }
 
@@ -173,13 +173,13 @@ var enumTeamsAuditCmd = &cobra.Command{
 	Short: "Audit a Microsoft Teams tenant's external posture into graded findings",
 	Long: `Turn a single seed user's Teams enumeration result into graded security
 findings about the tenant's external-exposure posture. The audit reuses the
-"enum teams users" machinery for one known-valid seed address, derives the
+"enum active teams users" machinery for one known-valid seed address, derives the
 tenant posture, and grades it into findings (external/cross-tenant chat,
 user-enumeration oracle, presence and out-of-office disclosure, and account
 metadata disclosure).
 
 A valid access token is required. Provide it directly with --access-token,
-reuse a token captured by "enum teams auth -o" with --token-file, or omit both
+reuse a token captured by "enum active teams auth -o" with --token-file, or omit both
 to run the interactive device-code flow inline. When a refresh token is
 available, an expired access token is refreshed once automatically.
 
@@ -189,17 +189,17 @@ Teams presence (availability and device type) and any out-of-office note are
 fetched by default, enabling the presence/out-of-office findings. Pass
 --no-presence to skip the presence lookups (those findings are not evaluated).`,
 	Example: `  # Audit a tenant via a single known-valid seed address (device-code auth inline)
-  brutus enum teams audit --email alice@contoso.com
+  brutus enum active teams audit --email alice@contoso.com
 
   # Skip presence/out-of-office lookups (presence/OOO findings not evaluated)
-  brutus enum teams audit --email alice@contoso.com --no-presence
+  brutus enum active teams audit --email alice@contoso.com --no-presence
 
-  # Reuse a token captured earlier with "enum teams auth -o"
-  brutus enum teams auth -o token.jsonl
-  brutus enum teams audit --email alice@contoso.com --token-file token.jsonl
+  # Reuse a token captured earlier with "enum active teams auth -o"
+  brutus enum active teams auth -o token.jsonl
+  brutus enum active teams audit --email alice@contoso.com --token-file token.jsonl
 
   # Emit findings as JSONL
-  brutus enum teams audit --email alice@contoso.com --json`,
+  brutus enum active teams audit --email alice@contoso.com --json`,
 	RunE: runEnumTeamsAudit,
 }
 
@@ -221,7 +221,7 @@ func init() {
 	uf.IntVar(&flagTeamsEnumLimit, "limit", 0, "When generating with --domain, cap to the first N (most-likely) candidates (0 = all)")
 	uf.StringVar(&flagTeamsEnumAccessToken, "access-token", "", "Access token to use (instead of device-code or --token-file)")
 	uf.StringVar(&flagTeamsEnumRefreshToken, "refresh-token", "", "Refresh token used to renew an expired access token")
-	uf.StringVar(&flagTeamsEnumTokenFile, "token-file", "", "JSONL token file from \"enum teams auth -o\" to reuse")
+	uf.StringVar(&flagTeamsEnumTokenFile, "token-file", "", "JSONL token file from \"enum active teams auth -o\" to reuse")
 	uf.BoolVar(&flagTeamsEnumNoPresence, "no-presence", false, "Skip Teams presence / out-of-office lookups (fewer requests; presence is gathered by default)")
 	// NOTE: no -t/-s shorthands here: -t collides with the global --threads/-t
 	// persistent flag, and -s is reserved for consistency with the auth path.
@@ -236,7 +236,7 @@ func init() {
 	af.StringVar(&flagTeamsAuditEmail, "email", "", "Single known-valid seed email address to audit (required)")
 	af.StringVar(&flagTeamsAuditAccessToken, "access-token", "", "Access token to use (instead of device-code or --token-file)")
 	af.StringVar(&flagTeamsAuditRefreshToken, "refresh-token", "", "Refresh token used to renew an expired access token")
-	af.StringVar(&flagTeamsAuditTokenFile, "token-file", "", "JSONL token file from \"enum teams auth -o\" to reuse")
+	af.StringVar(&flagTeamsAuditTokenFile, "token-file", "", "JSONL token file from \"enum active teams auth -o\" to reuse")
 	af.BoolVar(&flagTeamsAuditNoPresence, "no-presence", false, "Skip Teams presence / out-of-office lookups (fewer requests; presence is gathered by default)")
 	// NOTE: no -t/-s shorthands here: -t collides with the global --threads/-t
 	// persistent flag, and -s is reserved for consistency with the auth path.
@@ -248,7 +248,7 @@ func init() {
 	enumTeamsCmd.AddCommand(enumTeamsAuditCmd)
 }
 
-// runEnumTeamsAuth implements the "enum teams auth" subcommand.
+// runEnumTeamsAuth implements the "enum active teams auth" subcommand.
 func runEnumTeamsAuth(cmd *cobra.Command, args []string) error {
 	useColor := isColorEnabled(flagNoColor)
 
@@ -334,7 +334,7 @@ func autoSaveTeamsToken(tok *teams.TokenSet, useColor bool) {
 
 	fmt.Fprintf(os.Stderr, "%s%s Full tokens saved to %s (mode 0600)%s\n",
 		colorIf(useColor, ColorGreen), SymbolSuccess, path, colorIf(useColor, ColorReset))
-	fmt.Fprintf(os.Stderr, "%s Reuse: brutus enum teams users -E emails.txt   (auto-loads %s)\n",
+	fmt.Fprintf(os.Stderr, "%s Reuse: brutus enum active teams users -E emails.txt   (auto-loads %s)\n",
 		dim(useColor, SymbolInfo), path)
 	if !flagJSON && flagOutputFile == "" {
 		fmt.Fprintf(os.Stderr, "%s Terminal output is truncated; full token values are in %s (or use --json / -o FILE).\n",
@@ -342,7 +342,7 @@ func autoSaveTeamsToken(tok *teams.TokenSet, useColor bool) {
 	}
 }
 
-// runEnumTeamsUsers implements the "enum teams users" subcommand.
+// runEnumTeamsUsers implements the "enum active teams users" subcommand.
 func runEnumTeamsUsers(cmd *cobra.Command, args []string) error {
 	useColor := isColorEnabled(flagNoColor)
 
@@ -453,7 +453,7 @@ func runEnumTeamsUsers(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// runEnumTeamsAudit implements the "enum teams audit" subcommand.
+// runEnumTeamsAudit implements the "enum active teams audit" subcommand.
 func runEnumTeamsAudit(cmd *cobra.Command, args []string) error {
 	if strings.TrimSpace(flagTeamsAuditEmail) == "" {
 		return fmt.Errorf("--email <known-valid address> is required")
@@ -669,7 +669,7 @@ func teamsEnumResolveTokens(ctx context.Context, src teamsTokenSource, useColor 
 	}
 
 	// No explicit source given: try the default credential store written by
-	// "enum teams auth" so users authenticate once, then enumerate seamlessly.
+	// "enum active teams auth" so users authenticate once, then enumerate seamlessly.
 	// A missing or unparseable file falls through to the device-code flow.
 	if at, rt, ok := teamsEnumLoadDefaultTokens(useColor); ok {
 		return at, rt, nil
@@ -704,7 +704,7 @@ func teamsEnumLoadDefaultTokens(useColor bool) (accessToken, refreshToken string
 }
 
 // teamsEnumReadTokenFile reads the first JSONL line of a token file written by
-// "enum teams auth -o" and returns its access and refresh tokens.
+// "enum active teams auth -o" and returns its access and refresh tokens.
 func teamsEnumReadTokenFile(path string) (accessToken, refreshToken string, err error) {
 	lines, err := loadLinesFromFile(path)
 	if err != nil {

--- a/cmd/brutus/cmd_enum_teams_test.go
+++ b/cmd/brutus/cmd_enum_teams_test.go
@@ -34,15 +34,25 @@ import (
 // ---------------------------------------------------------------------------
 
 func TestTeamsCommandRegistered(t *testing.T) {
-	// Verify enumTeamsCmd is registered with enumCmd.
-	var teamsFound bool
+	// Verify enumActiveCmd is a direct child of enumCmd (hard move).
+	var activeFound bool
 	for _, cmd := range enumCmd.Commands() {
+		if cmd.Use == "active" {
+			activeFound = true
+			break
+		}
+	}
+	require.True(t, activeFound, "active subcommand must be registered with enumCmd")
+
+	// Verify enumTeamsCmd is registered with enumActiveCmd (not enumCmd directly).
+	var teamsFound bool
+	for _, cmd := range enumActiveCmd.Commands() {
 		if cmd.Use == "teams" {
 			teamsFound = true
 			break
 		}
 	}
-	require.True(t, teamsFound, "teams subcommand must be registered with enumCmd")
+	require.True(t, teamsFound, "teams subcommand must be registered with enumActiveCmd (hard move)")
 
 	// Verify enumTeamsAuthCmd is registered with enumTeamsCmd.
 	var authFound bool
@@ -134,7 +144,7 @@ func TestEnumTeamsAuth_NoFlagCollisionPanic(t *testing.T) {
 	// Redirect cobra output so --help text doesn't pollute test output.
 	rootCmd.SetOut(io.Discard)
 	rootCmd.SetErr(io.Discard)
-	rootCmd.SetArgs([]string{"enum", "teams", "auth", "--help"})
+	rootCmd.SetArgs([]string{"enum", "active", "teams", "auth", "--help"})
 
 	// Restore global rootCmd state after the test so subsequent tests in the
 	// package are not affected by the mutated args/output writers.

--- a/pkg/enum/github/existence.go
+++ b/pkg/enum/github/existence.go
@@ -1,0 +1,247 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package github
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"os"
+	"runtime/debug"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/time/rate"
+
+	"github.com/praetorian-inc/brutus/pkg/enum"
+)
+
+// ---------------------------------------------------------------------------
+// Existence enumeration (unauthenticated)
+// ---------------------------------------------------------------------------
+
+// Enumerate checks each email's existence using a bounded worker pool, applying
+// rate limiting and jitter when rateLimit > 0. Results preserve input order. It
+// is a thin wrapper around EnumerateWith with no per-result callback.
+func (e *Enumerator) Enumerate(ctx context.Context, emails []string, threads int, rateLimit float64, jitter time.Duration) []Result {
+	return e.EnumerateWith(ctx, emails, threads, rateLimit, jitter, nil)
+}
+
+// EnumerateWith runs existence enumeration with bounded concurrency and invokes
+// onResult (if non-nil) for each completed result, serialized so callers can
+// print/stream safely. It still returns all results in input order.
+//
+// The session (CSRF token + cookies) is established ONCE before the worker pool
+// and shared read-only across workers. If session establishment fails, every
+// Result is returned carrying that error.
+//
+// onResult is called under the same mutex that guards the results slice, so
+// callback invocations never interleave and never race the slice. The callback
+// must be cheap and self-contained and must NOT call back into the Enumerator.
+func (e *Enumerator) EnumerateWith(ctx context.Context, emails []string, threads int, rateLimit float64, jitter time.Duration, onResult func(Result)) []Result {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	results := make([]Result, len(emails))
+	var mu sync.Mutex
+	record := func(i int, res Result) {
+		mu.Lock()
+		defer mu.Unlock()
+		results[i] = res
+		if onResult != nil {
+			onResult(res)
+		}
+	}
+
+	sess, err := e.establishSession(ctx)
+	if err != nil {
+		// Without a session no checks are possible; surface the error on every
+		// result so the caller (and JSONL output) reflects the failure per email.
+		for i, email := range emails {
+			record(i, Result{Email: email, Error: err})
+		}
+		return results
+	}
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(threads)
+
+	var limiter *rate.Limiter
+	if rateLimit > 0 {
+		limiter = rate.NewLimiter(rate.Limit(rateLimit), 1)
+	}
+
+	for i, email := range emails {
+		i, email := i, email
+		g.Go(func() error {
+			defer func() {
+				if r := recover(); r != nil {
+					fmt.Fprintf(os.Stderr, "github enum: panic checking %s: %v\n%s\n", email, r, debug.Stack())
+					record(i, Result{
+						Email: email,
+						Error: fmt.Errorf("github enum: panicked: %v", r),
+					})
+				}
+			}()
+
+			select {
+			case <-ctx.Done():
+				return nil
+			default:
+			}
+
+			if limiter != nil {
+				if err := limiter.Wait(ctx); err != nil {
+					return nil
+				}
+				if jitter > 0 {
+					delay := time.Duration(rand.Int63n(int64(jitter)))
+					select {
+					case <-time.After(delay):
+					case <-ctx.Done():
+						return nil
+					}
+				}
+			}
+
+			record(i, e.checkEmail(ctx, sess, email))
+			return nil
+		})
+	}
+
+	// Worker goroutines never return a non-nil error (per-email failures are
+	// encoded in each Result), so the returned error is always nil.
+	_ = g.Wait()
+	return results
+}
+
+// ---------------------------------------------------------------------------
+// Existence helpers
+// ---------------------------------------------------------------------------
+
+// establishSession GETs the join page, parses the CSRF authenticity token from
+// the auto-check[src="/email_validity_checks"] element's hidden input, and
+// captures the response cookies. The parsed token + cookies are reused across
+// all existence checks. As a sanity check it verifies that a random,
+// almost-certainly-nonexistent address returns 200 (available); if it does not,
+// the endpoint likely changed and a warning is emitted to stderr.
+func (e *Enumerator) establishSession(ctx context.Context) (*session, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, e.webBaseURL+joinPath, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("github enum: creating join request: %w", err)
+	}
+
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("github enum: join request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Bounded read — reuses enum.ReadResponseBody (1 MB default) so a hostile or
+	// misbehaving join endpoint cannot exhaust memory via an unbounded HTML body.
+	body, err := enum.ReadResponseBody(resp, 0)
+	if err != nil {
+		return nil, fmt.Errorf("github enum: reading join page: %w", err)
+	}
+
+	csrf, err := parseCSRFToken(bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("github enum: parsing join page: %w", err)
+	}
+
+	sess := &session{
+		csrfToken:    csrf,
+		cookieHeader: cookieHeader(resp.Cookies()),
+	}
+
+	// Sanity check: a random address should be available (200). If not, warn —
+	// the endpoint contract may have changed.
+	sanityEmail := e.newName() + "@foobar.com"
+	exists, err := e.postValidity(ctx, sess, sanityEmail)
+	if err != nil {
+		return nil, fmt.Errorf("github enum: sanity check failed: %w", err)
+	}
+	if exists {
+		fmt.Fprintf(os.Stderr,
+			"github enum: WARNING sanity-check address %q returned in-use; the email_validity_checks endpoint may have changed (results may be unreliable)\n",
+			sanityEmail)
+	}
+
+	return sess, nil
+}
+
+// checkEmail POSTs a single email to the validity endpoint and maps the result.
+// HTTP 429 is retried (bounded, ctx-aware) after sleeping. Transport failures
+// and exhausted retries are encoded in the Result's Error field.
+func (e *Enumerator) checkEmail(ctx context.Context, sess *session, email string) Result {
+	res := Result{Email: email}
+	exists, err := e.postValidity(ctx, sess, email)
+	if err != nil {
+		res.Error = err
+		return res
+	}
+	res.Exists = exists
+	return res
+}
+
+// postValidity POSTs email to {web}/email_validity_checks with the session's
+// CSRF token and cookies. It returns true when the address is in use (HTTP 422),
+// false when available (HTTP 200), retrying on HTTP 429 up to maxRateLimitRetries.
+func (e *Enumerator) postValidity(ctx context.Context, sess *session, email string) (bool, error) {
+	form := url.Values{}
+	form.Set("authenticity_token", sess.csrfToken)
+	form.Set("value", email)
+	body := form.Encode()
+
+	for attempt := 0; ; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.webBaseURL+validityCheckPath, strings.NewReader(body))
+		if err != nil {
+			return false, fmt.Errorf("creating validity request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		if sess.cookieHeader != "" {
+			req.Header.Set("Cookie", sess.cookieHeader)
+		}
+
+		resp, err := e.httpClient.Do(req)
+		if err != nil {
+			return false, fmt.Errorf("validity request failed: %w", err)
+		}
+		status := resp.StatusCode
+		_ = resp.Body.Close()
+
+		switch status {
+		case http.StatusUnprocessableEntity: // 422 — in use (account exists)
+			return true, nil
+		case http.StatusOK: // 200 — available (no account)
+			return false, nil
+		case http.StatusTooManyRequests: // 429 — rate limited
+			if attempt >= maxRateLimitRetries {
+				return false, fmt.Errorf("rate limited (HTTP 429) after %d retries", attempt)
+			}
+			if err := e.sleep(ctx, rateLimitBackoff); err != nil {
+				return false, err
+			}
+			continue
+		default:
+			return false, fmt.Errorf("unexpected status %d from validity endpoint", status)
+		}
+	}
+}

--- a/pkg/enum/github/github.go
+++ b/pkg/enum/github/github.go
@@ -1,0 +1,276 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package github provides GitHub account enumeration by email address. It is a
+// Go port of GhEmailBrute with two distinct capabilities:
+//
+//   - Existence (unauthenticated): the github.com/join sign-up page exposes an
+//     email_validity_checks endpoint. POSTing an email there returns HTTP 422
+//     when the address is already in use (an account exists) and HTTP 200 when
+//     it is available (no account). No token or sign-in is required.
+//
+//   - Username reveal (authenticated): given a GitHub PAT with repo+delete_repo
+//     scope, a throwaway private repo is created and one commit per target email
+//     is pushed with that email as the commit author/committer. GitHub resolves
+//     each commit's author.login from the email even when the account has email
+//     privacy enabled, mapping email -> login. The repo is ALWAYS deleted after.
+//
+// The existence path mirrors the concurrency model of the google enumerator
+// (errgroup + rate.Limiter + jitter + serialized result callback). The reveal
+// path is sequential by design (all commits target one branch). The PAT is
+// never logged.
+//
+// Source is split across cohesive files in this package:
+//   - github.go   — package doc, Result, Enumerator, NewEnumerator, shared helpers
+//   - existence.go — Enumerate/EnumerateWith + session/CSRF/validity helpers
+//   - reveal.go    — Reveal + repo create/push/list/delete + apiRequest
+package github
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/net/html"
+
+	"github.com/praetorian-inc/brutus/pkg/brutus"
+)
+
+// Result is the outcome of checking (and optionally revealing) a single email.
+// Username is populated only by Reveal and only when GitHub linked the commit's
+// author email to an account login. Email and Username are server-/user-derived
+// and are NOT sanitized here; sanitization happens at the output layer.
+type Result struct {
+	Email    string
+	Exists   bool
+	Username string
+	Error    error
+}
+
+const (
+	webBaseURLDefault    = "https://github.com"
+	apiBaseURLDefault    = "https://api.github.com"
+	settleDelayDefault   = 10 * time.Second
+	validityCheckPath    = "/email_validity_checks"
+	joinPath             = "/join"
+	maxRateLimitRetries  = 5
+	rateLimitBackoff     = 2 * time.Second
+	defaultBranchDefault = "main"
+	// commitContent is a tiny constant base64 blob ("Haxor"), matching the
+	// reference implementation's per-commit file content.
+	commitContent = "SGF4b3I="
+)
+
+// Enumerator performs GitHub account enumeration. The existence path is safe for
+// concurrent use; Reveal is sequential.
+type Enumerator struct {
+	// httpClient is used by the unauthenticated existence flow. It intentionally
+	// FOLLOWS redirects: github.com/join 302-redirects to github.com/signup, and
+	// the CSRF authenticity_token (inside <auto-check src="/email_validity_checks">)
+	// only exists on the final /signup page. This flow carries no token, so
+	// following redirects is safe.
+	httpClient *http.Client
+	// apiClient is used by the authenticated reveal flow's API calls, which carry
+	// "Authorization: Bearer <PAT>". It is a clone of httpClient that does NOT
+	// follow redirects (PAT-leak protection): a subdomain-match redirect, notably
+	// under the untrusted --proxy/MITM path this tool supports, could otherwise
+	// forward the PAT to an attacker-controlled host. The proxy transport is
+	// shared with httpClient. Mirrors pkg/enum/google/google.go.
+	apiClient *http.Client
+	token     string
+
+	// Base URLs default to the real GitHub hosts and are overridable by tests.
+	webBaseURL string
+	apiBaseURL string
+
+	// settleDelay is how long Reveal waits after pushing commits before listing
+	// them, giving GitHub time to resolve author logins. Overridable by tests.
+	settleDelay time.Duration
+
+	// sleep waits for d or until ctx is cancelled; overridable by tests to avoid
+	// real delays. newName generates a random hex name for repos and files;
+	// overridable by tests for determinism.
+	sleep   func(ctx context.Context, d time.Duration) error
+	newName func() string
+}
+
+// session holds the read-only state established once before the worker pool:
+// the CSRF authenticity token parsed from the join page and the Cookie header
+// built from the join response's Set-Cookie values. It is shared across workers.
+type session struct {
+	csrfToken    string
+	cookieHeader string
+}
+
+// ---------------------------------------------------------------------------
+// Constructor
+// ---------------------------------------------------------------------------
+
+// NewEnumerator builds an Enumerator. The HTTP client is built via
+// brutus.NewHTTPClientWithProxy so the SOCKS5 --proxy flag works. token may be
+// empty (existence-only mode); Reveal requires a non-empty token.
+func NewEnumerator(proxyURL string, timeout time.Duration, token string) (*Enumerator, error) {
+	httpClient, err := brutus.NewHTTPClientWithProxy(timeout, nil, proxyURL)
+	if err != nil {
+		return nil, fmt.Errorf("github enum: configuring HTTP client: %w", err)
+	}
+
+	// httpClient FOLLOWS redirects (the default): the existence flow's join-page
+	// GET hits github.com/join, which 302-redirects to github.com/signup where the
+	// CSRF authenticity_token lives. That flow carries no token, so following the
+	// redirect is safe and required.
+	//
+	// apiClient is a clone of httpClient that does NOT follow redirects. The reveal
+	// flow's API calls carry "Authorization: Bearer <PAT>", and a subdomain-match
+	// redirect (notably under the untrusted --proxy/MITM path) could forward the
+	// PAT to an attacker-controlled host. Refuse redirects there (PAT-leak
+	// protection) while keeping the shared proxy transport. Mirrors
+	// pkg/enum/google/google.go.
+	apiClient := *httpClient
+	apiClient.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+
+	return &Enumerator{
+		httpClient:  httpClient,
+		apiClient:   &apiClient,
+		token:       token,
+		webBaseURL:  webBaseURLDefault,
+		apiBaseURL:  apiBaseURLDefault,
+		settleDelay: settleDelayDefault,
+		sleep:       sleepCtx,
+		newName:     randomHexName,
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Package helpers
+// ---------------------------------------------------------------------------
+
+// parseCSRFToken walks the join page HTML and returns the value of the hidden
+// input nested inside the <auto-check src="/email_validity_checks"> element.
+func parseCSRFToken(r io.Reader) (string, error) {
+	doc, err := html.Parse(r)
+	if err != nil {
+		return "", fmt.Errorf("parsing HTML: %w", err)
+	}
+
+	var token string
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if token != "" {
+			return
+		}
+		if n.Type == html.ElementNode && n.Data == "auto-check" && hasAttr(n, "src", validityCheckPath) {
+			if v, ok := findHiddenInputValue(n); ok {
+				token = v
+				return
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(doc)
+
+	if token == "" {
+		return "", fmt.Errorf("CSRF authenticity token not found on join page")
+	}
+	return token, nil
+}
+
+// findHiddenInputValue returns the value attribute of the first descendant
+// <input type="hidden"> of n.
+func findHiddenInputValue(n *html.Node) (string, bool) {
+	var value string
+	var found bool
+	var walk func(*html.Node)
+	walk = func(node *html.Node) {
+		if found {
+			return
+		}
+		if node.Type == html.ElementNode && node.Data == "input" && hasAttr(node, "type", "hidden") {
+			if v, ok := attrValue(node, "value"); ok {
+				value = v
+				found = true
+				return
+			}
+		}
+		for c := node.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(n)
+	return value, found
+}
+
+// hasAttr reports whether n has an attribute key equal to want.
+func hasAttr(n *html.Node, key, want string) bool {
+	v, ok := attrValue(n, key)
+	return ok && v == want
+}
+
+// attrValue returns the value of n's attribute key.
+func attrValue(n *html.Node, key string) (string, bool) {
+	for _, a := range n.Attr {
+		if a.Key == key {
+			return a.Val, true
+		}
+	}
+	return "", false
+}
+
+// cookieHeader builds a "name=value; ..." Cookie header string from cookies.
+func cookieHeader(cookies []*http.Cookie) string {
+	parts := make([]string, 0, len(cookies))
+	for _, c := range cookies {
+		parts = append(parts, c.Name+"="+c.Value)
+	}
+	return strings.Join(parts, "; ")
+}
+
+// randomHexName returns 30 hex chars from 15 random bytes, mirroring the Python
+// reference's binascii.b2a_hex(os.urandom(15)).
+func randomHexName() string {
+	b := make([]byte, 15)
+	// math/rand is sufficient here: these names only need to be unique within a
+	// single run, not cryptographically unpredictable.
+	_, _ = rand.Read(b)
+	var sb strings.Builder
+	for _, x := range b {
+		sb.WriteString(strconv.FormatInt(int64(x>>4), 16))
+		sb.WriteString(strconv.FormatInt(int64(x&0x0f), 16))
+	}
+	return sb.String()
+}
+
+// sleepCtx waits for d or returns ctx.Err() if ctx is cancelled first.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-t.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/pkg/enum/github/github_test.go
+++ b/pkg/enum/github/github_test.go
@@ -1,0 +1,870 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// White-box tests for pkg/enum/github. Being in the same package lets us set
+// the unexported webBaseURL, apiBaseURL, settleDelay, sleep, and newName
+// fields on the Enumerator directly — the same pattern as pkg/enum/google.
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Test infrastructure helpers
+// ---------------------------------------------------------------------------
+
+// noopSleep is a sleep function that returns immediately without sleeping.
+// It is used to replace the real sleepCtx in tests so rate-limit retries don't
+// cause real delays.
+func noopSleep(_ context.Context, _ time.Duration) error { return nil }
+
+// deterministicName returns a predictable name for use in Reveal flow tests,
+// where the same name is returned every call. Tests that need unique names per
+// call should use a counter-based newName.
+func deterministicName() string { return "test-repo-name" }
+
+// counterName returns a newName func that returns "name-N" (N=0,1,2,...),
+// which is useful when pushCommit calls newName multiple times.
+func counterName() func() string {
+	var n atomic.Int64
+	return func() string {
+		return fmt.Sprintf("name-%d", n.Add(1))
+	}
+}
+
+// webMux builds an http.ServeMux that fakes the GitHub web flow. The statusFor
+// map controls which HTTP status the /email_validity_checks POST returns per
+// email value (default 200 = available).
+//
+// It serves:
+//
+//	GET  /join                        — returns an HTML page with the CSRF token
+//	POST /email_validity_checks       — returns statusFor[email] (or 200)
+func webMux(t *testing.T, csrfToken string, statusFor map[string]int) *http.ServeMux {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	// /join returns a minimal HTML page with the auto-check block.
+	mux.HandleFunc("/join", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintf(w, `<!DOCTYPE html><html><body>
+<auto-check src="/email_validity_checks">
+  <input type="hidden" value="%s">
+</auto-check>
+</body></html>`, csrfToken)
+	})
+
+	// /email_validity_checks returns the configured status per email.
+	mux.HandleFunc("/email_validity_checks", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		email := r.FormValue("value")
+		status, ok := statusFor[email]
+		if !ok {
+			status = http.StatusOK // default: available
+		}
+		w.WriteHeader(status)
+	})
+
+	return mux
+}
+
+// newWebServer starts an httptest.Server using webMux.
+func newWebServer(t *testing.T, csrfToken string, statusFor map[string]int) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(webMux(t, csrfToken, statusFor))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// commitEntry is one entry in the fake /commits list response.
+type commitEntry struct {
+	Commit struct {
+		Author struct {
+			Email string `json:"email"`
+		} `json:"author"`
+	} `json:"commit"`
+	Author *loginEntry `json:"author"`
+}
+
+// loginEntry is the top-level author object (nullable in real GitHub API).
+type loginEntry struct {
+	Login string `json:"login"`
+}
+
+// apiMux builds an http.ServeMux that fakes the GitHub REST API. The
+// emailToLogin map drives commit-author resolution (nil means no linked
+// account).
+//
+// It serves:
+//
+//	GET    /user                            — returns {"login":"testowner"}
+//	POST   /user/repos                      — creates a repo named "test-repo-name"
+//	PUT    /repos/{owner}/{repo}/contents/* — file-create (201 Created)
+//	GET    /repos/{owner}/{repo}/commits    — returns commits from emailToLogin
+//	DELETE /repos/{owner}/{repo}            — succeeds (204 No Content)
+func apiMux(t *testing.T, token string, emailToLogin map[string]*string, deleteStatus int) *http.ServeMux {
+	t.Helper()
+
+	mux := http.NewServeMux()
+
+	// Verify the token is sent as Bearer on every request.
+	checkAuth := func(t *testing.T, r *http.Request) bool {
+		t.Helper()
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer "+token {
+			return false
+		}
+		return true
+	}
+
+	mux.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
+		if !checkAuth(t, r) {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"login":"testowner"}`)
+	})
+
+	mux.HandleFunc("/user/repos", func(w http.ResponseWriter, r *http.Request) {
+		if !checkAuth(t, r) {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprintf(w, `{"name":"test-repo-name","default_branch":"main"}`)
+	})
+
+	// /repos/{owner}/{repo}/contents/{file} — accepts PUT, returns 201
+	mux.HandleFunc("/repos/", func(w http.ResponseWriter, r *http.Request) {
+		if !checkAuth(t, r) {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		// Distinguish commits (GET) from delete (DELETE) from contents (PUT).
+		path := r.URL.Path
+		switch {
+		case r.Method == http.MethodDelete:
+			if deleteStatus == 0 {
+				w.WriteHeader(http.StatusNoContent)
+			} else {
+				w.WriteHeader(deleteStatus)
+			}
+		case r.Method == http.MethodGet && strings.Contains(path, "/commits"):
+			w.Header().Set("Content-Type", "application/json")
+			commits := make([]commitEntry, 0, len(emailToLogin))
+			for email, login := range emailToLogin {
+				ce := commitEntry{}
+				ce.Commit.Author.Email = email
+				if login != nil {
+					ce.Author = &loginEntry{Login: *login}
+				}
+				commits = append(commits, ce)
+			}
+			_ = json.NewEncoder(w).Encode(commits)
+		case r.Method == http.MethodPut && strings.Contains(path, "/contents/"):
+			w.WriteHeader(http.StatusCreated)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	return mux
+}
+
+// newAPIServer starts an httptest.Server using apiMux.
+func newAPIServer(t *testing.T, token string, emailToLogin map[string]*string, deleteStatus int) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(apiMux(t, token, emailToLogin, deleteStatus))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// newTestEnumerator builds an Enumerator wired to the provided web+api test
+// servers with noop sleep and deterministic naming to keep tests fast and
+// repeatable.
+func newTestEnumerator(t *testing.T, webSrv, apiSrv *httptest.Server, token string) *Enumerator {
+	t.Helper()
+	e, err := NewEnumerator("", 5*time.Second, token)
+	require.NoError(t, err, "NewEnumerator must succeed")
+	if webSrv != nil {
+		e.webBaseURL = webSrv.URL
+	}
+	if apiSrv != nil {
+		e.apiBaseURL = apiSrv.URL
+	}
+	e.settleDelay = 0
+	e.sleep = noopSleep
+	e.newName = deterministicName
+	return e
+}
+
+// strPtr returns a pointer to s, used to build emailToLogin maps.
+func strPtr(s string) *string { return &s }
+
+// ---------------------------------------------------------------------------
+// Existence tests: 422 → Exists=true, 200 → Exists=false
+// ---------------------------------------------------------------------------
+
+// TestExistence_422_ExistsTrue verifies that an HTTP 422 from the validity
+// endpoint is mapped to Exists=true.
+func TestExistence_422_ExistsTrue(t *testing.T) {
+	t.Parallel()
+
+	webSrv := newWebServer(t, "csrf-token-abc", map[string]int{
+		"alice@example.com": http.StatusUnprocessableEntity, // 422
+	})
+	e := newTestEnumerator(t, webSrv, nil, "")
+
+	results := e.Enumerate(context.Background(), []string{"alice@example.com"}, 1, 0, 0)
+
+	require.Len(t, results, 1)
+	require.NoError(t, results[0].Error)
+	assert.True(t, results[0].Exists, "HTTP 422 must map to Exists=true (account already in use)")
+	assert.Equal(t, "alice@example.com", results[0].Email)
+}
+
+// TestExistence_200_ExistsFalse verifies that an HTTP 200 from the validity
+// endpoint is mapped to Exists=false.
+func TestExistence_200_ExistsFalse(t *testing.T) {
+	t.Parallel()
+
+	webSrv := newWebServer(t, "csrf-token-abc", map[string]int{
+		"nobody@example.com": http.StatusOK, // 200
+	})
+	e := newTestEnumerator(t, webSrv, nil, "")
+
+	results := e.Enumerate(context.Background(), []string{"nobody@example.com"}, 1, 0, 0)
+
+	require.Len(t, results, 1)
+	require.NoError(t, results[0].Error)
+	assert.False(t, results[0].Exists, "HTTP 200 must map to Exists=false (address available)")
+}
+
+// ---------------------------------------------------------------------------
+// 429 retry: retries then succeeds
+// ---------------------------------------------------------------------------
+
+// TestExistence_429_RetryThenSucceed verifies that a 429 response causes a
+// retry (with noopSleep so no actual delay), and that the subsequent 422
+// response is correctly returned as Exists=true.
+func TestExistence_429_RetryThenSucceed(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/join", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `<!DOCTYPE html><html><body>
+<auto-check src="/email_validity_checks">
+  <input type="hidden" value="csrf-abc">
+</auto-check>
+</body></html>`)
+	})
+	mux.HandleFunc("/email_validity_checks", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		email := r.FormValue("value")
+		// Skip sanity-check address (it ends in @foobar.com — see establishSession).
+		if strings.HasSuffix(email, "@foobar.com") {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		n := callCount.Add(1)
+		if n == 1 {
+			w.WriteHeader(http.StatusTooManyRequests) // first call: 429
+		} else {
+			w.WriteHeader(http.StatusUnprocessableEntity) // second call: 422 → exists
+		}
+	})
+	webSrv := httptest.NewServer(mux)
+	t.Cleanup(webSrv.Close)
+
+	e, err := NewEnumerator("", 5*time.Second, "")
+	require.NoError(t, err)
+	e.webBaseURL = webSrv.URL
+	e.sleep = noopSleep
+	e.newName = deterministicName
+
+	results := e.Enumerate(context.Background(), []string{"retry@example.com"}, 1, 0, 0)
+
+	require.Len(t, results, 1)
+	require.NoError(t, results[0].Error, "429 followed by 422 must not produce an error")
+	assert.True(t, results[0].Exists, "after 429 retry, 422 must yield Exists=true")
+	assert.Equal(t, int32(2), callCount.Load(), "exactly 2 calls to validity endpoint expected (1 retry)")
+}
+
+// ---------------------------------------------------------------------------
+// Session parse failure → error on all results
+// ---------------------------------------------------------------------------
+
+// TestSessionParseFail_JoinPageMissingAutoCheck verifies that when the join
+// page HTML does not contain the expected <auto-check> block, every Result
+// carries the session error.
+func TestSessionParseFail_JoinPageMissingAutoCheck(t *testing.T) {
+	t.Parallel()
+
+	// Serve a join page that has no auto-check block.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == joinPath {
+			// HTML without the auto-check element.
+			fmt.Fprint(w, `<!DOCTYPE html><html><body><p>no auto-check here</p></body></html>`)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	e, err := NewEnumerator("", 5*time.Second, "")
+	require.NoError(t, err)
+	e.webBaseURL = srv.URL
+	e.sleep = noopSleep
+	e.newName = deterministicName
+
+	emails := []string{"a@example.com", "b@example.com"}
+	results := e.Enumerate(context.Background(), emails, 1, 0, 0)
+
+	require.Len(t, results, len(emails))
+	for i, r := range results {
+		assert.Error(t, r.Error, "result[%d] must carry a session error when CSRF parsing fails", i)
+		// The error must mention the parsing failure; not a connection issue.
+		assert.Contains(t, r.Error.Error(), "CSRF",
+			"error for result[%d] must mention CSRF token not found", i)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Sanity-check: address that should not exist does not come back as 422
+// ---------------------------------------------------------------------------
+
+// TestSanityCheck_RandomAddressReturns200 is a behavioral test confirming that
+// the sanity-check path inside establishSession does NOT block session setup
+// when the random address correctly returns 200 (the expected case). The
+// existence check then works normally.
+func TestSanityCheck_RandomAddressReturns200(t *testing.T) {
+	t.Parallel()
+
+	webSrv := newWebServer(t, "csrf-token-sanity", map[string]int{
+		"alice@example.com": http.StatusUnprocessableEntity,
+		// Random @foobar.com sanity check is not in map → defaults to 200 (OK)
+	})
+	e := newTestEnumerator(t, webSrv, nil, "")
+
+	results := e.Enumerate(context.Background(), []string{"alice@example.com"}, 1, 0, 0)
+
+	require.Len(t, results, 1)
+	require.NoError(t, results[0].Error)
+	assert.True(t, results[0].Exists)
+}
+
+// ---------------------------------------------------------------------------
+// Reveal: happy path — email → username mapping
+// ---------------------------------------------------------------------------
+
+// TestReveal_HappyPath verifies that Reveal creates a repo, pushes commits,
+// lists them, and returns the correct email→username mapping. Also tests that
+// a commit entry with a null (nil) top-level author is excluded from the map
+// (no GitHub account linked to that email).
+func TestReveal_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	const token = "ghp-test-token-happy"
+	loginAlice := "alice-gh"
+	// bob has nil top-level author → should be excluded from mapping.
+	emailToLogin := map[string]*string{
+		"alice@example.com": &loginAlice,
+		"bob@example.com":   nil, // null author — no linked account
+	}
+
+	apiSrv := newAPIServer(t, token, emailToLogin, 0)
+	e := newTestEnumerator(t, nil, apiSrv, token)
+
+	mapping, err := e.Reveal(context.Background(), []string{"alice@example.com", "bob@example.com"})
+
+	require.NoError(t, err)
+	assert.Equal(t, "alice-gh", mapping["alice@example.com"],
+		"alice's email must map to her login")
+	_, bobPresent := mapping["bob@example.com"]
+	assert.False(t, bobPresent,
+		"bob's email must be excluded from mapping when top-level author is null")
+}
+
+// ---------------------------------------------------------------------------
+// Reveal: empty token returns error
+// ---------------------------------------------------------------------------
+
+// TestReveal_EmptyToken verifies that Reveal returns an error immediately
+// when called on an Enumerator with an empty token.
+func TestReveal_EmptyToken(t *testing.T) {
+	t.Parallel()
+
+	// No servers needed — the error must be returned before any HTTP call.
+	e := &Enumerator{
+		token:       "",
+		sleep:       noopSleep,
+		newName:     deterministicName,
+		settleDelay: 0,
+		httpClient:  http.DefaultClient,
+		webBaseURL:  webBaseURLDefault,
+		apiBaseURL:  apiBaseURLDefault,
+	}
+
+	_, err := e.Reveal(context.Background(), []string{"a@example.com"})
+	require.Error(t, err, "Reveal with empty token must return an error")
+	assert.Contains(t, err.Error(), "token required",
+		"error must mention that a token is required")
+}
+
+// ---------------------------------------------------------------------------
+// Reveal: repo cleanup (DELETE) is always attempted
+// ---------------------------------------------------------------------------
+
+// TestReveal_DeleteAlwaysAttempted verifies that the repo DELETE is always
+// called even when a mid-flow step (pushCommit) fails. The DELETE is the
+// deferred cleanup that Reveal guarantees to call. We confirm the DELETE was
+// attempted by having it return a status that would only be hit if called.
+func TestReveal_DeleteAlwaysAttempted(t *testing.T) {
+	t.Parallel()
+
+	const token = "ghp-test-token-delalways"
+
+	var deleteCount atomic.Int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+token {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_, _ = fmt.Fprintf(w, `{"login":"testowner"}`)
+	})
+	mux.HandleFunc("/user/repos", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+token {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprintf(w, `{"name":"test-repo-name","default_branch":"main"}`)
+	})
+	mux.HandleFunc("/repos/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+token {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		switch r.Method {
+		case http.MethodDelete:
+			deleteCount.Add(1)
+			w.WriteHeader(http.StatusNoContent) // delete succeeds
+		case http.MethodPut:
+			// pushCommit fails — forces early return from Reveal.
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	apiSrv := httptest.NewServer(mux)
+	t.Cleanup(apiSrv.Close)
+
+	e, err := NewEnumerator("", 5*time.Second, token)
+	require.NoError(t, err)
+	e.apiBaseURL = apiSrv.URL
+	e.settleDelay = 0
+	e.sleep = noopSleep
+	e.newName = deterministicName
+
+	_, revErr := e.Reveal(context.Background(), []string{"alice@example.com"})
+	require.Error(t, revErr, "Reveal must return an error when pushCommit fails")
+	// The DELETE must have been called exactly once (deferred cleanup).
+	assert.Equal(t, int32(1), deleteCount.Load(),
+		"repo DELETE must be called exactly once as deferred cleanup, even when pushCommit fails")
+}
+
+// ---------------------------------------------------------------------------
+// Auth header: PAT is sent as Bearer <token> on every API call
+// ---------------------------------------------------------------------------
+
+// TestReveal_BearerTokenSentToAPI verifies that the PAT is sent as
+// "Authorization: Bearer <token>" on every API request and is never embedded
+// in any Result.Error text.
+func TestReveal_BearerTokenSentToAPI(t *testing.T) {
+	t.Parallel()
+
+	const token = "ghp-secret-test-token-bearer-check"
+
+	var badAuthCount atomic.Int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+token {
+			badAuthCount.Add(1)
+		}
+		_, _ = fmt.Fprintf(w, `{"login":"testowner"}`)
+	})
+	mux.HandleFunc("/user/repos", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+token {
+			badAuthCount.Add(1)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprintf(w, `{"name":"test-repo-name","default_branch":"main"}`)
+	})
+	mux.HandleFunc("/repos/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+token {
+			badAuthCount.Add(1)
+		}
+		switch r.Method {
+		case http.MethodDelete:
+			w.WriteHeader(http.StatusNoContent)
+		case http.MethodGet:
+			// Return a mapping where alice has a linked account.
+			loginAlice := "alice-gh"
+			commits := []commitEntry{{}}
+			commits[0].Commit.Author.Email = "alice@example.com"
+			commits[0].Author = &loginEntry{Login: loginAlice}
+			_ = json.NewEncoder(w).Encode(commits)
+		case http.MethodPut:
+			w.WriteHeader(http.StatusCreated)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	apiSrv := httptest.NewServer(mux)
+	t.Cleanup(apiSrv.Close)
+
+	e, err := NewEnumerator("", 5*time.Second, token)
+	require.NoError(t, err)
+	e.apiBaseURL = apiSrv.URL
+	e.settleDelay = 0
+	e.sleep = noopSleep
+	e.newName = deterministicName
+
+	mapping, revErr := e.Reveal(context.Background(), []string{"alice@example.com"})
+	require.NoError(t, revErr)
+
+	// No API request must have used wrong auth.
+	assert.Zero(t, badAuthCount.Load(),
+		"every API request must send Authorization: Bearer %s", token)
+
+	// Token must not appear in any result value.
+	for email, login := range mapping {
+		assert.NotContains(t, email, token,
+			"token must not appear in result email")
+		assert.NotContains(t, login, token,
+			"token must not appear in result username")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Token never appears in Result.Error text
+// ---------------------------------------------------------------------------
+
+// TestReveal_TokenNotLeakedInError verifies that even when the API returns an
+// unexpected error, the PAT value never appears in the error string returned
+// by Reveal.
+func TestReveal_TokenNotLeakedInError(t *testing.T) {
+	t.Parallel()
+
+	const token = "ghp-secret-should-never-appear-in-error"
+
+	// /user returns 500 — forces an error immediately.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	e, err := NewEnumerator("", 5*time.Second, token)
+	require.NoError(t, err)
+	e.apiBaseURL = srv.URL
+	e.settleDelay = 0
+	e.sleep = noopSleep
+	e.newName = deterministicName
+
+	_, revErr := e.Reveal(context.Background(), []string{"a@example.com"})
+	require.Error(t, revErr, "a 500 on /user must cause Reveal to fail")
+	assert.NotContains(t, revErr.Error(), token,
+		"PAT must never appear in Reveal error text")
+}
+
+// ---------------------------------------------------------------------------
+// Reveal: DELETE failure surfaces owner/repo for manual cleanup
+// ---------------------------------------------------------------------------
+
+// TestReveal_DeleteFailure_SurfacesRepoForManualCleanup is a focused regression
+// test for the P1-A security fix: when the deferred repo DELETE fails, Reveal
+// must (a) return a non-nil error, (b) include the full "owner/repo" path so
+// the operator can remove the orphaned private repo manually, (c) still return
+// the reveal mapping (the data already collected should not be thrown away), and
+// (d) never include the PAT in the error text.
+//
+// The happy path succeeds (/user, /user/repos, pushCommit, listCommits all OK),
+// but the DELETE returns HTTP 500. This is the path previously not exercised by
+// any test.
+func TestReveal_DeleteFailure_SurfacesRepoForManualCleanup(t *testing.T) {
+	t.Parallel()
+
+	const token = "ghp-test-token-delete-failure"
+	loginAlice := "alice-gh"
+	emailToLogin := map[string]*string{
+		"alice@example.com": &loginAlice,
+	}
+
+	// deleteStatus=500 makes the fake DELETE handler return 500, causing
+	// deleteRepo to return an error and the deferred cleanup in Reveal to
+	// annotate err with the owner/repo path.
+	apiSrv := newAPIServer(t, token, emailToLogin, http.StatusInternalServerError)
+	e := newTestEnumerator(t, nil, apiSrv, token)
+
+	mapping, err := e.Reveal(context.Background(), []string{"alice@example.com"})
+
+	// The delete failure must bubble up as a non-nil error.
+	require.Error(t, err, "Reveal must return an error when the temp-repo DELETE fails")
+
+	// The error must contain the full owner/repo path so the operator knows what
+	// to delete manually. The fake /user handler returns login "testowner" and
+	// deterministicName returns "test-repo-name", so the path is
+	// "testowner/test-repo-name".
+	assert.Contains(t, err.Error(), "testowner/test-repo-name",
+		"error must contain the full owner/repo so the operator can delete it manually")
+
+	// The reveal data (email→username mapping) collected before the failed
+	// delete must still be returned — the operator should not lose their results
+	// just because cleanup failed.
+	assert.Equal(t, map[string]string{"alice@example.com": "alice-gh"}, mapping,
+		"resolved email→username mapping must be returned even when DELETE fails")
+
+	// The PAT must never appear in the error text.
+	assert.NotContains(t, err.Error(), token,
+		"PAT must never appear in Reveal error text")
+}
+
+// TestReveal_MidFlowErrorAndDeleteFailure_OriginalErrorJoined exercises the
+// joined-error path in reveal.go: when Reveal has already failed mid-flow (e.g.
+// pushCommit returns an error) AND the deferred DELETE also fails, the returned
+// error must reference the original failure (joined via %w) rather than only
+// reporting the delete error.
+func TestReveal_MidFlowErrorAndDeleteFailure_OriginalErrorJoined(t *testing.T) {
+	t.Parallel()
+
+	const token = "ghp-test-token-dual-failure"
+
+	// Build a custom mux: /user and /user/repos succeed, PUT /contents fails
+	// (pushCommit error), and DELETE also fails (500).
+	mux := http.NewServeMux()
+	mux.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+token {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_, _ = fmt.Fprintf(w, `{"login":"testowner"}`)
+	})
+	mux.HandleFunc("/user/repos", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+token {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprintf(w, `{"name":"test-repo-name","default_branch":"main"}`)
+	})
+	mux.HandleFunc("/repos/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+token {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		switch r.Method {
+		case http.MethodDelete:
+			// DELETE fails — this triggers the "both original and delete error" branch.
+			w.WriteHeader(http.StatusInternalServerError)
+		case http.MethodPut:
+			// pushCommit fails — this is the original mid-flow error.
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	apiSrv := httptest.NewServer(mux)
+	t.Cleanup(apiSrv.Close)
+
+	e, err := NewEnumerator("", 5*time.Second, token)
+	require.NoError(t, err)
+	e.apiBaseURL = apiSrv.URL
+	e.settleDelay = 0
+	e.sleep = noopSleep
+	e.newName = deterministicName
+
+	_, revErr := e.Reveal(context.Background(), []string{"alice@example.com"})
+
+	// Must be non-nil — both original and delete error occurred.
+	require.Error(t, revErr, "Reveal must return an error when both pushCommit and DELETE fail")
+
+	// The joined error format from reveal.go is:
+	//   "<original>; ADDITIONALLY failed to delete temp repo %q (delete it manually): <del err>"
+	// The original pushCommit error mentions "pushing commit" and the joined
+	// message must mention the owner/repo for manual cleanup.
+	assert.Contains(t, revErr.Error(), "pushing commit",
+		"joined error must still reference the original pushCommit failure")
+	assert.Contains(t, revErr.Error(), "testowner/test-repo-name",
+		"joined error must contain the owner/repo path for manual cleanup")
+
+	// PAT must never appear in any error text.
+	assert.NotContains(t, revErr.Error(), token,
+		"PAT must never appear in Reveal error text")
+}
+
+// ---------------------------------------------------------------------------
+// EnumerateWith: callback invoked once per email, results in input order
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Redirect regression: /join 302 → /signup, CSRF only on final page
+// ---------------------------------------------------------------------------
+
+// TestExistence_FollowsJoinRedirectForCSRF is a regression test for the bug
+// where the existence client refused to follow redirects: the real
+// github.com/join returns a 302 to /signup, and the CSRF authenticity_token
+// (inside <auto-check src="/email_validity_checks">) only exists on that final
+// page. When redirects were not followed, establishSession got an empty 302
+// body and returned "CSRF authenticity token not found on join page", causing
+// every existence check to fail.
+//
+// The existing web-server helper (webMux / newWebServer) serves the CSRF
+// directly from /join with no redirect, so it did NOT catch this regression.
+// This test stands up its own httptest server whose /join handler 302-redirects
+// to /signup, which is the only place the CSRF HTML is served.
+func TestExistence_FollowsJoinRedirectForCSRF(t *testing.T) {
+	t.Parallel()
+
+	const csrfToken = "csrf-redirect-test-token"
+
+	// signupHTML is the minimal HTML that parseCSRFToken expects: an
+	// <auto-check src="/email_validity_checks"> element containing a hidden
+	// input whose value is the CSRF token.
+	signupHTML := fmt.Sprintf(`<!DOCTYPE html><html><body>
+<auto-check src="/email_validity_checks">
+  <input type="hidden" value="%s">
+</auto-check>
+</body></html>`, csrfToken)
+
+	mux := http.NewServeMux()
+
+	// /join responds with a 302 redirect to /signup (mirroring the real
+	// github.com/join → github.com/signup flow). The CSRF token is NOT here.
+	mux.HandleFunc("/join", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/signup", http.StatusFound)
+	})
+
+	// /signup serves the CSRF-bearing HTML. This is the final page the client
+	// must land on after following the redirect.
+	mux.HandleFunc("/signup", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, signupHTML)
+	})
+
+	// /email_validity_checks returns 422 for the target email (account exists)
+	// and 200 for everything else (including the sanity-check @foobar.com address).
+	mux.HandleFunc("/email_validity_checks", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		email := r.FormValue("value")
+		if email == "target@example.com" {
+			w.WriteHeader(http.StatusUnprocessableEntity) // 422 → exists
+		} else {
+			w.WriteHeader(http.StatusOK) // 200 → available (sanity-check passes)
+		}
+	})
+
+	redirectSrv := httptest.NewServer(mux)
+	t.Cleanup(redirectSrv.Close)
+
+	e := newTestEnumerator(t, redirectSrv, nil, "")
+
+	results := e.Enumerate(context.Background(), []string{"target@example.com"}, 1, 0, 0)
+
+	require.Len(t, results, 1)
+	require.NoError(t, results[0].Error,
+		"establishSession must succeed by following the /join → /signup redirect to find the CSRF token")
+	assert.True(t, results[0].Exists,
+		"HTTP 422 from validity endpoint must map to Exists=true")
+}
+
+// ---------------------------------------------------------------------------
+// EnumerateWith: callback invoked once per email, results in input order
+// ---------------------------------------------------------------------------
+
+// TestEnumerateWith_CallbackSerializationAndOrder verifies that onResult is
+// called exactly once per email (under concurrent workers) and that the
+// returned slice preserves input order.
+func TestEnumerateWith_CallbackSerializationAndOrder(t *testing.T) {
+	t.Parallel()
+
+	emails := []string{
+		"a@example.com",
+		"b@example.com",
+		"c@example.com",
+		"d@example.com",
+	}
+
+	// a@ and c@ exist (422); b@ and d@ do not (200).
+	statusFor := map[string]int{
+		"a@example.com": http.StatusUnprocessableEntity,
+		"b@example.com": http.StatusOK,
+		"c@example.com": http.StatusUnprocessableEntity,
+		"d@example.com": http.StatusOK,
+	}
+	webSrv := newWebServer(t, "csrf-order-test", statusFor)
+	e := newTestEnumerator(t, webSrv, nil, "")
+
+	var cbEmails []string
+	results := e.EnumerateWith(
+		context.Background(),
+		emails,
+		4,
+		0,
+		0,
+		func(r Result) {
+			cbEmails = append(cbEmails, r.Email)
+		},
+	)
+
+	// Returned slice must be one-per-input-email.
+	require.Len(t, results, len(emails))
+
+	// Callback must be invoked exactly once per email.
+	assert.Len(t, cbEmails, len(emails),
+		"onResult callback must be called exactly once per email")
+
+	// Returned results must be in input order.
+	for i, r := range results {
+		assert.Equal(t, emails[i], r.Email,
+			"result[%d] must correspond to input email[%d]", i, i)
+	}
+
+	// Existence results must match the configured status map.
+	assert.True(t, results[0].Exists, "a@ (422) must be Exists=true")
+	assert.False(t, results[1].Exists, "b@ (200) must be Exists=false")
+	assert.True(t, results[2].Exists, "c@ (422) must be Exists=true")
+	assert.False(t, results[3].Exists, "d@ (200) must be Exists=false")
+}

--- a/pkg/enum/github/reveal.go
+++ b/pkg/enum/github/reveal.go
@@ -1,0 +1,316 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package github
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/praetorian-inc/brutus/pkg/enum"
+)
+
+// ---------------------------------------------------------------------------
+// Username reveal (authenticated)
+// ---------------------------------------------------------------------------
+
+// Reveal resolves GitHub usernames for the given (existing) emails. It requires
+// a non-empty token. A throwaway private repo is created, one commit per email
+// is pushed with that email as author/committer, the commits are listed after a
+// settle delay, and email -> login pairs are collected. The repo is ALWAYS
+// deleted before returning (even on mid-flow error). If deletion fails, the
+// returned error is annotated with the full owner/repo so the operator can
+// remove it manually. The token is never logged.
+//
+// Logins are omitted from the map when GitHub did not link an account to the
+// commit author email (author absent/null).
+func (e *Enumerator) Reveal(ctx context.Context, emails []string) (mapping map[string]string, err error) {
+	if e.token == "" {
+		return nil, fmt.Errorf("github reveal: token required (set GITHUB_TOKEN or --token)")
+	}
+
+	var login string
+	login, err = e.getAuthUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var repo, branch string
+	repo, branch, err = e.createRepo(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// ALWAYS delete the repo, even if a later step fails. Reveal uses NAMED
+	// returns so this deferred reassignment of err actually propagates to the
+	// caller — with unnamed returns the `return mapping, err` value is captured
+	// before the defer runs and a delete failure would be silently lost
+	// (orphaning a private repo under the operator's account). On delete failure
+	// the returned error carries the full owner/repo so the operator can remove
+	// it manually; if the function already failed, the original error is joined
+	// (not overwritten). The token is never included in the error.
+	defer func() {
+		if delErr := e.deleteRepo(ctx, login, repo); delErr != nil {
+			repoURL := login + "/" + repo
+			if err != nil {
+				err = fmt.Errorf("%w; ADDITIONALLY failed to delete temp repo %q (delete it manually): %v", err, repoURL, delErr)
+			} else {
+				err = fmt.Errorf("github reveal: failed to delete temp repo %q (delete it manually): %v", repoURL, delErr)
+			}
+		}
+	}()
+
+	for _, email := range emails {
+		if err = e.pushCommit(ctx, login, repo, email); err != nil {
+			return nil, err
+		}
+	}
+
+	if err = e.sleep(ctx, e.settleDelay); err != nil {
+		return nil, err
+	}
+
+	mapping, err = e.listCommitLogins(ctx, login, repo, branch)
+	if err != nil {
+		return nil, err
+	}
+	return mapping, nil
+}
+
+// ---------------------------------------------------------------------------
+// Reveal helpers
+// ---------------------------------------------------------------------------
+
+// getAuthUser GETs {api}/user and returns the authenticated account's login.
+func (e *Enumerator) getAuthUser(ctx context.Context) (string, error) {
+	resp, err := e.apiRequest(ctx, http.MethodGet, "/user", nil)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("github reveal: GET /user returned HTTP %d", resp.StatusCode)
+	}
+
+	// Bounded read — reuses enum.ReadResponseBody (1 MB default) before unmarshal.
+	body, err := enum.ReadResponseBody(resp, 0)
+	if err != nil {
+		return "", fmt.Errorf("github reveal: reading /user: %w", err)
+	}
+
+	var user struct {
+		Login string `json:"login"`
+	}
+	if err := json.Unmarshal(body, &user); err != nil {
+		return "", fmt.Errorf("github reveal: decoding /user: %w", err)
+	}
+	if user.Login == "" {
+		return "", fmt.Errorf("github reveal: /user returned an empty login")
+	}
+	return user.Login, nil
+}
+
+// createRepo POSTs {api}/user/repos to create a private throwaway repo, returning
+// its name and default branch (falling back to "main" when absent).
+func (e *Enumerator) createRepo(ctx context.Context) (repo string, branch string, err error) {
+	name := e.newName()
+	payload := map[string]any{"name": name, "private": true}
+
+	resp, err := e.apiRequest(ctx, http.MethodPost, "/user/repos", payload)
+	if err != nil {
+		return "", "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated {
+		return "", "", fmt.Errorf("github reveal: creating repo returned HTTP %d", resp.StatusCode)
+	}
+
+	// Bounded read — reuses enum.ReadResponseBody (1 MB default) before unmarshal.
+	body, err := enum.ReadResponseBody(resp, 0)
+	if err != nil {
+		return "", "", fmt.Errorf("github reveal: reading repo creation: %w", err)
+	}
+
+	var created struct {
+		Name          string `json:"name"`
+		DefaultBranch string `json:"default_branch"`
+	}
+	if err := json.Unmarshal(body, &created); err != nil {
+		return "", "", fmt.Errorf("github reveal: decoding repo creation: %w", err)
+	}
+	if created.Name == "" {
+		created.Name = name
+	}
+	if created.DefaultBranch == "" {
+		created.DefaultBranch = defaultBranchDefault
+	}
+	return created.Name, created.DefaultBranch, nil
+}
+
+// pushCommit PUTs a new file to {api}/repos/{owner}/{repo}/contents/{file} with
+// the target email set as both author and committer, so GitHub attributes the
+// commit to that email. HTTP 429 is retried (bounded). Commits are pushed
+// sequentially by the caller (single branch).
+func (e *Enumerator) pushCommit(ctx context.Context, owner, repo, email string) error {
+	for attempt := 0; ; attempt++ {
+		file := e.newName()
+		payload := map[string]any{
+			"message":   "Test",
+			"content":   commitContent,
+			"author":    map[string]string{"name": "TestUser", "email": email},
+			"committer": map[string]string{"name": "TestUser", "email": email},
+		}
+		path := "/repos/" + owner + "/" + repo + "/contents/" + file
+
+		resp, err := e.apiRequest(ctx, http.MethodPut, path, payload)
+		if err != nil {
+			return err
+		}
+		status := resp.StatusCode
+		_ = resp.Body.Close()
+
+		switch status {
+		case http.StatusCreated, http.StatusOK:
+			return nil
+		case http.StatusTooManyRequests:
+			if attempt >= maxRateLimitRetries {
+				return fmt.Errorf("github reveal: pushing commit rate limited (HTTP 429) after %d retries", attempt)
+			}
+			if err := e.sleep(ctx, rateLimitBackoff); err != nil {
+				return err
+			}
+			continue
+		default:
+			return fmt.Errorf("github reveal: pushing commit returned HTTP %d", status)
+		}
+	}
+}
+
+// listCommitLogins paginates {api}/repos/{owner}/{repo}/commits?sha={branch} and
+// returns a map of commit author email -> account login. Commits whose top-level
+// author (the linked GitHub account) is absent/null are omitted (no linked
+// account for that email).
+func (e *Enumerator) listCommitLogins(ctx context.Context, owner, repo, branch string) (map[string]string, error) {
+	mapping := make(map[string]string)
+
+	for page := 1; ; page++ {
+		path := fmt.Sprintf("/repos/%s/%s/commits?sha=%s&per_page=100&page=%d",
+			owner, repo, url.QueryEscape(branch), page)
+
+		resp, err := e.apiRequest(ctx, http.MethodGet, path, nil)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode != http.StatusOK {
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("github reveal: listing commits returned HTTP %d", resp.StatusCode)
+		}
+
+		// Bounded read — reuses enum.ReadResponseBody (1 MB default) before
+		// unmarshal so a hostile API response cannot exhaust memory.
+		body, readErr := enum.ReadResponseBody(resp, 0)
+		_ = resp.Body.Close()
+		if readErr != nil {
+			return nil, fmt.Errorf("github reveal: reading commits: %w", readErr)
+		}
+
+		var commits []struct {
+			Commit struct {
+				Author struct {
+					Email string `json:"email"`
+				} `json:"author"`
+			} `json:"commit"`
+			Author *struct {
+				Login string `json:"login"`
+			} `json:"author"`
+		}
+		if decodeErr := json.Unmarshal(body, &commits); decodeErr != nil {
+			return nil, fmt.Errorf("github reveal: decoding commits: %w", decodeErr)
+		}
+
+		for i := range commits {
+			email := commits[i].Commit.Author.Email
+			// author is null when the email isn't linked to a GitHub account.
+			if commits[i].Author == nil || commits[i].Author.Login == "" {
+				continue
+			}
+			if email == "" {
+				continue
+			}
+			mapping[email] = commits[i].Author.Login
+		}
+
+		if len(commits) < 100 {
+			break
+		}
+	}
+
+	return mapping, nil
+}
+
+// deleteRepo DELETEs {api}/repos/{owner}/{repo}. A 404 is treated as success
+// (already gone). This is invoked from Reveal's deferred cleanup.
+func (e *Enumerator) deleteRepo(ctx context.Context, owner, repo string) error {
+	resp, err := e.apiRequest(ctx, http.MethodDelete, "/repos/"+owner+"/"+repo, nil)
+	if err != nil {
+		return err
+	}
+	status := resp.StatusCode
+	_ = resp.Body.Close()
+
+	if status == http.StatusNoContent || status == http.StatusOK || status == http.StatusNotFound {
+		return nil
+	}
+	return fmt.Errorf("DELETE returned HTTP %d", status)
+}
+
+// apiRequest issues an authenticated GitHub REST API request. payload, when
+// non-nil, is JSON-encoded as the request body. The Authorization header carries
+// the bearer token (never logged) and Accept requests the v3 media type.
+func (e *Enumerator) apiRequest(ctx context.Context, method, path string, payload any) (*http.Response, error) {
+	var body io.Reader
+	if payload != nil {
+		buf, err := json.Marshal(payload)
+		if err != nil {
+			return nil, fmt.Errorf("github reveal: encoding request body: %w", err)
+		}
+		body = bytes.NewReader(buf)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, e.apiBaseURL+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("github reveal: creating %s %s request: %w", method, path, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+e.token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	if payload != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	// Use apiClient (no-follow): this request carries the PAT, so redirects must
+	// not be followed to avoid leaking the token across hosts (PAT-leak
+	// protection). The existence flow uses httpClient, which follows redirects.
+	resp, err := e.apiClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("github reveal: %s %s failed: %w", method, path, err)
+	}
+	return resp, nil
+}


### PR DESCRIPTION
## Summary

Two related changes to `brutus enum`:

1. **Group active sources under `brutus enum active`** (mirrors the recent `enum passive` grouping). `oracles`, `google`, `kerberos`, `teams`, and `custom` move under a new `active` parent. **Hard move** — the old `brutus enum <name>` paths are removed (no back-compat aliases). `enum generate` stays top-level (local wordlist utility); `enum passive` is untouched.

2. **Add `brutus enum active github`** — a Go port of [GhEmailBrute](https://github.com/AdnaneKhan/GhEmailBrute).

### New command layout
```
brutus enum
├── active        ← NEW
│   ├── oracles  (+ discover)
│   ├── google
│   ├── kerberos
│   ├── teams    (+ auth, users, audit)
│   ├── github   ← NEW
│   └── custom
├── generate      (top-level)
└── passive       (unchanged)
```

### `enum active github`
- **Existence (unauthenticated, default):** scrape the CSRF token from GitHub's signup page (following `/join` → `/signup`) and POST `/email_validity_checks`; **422 = in use, 200 = available**. Bounded, context-aware 429 backoff. Reuses the shared `--domain`/`--format`/`--limit` wordlist generator (same as `google`).
- **Username reveal (authenticated, optional):** with a PAT via `GITHUB_TOKEN` or `--token` (scopes `repo`+`delete_repo`), create a temporary private repo, push one commit per existing email (author/committer = the email), list commits to resolve `email → author.login` (works even under commit-email privacy), then **always delete the repo**. On delete failure the `owner/repo` is surfaced for manual cleanup. The token is never logged, and token-bearing API requests do not follow redirects (PAT-leak protection); the token-less existence flow does follow redirects.

Implementation mirrors the `pkg/enum/google` concurrency model (errgroup + rate limiter + jitter + serialized result callback), split across `github.go` / `existence.go` / `reveal.go`. Human and JSONL output sanitize server-controlled email/username before printing to a TTY.

## Testing
- `go build ./...` clean; `gofmt`/`go vet` clean.
- `go test -race ./pkg/enum/github/... ./cmd/brutus/...` — all passing (14 github-package tests + cmd wiring/parsing/output tests, plus 5 existing tests updated for the hard move).
- Live-verified: `octocat@github.com` → `exists:true`; existence works through the real `/join`→`/signup` redirect.

## Review
Went through code review + security review. Security review caught and we fixed: a dropped repo-cleanup error (named-return bug), PAT redirect-leak exposure, and unbounded response reads. A redirect-scope regression (existence must follow `/join`→`/signup`) was found during live testing, fixed, and is now covered by a dedicated regression test.

## Notes
- Unrelated in-progress `dehashed` changes in the working tree were deliberately excluded from this PR.
- JSONL reveal output emits two records per revealed email by design (an existence record, then an updated record carrying the resolved username); the later record is authoritative. Documented at the emit sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
