### PR TITLE
fix(enum/hunter): treat --limit as a total result cap, not page size

### DIFF
--- a/cmd/brutus/cmd_enum.go
+++ b/cmd/brutus/cmd_enum.go
@@ -176,6 +176,19 @@ func capResults(results []string, limit int) []string {
 	return results[:limit]
 }
 
+// pageSizeForLimit derives an API page size from a --limit total cap: min(limit,100),
+// or 100 (defaultPageSize) when limit is unbounded (0). Callers pass --limit separately
+// as the accumulated-total bound.
+func pageSizeForLimit(limit int) int {
+	if limit <= 0 {
+		return 100
+	}
+	if limit > 100 {
+		return 100
+	}
+	return limit
+}
+
 // loadLinesFromFile reads lines from a file (one per line).
 // If path is "-", reads from stdin. Used for both emails and usernames.
 func loadLinesFromFile(path string) ([]string, error) {

--- a/cmd/brutus/cmd_enum_apollo.go
+++ b/cmd/brutus/cmd_enum_apollo.go
@@ -236,17 +236,3 @@ func classifyApolloError(err error) error {
 	}
 	return fmt.Errorf("apollo people search failed: %w", err)
 }
-
-// pageSizeForLimit derives the people-search per_page from --limit: min(limit, 100),
-// or defaultPageSize (100) when limit is unbounded (0). This never requests a
-// per_page above Apollo's 100 max while --limit separately bounds the accumulated
-// total inside SearchPeople.
-func pageSizeForLimit(limit int) int {
-	if limit <= 0 {
-		return 100
-	}
-	if limit > 100 {
-		return 100
-	}
-	return limit
-}

--- a/cmd/brutus/cmd_enum_hunter.go
+++ b/cmd/brutus/cmd_enum_hunter.go
@@ -65,7 +65,7 @@ Requires a Hunter.io API key via the HUNTER_API_KEY environment variable
 	f.StringVarP(&flagHunterDomain, "domain", "d", "", "Domain to search (required)")
 	f.StringVar(&flagHunterAPIKey, "api-key", "",
 		"Hunter.io API key (overrides HUNTER_API_KEY; WARNING: visible in process list and shell history — prefer HUNTER_API_KEY)")
-	f.IntVar(&flagHunterLimit, "limit", 100, "Results per API page (pagination page size)")
+	f.IntVar(&flagHunterLimit, "limit", 0, "Maximum number of people to return (0 = no cap, return all)")
 	_ = cmd.MarkFlagRequired("domain")
 
 	return cmd
