### PR TITLE
feat(enum): authenticated HTTP/HTTPS proxy support + --rotating-proxy

### DIFF
--- a/cmd/brutus/cmd_badkeys.go
+++ b/cmd/brutus/cmd_badkeys.go
@@ -56,7 +56,10 @@ func init() {
 }
 
 func runBadkeys(cmd *cobra.Command, args []string) error {
-	base := buildBaseConfig(cmd)
+	base, err := buildBaseConfig(cmd)
+	if err != nil {
+		return err
+	}
 
 	// Badkeys mode: SSH-only, embedded bad keys only
 	base.protocolOverride = "ssh"

--- a/cmd/brutus/cmd_creds.go
+++ b/cmd/brutus/cmd_creds.go
@@ -65,7 +65,10 @@ func init() {
 }
 
 func runCreds(cmd *cobra.Command, args []string) error {
-	base := buildBaseConfig(cmd)
+	base, err := buildBaseConfig(cmd)
+	if err != nil {
+		return err
+	}
 
 	// Load credentials (creds-specific)
 	usernames, passwords, credPairs, err := loadCredentialInputs(cmd)

--- a/cmd/brutus/cmd_enum_apollo.go
+++ b/cmd/brutus/cmd_enum_apollo.go
@@ -155,7 +155,14 @@ func runEnumApollo(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	client := apollo.NewClient(apiKey, flagTimeout, pageSizeForLimit(flagApolloLimit))
+	proxyURL, err := resolveProxyURL()
+	if err != nil {
+		return err
+	}
+	client, err := apollo.NewClient(apiKey, flagTimeout, pageSizeForLimit(flagApolloLimit), proxyURL)
+	if err != nil {
+		return err
+	}
 	result, err := client.Discover(ctx, flagApolloDomain, flagApolloTitles, flagApolloLimit)
 	if err != nil {
 		// Output any partial discovery (Discover returns partial + err) before

--- a/cmd/brutus/cmd_enum_custom.go
+++ b/cmd/brutus/cmd_enum_custom.go
@@ -108,6 +108,11 @@ func runEnumCustom(cmd *cobra.Command, args []string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	proxyURL, err := resolveProxyURL()
+	if err != nil {
+		return err
+	}
+
 	cfg := &enum.Config{
 		Emails:    subjects,
 		Threads:   flagThreads,
@@ -115,6 +120,7 @@ func runEnumCustom(cmd *cobra.Command, args []string) error {
 		RateLimit: flagRateLimit,
 		Jitter:    flagJitter,
 		Verbose:   flagVerbose,
+		ProxyURL:  proxyURL,
 	}
 	// Apply the spec's rate-limit hint as a default only when the operator did
 	// not explicitly set --rate-limit (operator overrides).

--- a/cmd/brutus/cmd_enum_dehashed.go
+++ b/cmd/brutus/cmd_enum_dehashed.go
@@ -136,7 +136,14 @@ func runEnumDehashed(cmd *cobra.Command, args []string) error {
 			dim(useColor, SymbolInfo), flagDehashedDomain)
 	}
 
-	client := dehashed.NewClient(apiKey, flagTimeout, min(flagDehashedLimit, 100))
+	proxyURL, err := resolveProxyURL()
+	if err != nil {
+		return err
+	}
+	client, err := dehashed.NewClient(apiKey, flagTimeout, min(flagDehashedLimit, 100), proxyURL)
+	if err != nil {
+		return err
+	}
 	result, err := client.Search(ctx, flagDehashedDomain, flagDehashedLimit)
 	if err != nil {
 		return classifyDehashedError(err)

--- a/cmd/brutus/cmd_enum_github.go
+++ b/cmd/brutus/cmd_enum_github.go
@@ -126,7 +126,12 @@ func runEnumGithub(cmd *cobra.Command, args []string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	enumerator, err := githubenum.NewEnumerator(flagProxy, flagTimeout, token)
+	proxyURL, err := resolveProxyURL()
+	if err != nil {
+		return err
+	}
+
+	enumerator, err := githubenum.NewEnumerator(proxyURL, flagTimeout, token)
 	if err != nil {
 		return fmt.Errorf("github: %w", err)
 	}

--- a/cmd/brutus/cmd_enum_github.go
+++ b/cmd/brutus/cmd_enum_github.go
@@ -131,7 +131,7 @@ func runEnumGithub(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	enumerator, err := githubenum.NewEnumerator(proxyURL, flagTimeout, token)
+	enumerator, err := githubenum.NewEnumerator(proxyURL, flagTimeout, token, flagRotatingProxy)
 	if err != nil {
 		return fmt.Errorf("github: %w", err)
 	}

--- a/cmd/brutus/cmd_enum_github_map.go
+++ b/cmd/brutus/cmd_enum_github_map.go
@@ -100,7 +100,12 @@ func runEnumGithubMap(cmd *cobra.Command, args []string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	enumerator, err := githubenum.NewEnumerator(flagProxy, flagTimeout, token)
+	proxyURL, err := resolveProxyURL()
+	if err != nil {
+		return err
+	}
+
+	enumerator, err := githubenum.NewEnumerator(proxyURL, flagTimeout, token, flagRotatingProxy)
 	if err != nil {
 		return fmt.Errorf("github: %w", err)
 	}

--- a/cmd/brutus/cmd_enum_google.go
+++ b/cmd/brutus/cmd_enum_google.go
@@ -109,7 +109,12 @@ func runEnumGoogle(cmd *cobra.Command, args []string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	enumerator, err := google.NewEnumerator(flagProxy, flagTimeout)
+	proxyURL, err := resolveProxyURL()
+	if err != nil {
+		return err
+	}
+
+	enumerator, err := google.NewEnumerator(proxyURL, flagTimeout)
 	if err != nil {
 		return fmt.Errorf("google: %w", err)
 	}

--- a/cmd/brutus/cmd_enum_hunter.go
+++ b/cmd/brutus/cmd_enum_hunter.go
@@ -101,7 +101,14 @@ func runEnumHunter(cmd *cobra.Command, args []string) error {
 			dim(useColor, SymbolInfo), flagHunterDomain)
 	}
 
-	client := hunter.NewClient(apiKey, flagTimeout, flagHunterLimit)
+	proxyURL, err := resolveProxyURL()
+	if err != nil {
+		return err
+	}
+	client, err := hunter.NewClient(apiKey, flagTimeout, flagHunterLimit, proxyURL)
+	if err != nil {
+		return err
+	}
 	result, err := client.Search(ctx, flagHunterDomain)
 	if err != nil {
 		return classifyHunterError(err)

--- a/cmd/brutus/cmd_enum_lusha.go
+++ b/cmd/brutus/cmd_enum_lusha.go
@@ -136,7 +136,14 @@ func runEnumLusha(cmd *cobra.Command, args []string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	client := lusha.NewClient(apiKey, flagTimeout)
+	proxyURL, err := resolveProxyURL()
+	if err != nil {
+		return err
+	}
+	client, err := lusha.NewClient(apiKey, flagTimeout, proxyURL)
+	if err != nil {
+		return err
+	}
 
 	// Roster mode: enumerate a whole company by domain via the prospecting API.
 	if isLushaRosterMode() {

--- a/cmd/brutus/cmd_enum_oracles.go
+++ b/cmd/brutus/cmd_enum_oracles.go
@@ -164,6 +164,11 @@ func runEnumOracles(cmd *cobra.Command, args []string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	proxyURL, err := resolveProxyURL()
+	if err != nil {
+		return err
+	}
+
 	// Phase 1: DNS TXT recon — supporting context, not the headline. Surfaces
 	// the candidate oracles so the oracle check below has something to validate.
 	// Full TXT detail stays under --verbose and in JSON; the human path leads
@@ -283,6 +288,7 @@ func runEnumOracles(cmd *cobra.Command, args []string) error {
 			Threads:  flagThreads,
 			Timeout:  flagTimeout,
 			Verbose:  flagVerbose,
+			ProxyURL: proxyURL,
 		}
 		validResults, validErr := enum.EnumerateWithContext(ctx, validCfg)
 		if validErr != nil {
@@ -366,6 +372,7 @@ func runEnumOracles(cmd *cobra.Command, args []string) error {
 		RateLimit: flagRateLimit,
 		Jitter:    flagJitter,
 		Verbose:   flagVerbose,
+		ProxyURL:  proxyURL,
 	}
 
 	results, err := enum.EnumerateWithContext(ctx, cfg)
@@ -392,6 +399,11 @@ func runEnumDiscover(cmd *cobra.Command, args []string) error {
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
+
+	proxyURL, err := resolveProxyURL()
+	if err != nil {
+		return err
+	}
 
 	// Phase 1: Determine oracles to test
 	var services []string
@@ -455,6 +467,7 @@ func runEnumDiscover(cmd *cobra.Command, args []string) error {
 			Threads:  flagThreads,
 			Timeout:  flagTimeout,
 			Verbose:  flagVerbose,
+			ProxyURL: proxyURL,
 		}
 		var enumErr error
 		results, enumErr = enum.EnumerateWithContext(ctx, cfg)
@@ -529,7 +542,12 @@ func confirmTeamsOracle(ctx context.Context, knownValid string, useColor bool) s
 		return "teams: available (unconfirmed) — run `brutus enum active teams auth` then re-run to confirm"
 	}
 
-	enumerator, err := teams.NewEnumerator(accessToken, refreshToken, flagProxy, flagTimeout, false)
+	proxyURL, err := resolveProxyURL()
+	if err != nil {
+		return fmt.Sprintf("teams: proxy misconfigured: %v", err)
+	}
+
+	enumerator, err := teams.NewEnumerator(accessToken, refreshToken, proxyURL, flagTimeout, false)
 	if err != nil {
 		return fmt.Sprintf("teams: unconfirmed (enumerator setup failed: %v)", err)
 	}
@@ -537,7 +555,7 @@ func confirmTeamsOracle(ctx context.Context, knownValid string, useColor bool) s
 	// Wire a refresh callback only when a refresh token is available, mirroring
 	// runEnumTeamsUsers so an expired access token is renewed once.
 	if refreshToken != "" {
-		client, cerr := teams.NewClient("organizations", teams.DefaultClientID, teams.DefaultScope, flagProxy, flagTimeout)
+		client, cerr := teams.NewClient("organizations", teams.DefaultClientID, teams.DefaultScope, proxyURL, flagTimeout)
 		if cerr == nil {
 			enumerator.SetRefreshFunc(func(ctx context.Context) (string, error) {
 				tok, rerr := client.RefreshAccessToken(ctx, refreshToken)

--- a/cmd/brutus/cmd_enum_teams.go
+++ b/cmd/brutus/cmd_enum_teams.go
@@ -264,7 +264,12 @@ func runEnumTeamsAuth(cmd *cobra.Command, args []string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	client, err := teams.NewClient(flagTeamsTenant, flagTeamsClientID, flagTeamsScope, flagProxy, flagTimeout)
+	proxyURL, err := resolveProxyURL()
+	if err != nil {
+		return err
+	}
+
+	client, err := teams.NewClient(flagTeamsTenant, flagTeamsClientID, flagTeamsScope, proxyURL, flagTimeout)
 	if err != nil {
 		return fmt.Errorf("teams auth: %w", err)
 	}
@@ -376,7 +381,12 @@ func runEnumTeamsUsers(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	enumerator, err := teams.NewEnumerator(accessToken, refreshToken, flagProxy, flagTimeout, !flagTeamsEnumNoPresence)
+	proxyURL, err := resolveProxyURL()
+	if err != nil {
+		return err
+	}
+
+	enumerator, err := teams.NewEnumerator(accessToken, refreshToken, proxyURL, flagTimeout, !flagTeamsEnumNoPresence)
 	if err != nil {
 		return fmt.Errorf("teams users: %w", err)
 	}
@@ -384,7 +394,7 @@ func runEnumTeamsUsers(cmd *cobra.Command, args []string) error {
 
 	// Only wire a refresh callback when a refresh token is available.
 	if refreshToken != "" {
-		client, cerr := teams.NewClient(flagTeamsEnumTenant, flagTeamsEnumClientID, flagTeamsEnumScope, flagProxy, flagTimeout)
+		client, cerr := teams.NewClient(flagTeamsEnumTenant, flagTeamsEnumClientID, flagTeamsEnumScope, proxyURL, flagTimeout)
 		if cerr != nil {
 			return fmt.Errorf("teams users: %w", cerr)
 		}
@@ -494,7 +504,12 @@ func runEnumTeamsAudit(cmd *cobra.Command, args []string) error {
 
 	presenceChecked := !flagTeamsAuditNoPresence
 
-	enumerator, err := teams.NewEnumerator(accessToken, refreshToken, flagProxy, flagTimeout, presenceChecked)
+	proxyURL, err := resolveProxyURL()
+	if err != nil {
+		return err
+	}
+
+	enumerator, err := teams.NewEnumerator(accessToken, refreshToken, proxyURL, flagTimeout, presenceChecked)
 	if err != nil {
 		return fmt.Errorf("teams audit: %w", err)
 	}
@@ -502,7 +517,7 @@ func runEnumTeamsAudit(cmd *cobra.Command, args []string) error {
 
 	// Only wire a refresh callback when a refresh token is available.
 	if refreshToken != "" {
-		client, cerr := teams.NewClient(flagTeamsAuditTenant, flagTeamsAuditClientID, flagTeamsAuditScope, flagProxy, flagTimeout)
+		client, cerr := teams.NewClient(flagTeamsAuditTenant, flagTeamsAuditClientID, flagTeamsAuditScope, proxyURL, flagTimeout)
 		if cerr != nil {
 			return fmt.Errorf("teams audit: %w", cerr)
 		}
@@ -735,7 +750,12 @@ func teamsEnumReadTokenFile(path string) (accessToken, refreshToken string, err 
 // teamsEnumDeviceCodeTokens runs the interactive device-code flow inline and
 // returns the resulting access and refresh tokens.
 func teamsEnumDeviceCodeTokens(ctx context.Context, src teamsTokenSource, useColor bool) (accessToken, refreshToken string, err error) {
-	client, err := teams.NewClient(src.tenant, src.clientID, src.scope, flagProxy, flagTimeout)
+	proxyURL, err := resolveProxyURL()
+	if err != nil {
+		return "", "", err
+	}
+
+	client, err := teams.NewClient(src.tenant, src.clientID, src.scope, proxyURL, flagTimeout)
 	if err != nil {
 		return "", "", fmt.Errorf("teams enum: %w", err)
 	}

--- a/cmd/brutus/cmd_logon.go
+++ b/cmd/brutus/cmd_logon.go
@@ -170,7 +170,10 @@ func runLogonChecks(cmd *cobra.Command, checks logon.Check) error {
 		return fmt.Errorf("--open requires --web (starts a web terminal and opens the browser)")
 	}
 
-	base := buildBaseConfig(cmd)
+	base, err := buildBaseConfig(cmd)
+	if err != nil {
+		return err
+	}
 	base.checks = checks
 
 	// AI config (logon-specific)

--- a/cmd/brutus/cmd_snmp.go
+++ b/cmd/brutus/cmd_snmp.go
@@ -58,7 +58,10 @@ func init() {
 }
 
 func runSNMP(cmd *cobra.Command, args []string) error {
-	base := buildBaseConfig(cmd)
+	base, err := buildBaseConfig(cmd)
+	if err != nil {
+		return err
+	}
 
 	// Load custom community strings from -c/-C
 	communityFlagSet := isFlagChanged(cmd, "community")

--- a/cmd/brutus/cmd_web.go
+++ b/cmd/brutus/cmd_web.go
@@ -62,7 +62,10 @@ func init() {
 }
 
 func runWeb(cmd *cobra.Command, args []string) error {
-	base := buildBaseConfig(cmd)
+	base, err := buildBaseConfig(cmd)
+	if err != nil {
+		return err
+	}
 
 	// Load credential pairs (-c/-C)
 	credPairs, err := loadCredentials(flagCredentials, flagCredentialsFile)

--- a/cmd/brutus/flags.go
+++ b/cmd/brutus/flags.go
@@ -75,7 +75,10 @@ var (
 var flagVerifyTLS bool
 
 // Proxy flags
-var flagProxy string
+var (
+	flagProxy     string
+	flagProxyUser string
+)
 
 // Mode flag (global)
 var flagMode string
@@ -134,7 +137,8 @@ func registerSharedFlags(cmd *cobra.Command) {
 	pf.StringVarP(&flagMode, "mode", "m", "default", "Aggressiveness tier: cautious, default, aggressive")
 
 	// Proxy
-	pf.StringVar(&flagProxy, "proxy", "", "SOCKS5 proxy URL (e.g., socks5://127.0.0.1:1080 or socks5://user:pass@host:port)")
+	pf.StringVar(&flagProxy, "proxy", "", "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080")
+	pf.StringVar(&flagProxyUser, "proxy-user", "", "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.")
 
 	// Output
 	pf.BoolVar(&flagJSON, "json", false, "JSON output format")
@@ -207,13 +211,22 @@ func registerRootFlags(cmd *cobra.Command) {
 // Config builder
 // ---------------------------------------------------------------------------
 
+// resolveProxyURL merges the --proxy and --proxy-user flags into a single
+// canonical proxy URL. Returns "" when no proxy is configured.
+func resolveProxyURL() (string, error) {
+	return brutus.BuildProxyURL(flagProxy, flagProxyUser)
+}
+
 // buildBaseConfig constructs a baseConfigOptions with only the shared fields.
 // Subcommand-specific loading (credentials, keys, AI config) is handled by
 // each subcommand's runXxx function.
 //
 // Mode presets supply defaults for threads, timeout, rate-limit, jitter,
 // max-attempts, and retries. Explicit CLI flags override presets.
-func buildBaseConfig(cmd *cobra.Command) *baseConfigOptions {
+//
+// Proxy resolution fails closed: when --proxy/--proxy-user are misconfigured,
+// it returns an error rather than silently degrading to a direct connection.
+func buildBaseConfig(cmd *cobra.Command) (*baseConfigOptions, error) {
 	mode := brutus.NormalizeMode(flagMode)
 	presets := mode.Presets()
 
@@ -248,6 +261,11 @@ func buildBaseConfig(cmd *cobra.Command) *baseConfigOptions {
 		maxRetries = flagRetries
 	}
 
+	proxyURL, err := resolveProxyURL()
+	if err != nil {
+		return nil, err
+	}
+
 	return &baseConfigOptions{
 		threads:          threads,
 		timeout:          timeout,
@@ -265,10 +283,10 @@ func buildBaseConfig(cmd *cobra.Command) *baseConfigOptions {
 		mode:             flagMode,
 		anthropicKey:     os.Getenv("ANTHROPIC_API_KEY"),
 		perplexityKey:    os.Getenv("PERPLEXITY_API_KEY"),
-		proxyURL:         flagProxy,
+		proxyURL:         proxyURL,
 		noNLAProbe:       flagNoNLAProbe,
 		fast:             flagFast,
-	}
+	}, nil
 }
 
 // loadCredentialInputs loads usernames, passwords, and pre-paired credentials

--- a/cmd/brutus/flags.go
+++ b/cmd/brutus/flags.go
@@ -76,8 +76,9 @@ var flagVerifyTLS bool
 
 // Proxy flags
 var (
-	flagProxy     string
-	flagProxyUser string
+	flagProxy         string
+	flagProxyUser     string
+	flagRotatingProxy bool
 )
 
 // Mode flag (global)
@@ -139,6 +140,7 @@ func registerSharedFlags(cmd *cobra.Command) {
 	// Proxy
 	pf.StringVar(&flagProxy, "proxy", "", "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080")
 	pf.StringVar(&flagProxyUser, "proxy-user", "", "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.")
+	pf.BoolVar(&flagRotatingProxy, "rotating-proxy", false, "Signal that --proxy rotates exit IPs (e.g. Bright Data): reduces per-IP rate-limit backoff during GitHub existence enumeration (short retry delay, higher retry ceiling). No effect on token-rate-limited reveal.")
 
 	// Output
 	pf.BoolVar(&flagJSON, "json", false, "JSON output format")

--- a/cmd/brutus/logon_flags_wiring_test.go
+++ b/cmd/brutus/logon_flags_wiring_test.go
@@ -54,7 +54,8 @@ func TestLogonFlagsWiring(t *testing.T) {
 		resetLogonFlags()
 		require.NoError(t, logonCmd.ParseFlags([]string{}))
 
-		base := buildBaseConfig(logonCmd)
+		base, err := buildBaseConfig(logonCmd)
+		require.NoError(t, err)
 		assert.False(t, base.noNLAProbe,
 			"base.noNLAProbe must default to false (--no-nla-probe not passed)")
 	})
@@ -63,7 +64,8 @@ func TestLogonFlagsWiring(t *testing.T) {
 		resetLogonFlags()
 		require.NoError(t, logonCmd.ParseFlags([]string{"--no-nla-probe"}))
 
-		base := buildBaseConfig(logonCmd)
+		base, err := buildBaseConfig(logonCmd)
+		require.NoError(t, err)
 		assert.True(t, base.noNLAProbe,
 			"base.noNLAProbe must be true after parsing --no-nla-probe")
 	})
@@ -83,12 +85,16 @@ func TestFastFlagWiring(t *testing.T) {
 	t.Run("default_false", func(t *testing.T) {
 		resetLogonFlags()
 		require.NoError(t, logonCmd.ParseFlags([]string{}))
-		assert.False(t, buildBaseConfig(logonCmd).fast, "fast defaults false")
+		base, err := buildBaseConfig(logonCmd)
+		require.NoError(t, err)
+		assert.False(t, base.fast, "fast defaults false")
 	})
 	t.Run("set_true", func(t *testing.T) {
 		resetLogonFlags()
 		require.NoError(t, logonCmd.ParseFlags([]string{"--fast"}))
-		assert.True(t, buildBaseConfig(logonCmd).fast, "--fast sets base.fast")
+		base, err := buildBaseConfig(logonCmd)
+		require.NoError(t, err)
+		assert.True(t, base.fast, "--fast sets base.fast")
 	})
 	t.Run("registered_on_all_three", func(t *testing.T) {
 		for _, c := range []*cobra.Command{logonCmd, stickykeysCmd, utilmanCmd} {
@@ -114,7 +120,8 @@ func TestConnectTimeoutFlagWiring(t *testing.T) {
 	t.Run("default_is_3s", func(t *testing.T) {
 		resetLogonFlags()
 		require.NoError(t, logonCmd.ParseFlags([]string{}))
-		base := buildBaseConfig(logonCmd)
+		base, err := buildBaseConfig(logonCmd)
+		require.NoError(t, err)
 		assert.Equal(t, 3*time.Second, base.connectTimeout,
 			"connect-timeout must default to 3s")
 	})
@@ -122,7 +129,8 @@ func TestConnectTimeoutFlagWiring(t *testing.T) {
 	t.Run("override_applies", func(t *testing.T) {
 		resetLogonFlags()
 		require.NoError(t, logonCmd.ParseFlags([]string{"--connect-timeout", "7s"}))
-		base := buildBaseConfig(logonCmd)
+		base, err := buildBaseConfig(logonCmd)
+		require.NoError(t, err)
 		assert.Equal(t, 7*time.Second, base.connectTimeout,
 			"connect-timeout must reflect the parsed flag")
 	})
@@ -198,7 +206,8 @@ func TestScanTimeoutFlagWiring(t *testing.T) {
 			resetLogonFlags()
 			require.NoError(t, tc.cmd.ParseFlags(tc.args))
 
-			base := buildBaseConfig(tc.cmd)
+			base, err := buildBaseConfig(tc.cmd)
+			require.NoError(t, err)
 			assert.Equal(t, tc.want, base.timeout, tc.wantMsg)
 		})
 	}
@@ -256,7 +265,8 @@ func TestTimeoutNotRejectedOnNonLogonCommands(t *testing.T) {
 		require.NoError(t, credsCmd.ParseFlags([]string{"--timeout", "5s"}),
 			"--timeout must still be accepted on credsCmd without error")
 
-		base := buildBaseConfig(credsCmd)
+		base, err := buildBaseConfig(credsCmd)
+		require.NoError(t, err)
 		assert.Equal(t, 5*time.Second, base.timeout,
 			"creds base.timeout must reflect --timeout 5s (non-logon command keeps --timeout)")
 	})

--- a/cmd/brutus/proxy_resolve_test.go
+++ b/cmd/brutus/proxy_resolve_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildBaseConfig_ProxyUserWithoutProxy is a fail-closed regression test at
+// the cmd layer: passing --proxy-user without --proxy must cause buildBaseConfig
+// to return a non-nil error (not a silent direct connection).
+//
+// This guards against regressions where resolveProxyURL inside buildBaseConfig
+// accepts a proxy-user-only configuration and silently degrades to a direct
+// connection, leaking credentials or bypassing the intended proxy path.
+func TestBuildBaseConfig_ProxyUserWithoutProxy(t *testing.T) {
+	// Save and restore the package-level proxy flag vars so this test does not
+	// bleed state into parallel tests.
+	origProxy := flagProxy
+	origProxyUser := flagProxyUser
+	t.Cleanup(func() {
+		flagProxy = origProxy
+		flagProxyUser = origProxyUser
+	})
+
+	// Simulate --proxy-user set, --proxy empty (the misconfigured case).
+	flagProxy = ""
+	flagProxyUser = "u:p"
+
+	// buildBaseConfig reads proxy state via resolveProxyURL(), which calls
+	// brutus.BuildProxyURL(flagProxy, flagProxyUser). With a non-empty proxyUser
+	// and an empty proxyURL that function must return an error.
+	base, err := buildBaseConfig(logonCmd)
+
+	require.Error(t, err,
+		"buildBaseConfig must return an error when --proxy-user is set without --proxy")
+	assert.Nil(t, base,
+		"buildBaseConfig must return nil options on proxy misconfiguration")
+	assert.Contains(t, err.Error(), "requires",
+		"error message must contain 'requires' to explain the constraint")
+}

--- a/internal/enumplugins/google/google.go
+++ b/internal/enumplugins/google/google.go
@@ -39,7 +39,7 @@ type Plugin struct{}
 func (p *Plugin) Name() string { return "google" }
 
 // Check tests if an email account exists on Google Workspace, building a fresh
-// (unauthenticated, no-proxy) enumerator per call and delegating to
+// (unauthenticated, honoring --proxy from context) enumerator per call and delegating to
 // google.CheckAccount. Confidence is high when the account is confirmed,
 // medium otherwise — preserving the previous plugin behavior.
 func (p *Plugin) Check(ctx context.Context, email string, timeout time.Duration) *enum.Result {
@@ -49,7 +49,7 @@ func (p *Plugin) Check(ctx context.Context, email string, timeout time.Duration)
 		Email:   email,
 	}
 
-	enumerator, err := googleenum.NewEnumerator("", timeout)
+	enumerator, err := googleenum.NewEnumerator(enum.ProxyURLFromContext(ctx), timeout)
 	if err != nil {
 		result.Confidence = enum.ConfidenceMedium
 		result.Error = err

--- a/internal/enumplugins/microsoft365/microsoft365.go
+++ b/internal/enumplugins/microsoft365/microsoft365.go
@@ -74,7 +74,10 @@ func (p *Plugin) Check(ctx context.Context, email string, timeout time.Duration)
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	client := enum.NewEnumHTTPClient(timeout)
+	client := enum.HTTPClientFromContext(ctx)
+	if client == nil {
+		client = enum.NewEnumHTTPClient(timeout)
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		result.Error = fmt.Errorf("request failed: %w", err)

--- a/pkg/brutus/http.go
+++ b/pkg/brutus/http.go
@@ -32,26 +32,52 @@ func NewHTTPClient(timeout time.Duration, tlsConfig *tls.Config) *http.Client {
 }
 
 // NewHTTPClientWithProxy creates an *http.Client that routes requests through a
-// SOCKS5 proxy when proxyURL is non-empty. Returns an error if the proxy URL is
-// invalid or uses an unsupported scheme, rather than silently falling back to a
-// direct connection.
+// proxy when proxyURL is non-empty. Supports socks5/socks5h (raw TCP dialing)
+// and http/https (HTTP CONNECT / absolute-form, with Proxy-Authorization
+// derived from URL userinfo). Returns an error if the proxy URL is invalid or
+// uses an unsupported scheme, rather than silently falling back to a direct
+// connection.
 func NewHTTPClientWithProxy(timeout time.Duration, tlsConfig *tls.Config, proxyURL string) (*http.Client, error) {
-	transport := &http.Transport{
-		TLSClientConfig: tlsConfig,
+	transport, err := ProxyTransport(proxyURL, timeout, tlsConfig)
+	if err != nil {
+		return nil, err
 	}
-
-	if proxyURL != "" {
-		dialFunc, err := NewProxyDialFunc(proxyURL, timeout)
-		if err != nil {
-			return nil, fmt.Errorf("configuring proxy: %w", err)
-		}
-		transport.DialContext = dialFunc
-	}
-
 	return &http.Client{
 		Timeout:   timeout,
 		Transport: transport,
 	}, nil
+}
+
+// ProxyTransport builds an *http.Transport configured to route requests through
+// proxyURL. An empty proxyURL yields a direct transport. socks5/socks5h proxies
+// are wired via DialContext; http/https proxies via Transport.Proxy (Go injects
+// Proxy-Authorization from the URL userinfo automatically). tlsConfig may be nil.
+func ProxyTransport(proxyURL string, timeout time.Duration, tlsConfig *tls.Config) (*http.Transport, error) {
+	transport := &http.Transport{
+		TLSClientConfig: tlsConfig,
+	}
+
+	if proxyURL == "" {
+		return transport, nil
+	}
+
+	u, err := parseProxyURL(proxyURL)
+	if err != nil {
+		return nil, err
+	}
+
+	switch u.Scheme {
+	case proxySchemeSOCKS5, proxySchemeSOCKS5H:
+		dialFunc, err := socksDialFunc(u, timeout)
+		if err != nil {
+			return nil, fmt.Errorf("configuring proxy: %w", err)
+		}
+		transport.DialContext = dialFunc
+	case proxySchemeHTTP, proxySchemeHTTPS:
+		transport.Proxy = http.ProxyURL(u)
+	}
+
+	return transport, nil
 }
 
 // SchemeFromTLSMode returns "https" if TLS is enabled, "http" otherwise.

--- a/pkg/brutus/net.go
+++ b/pkg/brutus/net.go
@@ -50,30 +50,37 @@ func DialWithProxy(ctx context.Context, network, address string, timeout time.Du
 // or http.Transport.DialContext.
 type ProxyDialFunc func(ctx context.Context, network, address string) (net.Conn, error)
 
-// NewProxyDialFunc returns a context-aware dial function that routes connections
-// through the given SOCKS5 proxy. Returns nil and no error if proxyURL is empty.
+// NewProxyDialFunc returns a context-aware dial function that routes raw TCP
+// connections through the given SOCKS5 proxy. Returns nil and no error if
+// proxyURL is empty. Only socks5/socks5h are supported here; HTTP(S) proxies
+// cannot tunnel arbitrary TCP and are rejected (use them via the HTTP client
+// path instead).
 func NewProxyDialFunc(proxyURL string, timeout time.Duration) (ProxyDialFunc, error) {
 	if proxyURL == "" {
 		return nil, nil
 	}
 
-	u, err := url.Parse(proxyURL)
+	u, err := parseProxyURL(proxyURL)
 	if err != nil {
-		return nil, fmt.Errorf("invalid proxy URL %q: %w", proxyURL, err)
+		return nil, err
 	}
 
 	switch u.Scheme {
-	case "socks5", "socks5h":
-		// OK
+	case proxySchemeSOCKS5, proxySchemeSOCKS5H:
+		return socksDialFunc(u, timeout)
 	default:
-		return nil, fmt.Errorf("unsupported proxy scheme %q (supported: socks5, socks5h)", u.Scheme)
+		return nil, fmt.Errorf("unsupported proxy scheme %q for raw TCP dialing (supported: socks5, socks5h)", u.Scheme)
 	}
+}
 
+// socksDialFunc builds a context-aware dial function from an already-parsed
+// socks5/socks5h proxy URL.
+func socksDialFunc(u *url.URL, timeout time.Duration) (ProxyDialFunc, error) {
 	baseDialer := &net.Dialer{Timeout: timeout}
 
 	socksDialer, err := proxy.FromURL(u, baseDialer)
 	if err != nil {
-		return nil, fmt.Errorf("creating SOCKS5 dialer from %q: %w", proxyURL, err)
+		return nil, fmt.Errorf("creating SOCKS5 dialer from %q: %w", u.Redacted(), err)
 	}
 
 	// Prefer DialContext for proper cancellation support.

--- a/pkg/brutus/proxy.go
+++ b/pkg/brutus/proxy.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package brutus
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// Supported proxy URL schemes.
+const (
+	proxySchemeHTTP    = "http"
+	proxySchemeHTTPS   = "https"
+	proxySchemeSOCKS5  = "socks5"
+	proxySchemeSOCKS5H = "socks5h"
+)
+
+// parseProxyURL parses and validates a proxy URL, accepting the HTTP(S) and
+// SOCKS5 schemes. Returning the parsed *url.URL keeps credential handling
+// centralized so callers never re-parse.
+func parseProxyURL(proxyURL string) (*url.URL, error) {
+	u, err := url.Parse(proxyURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid proxy URL: %w", err)
+	}
+	switch u.Scheme {
+	case proxySchemeHTTP, proxySchemeHTTPS, proxySchemeSOCKS5, proxySchemeSOCKS5H:
+		return u, nil
+	default:
+		return nil, fmt.Errorf("unsupported proxy scheme %q (supported: http, https, socks5, socks5h)", u.Scheme)
+	}
+}
+
+// BuildProxyURL merges a --proxy value with optional --proxy-user credentials
+// into a single canonical proxy URL string consumed by the HTTP and SOCKS5
+// plumbing (NewHTTPClientWithProxy, ProxyTransport, NewProxyDialFunc).
+//
+// Behavior mirrors curl: a scheme-less proxy value (a bare host:port such as
+// "brd.superproxy.io:33335") defaults to the http scheme. Credentials supplied
+// via proxyUser ("user:pass", or "user" for a password-less proxy) take
+// precedence over any userinfo already embedded in proxyURL, so the explicit
+// flag always wins.
+//
+// Returns "" when proxyURL is empty. Returns an error when proxyUser is set
+// without proxyURL, the scheme is unsupported, or the result has no host.
+func BuildProxyURL(proxyURL, proxyUser string) (string, error) {
+	proxyURL = strings.TrimSpace(proxyURL)
+	proxyUser = strings.TrimSpace(proxyUser)
+
+	if proxyURL == "" {
+		if proxyUser != "" {
+			return "", fmt.Errorf("--proxy-user requires --proxy")
+		}
+		return "", nil
+	}
+
+	// Default a bare host:port to http, matching curl's --proxy default.
+	if !strings.Contains(proxyURL, "://") {
+		proxyURL = proxySchemeHTTP + "://" + proxyURL
+	}
+
+	u, err := parseProxyURL(proxyURL)
+	if err != nil {
+		return "", err
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("invalid proxy URL %q: missing host", u.Redacted())
+	}
+
+	if proxyUser != "" {
+		if name, pass, found := strings.Cut(proxyUser, ":"); found {
+			u.User = url.UserPassword(name, pass)
+		} else {
+			u.User = url.User(proxyUser)
+		}
+	}
+
+	return u.String(), nil
+}

--- a/pkg/brutus/proxy_test.go
+++ b/pkg/brutus/proxy_test.go
@@ -2,9 +2,17 @@ package brutus
 
 import (
 	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewProxyDialFunc_EmptyURL(t *testing.T) {
@@ -96,9 +104,10 @@ func TestNewHTTPClientWithProxy_EmptyProxy(t *testing.T) {
 
 func TestNewHTTPClientWithProxy_InvalidProxy(t *testing.T) {
 	// Invalid proxy should return an error instead of silently falling back.
-	_, err := NewHTTPClientWithProxy(5*time.Second, nil, "http://bad:1080")
+	// ftp:// is not a supported proxy scheme; must error (no silent fallback).
+	_, err := NewHTTPClientWithProxy(5*time.Second, nil, "ftp://bad:1080")
 	if err == nil {
-		t.Fatal("expected error for invalid proxy scheme")
+		t.Fatal("expected error for unsupported proxy scheme")
 	}
 }
 
@@ -142,4 +151,219 @@ func TestNewHTTPClient_BackwardCompat(t *testing.T) {
 	if client.Timeout != 5*time.Second {
 		t.Errorf("expected timeout 5s, got %v", client.Timeout)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// TestBuildProxyURL — Section A
+// ---------------------------------------------------------------------------
+
+func TestBuildProxyURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		proxyURL    string
+		proxyUser   string
+		wantURL     string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:     "bare host:port defaults to http scheme",
+			proxyURL: "brd.superproxy.io:33335",
+			wantURL:  "http://brd.superproxy.io:33335",
+		},
+		{
+			name:      "bare host:port + proxyUser with password",
+			proxyURL:  "brd.superproxy.io:33335",
+			proxyUser: "u:p",
+			wantURL:   "http://u:p@brd.superproxy.io:33335",
+		},
+		{
+			name:      "proxyUser username-only (no colon) sets userinfo without password",
+			proxyURL:  "brd.superproxy.io:33335",
+			proxyUser: "u",
+			wantURL:   "http://u@brd.superproxy.io:33335",
+		},
+		{
+			name:     "socks5 scheme preserved",
+			proxyURL: "socks5://h:1080",
+			wantURL:  "socks5://h:1080",
+		},
+		{
+			name:     "https scheme preserved",
+			proxyURL: "https://h:8080",
+			wantURL:  "https://h:8080",
+		},
+		{
+			name:      "proxyUser overrides embedded userinfo",
+			proxyURL:  "http://old:old@h:8080",
+			proxyUser: "new:new2",
+			wantURL:   "http://new:new2@h:8080",
+		},
+		{
+			name:     "empty proxy and empty user returns empty string, no error",
+			proxyURL: "",
+			wantURL:  "",
+		},
+		{
+			name:        "empty proxy with non-empty user returns error containing 'requires'",
+			proxyURL:    "",
+			proxyUser:   "u:p",
+			wantErr:     true,
+			errContains: "requires",
+		},
+		{
+			name:     "unsupported scheme ftp returns error",
+			proxyURL: "ftp://h:1",
+			wantErr:  true,
+		},
+		{
+			name:     "whitespace trimmed from proxyURL",
+			proxyURL: "  http://h:8080  ",
+			wantURL:  "http://h:8080",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := BuildProxyURL(tt.proxyURL, tt.proxyUser)
+			if tt.wantErr {
+				require.Error(t, err, "expected an error but got none")
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantURL != "" {
+				assert.Equal(t, tt.wantURL, got)
+			}
+		})
+	}
+}
+
+// TestBuildProxyURL_BrightDataCredentials verifies the Bright-Data-style table
+// entry from the task spec: the returned URL is non-empty and parseable.
+// The full round-trip (percent-decoded user/pass) is in TestBuildProxyURL_BrightDataRoundTrip.
+func TestBuildProxyURL_BrightDataCredentials(t *testing.T) {
+	const (
+		user = "brd-customer-hl_e2c7d411-zone-brightdatacenter_proxies"
+		pass = "7rgw7v3345ni"
+	)
+	got, err := BuildProxyURL("http://brd.superproxy.io:33335", user+":"+pass)
+	require.NoError(t, err)
+	assert.NotEmpty(t, got)
+	_, parseErr := (&url.URL{}).Parse(got)
+	assert.NoError(t, parseErr, "output URL must be parseable")
+}
+
+// TestBuildProxyURL_BrightDataRoundTrip verifies that a realistic Bright Data
+// username (containing underscores and hyphens) round-trips through
+// BuildProxyURL: parsing the output URL must yield the same user/pass
+// (percent-decoded) that were supplied.
+func TestBuildProxyURL_BrightDataRoundTrip(t *testing.T) {
+	const (
+		wantUser = "brd-customer-hl_e2c7d411-zone-brightdatacenter_proxies"
+		wantPass = "7rgw7v3345ni"
+	)
+
+	result, err := BuildProxyURL("http://brd.superproxy.io:33335", wantUser+":"+wantPass)
+	require.NoError(t, err)
+	require.NotEmpty(t, result)
+
+	parsed, err := url.Parse(result)
+	require.NoError(t, err)
+	require.NotNil(t, parsed.User, "expected userinfo in parsed URL")
+
+	gotUser := parsed.User.Username()
+	gotPass, _ := parsed.User.Password()
+	assert.Equal(t, wantUser, gotUser, "percent-decoded username must match")
+	assert.Equal(t, wantPass, gotPass, "percent-decoded password must match")
+}
+
+// ---------------------------------------------------------------------------
+// TestProxyTransport — Section B
+// ---------------------------------------------------------------------------
+
+func TestProxyTransport(t *testing.T) {
+	t.Run("http proxy sets Transport.Proxy not DialContext", func(t *testing.T) {
+		transport, err := ProxyTransport("http://u:p@h:8080", 5*time.Second, nil)
+		require.NoError(t, err)
+		require.NotNil(t, transport)
+		assert.NotNil(t, transport.Proxy, "expected Proxy to be set for http scheme")
+		assert.Nil(t, transport.DialContext, "expected DialContext to be nil for http scheme")
+
+		// Call transport.Proxy with a sample request and assert the returned URL host/user.
+		req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+		proxyURL, err := transport.Proxy(req)
+		require.NoError(t, err)
+		require.NotNil(t, proxyURL)
+		assert.Equal(t, "h:8080", proxyURL.Host)
+		require.NotNil(t, proxyURL.User, "expected userinfo on proxy URL")
+		assert.Equal(t, "u", proxyURL.User.Username())
+		pass, _ := proxyURL.User.Password()
+		assert.Equal(t, "p", pass)
+	})
+
+	t.Run("socks5 proxy sets DialContext not Proxy", func(t *testing.T) {
+		transport, err := ProxyTransport("socks5://h:1080", 5*time.Second, nil)
+		require.NoError(t, err)
+		require.NotNil(t, transport)
+		assert.NotNil(t, transport.DialContext, "expected DialContext to be set for socks5 scheme")
+		assert.Nil(t, transport.Proxy, "expected Proxy to be nil for socks5 scheme")
+	})
+
+	t.Run("empty proxy sets neither Proxy nor DialContext", func(t *testing.T) {
+		transport, err := ProxyTransport("", 5*time.Second, nil)
+		require.NoError(t, err)
+		require.NotNil(t, transport)
+		assert.Nil(t, transport.Proxy)
+		assert.Nil(t, transport.DialContext)
+	})
+
+	t.Run("unsupported scheme ftp returns error", func(t *testing.T) {
+		_, err := ProxyTransport("ftp://h:1", 5*time.Second, nil)
+		require.Error(t, err)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestProxyAuthorization_EndToEnd — Section C
+// ---------------------------------------------------------------------------
+
+// TestProxyAuthorization_EndToEnd stands up an httptest server acting as an
+// HTTP forward proxy. It verifies that NewHTTPClientWithProxy produces a client
+// that automatically injects Proxy-Authorization: Basic <credentials> when the
+// proxy URL contains userinfo, for plain-HTTP target requests (which Go sends
+// to the proxy in absolute form without CONNECT).
+func TestProxyAuthorization_EndToEnd(t *testing.T) {
+	const (
+		proxyUser = "user"
+		proxyPass = "pass"
+	)
+	// expected Basic auth token: base64("user:pass")
+	wantBasic := "Basic " + base64.StdEncoding.EncodeToString([]byte(proxyUser+":"+proxyPass))
+
+	var gotProxyAuth string
+
+	// Proxy handler: capture Proxy-Authorization, echo 200 with body.
+	proxySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotProxyAuth = r.Header.Get("Proxy-Authorization")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintln(w, "proxy-ok")
+	}))
+	defer proxySrv.Close()
+
+	proxyURL := fmt.Sprintf("http://%s:%s@%s", proxyUser, proxyPass, proxySrv.Listener.Addr().String())
+	client, err := NewHTTPClientWithProxy(5*time.Second, nil, proxyURL)
+	require.NoError(t, err)
+
+	// Make a GET to a plain-http URL. Go sends it to the proxy in absolute form.
+	resp, err := client.Get("http://target.example/path")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.ReadAll(resp.Body)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, wantBasic, gotProxyAuth,
+		"proxy handler must receive Proxy-Authorization: Basic <base64(user:pass)>")
 }

--- a/pkg/enum/apollo/apollo.go
+++ b/pkg/enum/apollo/apollo.go
@@ -150,16 +150,20 @@ type Client struct {
 
 // NewClient builds an Apollo client. timeout is the per-request HTTP budget.
 // pageSize <= 0 falls back to defaultPageSize.
-func NewClient(apiKey string, timeout time.Duration, pageSize int) *Client {
+func NewClient(apiKey string, timeout time.Duration, pageSize int, proxyURL string) (*Client, error) {
 	if pageSize <= 0 {
 		pageSize = defaultPageSize
 	}
+	httpClient, err := enum.NewEnumHTTPClientWithProxy(timeout, proxyURL)
+	if err != nil {
+		return nil, err
+	}
 	return &Client{
 		apiKey:     apiKey,
-		httpClient: enum.NewEnumHTTPClient(timeout),
+		httpClient: httpClient,
 		baseURL:    defaultBaseURL,
 		pageSize:   pageSize,
-	}
+	}, nil
 }
 
 // Discover paginates people-search for domain (optionally filtered by titles),

--- a/pkg/enum/apollo/apollo_test.go
+++ b/pkg/enum/apollo/apollo_test.go
@@ -36,7 +36,7 @@ import (
 // newTestClient creates a Client pointed at baseURL, overriding the default
 // base URL set by NewClient. Mirrors hunter_test.go:122-126.
 func newTestClient(baseURL string) *Client {
-	c := NewClient("testkey", 5*time.Second, 10)
+	c, _ := NewClient("testkey", 5*time.Second, 10, "") // Empty proxy never errors.
 	c.baseURL = baseURL
 	return c
 }

--- a/pkg/enum/custom/plugin.go
+++ b/pkg/enum/custom/plugin.go
@@ -50,7 +50,10 @@ func (p *Plugin) Check(ctx context.Context, subject string, timeout time.Duratio
 		return result
 	}
 
-	client := enum.NewEnumHTTPClient(timeout)
+	client := enum.HTTPClientFromContext(ctx)
+	if client == nil {
+		client = enum.NewEnumHTTPClient(timeout)
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		result.Error = err

--- a/pkg/enum/dehashed/dehashed.go
+++ b/pkg/enum/dehashed/dehashed.go
@@ -188,16 +188,20 @@ type Client struct {
 
 // NewClient builds a DeHashed client. timeout is the per-request HTTP budget.
 // pageSize <= 0 falls back to defaultPageSize (100, the API maximum).
-func NewClient(apiKey string, timeout time.Duration, pageSize int) *Client {
+func NewClient(apiKey string, timeout time.Duration, pageSize int, proxyURL string) (*Client, error) {
 	if pageSize <= 0 {
 		pageSize = defaultPageSize
 	}
+	httpClient, err := enum.NewEnumHTTPClientWithProxy(timeout, proxyURL)
+	if err != nil {
+		return nil, err
+	}
 	return &Client{
 		apiKey:     apiKey,
-		httpClient: enum.NewEnumHTTPClient(timeout),
+		httpClient: httpClient,
 		baseURL:    baseURL,
 		pageSize:   pageSize,
-	}
+	}, nil
 }
 
 // Search runs a domain search, following pagination until exhausted, and

--- a/pkg/enum/dehashed/dehashed_test.go
+++ b/pkg/enum/dehashed/dehashed_test.go
@@ -34,7 +34,7 @@ import (
 // ---------------------------------------------------------------------------
 
 func newTestClient(baseURL string) *Client {
-	c := NewClient("testkey", 5*time.Second, 10)
+	c, _ := NewClient("testkey", 5*time.Second, 10, "") // Empty proxy never errors.
 	c.baseURL = baseURL
 	return c
 }
@@ -678,7 +678,8 @@ func TestDo_SetsAuthHeader(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewClient(testKey, 5*time.Second, 10)
+	c, err := NewClient(testKey, 5*time.Second, 10, "")
+	require.NoError(t, err)
 	c.baseURL = srv.URL
 
 	_, _ = c.do(context.Background(), searchRequest{Query: "domain:example.com", Size: 10, Page: 1})

--- a/pkg/enum/enum.go
+++ b/pkg/enum/enum.go
@@ -18,6 +18,7 @@ package enum
 import (
 	"context"
 	"errors"
+	"net/http"
 	"time"
 )
 
@@ -30,6 +31,41 @@ type Config struct {
 	RateLimit float64       // max requests per second (0 = unlimited)
 	Jitter    time.Duration // random delay variance for rate limiting
 	Verbose   bool          // verbose logging to stderr
+	ProxyURL  string        // proxy URL for HTTP enum sources (empty = direct)
+}
+
+// httpClientCtxKey is the context key under which the shared per-run enum HTTP
+// client is stored. Plugin oracles retrieve it via HTTPClientFromContext so a
+// single pooled (and possibly proxied) client is reused across all checks.
+type httpClientCtxKey struct{}
+
+// WithHTTPClient returns a context carrying client for plugin oracles to reuse.
+func WithHTTPClient(ctx context.Context, client *http.Client) context.Context {
+	return context.WithValue(ctx, httpClientCtxKey{}, client)
+}
+
+// HTTPClientFromContext returns the shared enum HTTP client stored in ctx, or
+// nil if none was set.
+func HTTPClientFromContext(ctx context.Context) *http.Client {
+	client, _ := ctx.Value(httpClientCtxKey{}).(*http.Client)
+	return client
+}
+
+// proxyURLCtxKey is the context key under which the per-run proxy URL is stored.
+// Plugin oracles that build a specialized client (e.g. the google enumerator)
+// read it via ProxyURLFromContext to honor --proxy.
+type proxyURLCtxKey struct{}
+
+// WithProxyURL returns a context carrying the proxy URL for plugin oracles that
+// construct their own HTTP client.
+func WithProxyURL(ctx context.Context, proxyURL string) context.Context {
+	return context.WithValue(ctx, proxyURLCtxKey{}, proxyURL)
+}
+
+// ProxyURLFromContext returns the proxy URL stored in ctx, or "" if none was set.
+func ProxyURLFromContext(ctx context.Context) string {
+	proxyURL, _ := ctx.Value(proxyURLCtxKey{}).(string)
+	return proxyURL
 }
 
 // validate checks the configuration and applies defaults.

--- a/pkg/enum/enum_test.go
+++ b/pkg/enum/enum_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enum
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// TestHTTPClientContext — Section E: WithHTTPClient / HTTPClientFromContext
+// ---------------------------------------------------------------------------
+
+func TestHTTPClientContext_RoundTrip(t *testing.T) {
+	client := &http.Client{}
+	ctx := WithHTTPClient(context.Background(), client)
+	got := HTTPClientFromContext(ctx)
+	assert.Same(t, client, got, "HTTPClientFromContext must return the same *http.Client stored by WithHTTPClient")
+}
+
+func TestHTTPClientContext_Default(t *testing.T) {
+	got := HTTPClientFromContext(context.Background())
+	assert.Nil(t, got, "HTTPClientFromContext on a plain Background context must return nil")
+}
+
+// ---------------------------------------------------------------------------
+// TestProxyURLContext — Section E: WithProxyURL / ProxyURLFromContext
+// ---------------------------------------------------------------------------
+
+func TestProxyURLContext_RoundTrip(t *testing.T) {
+	const wantURL = "http://proxy.example:8080"
+	ctx := WithProxyURL(context.Background(), wantURL)
+	got := ProxyURLFromContext(ctx)
+	assert.Equal(t, wantURL, got, "ProxyURLFromContext must return the URL stored by WithProxyURL")
+}
+
+func TestProxyURLContext_Default(t *testing.T) {
+	got := ProxyURLFromContext(context.Background())
+	assert.Equal(t, "", got, "ProxyURLFromContext on a plain Background context must return empty string")
+}

--- a/pkg/enum/github/existence.go
+++ b/pkg/enum/github/existence.go
@@ -233,10 +233,10 @@ func (e *Enumerator) postValidity(ctx context.Context, sess *session, email stri
 		case http.StatusOK: // 200 — available (no account)
 			return false, nil
 		case http.StatusTooManyRequests: // 429 — rate limited
-			if attempt >= maxRateLimitRetries {
+			if attempt >= e.existenceMaxRetries {
 				return false, fmt.Errorf("rate limited (HTTP 429) after %d retries", attempt)
 			}
-			if err := e.sleep(ctx, rateLimitBackoff); err != nil {
+			if err := e.sleep(ctx, e.existenceBackoff); err != nil {
 				return false, err
 			}
 			continue

--- a/pkg/enum/github/github.go
+++ b/pkg/enum/github/github.go
@@ -64,14 +64,16 @@ type Result struct {
 }
 
 const (
-	webBaseURLDefault    = "https://github.com"
-	apiBaseURLDefault    = "https://api.github.com"
-	settleDelayDefault   = 10 * time.Second
-	validityCheckPath    = "/email_validity_checks"
-	joinPath             = "/join"
-	maxRateLimitRetries  = 5
-	rateLimitBackoff     = 2 * time.Second
-	defaultBranchDefault = "main"
+	webBaseURLDefault       = "https://github.com"
+	apiBaseURLDefault       = "https://api.github.com"
+	settleDelayDefault      = 10 * time.Second
+	validityCheckPath       = "/email_validity_checks"
+	joinPath                = "/join"
+	maxRateLimitRetries     = 5
+	rateLimitBackoff        = 2 * time.Second
+	rotatingProxyBackoff    = 100 * time.Millisecond
+	rotatingProxyMaxRetries = 15
+	defaultBranchDefault    = "main"
 	// commitContent is a tiny constant base64 blob ("Haxor"), matching the
 	// reference implementation's per-commit file content.
 	commitContent = "SGF4b3I="
@@ -94,6 +96,13 @@ type Enumerator struct {
 	// shared with httpClient. Mirrors pkg/enum/google/google.go.
 	apiClient *http.Client
 	token     string
+
+	// existenceBackoff / existenceMaxRetries control 429 retry pacing on the
+	// unauthenticated, IP-rate-limited existence endpoint. With a rotating proxy
+	// (--rotating-proxy) each retry uses a fresh exit IP, so a short backoff and
+	// higher ceiling are used instead of the conservative defaults.
+	existenceBackoff    time.Duration
+	existenceMaxRetries int
 
 	// Base URLs default to the real GitHub hosts and are overridable by tests.
 	webBaseURL string
@@ -124,11 +133,21 @@ type session struct {
 
 // NewEnumerator builds an Enumerator. The HTTP client is built via
 // brutus.NewHTTPClientWithProxy so the SOCKS5 --proxy flag works. token may be
-// empty (existence-only mode); Reveal requires a non-empty token.
-func NewEnumerator(proxyURL string, timeout time.Duration, token string) (*Enumerator, error) {
+// empty (existence-only mode); Reveal requires a non-empty token. When
+// rotatingProxy is true, the existence path uses a short 429 backoff and a
+// higher retry ceiling, since each retry egresses from a fresh exit IP; this
+// does not affect the token-rate-limited reveal path.
+func NewEnumerator(proxyURL string, timeout time.Duration, token string, rotatingProxy bool) (*Enumerator, error) {
 	httpClient, err := brutus.NewHTTPClientWithProxy(timeout, nil, proxyURL)
 	if err != nil {
 		return nil, fmt.Errorf("github enum: configuring HTTP client: %w", err)
+	}
+
+	existenceBackoff := rateLimitBackoff
+	existenceMaxRetries := maxRateLimitRetries
+	if rotatingProxy {
+		existenceBackoff = rotatingProxyBackoff
+		existenceMaxRetries = rotatingProxyMaxRetries
 	}
 
 	// httpClient FOLLOWS redirects (the default): the existence flow's join-page
@@ -148,14 +167,16 @@ func NewEnumerator(proxyURL string, timeout time.Duration, token string) (*Enume
 	}
 
 	return &Enumerator{
-		httpClient:  httpClient,
-		apiClient:   &apiClient,
-		token:       token,
-		webBaseURL:  webBaseURLDefault,
-		apiBaseURL:  apiBaseURLDefault,
-		settleDelay: settleDelayDefault,
-		sleep:       sleepCtx,
-		newName:     randomHexName,
+		httpClient:          httpClient,
+		apiClient:           &apiClient,
+		token:               token,
+		existenceBackoff:    existenceBackoff,
+		existenceMaxRetries: existenceMaxRetries,
+		webBaseURL:          webBaseURLDefault,
+		apiBaseURL:          apiBaseURLDefault,
+		settleDelay:         settleDelayDefault,
+		sleep:               sleepCtx,
+		newName:             randomHexName,
 	}, nil
 }
 

--- a/pkg/enum/github/github_test.go
+++ b/pkg/enum/github/github_test.go
@@ -212,7 +212,7 @@ func newAPIServer(t *testing.T, token string, emailToLogin map[string]*string, d
 // repeatable.
 func newTestEnumerator(t *testing.T, webSrv, apiSrv *httptest.Server, token string) *Enumerator {
 	t.Helper()
-	e, err := NewEnumerator("", 5*time.Second, token)
+	e, err := NewEnumerator("", 5*time.Second, token, false)
 	require.NoError(t, err, "NewEnumerator must succeed")
 	if webSrv != nil {
 		e.webBaseURL = webSrv.URL
@@ -305,7 +305,7 @@ func TestExistence_429_RetryThenSucceed(t *testing.T) {
 	webSrv := httptest.NewServer(mux)
 	t.Cleanup(webSrv.Close)
 
-	e, err := NewEnumerator("", 5*time.Second, "")
+	e, err := NewEnumerator("", 5*time.Second, "", false)
 	require.NoError(t, err)
 	e.webBaseURL = webSrv.URL
 	e.sleep = noopSleep
@@ -338,7 +338,7 @@ func TestSessionParseFail_JoinPageMissingAutoCheck(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	e, err := NewEnumerator("", 5*time.Second, "")
+	e, err := NewEnumerator("", 5*time.Second, "", false)
 	require.NoError(t, err)
 	e.webBaseURL = srv.URL
 	e.sleep = noopSleep
@@ -488,7 +488,7 @@ func TestReveal_DeleteAlwaysAttempted(t *testing.T) {
 	apiSrv := httptest.NewServer(mux)
 	t.Cleanup(apiSrv.Close)
 
-	e, err := NewEnumerator("", 5*time.Second, token)
+	e, err := NewEnumerator("", 5*time.Second, token, false)
 	require.NoError(t, err)
 	e.apiBaseURL = apiSrv.URL
 	e.settleDelay = 0
@@ -553,7 +553,7 @@ func TestReveal_BearerTokenSentToAPI(t *testing.T) {
 	apiSrv := httptest.NewServer(mux)
 	t.Cleanup(apiSrv.Close)
 
-	e, err := NewEnumerator("", 5*time.Second, token)
+	e, err := NewEnumerator("", 5*time.Second, token, false)
 	require.NoError(t, err)
 	e.apiBaseURL = apiSrv.URL
 	e.settleDelay = 0
@@ -594,7 +594,7 @@ func TestReveal_TokenNotLeakedInError(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	e, err := NewEnumerator("", 5*time.Second, token)
+	e, err := NewEnumerator("", 5*time.Second, token, false)
 	require.NoError(t, err)
 	e.apiBaseURL = srv.URL
 	e.settleDelay = 0
@@ -706,7 +706,7 @@ func TestReveal_MidFlowErrorAndDeleteFailure_OriginalErrorJoined(t *testing.T) {
 	apiSrv := httptest.NewServer(mux)
 	t.Cleanup(apiSrv.Close)
 
-	e, err := NewEnumerator("", 5*time.Second, token)
+	e, err := NewEnumerator("", 5*time.Second, token, false)
 	require.NoError(t, err)
 	e.apiBaseURL = apiSrv.URL
 	e.settleDelay = 0
@@ -867,4 +867,36 @@ func TestEnumerateWith_CallbackSerializationAndOrder(t *testing.T) {
 	assert.False(t, results[1].Exists, "b@ (200) must be Exists=false")
 	assert.True(t, results[2].Exists, "c@ (422) must be Exists=true")
 	assert.False(t, results[3].Exists, "d@ (200) must be Exists=false")
+}
+
+// ---------------------------------------------------------------------------
+// NewEnumerator: rotatingProxy flag wires correct backoff / retry constants
+// ---------------------------------------------------------------------------
+
+// TestNewEnumerator_RotatingProxy verifies that the rotatingProxy parameter
+// controls which 429-retry constants are stored on the Enumerator.
+// When false the defaults (rateLimitBackoff / maxRateLimitRetries) are used;
+// when true the faster rotating-proxy constants are used.
+func TestNewEnumerator_RotatingProxy(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rotatingProxy=false uses default throttle", func(t *testing.T) {
+		t.Parallel()
+		e, err := NewEnumerator("", time.Second, "", false)
+		require.NoError(t, err)
+		assert.Equal(t, rateLimitBackoff, e.existenceBackoff,
+			"existenceBackoff must equal rateLimitBackoff when rotatingProxy=false")
+		assert.Equal(t, maxRateLimitRetries, e.existenceMaxRetries,
+			"existenceMaxRetries must equal maxRateLimitRetries when rotatingProxy=false")
+	})
+
+	t.Run("rotatingProxy=true uses rotating-proxy throttle", func(t *testing.T) {
+		t.Parallel()
+		e, err := NewEnumerator("", time.Second, "", true)
+		require.NoError(t, err)
+		assert.Equal(t, rotatingProxyBackoff, e.existenceBackoff,
+			"existenceBackoff must equal rotatingProxyBackoff when rotatingProxy=true")
+		assert.Equal(t, rotatingProxyMaxRetries, e.existenceMaxRetries,
+			"existenceMaxRetries must equal rotatingProxyMaxRetries when rotatingProxy=true")
+	})
 }

--- a/pkg/enum/httpclient.go
+++ b/pkg/enum/httpclient.go
@@ -19,6 +19,8 @@ import (
 	"io"
 	"net/http"
 	"time"
+
+	"github.com/praetorian-inc/brutus/pkg/brutus"
 )
 
 // defaultUserAgent is a common browser UA to avoid fingerprinting.
@@ -45,14 +47,32 @@ func (t *uaTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 //   - No redirect following (returns last response)
 //   - Default User-Agent header
 //   - Specified timeout
+//
+// It never routes through a proxy; use NewEnumHTTPClientWithProxy to honor the
+// --proxy flag.
 func NewEnumHTTPClient(timeout time.Duration) *http.Client {
+	// Empty proxy never errors.
+	client, _ := NewEnumHTTPClientWithProxy(timeout, "")
+	return client
+}
+
+// NewEnumHTTPClientWithProxy returns an enum HTTP client (same safe defaults as
+// NewEnumHTTPClient) that routes requests through proxyURL when it is non-empty.
+// Supports http/https proxies (with authenticated credentials via URL userinfo)
+// and socks5/socks5h. Returns an error if the proxy URL is invalid or uses an
+// unsupported scheme.
+func NewEnumHTTPClientWithProxy(timeout time.Duration, proxyURL string) (*http.Client, error) {
+	transport, err := brutus.ProxyTransport(proxyURL, timeout, nil)
+	if err != nil {
+		return nil, err
+	}
 	return &http.Client{
 		Timeout: timeout,
 		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
-		Transport: &uaTransport{base: http.DefaultTransport},
-	}
+		Transport: &uaTransport{base: transport},
+	}, nil
 }
 
 // ReadResponseBody reads a response body with a size limit to prevent OOM from hostile endpoints.

--- a/pkg/enum/httpclient_test.go
+++ b/pkg/enum/httpclient_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enum
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// TestNewEnumHTTPClientWithProxy — Section D
+// ---------------------------------------------------------------------------
+
+func TestNewEnumHTTPClientWithProxy_EmptyProxy(t *testing.T) {
+	client, err := NewEnumHTTPClientWithProxy(5*time.Second, "")
+	require.NoError(t, err)
+	require.NotNil(t, client)
+}
+
+func TestNewEnumHTTPClientWithProxy_UnsupportedScheme(t *testing.T) {
+	_, err := NewEnumHTTPClientWithProxy(5*time.Second, "ftp://h:21")
+	require.Error(t, err, "unsupported scheme ftp must return error")
+}
+
+// TestNewEnumHTTPClientWithProxy_EndToEnd stands up an httptest forward proxy
+// that captures request headers. It asserts:
+//  1. Proxy-Authorization: Basic <base64("user:pass")> is injected automatically.
+//  2. The default User-Agent (Mozilla/5.0 ... Chrome/120...) is still present,
+//     proving the uaTransport wrapper survives the proxied transport.
+func TestNewEnumHTTPClientWithProxy_EndToEnd(t *testing.T) {
+	const (
+		proxyUser = "user"
+		proxyPass = "pass"
+	)
+	wantBasic := "Basic " + base64.StdEncoding.EncodeToString([]byte(proxyUser+":"+proxyPass))
+
+	var (
+		gotProxyAuth string
+		gotUserAgent string
+	)
+
+	proxySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotProxyAuth = r.Header.Get("Proxy-Authorization")
+		gotUserAgent = r.Header.Get("User-Agent")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintln(w, "proxy-ok")
+	}))
+	defer proxySrv.Close()
+
+	proxyURL := fmt.Sprintf("http://%s:%s@%s", proxyUser, proxyPass, proxySrv.Listener.Addr().String())
+	client, err := NewEnumHTTPClientWithProxy(5*time.Second, proxyURL)
+	require.NoError(t, err)
+
+	// Plain-http target — Go sends it to the proxy in absolute form.
+	resp, err := client.Get("http://target.example/path")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.ReadAll(resp.Body)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Proxy-Authorization must be present with correct Basic credentials.
+	assert.Equal(t, wantBasic, gotProxyAuth,
+		"Proxy-Authorization Basic header must match base64(user:pass)")
+
+	// Default User-Agent must be injected by the uaTransport wrapper.
+	assert.Contains(t, gotUserAgent, "Chrome/120",
+		"default User-Agent must contain Chrome/120 (injected by uaTransport)")
+	assert.Contains(t, gotUserAgent, "Mozilla/5.0",
+		"default User-Agent must contain Mozilla/5.0 (injected by uaTransport)")
+}

--- a/pkg/enum/hunter/hunter.go
+++ b/pkg/enum/hunter/hunter.go
@@ -125,16 +125,20 @@ type Client struct {
 
 // NewClient builds a Hunter client. timeout is the per-request HTTP budget.
 // pageSize <= 0 falls back to defaultPageSize.
-func NewClient(apiKey string, timeout time.Duration, pageSize int) *Client {
+func NewClient(apiKey string, timeout time.Duration, pageSize int, proxyURL string) (*Client, error) {
 	if pageSize <= 0 {
 		pageSize = defaultPageSize
 	}
+	httpClient, err := enum.NewEnumHTTPClientWithProxy(timeout, proxyURL)
+	if err != nil {
+		return nil, err
+	}
 	return &Client{
 		apiKey:     apiKey,
-		httpClient: enum.NewEnumHTTPClient(timeout),
+		httpClient: httpClient,
 		baseURL:    defaultBaseURL,
 		pageSize:   pageSize,
-	}
+	}, nil
 }
 
 // Search runs Domain Search for domain, following pagination until exhausted,

--- a/pkg/enum/hunter/hunter_test.go
+++ b/pkg/enum/hunter/hunter_test.go
@@ -124,7 +124,7 @@ func makeErrorResponse(details string) []byte {
 }
 
 func newTestClient(baseURL string) *Client {
-	c := NewClient("testkey", 5*time.Second, 10)
+	c, _ := NewClient("testkey", 5*time.Second, 10, "") // Empty proxy never errors.
 	c.baseURL = baseURL
 	return c
 }

--- a/pkg/enum/lusha/lusha.go
+++ b/pkg/enum/lusha/lusha.go
@@ -179,12 +179,16 @@ type Client struct {
 
 // NewClient builds a Lusha client. timeout is the per-request HTTP budget.
 // There is no page size: one identity in, one contact out.
-func NewClient(apiKey string, timeout time.Duration) *Client {
+func NewClient(apiKey string, timeout time.Duration, proxyURL string) (*Client, error) {
+	httpClient, err := enum.NewEnumHTTPClientWithProxy(timeout, proxyURL)
+	if err != nil {
+		return nil, err
+	}
 	return &Client{
 		apiKey:     apiKey,
-		httpClient: enum.NewEnumHTTPClient(timeout),
+		httpClient: httpClient,
 		baseURL:    defaultBaseURL,
-	}
+	}, nil
 }
 
 // Enrich resolves one identity to an enriched contact via v3 search-and-enrich.

--- a/pkg/enum/lusha/lusha_test.go
+++ b/pkg/enum/lusha/lusha_test.go
@@ -32,7 +32,7 @@ import (
 
 // newTestClient overrides baseURL for httptest usage.
 func newTestClient(baseURL string) *Client {
-	c := NewClient("testkey", 5*time.Second)
+	c, _ := NewClient("testkey", 5*time.Second, "") // Empty proxy never errors.
 	c.baseURL = baseURL
 	return c
 }

--- a/pkg/enum/workers.go
+++ b/pkg/enum/workers.go
@@ -72,6 +72,16 @@ func runTasks(ctx context.Context, cfg *Config, tasks []enumTask) ([]Result, err
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	// Build one shared enum HTTP client for the whole run so plugin oracles
+	// reuse a single pooled (and possibly proxied) transport. Surfaces proxy
+	// configuration errors once, before any checks run.
+	httpClient, err := NewEnumHTTPClientWithProxy(cfg.Timeout, cfg.ProxyURL)
+	if err != nil {
+		return nil, fmt.Errorf("configuring enum HTTP client: %w", err)
+	}
+	ctx = WithHTTPClient(ctx, httpClient)
+	ctx = WithProxyURL(ctx, cfg.ProxyURL)
+
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(cfg.Threads)
 


### PR DESCRIPTION
## Summary

Adds support for **HTTP/HTTPS proxies with authenticated credentials** (e.g. Bright Data) to the HTTP-based `brutus enum` sources, extending the previously SOCKS5-only proxy plumbing. Also adds `--rotating-proxy` to avoid wasting time on per-IP rate-limit backoff when the proxy rotates exit IPs.

Motivating example (now supported):
```
brutus enum active github -d fox.com --limit 10000 --format first.last \
  --proxy brd.superproxy.io:33335 \
  --proxy-user brd-customer-...-zone-datacenter:<password> \
  --rotating-proxy
```

## CLI changes
- `--proxy` now accepts `http`, `https`, `socks5`, `socks5h`. A bare `host:port` defaults to `http` (curl-compatible).
- `--proxy-user user:pass` (curl-style) supplies proxy credentials; takes precedence over userinfo embedded in `--proxy`.
- `--rotating-proxy` shortens the GitHub existence-check 429 backoff (2s → 100ms) and raises the retry ceiling (5 → 15), since each retry egresses from a fresh IP. No effect on the token-rate-limited reveal path.
- Misconfigured proxy intent (e.g. `--proxy-user` without `--proxy`) **fails closed** — it errors instead of silently sending traffic direct (real-IP-leak prevention).

## Scope: every HTTP enum source honors the proxy
`github`, `google`, `teams`, `github map`, `dehashed`, `lusha`, `apollo`, `hunter`, plus the `microsoft365`/`google`/`custom` plugin oracles. The oracle path threads one pooled, proxied client + the proxy URL through context.

## Implementation
- **pkg/brutus**: `BuildProxyURL` (flag merge + scheme defaulting), `ProxyTransport` (socks5 via `DialContext`, http/https via `Transport.Proxy` — Go injects `Proxy-Authorization` from URL userinfo). Credentials redacted in errors via `url.Redacted()`.
- **pkg/enum**: `NewEnumHTTPClientWithProxy`; per-run shared client + proxy URL via context; `dehashed/lusha/apollo/hunter` constructors take a proxy URL.
- **pkg/enum/github**: existence-path 429 backoff is now configurable; `--rotating-proxy` tunes it. Reveal path unchanged (token-rate-limited).

## Security review outcomes (addressed)
- Fail-closed on bad proxy config (no silent direct connection).
- Credentials redacted in error messages.
- No-redirect (PAT/token-leak protection) preserved on the proxied clients.
- TLS verification passed through unchanged (no `InsecureSkipVerify`).
- No header-injection vector (`url.UserPassword` + Go's base64 Proxy-Authorization).

## Testing
- `BuildProxyURL` / `ProxyTransport` table tests; **end-to-end `Proxy-Authorization: Basic` assertions** through an httptest forward proxy (core + enum clients).
- Context-helper round-trips; `--rotating-proxy` backoff/retry behavior test.
- Fail-closed regression: `--proxy-user` without `--proxy` returns an error and a nil config.
- `go build ./...`, `go vet ./...`, and the full touched-package test suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)