### PR TITLE
feat(enum): live progress bar with rate + ETA for `enum active` scans

### DIFF
--- a/cmd/brutus/cmd_enum_github.go
+++ b/cmd/brutus/cmd_enum_github.go
@@ -135,9 +135,13 @@ func runEnumGithub(cmd *cobra.Command, args []string) error {
 	}
 
 	// Stream each completed result live. Human mode prints only EXISTS rows
-	// unless --verbose; JSON mode streams a JSONL line per result. A periodic
-	// progress counter goes to stderr (suppressed under --quiet/--json).
+	// unless --verbose; JSON mode streams a JSONL line per result. A live
+	// progress bar goes to stderr (suppressed under --quiet/--json); on a TTY it
+	// redraws in place with percent/rate/elapsed/ETA, off-TTY it emits throttled
+	// newline lines.
 	total := len(emails)
+	progress := newProgressReporter(os.Stderr, total, !flagQuiet && !flagJSON, useColor)
+	progress.Start()
 	var processed, found int
 	onResult := func(res githubenum.Result) {
 		processed++
@@ -152,16 +156,17 @@ func runEnumGithub(cmd *cobra.Command, args []string) error {
 			// should treat the later record as authoritative — this is not a bug.
 			outputGithubEnumJSONL(jsonWriter, []githubenum.Result{res})
 		} else if res.Exists || flagVerbose {
+			// Clear the in-place bar before printing a result row so the bar's
+			// partial line doesn't corrupt it; the bar redraws on the next tick.
+			progress.Clear()
 			outputGithubEnumResultLine(os.Stdout, res, useColor)
 		}
 
-		if !flagQuiet && !flagJSON && processed%500 == 0 {
-			fmt.Fprintf(os.Stderr, "%s processed %d/%d — %d found\n",
-				dim(useColor, SymbolInfo), processed, total, found)
-		}
+		progress.Update(processed, fmt.Sprintf("%d found", found))
 	}
 
 	results := enumerator.EnumerateWith(ctx, emails, flagThreads, flagRateLimit, flagJitter, onResult)
+	progress.Stop()
 
 	// Username reveal: only when a token is set and at least one account exists.
 	existing := existingEmails(results)
@@ -171,7 +176,12 @@ func runEnumGithub(cmd *cobra.Command, args []string) error {
 				dim(useColor, SymbolInfo), len(existing))
 		}
 