@@ -105,11 +105,11 @@ func runEnumHunter(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	client, err := hunter.NewClient(apiKey, flagTimeout, flagHunterLimit, proxyURL)
+	client, err := hunter.NewClient(apiKey, flagTimeout, pageSizeForLimit(flagHunterLimit), proxyURL)
 	if err != nil {
 		return err
 	}
-	result, err := client.Search(ctx, flagHunterDomain)
+	result, err := client.Search(ctx, flagHunterDomain, flagHunterLimit)
 	if err != nil {
 		return classifyHunterError(err)
 	}

--- a/pkg/enum/hunter/hunter.go
+++ b/pkg/enum/hunter/hunter.go
@@ -143,7 +143,9 @@ func NewClient(apiKey string, timeout time.Duration, pageSize int, proxyURL stri
 
 // Search runs Domain Search for domain, following pagination until exhausted,
 // and returns the aggregated DomainResult. Honors ctx cancellation between pages.
-func (c *Client) Search(ctx context.Context, domain string) (*DomainResult, error) {
+// limit caps the total number of People returned (consistent with the other enum
+// subcommands); limit <= 0 means no cap (fetch all pages).
+func (c *Client) Search(ctx context.Context, domain string, limit int) (*DomainResult, error) {
 	offset := 0
 	result := &DomainResult{Domain: domain}
 
@@ -170,6 +172,12 @@ func (c *Client) Search(ctx context.Context, domain string) (*DomainResult, erro
 
 		fetched := len(page.Data.Emails)
 		offset += fetched
+
+		// Reached the caller-requested cap: truncate and stop (no further requests).
+		if limit > 0 && len(result.People) >= limit {
+			result.People = result.People[:limit]
+			break
+		}
 
 		// Termination: empty page, short final page, or reached known total.
 		if fetched == 0 {

--- a/pkg/enum/hunter/hunter.go
+++ b/pkg/enum/hunter/hunter.go
@@ -150,7 +150,13 @@ func (c *Client) Search(ctx context.Context, domain string, limit int) (*DomainR
 	result := &DomainResult{Domain: domain}
 
 	for {
-		page, err := c.fetchPage(ctx, domain, offset)
+		perPage := c.pageSize
+		if limit > 0 {
+			if remaining := limit - len(result.People); remaining < perPage {
+				perPage = remaining
+			}
+		}
+		page, err := c.fetchPage(ctx, domain, offset, perPage)
 		if err != nil {
 			// Plan result cap is a soft stop: return what we collected so far.
 			// Other errors (auth, rate limit, etc.) remain fatal.
@@ -183,7 +189,7 @@ func (c *Client) Search(ctx context.Context, domain string, limit int) (*DomainR
 		if fetched == 0 {
 			break
 		}
-		if fetched < c.pageSize {
+		if fetched < perPage {
 			break
 		}
 		if result.Total > 0 && offset >= result.Total {
@@ -204,14 +210,16 @@ func (c *Client) Search(ctx context.Context, domain string, limit int) (*DomainR
 // ---------------------------------------------------------------------------
 
 // fetchPage performs a single paginated GET request to the Hunter.io API.
+// perPage is the requested page size for this request (sent as the "limit" query
+// param), letting the caller shrink the final page to only what's still needed.
 // The api_key is embedded in the query string per the Hunter API contract.
 // The full URL is never logged to prevent key leakage (P0-1 security requirement).
-func (c *Client) fetchPage(ctx context.Context, domain string, offset int) (*apiResponse, error) {
+func (c *Client) fetchPage(ctx context.Context, domain string, offset, perPage int) (*apiResponse, error) {
 	// Build query string — api_key goes here per Hunter's spec.
 	q := url.Values{
 		"domain":  {domain},
 		"api_key": {c.apiKey},
-		"limit":   {strconv.Itoa(c.pageSize)},
+		"limit":   {strconv.Itoa(perPage)},
 		"offset":  {strconv.Itoa(offset)},
 	}
 	rawURL := c.baseURL + "?" + q.Encode()

--- a/pkg/enum/hunter/hunter_test.go
+++ b/pkg/enum/hunter/hunter_test.go
@@ -329,7 +329,7 @@ func TestSearch_Pagination(t *testing.T) {
 			c := newTestClient(srv.URL)
 			c.pageSize = tc.pageSize
 
-			result, err := c.Search(context.Background(), "example.com")
+			result, err := c.Search(context.Background(), "example.com", 0)
 
 			if tc.wantErr != nil {
 				require.Error(t, err)
@@ -346,6 +346,30 @@ func TestSearch_Pagination(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestSearch_LimitCapsResults verifies --limit is honored as a total result cap
+// (consistent with dehashed/apollo/lusha) rather than a raw page size: a small
+// limit returns exactly that many people AND stops after a single request, so it
+// never paginates into Hunter's free-plan result cap.
+func TestSearch_LimitCapsResults(t *testing.T) {
+	allEmails := []apiEmail{
+		{Value: "a@example.com", Confidence: 90},
+		{Value: "b@example.com", Confidence: 80},
+		{Value: "c@example.com", Confidence: 70},
+	}
+	// total=50 (server claims many more available), pageSize=1 mirrors pageSizeForLimit(1).
+	srv, reqCount := pagedServer(t, allEmails, 50, 1, 0)
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	c.pageSize = 1
+
+	result, err := c.Search(context.Background(), "example.com", 1)
+	require.NoError(t, err)
+	assert.Len(t, result.People, 1, "limit=1 must return exactly one person")
+	assert.Equal(t, int32(1), reqCount.Load(), "limit=1 must stop after one request (never reaching the plan cap)")
+	assert.False(t, result.Truncated, "a user-requested --limit cap is not a plan-cap truncation")
 }
 
 // ---------------------------------------------------------------------------
@@ -384,7 +408,7 @@ func TestSearch_PlanLimited_ReturnsPartial(t *testing.T) {
 	c := newTestClient(srv.URL)
 	c.pageSize = pageSize
 
-	result, err := c.Search(context.Background(), "example.com")
+	result, err := c.Search(context.Background(), "example.com", 0)
 
 	require.NoError(t, err, "plan-cap mid-pagination must not return a fatal error")
 	assert.True(t, result.Truncated, "Truncated must be true when plan cap was hit")
@@ -454,7 +478,7 @@ func TestSearch_RateLimited_StillFatal(t *testing.T) {
 	c := newTestClient(srv.URL)
 	c.pageSize = pageSize
 
-	result, err := c.Search(context.Background(), "example.com")
+	result, err := c.Search(context.Background(), "example.com", 0)
 
 	require.Error(t, err, "mid-pagination 429 must return a fatal error")
 	assert.True(t, errors.Is(err, ErrRateLimited), "error must wrap ErrRateLimited")
@@ -479,6 +503,6 @@ func TestSearch_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 
-	_, err := c.Search(ctx, "example.com")
+	_, err := c.Search(ctx, "example.com", 0)
 	require.Error(t, err)
 }

--- a/pkg/enum/hunter/hunter_test.go
+++ b/pkg/enum/hunter/hunter_test.go
@@ -146,7 +146,7 @@ func TestFetchPage_200Decode(t *testing.T) {
 	defer srv.Close()
 
 	c := newTestClient(srv.URL)
-	page, err := c.fetchPage(context.Background(), "example.com", 0)
+	page, err := c.fetchPage(context.Background(), "example.com", 0, 10)
 	require.NoError(t, err)
 	assert.Equal(t, "Example Corp", page.Data.Organization)
 	assert.Len(t, page.Data.Emails, 2)
@@ -163,7 +163,7 @@ func TestFetchPage_401_Unauthorized(t *testing.T) {
 	defer srv.Close()
 
 	c := newTestClient(srv.URL)
-	_, err := c.fetchPage(context.Background(), "example.com", 0)
+	_, err := c.fetchPage(context.Background(), "example.com", 0, 10)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrUnauthorized), "expected ErrUnauthorized, got %v", err)
 
@@ -181,7 +181,7 @@ func TestFetchPage_429_RateLimited(t *testing.T) {
 	defer srv.Close()
 
 	c := newTestClient(srv.URL)
-	_, err := c.fetchPage(context.Background(), "example.com", 0)
+	_, err := c.fetchPage(context.Background(), "example.com", 0, 10)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrRateLimited))
 }
@@ -194,7 +194,7 @@ func TestFetchPage_451_LegalReasons(t *testing.T) {
 	defer srv.Close()
 
 	c := newTestClient(srv.URL)
-	_, err := c.fetchPage(context.Background(), "example.com", 0)
+	_, err := c.fetchPage(context.Background(), "example.com", 0, 10)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrLegalReasons))
 }
@@ -207,7 +207,7 @@ func TestFetchPage_MalformedJSON(t *testing.T) {
 	defer srv.Close()
 
 	c := newTestClient(srv.URL)
-	_, err := c.fetchPage(context.Background(), "example.com", 0)
+	_, err := c.fetchPage(context.Background(), "example.com", 0, 10)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "decoding hunter response")
 }
@@ -222,7 +222,7 @@ func TestFetchPage_QueryParams(t *testing.T) {
 	defer srv.Close()
 
 	c := newTestClient(srv.URL)
-	_, err := c.fetchPage(context.Background(), "test.io", 5)
+	_, err := c.fetchPage(context.Background(), "test.io", 5, 10)
 	require.NoError(t, err)
 
 	q := capturedURL.Query()
@@ -369,6 +369,46 @@ func TestSearch_LimitCapsResults(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, result.People, 1, "limit=1 must return exactly one person")
 	assert.Equal(t, int32(1), reqCount.Load(), "limit=1 must stop after one request (never reaching the plan cap)")
+	assert.False(t, result.Truncated, "a user-requested --limit cap is not a plan-cap truncation")
+}
+
+// TestSearch_LimitReducesFinalPageRequest verifies that when --limit is not a
+// multiple of the page size, Search asks the API for only the remaining number of
+// results on the final page instead of a full page it would discard (Hunter bills
+// per email returned). With pageSize=100 and limit=150 over a large domain, the
+// two requests must ask for limit=100 then limit=50.
+func TestSearch_LimitReducesFinalPageRequest(t *testing.T) {
+	// Large pool so the domain is never exhausted before the cap is hit.
+	pool := make([]apiEmail, 300)
+	for i := range pool {
+		pool[i] = apiEmail{Value: fmt.Sprintf("u%d@example.com", i), Confidence: 50}
+	}
+
+	var reqLimits []int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		offset, perPage := 0, 0
+		_, _ = fmt.Sscanf(q.Get("offset"), "%d", &offset)
+		_, _ = fmt.Sscanf(q.Get("limit"), "%d", &perPage)
+		reqLimits = append(reqLimits, perPage)
+
+		end := offset + perPage
+		if end > len(pool) {
+			end = len(pool)
+		}
+		page := pool[offset:end]
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(makeResponse("example.com", "Example Corp", page, len(pool), perPage, offset))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	c.pageSize = 100
+
+	result, err := c.Search(context.Background(), "example.com", 150)
+	require.NoError(t, err)
+	assert.Len(t, result.People, 150, "must return exactly the requested cap")
+	assert.Equal(t, []int{100, 50}, reqLimits, "final page must request only the remaining 50, not a full 100")
 	assert.False(t, result.Truncated, "a user-requested --limit cap is not a plan-cap truncation")
 }
 


### PR DESCRIPTION
## Problem

`enum hunter --limit N` mishandled the `--limit` flag. Running:

```
./brutus enum hunter --domain fox.com --api-key <key> --limit 1
```

failed with:

```
[-] Error: hunter domain search failed: hunter API error (HTTP 400): The search results are limited to 10 email addresses on your current plan.
```

## Root cause

`--limit` was wired as the **pagination page size** (`Client.pageSize`), whereas every other `enum` subcommand (dehashed, apollo, lusha, github, teams) treats `--limit` as a **total result cap**. With `--limit 1` the page size became 1, forcing one-email-per-request pagination that walked offset 0→10 straight into Hunter's free-plan result cap, surfacing the HTTP 400.

(On branches predating #190 the plan-cap 400 is fatal; even with #190's soft-stop, `--limit 1` still returned 10 results after 10 wasted requests instead of the 1 the user asked for.)

## Fix

Make Hunter consistent with its sibling subcommands:

- `Search` now accepts a `limit` param and stops (truncating `People`) once the cap is reached. `Truncated` stays reserved for the plan-cap soft-stop, so a user-requested `--limit` is **not** reported as a truncation.
- The CLI derives the API page size via the existing `pageSizeForLimit()` helper (`min(limit, 100)`) and passes `--limit` through to `Search`.
- `--limit` default changes `100` → `0` (0 = no cap), preserving the previous "return all" default behavior.

Now `--limit 1` returns one result in a **single request** and never reaches the plan cap.

## Testing

- New `TestSearch_LimitCapsResults`: `limit=1` returns exactly one person, in exactly one request, `Truncated == false`.
- Existing `Search` call sites updated to pass `0` (no cap).
- Verification: `go test ./pkg/enum/hunter/... ./cmd/brutus/...` ✅ · `go build ./...` ✅ · `go vet` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)