### PR TITLE
Email-pattern inference + confidence (port generate.go)

### DIFF
--- a/cmd/brutus/cmd_enum.go
+++ b/cmd/brutus/cmd_enum.go
@@ -159,7 +159,7 @@ func runEnumGenerateRanked() error {
 			return fmt.Errorf("generating ranked usernames: %w", err)
 		}
 		for _, r := range capRankedResults(ranked, flagEnumGenerateLimit) {
-			fmt.Fprintf(os.Stdout, "%s\t%.4f\n", r.Value, r.Confidence)
+			_, _ = fmt.Fprintf(os.Stdout, "%s\t%.4f\n", r.Value, r.Confidence)
 		}
 		return nil
 	}
@@ -169,7 +169,7 @@ func runEnumGenerateRanked() error {
 		return fmt.Errorf("generating ranked emails: %w", err)
 	}
 	for _, r := range capRankedResults(ranked, flagEnumGenerateLimit) {
-		fmt.Fprintf(os.Stdout, "%s\t%.4f\n", r.Value, r.Confidence)
+		_, _ = fmt.Fprintf(os.Stdout, "%s\t%.4f\n", r.Value, r.Confidence)
 	}
 	return nil
 }

--- a/cmd/brutus/cmd_enum.go
+++ b/cmd/brutus/cmd_enum.go
@@ -30,6 +30,7 @@ var (
 	flagEnumDomain        string
 	flagEnumFormat        string
 	flagEnumGenerateLimit int
+	flagEnumConfidence    bool
 )
 
 var enumCmd = &cobra.Command{
@@ -100,7 +101,10 @@ Available formats:
   brutus enum generate --domain example.com --limit 1000
 
   # Pipe the 500 most-likely usernames to Kerberos enum
-  brutus enum generate --format flast --limit 500 | brutus enum kerberos --dc 10.0.0.1 --domain CORP.LOCAL -U -`,
+  brutus enum generate --format flast --limit 500 | brutus enum kerberos --dc 10.0.0.1 --domain CORP.LOCAL -U -
+
+  # Generate emails with confidence scores (TSV: value\tconfidence)
+  brutus enum generate --domain example.com --confidence`,
 	RunE: runEnumGenerate,
 }
 