-		mapping, revErr := enumerator.Reveal(ctx, existing)
+		revealProgress := newProgressReporter(os.Stderr, len(existing), !flagQuiet && !flagJSON, useColor)
+		revealProgress.Start()
+		mapping, revErr := enumerator.RevealWith(ctx, existing, func(done, total int) {
+			revealProgress.Update(done, "commits pushed")
+		})
+		revealProgress.Stop()
 		if revErr != nil {
 			// Reveal failures are non-fatal to existence results; warn and continue.
 			fmt.Fprintf(os.Stderr, "%s github username reveal failed: %v\n",

--- a/cmd/brutus/cmd_enum_google.go
+++ b/cmd/brutus/cmd_enum_google.go
@@ -123,9 +123,12 @@ func runEnumGoogle(cmd *cobra.Command, args []string) error {
 	// Stream each completed result live (the callback is invoked serialized under
 	// the enumerator's results mutex, so output never interleaves and never races
 	// the results slice). Human mode prints only EXISTS rows unless --verbose;
-	// JSON mode streams a JSONL line per result. A periodic progress counter goes
-	// to stderr (suppressed under --quiet/--json).
+	// JSON mode streams a JSONL line per result. A live progress bar goes to
+	// stderr (suppressed under --quiet/--json); on a TTY it redraws in place with
+	// percent/rate/elapsed/ETA, off-TTY it emits throttled newline lines.
 	total := len(emails)
+	progress := newProgressReporter(os.Stderr, total, !flagQuiet && !flagJSON, useColor)
+	progress.Start()
 	var processed, found int
 	onResult := func(res google.Result) {
 		processed++
@@ -136,16 +139,17 @@ func runEnumGoogle(cmd *cobra.Command, args []string) error {
 		if flagJSON {
 			outputGoogleEnumJSONL(jsonWriter, []google.Result{res})
 		} else if res.Exists || flagVerbose {
+			// Clear the in-place bar before printing a result row so the bar's
+			// partial line doesn't corrupt it; the bar redraws on the next tick.
+			progress.Clear()
 			outputGoogleEnumResultLine(os.Stdout, res, useColor)
 		}
 
-		if !flagQuiet && !flagJSON && processed%500 == 0 {
-			fmt.Fprintf(os.Stderr, "%s processed %d/%d — %d found\n",
-				dim(useColor, SymbolInfo), processed, total, found)
-		}
+		progress.Update(processed, fmt.Sprintf("%d found", found))
 	}
 
 	results := enumerator.EnumerateWith(ctx, emails, flagThreads, flagRateLimit, flagJitter, onResult)
+	progress.Stop()
 
 	if !flagJSON {
 		outputGoogleEnumSummary(os.Stdout, results, useColor)

--- a/cmd/brutus/cmd_enum_teams.go
+++ b/cmd/brutus/cmd_enum_teams.go
@@ -406,9 +406,13 @@ func runEnumTeamsUsers(cmd *cobra.Command, args []string) error {
 	// Stream each completed result live (the callback is invoked serialized under
 	// the enumerator's results mutex, so output never interleaves and never races
 	// the results slice). Human mode prints only the positive signals (EXISTS /
-	// BLOCKED) unless --verbose; JSON mode streams a JSONL line per result. A
-	// periodic progress counter goes to stderr (suppressed under --quiet/--json).
+	// BLOCKED) unless --verbose; JSON mode streams a JSONL line per result. A live
+	// progress bar goes to stderr (suppressed under --quiet/--json); on a TTY it
+	// redraws in place with percent/rate/elapsed/ETA, off-TTY it emits throttled
+	// newline lines.
 	total := len(emails)
+	progress := newProgressReporter(os.Stderr, total, !flagQuiet && !flagJSON, useColor)
+	progress.Start()
 	var processed, found, blocked int
 	onResult := func(res teams.EnumResult) {
 		processed++
@@ -424,23 +428,24 @@ func runEnumTeamsUsers(cmd *cobra.Command, args []string) error {
 		} else {
 			switch res.Exists {
 			case teams.ExistenceYes, teams.ExistenceBlocked:
-				// Positive signals always print.
+				// Positive signals always print. Clear the in-place bar first so
+				// its partial line doesn't corrupt the row; it redraws next tick.
+				progress.Clear()
 				outputTeamsEnumResultLine(os.Stdout, res, useColor)
 			default:
 				// ExistenceNo / ExistenceUnknown are suppressed unless --verbose.
 				if flagVerbose {
+					progress.Clear()
 					outputTeamsEnumResultLine(os.Stdout, res, useColor)
 				}
 			}
 		}
 
-		if !flagQuiet && !flagJSON && processed%500 == 0 {
-			fmt.Fprintf(os.Stderr, "%s processed %d/%d — %d found, %d blocked\n",
-				dim(useColor, SymbolInfo), processed, total, found, blocked)
-		}
+		progress.Update(processed, fmt.Sprintf("%d found · %d blocked", found, blocked))
 	}
 
 	results := enumerator.EnumerateWith(ctx, emails, flagThreads, flagRateLimit, flagJitter, onResult)
+	progress.Stop()
 
 	posture := teams.DerivePosture(teamsEnumDomain(emails), results)
 

--- a/cmd/brutus/progress.go
+++ b/cmd/brutus/progress.go
@@ -1,0 +1,307 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/term"
+)
+
+// Live-progress tuning. The bar width is fixed so the line length is stable
+// (important for clean in-place redraws). TTY redraws are frequent enough that
+// the elapsed/ETA fields advance smoothly even while a rate-limited scan sits
+// between results; the non-TTY cadence is slow so piped/CI logs stay readable.
+const (
+	progressBarWidth     = 24
+	progressTTYInterval  = 150 * time.Millisecond
+	progressPipeInterval = 2 * time.Second
+)
+
+// progressReporter renders a live progress indicator for long-running enum
+// scans. On a TTY it redraws a single line in place (carriage return + clear
+// to end of line); off a TTY it emits a throttled newline line so piped/CI
+// logs stay readable. It is suppressed entirely (every method a no-op) when
+// disabled — used for --quiet and --json, which own stderr/stdout framing.
+//
+// The render cadence is decoupled from Update: a background goroutine redraws
+// on a timer, so the elapsed/ETA fields keep advancing between results. Update
+// only stores a cheap snapshot, so it is safe to call from the enumerator's
+// serialized onResult callback on the hot path.
+//
+// All exported methods are safe for concurrent use.
+type progressReporter struct {
+	w        io.Writer
+	total    int
+	enabled  bool
+	isTTY    bool
+	useColor bool
+	interval time.Duration
+
+	// now is the clock; overridable by tests for deterministic elapsed/ETA.
+	now func() time.Time
+
+	mu        sync.Mutex
+	start     time.Time
+	processed int
+	metrics   string
+	onScreen  bool // a TTY bar line is currently drawn (needs clearing)
+	stopped   bool // Stop has run; guards close(done) against a double call
+
+	done chan struct{}
+	wg   sync.WaitGroup
+}
+
+// newProgressReporter builds a reporter writing to w (typically os.Stderr).
+// enabled is the caller's gate (false under --quiet/--json). TTY detection is
+// best-effort: when w is not a terminal (piped, redirected, or not an *os.File)
+// the reporter falls back to throttled newline lines.
+func newProgressReporter(w io.Writer, total int, enabled, useColor bool) *progressReporter {
+	isTTY := enabled && writerIsTerminal(w)
+	interval := progressPipeInterval
+	if isTTY {
+		interval = progressTTYInterval
+	}
+	return &progressReporter{
+		w:        w,
+		total:    total,
+		enabled:  enabled,
+		isTTY:    isTTY,
+		useColor: useColor,
+		interval: interval,
+		now:      time.Now,
+		done:     make(chan struct{}),
+	}
+}
+
+// writerIsTerminal reports whether w refers to a terminal. It recognizes any
+// writer exposing an Fd() (notably *os.File) so tests using a bytes.Buffer are
+// treated as non-TTY.
+func writerIsTerminal(w io.Writer) bool {
+	f, ok := w.(interface{ Fd() uintptr })
+	if !ok {
+		return false
+	}
+	return term.IsTerminal(int(f.Fd()))
+}
+
+// Start records the start time and launches the background redraw goroutine.
+// It is a no-op when disabled. Call Stop exactly once when the work finishes.
+func (p *progressReporter) Start() {
+	if !p.enabled {
+		return
+	}
+	p.mu.Lock()
+	p.start = p.now()
+	p.mu.Unlock()
+
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		t := time.NewTicker(p.interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-p.done:
+				return
+			case <-t.C:
+				p.flush(false)
+			}
+		}
+	}()
+}
+
+// Update records the latest processed count and metrics tail (e.g. "8 found").
+// It does not render — the background goroutine does — so it is cheap enough
+// for the per-result hot path. No-op when disabled.
+//
+// metrics MUST be composed only of counts and fixed strings; it MUST NOT carry
+// untrusted server-/target-controlled data (e.g. a GitHub login), because the
+// reporter writes it to the terminal verbatim alongside raw ANSI control
+// sequences (\r\033[K).
+func (p *progressReporter) Update(processed int, metrics string) {
+	if !p.enabled {
+		return
+	}
+	p.mu.Lock()
+	p.processed = processed
+	p.metrics = metrics
+	p.mu.Unlock()
+}
+
+// Clear erases the current in-place bar line so the caller can print a result
+// row to the (shared) terminal without corrupting it; the bar redraws on the
+// next tick. No-op when disabled or off-TTY (where lines never redraw in place).
+//
+// Callers print the result row to stdout after Clear returns and the lock is
+// released, so the background ticker may redraw the bar in that small window.
+// This is a cosmetic interleave that self-heals on the next tick, not a data
+// race (the bar and the result row are separate streams).
+func (p *progressReporter) Clear() {
+	if !p.enabled || !p.isTTY {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.onScreen {
+		fmt.Fprint(p.w, "\r\033[K")
+		p.onScreen = false
+	}
+}
+
+// Stop halts the background goroutine and renders a final line terminated with
+// a newline so subsequent output starts cleanly. No-op when disabled. Idempotent:
+// a second call is a safe no-op so a future double-call/backstop can't panic on
+// close(done).
+func (p *progressReporter) Stop() {
+	if !p.enabled {
+		return
+	}
+	p.mu.Lock()
+	if p.stopped {
+		p.mu.Unlock()
+		return
+	}
+	p.stopped = true
+	p.mu.Unlock()
+	close(p.done)
+	p.wg.Wait()
+	p.flush(true)
+}
+
+// flush renders the current snapshot. On a TTY non-final renders redraw the
+// line in place (\r + clear) with no trailing newline; the final render adds a
+// newline. Off-TTY every render is a full newline line.
+func (p *progressReporter) flush(final bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	elapsed := time.Duration(0)
+	if !p.start.IsZero() {
+		elapsed = p.now().Sub(p.start)
+	}
+	line := dim(p.useColor, progressLine(p.processed, p.total, elapsed, p.metrics))
+
+	if p.isTTY {
+		fmt.Fprint(p.w, "\r\033[K"+line)
+		p.onScreen = true
+		if final {
+			fmt.Fprint(p.w, "\n")
+			p.onScreen = false
+		}
+		return
+	}
+	fmt.Fprint(p.w, line+"\n")
+}
+
+// progressLine builds the human-readable progress content (no color, no
+// carriage return). Pure and deterministic given its inputs, so it is unit
+// tested directly. Layout:
+//
+//	[*] [=====>    ] 42% · 4200/10000 · 38/s · elapsed 1m50s · ETA 2m32s · 8 found
+//
+// When total is 0 (unknown size) the bar, percentage, and ETA are omitted.
+func progressLine(processed, total int, elapsed time.Duration, metrics string) string {
+	var b strings.Builder
+	b.WriteString(SymbolInfo)
+
+	if total > 0 {
+		frac := float64(processed) / float64(total)
+		if frac > 1 {
+			frac = 1
+		}
+		filled := int(frac * progressBarWidth)
+		b.WriteString(" [")
+		for i := 0; i < progressBarWidth; i++ {
+			switch {
+			case i < filled:
+				b.WriteByte('=')
+			case i == filled:
+				b.WriteByte('>')
+			default:
+				b.WriteByte(' ')
+			}
+		}
+		b.WriteString("]")
+		fmt.Fprintf(&b, " %d%%", int(frac*100))
+		fmt.Fprintf(&b, " · %d/%d", processed, total)
+	} else {
+		fmt.Fprintf(&b, " %d", processed)
+	}
+
+	fmt.Fprintf(&b, " · %s", progressRate(processed, elapsed))
+	fmt.Fprintf(&b, " · elapsed %s", formatDuration(elapsed))
+
+	if total > 0 {
+		fmt.Fprintf(&b, " · ETA %s", progressETA(processed, total, elapsed))
+	}
+
+	if metrics != "" {
+		fmt.Fprintf(&b, " · %s", metrics)
+	}
+	return b.String()
+}
+
+// progressRate formats throughput as items/second. Below 10/s it keeps one
+// decimal so a slow, rate-limited scan still shows movement.
+func progressRate(processed int, elapsed time.Duration) string {
+	secs := elapsed.Seconds()
+	if processed <= 0 || secs <= 0 {
+		return "--/s"
+	}
+	rate := float64(processed) / secs
+	if rate >= 10 {
+		return fmt.Sprintf("%.0f/s", rate)
+	}
+	return fmt.Sprintf("%.1f/s", rate)
+}
+
+// progressETA estimates time remaining from the average rate so far. Returns
+// "--" before any progress (no rate to extrapolate from) or once complete.
+func progressETA(processed, total int, elapsed time.Duration) string {
+	secs := elapsed.Seconds()
+	if processed <= 0 || secs <= 0 || processed >= total {
+		return "--"
+	}
+	rate := float64(processed) / secs
+	remaining := float64(total-processed) / rate
+	return formatDuration(time.Duration(remaining * float64(time.Second)))
+}
+
+// formatDuration renders a coarse, human-friendly duration: "45s", "2m32s",
+// "1h03m" (seconds dropped past an hour). Sub-second renders as "0s".
+func formatDuration(d time.Duration) string {
+	if d < time.Second {
+		return "0s"
+	}
+	d = d.Round(time.Second)
+	h := d / time.Hour
+	d -= h * time.Hour
+	m := d / time.Minute
+	d -= m * time.Minute
+	s := d / time.Second
+	switch {
+	case h > 0:
+		return fmt.Sprintf("%dh%02dm", h, m)
+	case m > 0:
+		return fmt.Sprintf("%dm%02ds", m, s)
+	default:
+		return fmt.Sprintf("%ds", s)
+	}
+}

--- a/cmd/brutus/progress_test.go
+++ b/cmd/brutus/progress_test.go
@@ -1,0 +1,253 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// progressLine tests
+// ---------------------------------------------------------------------------
+
+// TestProgressLine_MidScan verifies the format of a mid-scan progress line with
+// a known total. The output must contain the bar brackets, percentage, count,
+// ETA label, and the custom metrics tail.
+func TestProgressLine_MidScan(t *testing.T) {
+	t.Parallel()
+
+	line := progressLine(4200, 10000, 110*time.Second, "8 found")
+
+	// Must start with the info symbol.
+	assert.True(t, strings.HasPrefix(line, SymbolInfo),
+		"progressLine must start with SymbolInfo (%q), got: %q", SymbolInfo, line)
+
+	// Bar brackets must be present.
+	assert.Contains(t, line, "[", "must contain opening bar bracket")
+	assert.Contains(t, line, "]", "must contain closing bar bracket")
+
+	// Percentage.
+	assert.Contains(t, line, "42%", "must contain 42% for 4200/10000")
+
+	// Count.
+	assert.Contains(t, line, "4200/10000", "must contain processed/total count")
+
+	// ETA label.
+	assert.Contains(t, line, "ETA", "must contain ETA label when total > 0")
+
+	// Metrics tail.
+	assert.Contains(t, line, "8 found", "must contain custom metrics string")
+}
+
+// TestProgressLine_UnknownTotal verifies that when total==0 the bar, percentage,
+// and ETA are omitted but the raw count is still shown.
+func TestProgressLine_UnknownTotal(t *testing.T) {
+	t.Parallel()
+
+	line := progressLine(37, 0, 5*time.Second, "")
+
+	// Must start with the info symbol.
+	assert.True(t, strings.HasPrefix(line, SymbolInfo),
+		"progressLine must start with SymbolInfo when total==0")
+
+	// Raw count must be present.
+	assert.Contains(t, line, "37", "must contain raw processed count")
+
+	// Percentage, ETA, and bar must be absent.
+	assert.NotContains(t, line, "%", "must NOT contain percentage when total==0")
+	assert.NotContains(t, line, "ETA", "must NOT contain ETA when total==0")
+	assert.NotContains(t, line, "[====", "must NOT contain bar when total==0")
+}
+
+// TestProgressLine_ZeroProcessed verifies the placeholder values shown before
+// any progress has been made.
+func TestProgressLine_ZeroProcessed(t *testing.T) {
+	t.Parallel()
+
+	line := progressLine(0, 100, 10*time.Second, "")
+
+	// Rate must show "--/s" when processed==0.
+	assert.Contains(t, line, "--/s", "rate must be '--/s' when processed==0")
+
+	// ETA must show "--" when processed==0.
+	assert.Contains(t, line, "ETA --", "ETA must be '--' when processed==0")
+}
+
+// ---------------------------------------------------------------------------
+// formatDuration table tests
+// ---------------------------------------------------------------------------
+
+// TestFormatDuration covers the coarse human-friendly rendering of durations.
+func TestFormatDuration(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		input    time.Duration
+		expected string
+	}{
+		{
+			name:     "sub-second renders as 0s",
+			input:    500 * time.Millisecond,
+			expected: "0s",
+		},
+		{
+			name:     "exactly 45 seconds",
+			input:    45 * time.Second,
+			expected: "45s",
+		},
+		{
+			name:     "152 seconds renders as 2m32s",
+			input:    152 * time.Second,
+			expected: "2m32s",
+		},
+		{
+			name:     "3780 seconds renders as 1h03m",
+			input:    3780 * time.Second,
+			expected: "1h03m",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, formatDuration(tc.input))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// progressRate tests
+// ---------------------------------------------------------------------------
+
+// TestProgressRate covers the throughput formatting for edge cases and both
+// decimal regimes.
+func TestProgressRate(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		processed int
+		elapsed   time.Duration
+		expected  string
+	}{
+		{
+			name:      "zero processed returns placeholder",
+			processed: 0,
+			elapsed:   10 * time.Second,
+			expected:  "--/s",
+		},
+		{
+			name:      "negative processed returns placeholder",
+			processed: -1,
+			elapsed:   10 * time.Second,
+			expected:  "--/s",
+		},
+		{
+			name:      "zero elapsed returns placeholder",
+			processed: 10,
+			elapsed:   0,
+			expected:  "--/s",
+		},
+		{
+			name:      "negative elapsed returns placeholder",
+			processed: 10,
+			elapsed:   -1 * time.Second,
+			expected:  "--/s",
+		},
+		{
+			name:      "slow rate (< 10/s) keeps one decimal: 5 items / 2s = 2.5/s",
+			processed: 5,
+			elapsed:   2 * time.Second,
+			expected:  "2.5/s",
+		},
+		{
+			name:      "fast rate (>= 10/s) has no decimal: 100 items / 2s = 50/s",
+			processed: 100,
+			elapsed:   2 * time.Second,
+			expected:  "50/s",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, progressRate(tc.processed, tc.elapsed))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Disabled reporter produces no output
+// ---------------------------------------------------------------------------
+
+// TestProgressReporter_DisabledNoOutput verifies that a reporter constructed
+// with enabled=false is a complete no-op: Start, Update, Clear, and Stop all
+// produce no bytes in the output writer.
+func TestProgressReporter_DisabledNoOutput(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	p := newProgressReporter(&buf, 100, false, false)
+
+	p.Start()
+	p.Update(5, "x")
+	p.Clear()
+	p.Stop()
+
+	assert.Equal(t, 0, buf.Len(), "disabled reporter must produce no output bytes")
+}
+
+// ---------------------------------------------------------------------------
+// Non-TTY flush: deterministic elapsed via injected clock
+// ---------------------------------------------------------------------------
+
+// TestProgressReporter_NonTTYFlush verifies that calling flush(true) on a
+// non-TTY reporter writes a newline-terminated line containing the expected
+// percentage, count, and metrics. The clock is injected to make elapsed
+// deterministic.
+func TestProgressReporter_NonTTYFlush(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	p := newProgressReporter(&buf, 10000, true, false) // enabled, no color
+
+	// Inject a fixed clock so elapsed is exactly 110 s.
+	fixed := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	p.start = fixed.Add(-110 * time.Second)
+	p.now = func() time.Time { return fixed }
+
+	p.Update(4200, "8 found")
+	p.flush(true)
+
+	out := buf.String()
+
+	// Must be newline-terminated.
+	require.True(t, strings.HasSuffix(out, "\n"),
+		"non-TTY flush must produce a newline-terminated line, got: %q", out)
+
+	// Must contain expected content.
+	assert.Contains(t, out, "42%", "must contain 42% for 4200/10000")
+	assert.Contains(t, out, "4200/10000", "must contain processed/total count")
+	assert.Contains(t, out, "8 found", "must contain metrics tail")
+}

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	golang.org/x/crypto v0.53.0
 	golang.org/x/net v0.56.0
 	golang.org/x/sync v0.21.0
+	golang.org/x/term v0.44.0
 	golang.org/x/time v0.15.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/pkg/enum/github/reveal.go
+++ b/pkg/enum/github/reveal.go
@@ -30,17 +30,29 @@ import (
 // Username reveal (authenticated)
 // ---------------------------------------------------------------------------
 
-// Reveal resolves GitHub usernames for the given (existing) emails. It requires
-// a non-empty token. A throwaway private repo is created, one commit per email
-// is pushed with that email as author/committer, the commits are listed after a
-// settle delay, and email -> login pairs are collected. The repo is ALWAYS
-// deleted before returning (even on mid-flow error). If deletion fails, the
-// returned error is annotated with the full owner/repo so the operator can
-// remove it manually. The token is never logged.
+// Reveal resolves GitHub usernames for the given (existing) emails. It is a
+// thin wrapper over RevealWith with no progress callback, preserving the
+// original signature for existing callers and tests.
+func (e *Enumerator) Reveal(ctx context.Context, emails []string) (mapping map[string]string, err error) {
+	return e.RevealWith(ctx, emails, nil)
+}
+
+// RevealWith resolves GitHub usernames for the given (existing) emails. It
+// requires a non-empty token. A throwaway private repo is created, one commit
+// per email is pushed with that email as author/committer, the commits are
+// listed after a settle delay, and email -> login pairs are collected. The repo
+// is ALWAYS deleted before returning (even on mid-flow error). If deletion
+// fails, the returned error is annotated with the full owner/repo so the
+// operator can remove it manually. The token is never logged.
+//
+// onProgress, when non-nil, is invoked after each successful commit push with
+// (done, total) where done is 1-based and total is len(emails). The push loop
+// is the long, blind phase of reveal, so this lets callers render live
+// progress. It is never called for the settle delay or the commit listing.
 //
 // Logins are omitted from the map when GitHub did not link an account to the
 // commit author email (author absent/null).
-func (e *Enumerator) Reveal(ctx context.Context, emails []string) (mapping map[string]string, err error) {
+func (e *Enumerator) RevealWith(ctx context.Context, emails []string, onProgress func(done, total int)) (mapping map[string]string, err error) {
 	if e.token == "" {
 		return nil, fmt.Errorf("github reveal: token required (set GITHUB_TOKEN or --token)")
 	}
@@ -57,7 +69,7 @@ func (e *Enumerator) Reveal(ctx context.Context, emails []string) (mapping map[s
 		return nil, err
 	}
 
-	// ALWAYS delete the repo, even if a later step fails. Reveal uses NAMED
+	// ALWAYS delete the repo, even if a later step fails. RevealWith uses NAMED
 	// returns so this deferred reassignment of err actually propagates to the
 	// caller — with unnamed returns the `return mapping, err` value is captured
 	// before the defer runs and a delete failure would be silently lost
@@ -76,9 +88,12 @@ func (e *Enumerator) Reveal(ctx context.Context, emails []string) (mapping map[s
 		}
 	}()
 
-	for _, email := range emails {
+	for i, email := range emails {
 		if err = e.pushCommit(ctx, login, repo, email); err != nil {
 			return nil, err
+		}
+		if onProgress != nil {
+			onProgress(i+1, len(emails))
 		}
 	}
 

--- a/pkg/enum/github/reveal_test.go
+++ b/pkg/enum/github/reveal_test.go
@@ -1,0 +1,109 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package github
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// RevealWith: onProgress callback sequencing
+// ---------------------------------------------------------------------------
+
+// TestRevealWith_ProgressCallback verifies that RevealWith invokes onProgress
+// exactly once per email, with strictly increasing done values 1, 2, …, N and
+// total always equal to len(emails). The final invocation must have done ==
+// len(emails).
+func TestRevealWith_ProgressCallback(t *testing.T) {
+	t.Parallel()
+
+	const token = "ghp-test-token-progress-cb"
+
+	emails := []string{
+		"alice@example.com",
+		"bob@example.com",
+		"carol@example.com",
+	}
+
+	// Build emailToLogin with all three emails so the commit listing succeeds.
+	loginAlice := "alice-gh"
+	loginBob := "bob-gh"
+	loginCarol := "carol-gh"
+	emailToLogin := map[string]*string{
+		"alice@example.com": &loginAlice,
+		"bob@example.com":   &loginBob,
+		"carol@example.com": &loginCarol,
+	}
+
+	apiSrv := newAPIServer(t, token, emailToLogin, 0)
+	e := newTestEnumerator(t, nil, apiSrv, token)
+
+	// Collect (done, total) pairs from the callback in order.
+	type pair struct{ done, total int }
+	var calls []pair
+
+	mapping, err := e.RevealWith(context.Background(), emails, func(done, total int) {
+		calls = append(calls, pair{done, total})
+	})
+
+	require.NoError(t, err)
+
+	// mapping must be non-nil even though we care about the callback here.
+	require.NotNil(t, mapping)
+
+	// Callback must be invoked exactly once per email.
+	require.Len(t, calls, len(emails),
+		"onProgress must be called exactly once per email")
+
+	// done must be strictly increasing 1 … N and total must always be N.
+	N := len(emails)
+	for i, c := range calls {
+		assert.Equal(t, i+1, c.done,
+			"call[%d]: done must be %d (1-based), got %d", i, i+1, c.done)
+		assert.Equal(t, N, c.total,
+			"call[%d]: total must be %d (len(emails)), got %d", i, N, c.total)
+	}
+
+	// Final invocation must have done == len(emails).
+	last := calls[len(calls)-1]
+	assert.Equal(t, N, last.done,
+		"last callback invocation must have done == len(emails)")
+}
+
+// TestRevealWith_NilCallback verifies that passing a nil onProgress callback to
+// RevealWith works correctly (Reveal's thin wrapper relies on this).
+func TestRevealWith_NilCallback(t *testing.T) {
+	t.Parallel()
+
+	const token = "ghp-test-token-nil-cb"
+
+	loginAlice := "alice-gh"
+	emailToLogin := map[string]*string{
+		"alice@example.com": &loginAlice,
+	}
+
+	apiSrv := newAPIServer(t, token, emailToLogin, 0)
+	e := newTestEnumerator(t, nil, apiSrv, token)
+
+	// Must not panic with nil callback — this is the Reveal path.
+	mapping, err := e.RevealWith(context.Background(), []string{"alice@example.com"}, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "alice-gh", mapping["alice@example.com"])
+}


### PR DESCRIPTION
## What

Adds a live, in-place progress indicator to the `enum active` scans (`github`, `google`, `teams`), replacing the previous `processed N/M` counter that printed a newline every 500 results with no rate or ETA — so a long run is no longer a blind wait.

On a TTY:

```
[*] [===========>            ] 47% · 4731/10000 · 41/s · elapsed 1m54s · ETA 2m08s · 6 found
```

- A **background ticker** redraws on a timer, so **elapsed/ETA keep advancing even while the scan is stalled on rate limiting** (the common case against GitHub's signup endpoint).
- **Off-TTY** (piped/CI): falls back to throttled newline lines (~2s).
- **Suppressed** entirely under `--quiet` / `--json`.
- `Update()` stores a cheap snapshot under a mutex, so it's safe on the serialized `onResult` hot path.

## Why

The `enum active github -d <domain> --limit 10000` workflow runs for a long time with no feedback on how far along it is or how long remains.

## Changes

- **New** `cmd/brutus/progress.go` — reusable `progressReporter` + pure helpers (`progressLine`/`progressRate`/`progressETA`/`formatDuration`). De-duplicates the `processed%500` counter that was copy-pasted across three commands.
- Wired into `cmd_enum_github.go`, `cmd_enum_google.go` (`N found`) and `cmd_enum_teams.go` (`N found · M blocked`).
- `pkg/enum/github/reveal.go` — adds `RevealWith(ctx, emails, onProgress)`; `Reveal` kept as a thin wrapper so existing callers/tests are unchanged. The github reveal phase now shows a second bar over the commit-push loop.
- Adds `golang.org/x/term` for cross-platform TTY detection.

## Testing

- New `cmd/brutus/progress_test.go` (9 cases: `progressLine` mid-scan / unknown-total / zero-processed, `formatDuration`, `progressRate`, disabled no-op, non-TTY flush with injected clock) and `pkg/enum/github/reveal_test.go` (`RevealWith` fires `onProgress` once per email, monotonic to `len(emails)`; nil-callback wrapper path).
- `go build ./...`, `go vet`, `gofmt -l`, and `go test -race ./cmd/brutus/... ./pkg/enum/github/...` all green.
- Reviewed for correctness/concurrency and security (token never enters the progress output; reveal repo-deletion cleanup semantics preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)