### PR TITLE
feat(enum/github): add `--no-reveal` to run existence-only (skip username mapping)

### DIFF
--- a/cmd/brutus/cmd_enum_github.go
+++ b/cmd/brutus/cmd_enum_github.go
@@ -38,6 +38,7 @@ var (
 	flagGithubEnumFormat    string
 	flagGithubEnumLimit     int
 	flagGithubEnumToken     string
+	flagGithubEnumNoReveal  bool
 )
 
 var enumGithubCmd = &cobra.Command{
@@ -59,7 +60,8 @@ repository is created, one commit per existing email is pushed with that email
 as the commit author, GitHub resolves the author's login (even when email
 privacy is enabled), and the temporary repository is then ALWAYS deleted. If the
 cleanup delete ever fails, the repository name is printed so you can remove it
-manually.
+manually. Pass --no-reveal to skip this step and run existence-only even when a
+token is present.
 
 Provide targets directly with --emails/-e or --email-file/-E, or pass --domain
 to generate the candidate wordlist internally from a bundled, frequency-ranked
@@ -93,6 +95,7 @@ func init() {
 	f.StringVar(&flagGithubEnumFormat, "format", "first.last", "Username format for --domain generation (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first)")
 	f.IntVar(&flagGithubEnumLimit, "limit", 0, "When generating with --domain, cap to the first N (most-likely) candidates (0 = all)")
 	f.StringVar(&flagGithubEnumToken, "token", "", "GitHub PAT for username reveal (overrides GITHUB_TOKEN; visible in process list — prefer the env var)")
+	f.BoolVar(&flagGithubEnumNoReveal, "no-reveal", false, "Skip username reveal after existence enumeration (existence-only; no token used, no temp repo created)")
 	// NOTE: no -t shorthand: it collides with the global persistent --threads/-t
 	// flag, which cobra merges into this subcommand at execute time.
 	enumActiveCmd.AddCommand(enumGithubCmd)
@@ -168,9 +171,10 @@ func runEnumGithub(cmd *cobra.Command, args []string) error {
 	results := enumerator.EnumerateWith(ctx, emails, flagThreads, flagRateLimit, flagJitter, onResult)
 	progress.Stop()
 
-	// Username reveal: only when a token is set and at least one account exists.
+	// Username reveal: only when not disabled, a token is set, and at least one
+	// account exists.
 	existing := existingEmails(results)
-	if token != "" && len(existing) > 0 {
+	if !flagGithubEnumNoReveal && token != "" && len(existing) > 0 {
 		if !flagQuiet && !flagJSON {
 			fmt.Fprintf(os.Stderr, "%s Revealing usernames for %d existing account(s) via a temporary private repo (deleted afterward)...\n",
 				dim(useColor, SymbolInfo), len(existing))

--- a/cmd/brutus/cmd_enum_github_test.go
+++ b/cmd/brutus/cmd_enum_github_test.go
@@ -127,6 +127,24 @@ func TestEnumGithubCmd_WiredUnderActiveCmd(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// --no-reveal flag contract
+// ---------------------------------------------------------------------------
+
+// TestEnumGithubCmd_NoRevealFlag asserts the flag-level contract for the
+// boolean --no-reveal flag registered on enumGithubCmd:
+//  1. The flag exists on the command.
+//  2. Its default value is "false".
+//  3. It is typed as a bool flag.
+//  4. It has no shorthand (empty string).
+func TestEnumGithubCmd_NoRevealFlag(t *testing.T) {
+	f := enumGithubCmd.Flags().Lookup("no-reveal")
+	require.NotNil(t, f, "--no-reveal flag must exist on enumGithubCmd")
+	assert.Equal(t, "false", f.DefValue, "--no-reveal default must be \"false\"")
+	assert.Equal(t, "bool", f.Value.Type(), "--no-reveal must be a bool flag")
+	assert.Equal(t, "", f.Shorthand, "--no-reveal must have no shorthand")
+}
+
+// ---------------------------------------------------------------------------
 // githubEnumTargets
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Adds `--no-reveal` to `enum active github`. When set, the command runs **existence-only** and skips the authenticated username-reveal (email→`@username` mapping) step that otherwise runs automatically whenever a token is present.

```
# existence-only, even though a token is in the environment
brutus enum active github -d fox.com --limit 10000 --format first.last --no-reveal
```

## Why

The reveal step creates a temporary private repo and pushes one commit per existing account. When you only want the existence signal (or don't want any authenticated/repo-creating activity), there was no way to opt out short of unsetting `GITHUB_TOKEN`. `--no-reveal` makes existence-only an explicit, first-class choice.

## Behavior

- Default `false` → **current behavior is unchanged** (reveal still runs when a token is present and accounts exist).
- When `true` → the reveal block is skipped entirely; no token is used for reveal and no temp repo is created. Existence enumeration is untouched.
- The `map` subcommand (reveal-only by design) is unaffected.

## Changes

- `cmd_enum_github.go`: new `--no-reveal` bool flag; reveal gate becomes `!flagGithubEnumNoReveal && token != "" && len(existing) > 0`; help text note added.
- `cmd_enum_github_test.go`: `TestEnumGithubCmd_NoRevealFlag` (flag exists, bool, default false, no shorthand).

## Verification

`go build ./...`, `go vet ./cmd/brutus/...`, `go test ./cmd/brutus/...` all pass. Manually confirmed: with a dummy `GITHUB_TOKEN` set, `--no-reveal` produces an existence-only summary with no reveal step attempted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)