@@ -110,6 +114,7 @@ func init() {
 	f.StringVarP(&flagEnumDomain, "domain", "d", "", "Domain to append to generated usernames (omit to generate usernames only)")
 	f.StringVar(&flagEnumFormat, "format", "first.last", "Username format (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first)")
 	f.IntVar(&flagEnumGenerateLimit, "limit", 0, "Emit only the first N (most-likely) results (0 = no limit, emit all)")
+	f.BoolVar(&flagEnumConfidence, "confidence", false, "Include confidence score per entry (TSV: value\\tconfidence)")
 
 	// Wire commands
 	enumCmd.AddCommand(enumGenerateCmd)
@@ -122,8 +127,11 @@ func init() {
 
 // runEnumGenerate handles the "enum generate" subcommand.
 func runEnumGenerate(cmd *cobra.Command, args []string) error {
+	if flagEnumConfidence {
+		return runEnumGenerateRanked()
+	}
+
 	if flagEnumDomain == "" {
-		// Generate usernames only (no domain)
 		usernames, err := enum.GenerateUsernames(flagEnumFormat)
 		if err != nil {
 			return fmt.Errorf("generating usernames: %w", err)
@@ -134,7 +142,6 @@ func runEnumGenerate(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// Generate emails with domain
 	emails, err := enum.GenerateEmails(flagEnumFormat, flagEnumDomain)
 	if err != nil {
 		return fmt.Errorf("generating emails: %w", err)
@@ -143,6 +150,35 @@ func runEnumGenerate(cmd *cobra.Command, args []string) error {
 		fmt.Println(e)
 	}
 	return nil
+}
+
+func runEnumGenerateRanked() error {
+	if flagEnumDomain == "" {
+		ranked, err := enum.GenerateRankedUsernames(flagEnumFormat)
+		if err != nil {
+			return fmt.Errorf("generating ranked usernames: %w", err)
+		}
+		for _, r := range capRankedResults(ranked, flagEnumGenerateLimit) {
+			fmt.Fprintf(os.Stdout, "%s\t%.4f\n", r.Value, r.Confidence)
+		}
+		return nil
+	}
+
+	ranked, err := enum.GenerateRankedEmails(flagEnumFormat, flagEnumDomain)
+	if err != nil {
+		return fmt.Errorf("generating ranked emails: %w", err)
+	}
+	for _, r := range capRankedResults(ranked, flagEnumGenerateLimit) {
+		fmt.Fprintf(os.Stdout, "%s\t%.4f\n", r.Value, r.Confidence)
+	}
+	return nil
+}
+
+func capRankedResults(results []enum.RankedEntry, limit int) []enum.RankedEntry {
+	if limit <= 0 || limit >= len(results) {
+		return results
+	}
+	return results[:limit]
 }
 
 // capResults returns the first limit elements of results (the most likely,

--- a/pkg/enum/generate.go
+++ b/pkg/enum/generate.go
@@ -113,6 +113,51 @@ func GenerateEmails(format, domain string) ([]string, error) {
 	return emails, nil
 }
 
+// RankedEntry pairs a generated value (username or email) with a confidence
+// score derived from its frequency rank in the wordlist. Confidence ranges
+// from 1.0 (most likely, rank 0) to just above 0.0 (least likely, last rank).
+type RankedEntry struct {
+	Value      string  `json:"value"`
+	Confidence float64 `json:"confidence"`
+}
+
+// GenerateRankedUsernames derives usernames like GenerateUsernames but returns
+// each entry paired with a confidence score. Confidence decays linearly from
+// 1.0 (rank 0) to just above 0.0 (last rank): 1.0 - rank/total.
+func GenerateRankedUsernames(format string) ([]RankedEntry, error) {
+	usernames, err := GenerateUsernames(format)
+	if err != nil {
+		return nil, err
+	}
+	return assignConfidence(usernames), nil
+}
+
+// GenerateRankedEmails generates emails like GenerateEmails but returns each
+// entry paired with a confidence score derived from its frequency rank.
+func GenerateRankedEmails(format, domain string) ([]RankedEntry, error) {
+	emails, err := GenerateEmails(format, domain)
+	if err != nil {
+		return nil, err
+	}
+	return assignConfidence(emails), nil
+}
+
+func assignConfidence(values []string) []RankedEntry {
+	n := len(values)
+	if n == 0 {
+		return nil
+	}
+	ranked := make([]RankedEntry, n)
+	total := float64(n)
+	for i, v := range values {
+		ranked[i] = RankedEntry{
+			Value:      v,
+			Confidence: 1.0 - float64(i)/total,
+		}
+	}
+	return ranked
+}
+
 // LoadServiceAccounts returns embedded service account names.
 func LoadServiceAccounts() ([]string, error) {
 	data, err := wordlistFS.ReadFile("wordlists/service-accounts.txt")

--- a/pkg/enum/generate_test.go
+++ b/pkg/enum/generate_test.go
@@ -408,6 +408,110 @@ func TestGenerateEmails_FirstUnderLast(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// TestGenerateRankedUsernames
+// ---------------------------------------------------------------------------
+
+// TestGenerateRankedUsernames_ConfidenceOrdering verifies that confidence
+// scores are monotonically non-increasing and bounded within (0.0, 1.0].
+func TestGenerateRankedUsernames_ConfidenceOrdering(t *testing.T) {
+	t.Parallel()
+
+	ranked, err := GenerateRankedUsernames(FormatFirstDotLast)
+	require.NoError(t, err)
+	require.NotEmpty(t, ranked)
+
+	// First entry must have the highest confidence (1.0).
+	assert.InDelta(t, 1.0, ranked[0].Confidence, 1e-9,
+		"rank-0 entry must have confidence ~1.0")
+
+	// Last entry must have confidence > 0.
+	assert.Greater(t, ranked[len(ranked)-1].Confidence, 0.0,
+		"last entry must have confidence > 0")
+
+	// Monotonically non-increasing.
+	for i := 1; i < len(ranked); i++ {
+		assert.LessOrEqual(t, ranked[i].Confidence, ranked[i-1].Confidence,
+			"confidence must be monotonically non-increasing at index %d", i)
+	}
+}
+
+// TestGenerateRankedUsernames_ValuesMatchPlain verifies that the Value fields
+// of ranked entries match the plain GenerateUsernames output exactly.
+func TestGenerateRankedUsernames_ValuesMatchPlain(t *testing.T) {
+	t.Parallel()
+
+	plain, err := GenerateUsernames(FormatFLast)
+	require.NoError(t, err)
+
+	ranked, err := GenerateRankedUsernames(FormatFLast)
+	require.NoError(t, err)
+
+	require.Equal(t, len(plain), len(ranked),
+		"ranked and plain must produce the same count")
+
+	for i := range plain {
+		assert.Equal(t, plain[i], ranked[i].Value,
+			"Value at index %d must match plain output", i)
+	}
+}
+
+// TestGenerateRankedUsernames_HeadEntry verifies the top-ranked entry.
+func TestGenerateRankedUsernames_HeadEntry(t *testing.T) {
+	t.Parallel()
+
+	ranked, err := GenerateRankedUsernames(FormatFirstDotLast)
+	require.NoError(t, err)
+	require.NotEmpty(t, ranked)
+
+	assert.Equal(t, "john.smith", ranked[0].Value)
+	assert.InDelta(t, 1.0, ranked[0].Confidence, 1e-9)
+}
+
+// ---------------------------------------------------------------------------
+// TestGenerateRankedEmails
+// ---------------------------------------------------------------------------
+
+// TestGenerateRankedEmails_ConfidenceAndDomain verifies ranked emails have
+// the domain appended and confidence scores match the username ranking.
+func TestGenerateRankedEmails_ConfidenceAndDomain(t *testing.T) {
+	t.Parallel()
+
+	const domain = "corp.com"
+	ranked, err := GenerateRankedEmails(FormatFirstDotLast, domain)
+	require.NoError(t, err)
+	require.NotEmpty(t, ranked)
+
+	assert.Equal(t, "john.smith@corp.com", ranked[0].Value)
+	assert.InDelta(t, 1.0, ranked[0].Confidence, 1e-9)
+
+	suffix := "@" + domain
+	for i, r := range ranked {
+		assert.True(t, strings.HasSuffix(r.Value, suffix),
+			"email at index %d (%q) must end with %q", i, r.Value, suffix)
+	}
+
+	// Confidence must match the corresponding ranked usernames.
+	rankedU, err := GenerateRankedUsernames(FormatFirstDotLast)
+	require.NoError(t, err)
+	require.Equal(t, len(rankedU), len(ranked))
+
+	for i := range ranked {
+		assert.InDelta(t, rankedU[i].Confidence, ranked[i].Confidence, 1e-9,
+			"confidence at index %d must match between usernames and emails", i)
+	}
+}
+
+// TestGenerateRankedEmails_UnknownFormat verifies that an unknown format
+// returns an empty result with no error, same as the plain version.
+func TestGenerateRankedEmails_UnknownFormat(t *testing.T) {
+	t.Parallel()
+
+	ranked, err := GenerateRankedEmails("bogus", "example.com")
+	require.NoError(t, err)
+	assert.Empty(t, ranked)
+}
+
+// ---------------------------------------------------------------------------
 // helpers
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add `RankedEntry` type pairing generated usernames/emails with a confidence score derived from frequency rank (1.0 = most likely, linear decay to ~0.0)
- Add `GenerateRankedUsernames` and `GenerateRankedEmails` functions — non-breaking, existing `Generate*` functions unchanged
- Add `--confidence` flag to `brutus enum generate` CLI — emits TSV (`value\tconfidence`)
- 5 new tests covering confidence ordering, monotonicity, value parity with plain output, and edge cases

Parent: [10T-313 — OSINT · Capabilities — Collection & account confirmation](https://linear.app/praetorianlabs/issue/10T-313)

## Test plan
- [x] `go test ./pkg/enum/ -run TestGenerateRanked` — all 5 pass
- [x] `go test ./pkg/enum/` — full suite passes, no regressions
- [x] `go build ./cmd/brutus/` — CLI compiles clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)