### PR TITLE
feat(enum/github): add `map` subcommand to correlate known emails to GitHub usernames

### DIFF
--- a/cmd/brutus/cmd_enum_github.go
+++ b/cmd/brutus/cmd_enum_github.go
@@ -214,25 +214,37 @@ func runEnumGithub(cmd *cobra.Command, args []string) error {
 // and --email-file, plus any --domain-generated candidates. It errors when no
 // targets are supplied.
 func githubEnumTargets() ([]string, error) {
-	var raw []string
-	if flagGithubEnumEmails != "" {
-		raw = append(raw, strings.Split(flagGithubEnumEmails, ",")...)
+	var generated []string
+	if flagGithubEnumDomain != "" {
+		g, err := githubEnumGenerate()
+		if err != nil {
+			return nil, err
+		}
+		generated = g
 	}
-	if flagGithubEnumEmailFile != "" {
-		lines, err := loadLinesFromFile(flagGithubEnumEmailFile)
+
+	return collectGithubEmails(flagGithubEnumEmails, flagGithubEnumEmailFile, generated,
+		fmt.Errorf("provide --emails/-e, --email-file/-E, or --domain"))
+}
+
+// collectGithubEmails parses, trims, and dedups email targets from an --emails
+// CSV and an --email-file (preserving first-seen order), then appends any
+// pre-generated candidates. noSourceErr is returned verbatim when no targets
+// resolve, letting each subcommand phrase its own guidance (the parent allows
+// --domain; the map subcommand does not).
+func collectGithubEmails(emailsCSV, emailFile string, generated []string, noSourceErr error) ([]string, error) {
+	var raw []string
+	if emailsCSV != "" {
+		raw = append(raw, strings.Split(emailsCSV, ",")...)
+	}
+	if emailFile != "" {
+		lines, err := loadLinesFromFile(emailFile)
 		if err != nil {
 			return nil, fmt.Errorf("reading --email-file: %w", err)
 		}
 		raw = append(raw, lines...)
 	}
-
-	if flagGithubEnumDomain != "" {
-		generated, err := githubEnumGenerate()
-		if err != nil {
-			return nil, err
-		}
-		raw = append(raw, generated...)
-	}
+	raw = append(raw, generated...)
 
 	seen := make(map[string]struct{})
 	var emails []string
@@ -249,7 +261,7 @@ func githubEnumTargets() ([]string, error) {
 	}
 
 	if len(emails) == 0 {
-		return nil, fmt.Errorf("provide --emails/-e, --email-file/-E, or --domain")
+		return nil, noSourceErr
 	}
 	return emails, nil
 }

--- a/cmd/brutus/cmd_enum_github_map.go
+++ b/cmd/brutus/cmd_enum_github_map.go
@@ -1,0 +1,152 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/spf13/cobra"
+
+	githubenum "github.com/praetorian-inc/brutus/pkg/enum/github"
+)
+
+// File-local flag variables for the "enum active github map" subcommand. A
+// separate block (distinct from the parent github command's flags) avoids
+// cross-command flag-state bleed.
+var (
+	flagGithubMapEmails    string
+	flagGithubMapEmailFile string
+	flagGithubMapToken     string
+)
+
+var enumGithubMapCmd = &cobra.Command{
+	Use:   "map",
+	Short: "Correlate known emails to GitHub usernames (reveal-only, skips existence checks)",
+	Long: `Correlate a list of emails you ALREADY believe are GitHub accounts to their
+GitHub usernames.
+
+map is reveal-only: it SKIPS the unauthenticated existence endpoint that the
+parent "github" command uses (GitHub heavily rate-limits that endpoint) and goes
+straight to the authenticated username-reveal step. Use it when you already
+know — or strongly believe — the supplied emails belong to GitHub accounts and
+you only need the email -> @username mapping.
+
+map REQUIRES a personal access token (via GITHUB_TOKEN or --token) with the
+"repo" and "delete_repo" scopes. It creates a temporary PRIVATE repository,
+pushes one commit per email with that email as the commit author, resolves the
+author's login (which works even when the account has email privacy enabled),
+and then ALWAYS deletes the repository afterward. Only emails GitHub links to an
+account are reported as correlated; the rest are reported as not correlated.`,
+	Example: `  # Correlate emails from a file (token from the environment)
+  export GITHUB_TOKEN=ghp_...
+  brutus enum active github map -E emails.txt
+
+  # Correlate a couple of emails inline
+  brutus enum active github map -e alice@example.com,bob@example.com`,
+	RunE: runEnumGithubMap,
+}
+
+func init() {
+	f := enumGithubMapCmd.Flags()
+	f.StringVarP(&flagGithubMapEmails, "emails", "e", "", "Comma-separated email addresses to correlate")
+	f.StringVarP(&flagGithubMapEmailFile, "email-file", "E", "", "File of email addresses, one per line (\"-\" for stdin)")
+	f.StringVar(&flagGithubMapToken, "token", "", "GitHub PAT (overrides GITHUB_TOKEN; visible in process list — prefer the env var)")
+	// NOTE: no -t shorthand — it collides with the global persistent --threads/-t.
+	enumGithubCmd.AddCommand(enumGithubMapCmd)
+}
+
+// runEnumGithubMap implements the "enum active github map" subcommand. It is
+// reveal-only: it skips the existence endpoint and resolves the supplied emails
+// straight to GitHub usernames via a temporary private repo (always deleted).
+func runEnumGithubMap(cmd *cobra.Command, args []string) error {
+	useColor := isColorEnabled(flagNoColor)
+
+	jsonWriter, forceJSON, closeOutput, err := setupOutputWriter(flagOutputFile)
+	if err != nil {
+		return err
+	}
+	defer closeOutput()
+	if forceJSON {
+		flagJSON = true
+	}
+
+	emails, err := collectGithubEmails(flagGithubMapEmails, flagGithubMapEmailFile, nil,
+		fmt.Errorf("provide --emails/-e or --email-file/-E"))
+	if err != nil {
+		return err
+	}
+
+	token := resolveGithubToken(flagGithubMapToken, useColor)
+	if token == "" {
+		return fmt.Errorf("github map: a GitHub PAT is required (set GITHUB_TOKEN or --token) with the \"repo\" and \"delete_repo\" scopes")
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	enumerator, err := githubenum.NewEnumerator(flagProxy, flagTimeout, token)
+	if err != nil {
+		return fmt.Errorf("github: %w", err)
+	}
+
+	if !flagQuiet && !flagJSON {
+		fmt.Fprintf(os.Stderr, "%s Correlating %d email(s) to GitHub accounts via a temporary private repo (deleted afterward)...\n",
+			dim(useColor, SymbolInfo), len(emails))
+		fmt.Fprintf(os.Stdout, "\n%s %s\n\n",
+			dim(useColor, SymbolInfo), heading(useColor, "GitHub Email → Account Correlation"))
+	}
+
+	progress := newProgressReporter(os.Stderr, len(emails), !flagQuiet && !flagJSON, useColor)
+	progress.Start()
+	mapping, revErr := enumerator.RevealWith(ctx, emails, func(done, total int) {
+		progress.Update(done, "commits pushed")
+	})
+	progress.Stop()
+	if revErr != nil {
+		return fmt.Errorf("github map: %w", revErr)
+	}
+
+	results := githubMapResults(emails, mapping)
+
+	if flagJSON {
+		outputGithubEnumJSONL(jsonWriter, results)
+		return nil
+	}
+
+	for i := range results {
+		if results[i].Exists || flagVerbose {
+			outputGithubEnumResultLine(os.Stdout, results[i], useColor)
+		}
+	}
+	outputGithubEnumSummary(os.Stdout, results, useColor)
+	return nil
+}
+
+// githubMapResults builds per-email results from the reveal mapping,
+// preserving input order. An email present in the mapping correlated to a
+// GitHub account (Exists=true with the resolved Username); an absent email did
+// not (Exists=false).
+func githubMapResults(emails []string, mapping map[string]string) []githubenum.Result {
+	results := make([]githubenum.Result, len(emails))
+	for i, e := range emails {
+		login, ok := mapping[e]
+		results[i] = githubenum.Result{Email: e, Exists: ok, Username: login}
+	}
+	return results
+}

--- a/cmd/brutus/cmd_enum_github_map_test.go
+++ b/cmd/brutus/cmd_enum_github_map_test.go
@@ -1,0 +1,179 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	githubenum "github.com/praetorian-inc/brutus/pkg/enum/github"
+)
+
+// ---------------------------------------------------------------------------
+// Flag registration
+// ---------------------------------------------------------------------------
+
+// TestEnumGithubMapCmd_Flags verifies that enumGithubMapCmd carries the
+// required flags and shorthands, and that no shorthand collides with the
+// global persistent --threads/-t flag.
+func TestEnumGithubMapCmd_Flags(t *testing.T) {
+	// --emails / -e
+	f := enumGithubMapCmd.Flags().Lookup("emails")
+	require.NotNil(t, f, "--emails flag must exist on enumGithubMapCmd")
+	sh := enumGithubMapCmd.Flags().ShorthandLookup("e")
+	require.NotNil(t, sh, "-e shorthand must exist on enumGithubMapCmd")
+	assert.Equal(t, "emails", sh.Name, "-e must map to --emails")
+
+	// --email-file / -E
+	f = enumGithubMapCmd.Flags().Lookup("email-file")
+	require.NotNil(t, f, "--email-file flag must exist on enumGithubMapCmd")
+	sh = enumGithubMapCmd.Flags().ShorthandLookup("E")
+	require.NotNil(t, sh, "-E shorthand must exist on enumGithubMapCmd")
+	assert.Equal(t, "email-file", sh.Name, "-E must map to --email-file")
+
+	// --token (no shorthand; -t collides with global persistent --threads/-t)
+	f = enumGithubMapCmd.Flags().Lookup("token")
+	require.NotNil(t, f, "--token flag must exist on enumGithubMapCmd")
+
+	// No -t shorthand: it collides with the global persistent --threads/-t.
+	noT := enumGithubMapCmd.Flags().ShorthandLookup("t")
+	require.Nil(t, noT,
+		"enumGithubMapCmd must not define a local -t shorthand (collides with global --threads/-t)")
+}
+
+// ---------------------------------------------------------------------------
+// Command wiring
+// ---------------------------------------------------------------------------
+
+// TestEnumGithubMapCmd_WiredUnderGithub verifies that enumGithubMapCmd is
+// registered as a child of enumGithubCmd with Use == "map".
+func TestEnumGithubMapCmd_WiredUnderGithub(t *testing.T) {
+	var found bool
+	for _, cmd := range enumGithubCmd.Commands() {
+		if cmd.Use == "map" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, `enumGithubCmd must have a "map" subcommand`)
+}
+
+// ---------------------------------------------------------------------------
+// collectGithubEmails
+// ---------------------------------------------------------------------------
+
+// TestCollectGithubEmails exercises the shared email-collection helper with
+// table-driven cases covering CSV dedup+trim, generated appending, and the
+// no-source sentinel error path.
+func TestCollectGithubEmails(t *testing.T) {
+	tests := []struct {
+		name         string
+		emailsCSV    string
+		emailFile    string
+		generated    []string
+		noSourceErr  error
+		wantEmails   []string
+		wantErrIs    error // non-nil → expect an error satisfying errors.Is
+	}{
+		{
+			name:        "CSV dedup + trim + order",
+			emailsCSV:   " a@x.com , b@x.com ,a@x.com ",
+			emailFile:   "",
+			generated:   nil,
+			noSourceErr: errors.New("provide --emails/-e or --email-file/-E"),
+			wantEmails:  []string{"a@x.com", "b@x.com"},
+		},
+		{
+			name:        "generated appended and deduped",
+			emailsCSV:   "a@x.com",
+			emailFile:   "",
+			generated:   []string{"b@x.com", "a@x.com", "c@x.com"},
+			noSourceErr: errors.New("provide --emails/-e or --email-file/-E"),
+			wantEmails:  []string{"a@x.com", "b@x.com", "c@x.com"},
+		},
+		{
+			name:        "no source returns sentinel error verbatim",
+			emailsCSV:   "",
+			emailFile:   "",
+			generated:   nil,
+			noSourceErr: errors.New("provide --emails/-e or --email-file/-E"),
+			wantErrIs:   errors.New("provide --emails/-e or --email-file/-E"),
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// Build the sentinel error for this case (so we can use errors.Is).
+			sentinel := tc.noSourceErr
+
+			got, err := collectGithubEmails(tc.emailsCSV, tc.emailFile, tc.generated, sentinel)
+
+			if tc.wantErrIs != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, sentinel,
+					"collectGithubEmails must return the exact sentinel error when no source is supplied")
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantEmails, got,
+				"email slice must be trimmed, deduped, and in first-seen order")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// githubMapResults
+// ---------------------------------------------------------------------------
+
+// TestGithubMapResults verifies that githubMapResults builds per-email results
+// from the reveal mapping, preserving input order and correctly marking
+// presence/absence in the mapping.
+func TestGithubMapResults(t *testing.T) {
+	emails := []string{"a@x.com", "b@x.com", "c@x.com"}
+	mapping := map[string]string{
+		"a@x.com": "alice",
+		"c@x.com": "carol",
+	}
+
+	results := githubMapResults(emails, mapping)
+
+	require.Len(t, results, 3)
+
+	// index 0: a@x.com → mapped to "alice"
+	assert.Equal(t, githubenum.Result{
+		Email:    "a@x.com",
+		Exists:   true,
+		Username: "alice",
+	}, results[0])
+
+	// index 1: b@x.com → not in mapping
+	assert.Equal(t, githubenum.Result{
+		Email:    "b@x.com",
+		Exists:   false,
+		Username: "",
+	}, results[1])
+
+	// index 2: c@x.com → mapped to "carol"
+	assert.Equal(t, githubenum.Result{
+		Email:    "c@x.com",
+		Exists:   true,
+		Username: "carol",
+	}, results[2])
+}


### PR DESCRIPTION
## What

Adds `enum active github map` — a **reveal-only** correlation command. Given a list of emails you already believe belong to GitHub accounts, it resolves them straight to `@username`, **skipping the unauthenticated existence endpoint** that github.com heavily rate-limits.

```
export GITHUB_TOKEN=ghp_...
brutus enum active github map -E emails.txt
brutus enum active github map -e alice@example.com,bob@example.com
```

## Why

The existence endpoint used by the parent `github` command gets aggressively rate-limited (a recent 10k-candidate run saw ~4.5k rate-limit errors). When you *already* know the emails are GitHub accounts and only need the username mapping, the authenticated reveal path is far faster and more reliable — it ran 38 known emails in ~48s with 38/38 resolved.

## How

- Requires a PAT (`GITHUB_TOKEN` or `--token`) with `repo` + `delete_repo` scopes. Clear error if absent (no unauthenticated path).
- Reuses the existing reveal mechanism (`RevealWith`): temporary **private** repo → one commit per email (email as author) → resolve author login (works even with email privacy enabled) → repo is **always** deleted afterward.
- Only emails GitHub links to an account are reported as correlated; the rest show as not correlated (only under `--verbose`).
- Reuses the existing result-line / summary / JSONL output helpers and the shared progress reporter.

## Refactor

Extracts the parent command's email parse/trim/dedup into a shared `collectGithubEmails` helper (DRY). Parent (`enum active github`) behavior is unchanged — existing tests preserved.

## Tests

New `cmd_enum_github_map_test.go`: flag registration, command wiring under `github`, `collectGithubEmails` (dedup/order/sentinel error), and `githubMapResults` (order + correlation mapping). `go build ./...`, `go vet`, and `go test ./cmd/brutus/...` all pass on the `dev` base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)