### PR TITLE
LinkedIn Sales Navigator connector via PhantomBuster

### DIFF
--- a/cmd/brutus/cmd_enum.go
+++ b/cmd/brutus/cmd_enum.go
@@ -126,7 +126,7 @@ func init() {
 	enumCmd.AddCommand(enumActiveCmd)
 
 	// Canonical path: the passive API-key OSINT/HUMINT sources live under "passive".
-	enumPassiveCmd.AddCommand(newEnumHunterCmd(), newEnumApolloCmd(), newEnumLushaCmd(), newEnumDehashedCmd())
+	enumPassiveCmd.AddCommand(newEnumHunterCmd(), newEnumApolloCmd(), newEnumLushaCmd(), newEnumDehashedCmd(), newEnumLinkedinCmd())
 	enumCmd.AddCommand(enumPassiveCmd)
 
 	// Hidden back-compat aliases: the old "enum <name>" paths still work but are

--- a/cmd/brutus/cmd_enum_linkedin.go
+++ b/cmd/brutus/cmd_enum_linkedin.go
@@ -128,9 +128,10 @@ func runEnumLinkedin(cmd *cobra.Command, args []string) error {
 				return
 			}
 			if status.Progress != nil {
+				pct, _ := status.Progress.Value.Float64()
 				fmt.Fprintf(os.Stderr, "\r%s Progress: %.0f%% %s",
 					dim(useColor, SymbolInfo),
-					status.Progress.Value*100,
+					pct*100,
 					status.Progress.Label)
 			}
 		}

--- a/cmd/brutus/cmd_enum_linkedin.go
+++ b/cmd/brutus/cmd_enum_linkedin.go
@@ -1,0 +1,187 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/spf13/cobra"
+
+	pb "github.com/praetorian-inc/brutus/pkg/enum/phantombuster"
+)
+
+var (
+	flagLinkedinAgentID    string
+	flagLinkedinAPIKey     string
+	flagLinkedinResultFile string
+	flagLinkedinSkipLaunch bool
+)
+
+func newEnumLinkedinCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "linkedin",
+		Short: "Scrape LinkedIn Sales Navigator profiles via PhantomBuster",
+		Long: `Launch a pre-configured PhantomBuster Sales Navigator scraper, poll until
+the run completes, and fetch the scraped profiles. The agent must already be
+configured in the PhantomBuster UI with its script, LinkedIn session cookie,
+and search parameters set. This command controls execution only.
+
+Output is a roster of people (name, title, department, company, LinkedIn URL)
+— no email addresses. Candidate email generation from these names is handled
+downstream by the email-pattern inference pipeline (enum generate).
+
+Requires a PhantomBuster API key via the PHANTOMBUSTER_KEY environment variable
+(or the --api-key flag).
+
+Authorized use only: respect LinkedIn's Terms of Service and only enumerate
+targets you are authorized to assess.`,
+		Example: `  # Launch a Sales Nav scraper and fetch results
+  brutus enum passive linkedin --agent-id 1234567890
+
+  # Fetch results from a previous run (skip launching a new one)
+  brutus enum passive linkedin --agent-id 1234567890 --skip-launch
+
+  # Specify a custom result filename
+  brutus enum passive linkedin --agent-id 1234567890 --result-file result.json
+
+  # Provide the key explicitly (note: visible in process list / shell history)
+  brutus enum passive linkedin --agent-id 1234567890 --api-key abc123`,
+		RunE: runEnumLinkedin,
+	}
+
+	f := cmd.Flags()
+	f.StringVar(&flagLinkedinAgentID, "agent-id", "",
+		"PhantomBuster agent ID for the Sales Navigator scraper (required)")
+	f.StringVar(&flagLinkedinAPIKey, "api-key", "",
+		"PhantomBuster API key (overrides PHANTOMBUSTER_KEY; WARNING: visible in process list and shell history — prefer PHANTOMBUSTER_KEY)")
+	f.StringVar(&flagLinkedinResultFile, "result-file", "result.csv",
+		"Result filename to download from S3 (default: result.csv)")
+	f.BoolVar(&flagLinkedinSkipLaunch, "skip-launch", false,
+		"Skip launching the agent — fetch results from the most recent run instead")
+	_ = cmd.MarkFlagRequired("agent-id")
+
+	return cmd
+}
+
+func runEnumLinkedin(cmd *cobra.Command, args []string) error {
+	useColor := isColorEnabled(flagNoColor)
+
+	apiKey, err := resolvePhantomBusterKey(flagLinkedinAPIKey)
+	if err != nil {
+		return err
+	}
+
+	jsonWriter, forceJSON, closeOutput, err := setupOutputWriter(flagOutputFile)
+	if err != nil {
+		return err
+	}
+	defer closeOutput()
+	if forceJSON {
+		flagJSON = true
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	client := pb.NewClient(apiKey, flagTimeout)
+
+	var resultData []byte
+
+	if flagLinkedinSkipLaunch {
+		if !flagQuiet && !flagJSON {
+			fmt.Fprintf(os.Stderr, "%s Fetching results from previous run (agent %s)...\n",
+				dim(useColor, SymbolInfo), flagLinkedinAgentID)
+		}
+		info, err := client.FetchAgentInfo(ctx, flagLinkedinAgentID)
+		if err != nil {
+			return classifyPhantomBusterError(err)
+		}
+		resultData, err = client.DownloadResult(ctx, info, flagLinkedinResultFile)
+		if err != nil {
+			return classifyPhantomBusterError(err)
+		}
+	} else {
+		if !flagQuiet && !flagJSON {
+			fmt.Fprintf(os.Stderr, "%s Launching PhantomBuster agent %s...\n",
+				dim(useColor, SymbolInfo), flagLinkedinAgentID)
+		}
+
+		onProgress := func(status pb.OutputStatus) {
+			if flagQuiet || flagJSON {
+				return
+			}
+			if status.Progress != nil {
+				fmt.Fprintf(os.Stderr, "\r%s Progress: %.0f%% %s",
+					dim(useColor, SymbolInfo),
+					status.Progress.Value*100,
+					status.Progress.Label)
+			}
+		}
+
+		resultData, err = client.RunAndFetch(ctx, flagLinkedinAgentID, flagLinkedinResultFile, onProgress)
+		if err != nil {
+			return classifyPhantomBusterError(err)
+		}
+
+		if !flagQuiet && !flagJSON {
+			fmt.Fprintf(os.Stderr, "\n")
+		}
+	}
+
+	result, err := pb.ParseSalesNavCSV(resultData)
+	if err != nil {
+		return fmt.Errorf("parsing Sales Navigator results: %w", err)
+	}
+	result.AgentID = flagLinkedinAgentID
+
+	logVerbose(flagVerbose, "LinkedIn returned %d profiles", result.Total)
+
+	if flagJSON {
+		outputLinkedinJSONL(jsonWriter, result)
+	} else {
+		outputLinkedinHuman(os.Stdout, result, useColor)
+	}
+
+	return nil
+}
+
+func resolvePhantomBusterKey(flagValue string) (string, error) {
+	if flagValue != "" {
+		return flagValue, nil
+	}
+	if key := os.Getenv("PHANTOMBUSTER_KEY"); key != "" {
+		return key, nil
+	}
+	return "", fmt.Errorf("PhantomBuster API key required: set PHANTOMBUSTER_KEY or pass --api-key")
+}
+
+func classifyPhantomBusterError(err error) error {
+	switch {
+	case errors.Is(err, pb.ErrUnauthorized):
+		return fmt.Errorf("phantombuster: invalid or missing API key (check PHANTOMBUSTER_KEY / --api-key)")
+	case errors.Is(err, pb.ErrNotFound):
+		return fmt.Errorf("phantombuster: agent not found (check --agent-id)")
+	case errors.Is(err, pb.ErrRateLimited):
+		return fmt.Errorf("phantombuster: rate limit exceeded — wait and retry")
+	case errors.Is(err, pb.ErrAgentFailed):
+		return fmt.Errorf("phantombuster: %w", err)
+	}
+	return fmt.Errorf("phantombuster: %w", err)
+}

--- a/cmd/brutus/cmd_enum_linkedin_output.go
+++ b/cmd/brutus/cmd_enum_linkedin_output.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	pb "github.com/praetorian-inc/brutus/pkg/enum/phantombuster"
+)
+
+func outputLinkedinHuman(w io.Writer, result *pb.ScrapeResult, useColor bool) {
+	_, _ = fmt.Fprintf(w, "\n%s %s\n", dim(useColor, SymbolInfo),
+		heading(useColor, "LinkedIn Sales Navigator"))
+	_, _ = fmt.Fprintf(w, "  Profiles scraped: %d\n", result.Total)
+
+	if len(result.Profiles) == 0 {
+		_, _ = fmt.Fprintf(w, "\n  %s No profiles found\n", dim(useColor, SymbolInfo))
+		_, _ = fmt.Fprintln(w)
+		return
+	}
+
+	_, _ = fmt.Fprintf(w, "\n  %s%-24s %-24s %-16s %-20s %-40s%s\n",
+		colorIf(useColor, ColorBold),
+		"Name", "Title", "Dept", "Company", "LinkedIn",
+		colorIf(useColor, ColorReset))
+
+	for i := range result.Profiles {
+		p := &result.Profiles[i]
+		name := sanitizeTerminal(p.FullName)
+		if name == "" {
+			name = sanitizeTerminal(p.FirstName + " " + p.LastName)
+		}
+		_, _ = fmt.Fprintf(w, "  %-24s %-24s %-16s %-20s %s%-40s%s\n",
+			truncate(name, 24),
+			truncate(sanitizeTerminal(p.Title), 24),
+			truncate(sanitizeTerminal(p.Department), 16),
+			truncate(sanitizeTerminal(p.Company), 20),
+			colorIf(useColor, ColorCyan),
+			truncate(sanitizeTerminal(p.LinkedinURL), 40),
+			colorIf(useColor, ColorReset))
+	}
+	_, _ = fmt.Fprintln(w)
+}
+
+func outputLinkedinJSONL(w io.Writer, result *pb.ScrapeResult) {
+	type linkedinJSON struct {
+		Type               string   `json:"type"`
+		FirstName          string   `json:"first_name,omitempty"`
+		LastName           string   `json:"last_name,omitempty"`
+		FullName           string   `json:"full_name,omitempty"`
+		Title              string   `json:"title,omitempty"`
+		Company            string   `json:"company,omitempty"`
+		CompanyURL         string   `json:"company_url,omitempty"`
+		Department         string   `json:"department,omitempty"`
+		Seniority          string   `json:"seniority,omitempty"`
+		Location           string   `json:"location,omitempty"`
+		LinkedinURL        string   `json:"linkedin_url,omitempty"`
+		SalesNavURL        string   `json:"sales_nav_url,omitempty"`
+		Headline           string   `json:"headline,omitempty"`
+		ConnectionDegree   string   `json:"connection_degree,omitempty"`
+		Sources            []string `json:"sources"`
+		VerificationStatus string   `json:"verification_status"`
+	}
+
+	enc := json.NewEncoder(w)
+	for i := range result.Profiles {
+		p := &result.Profiles[i]
+		jr := linkedinJSON{
+			Type:               "linkedin",
+			FirstName:          p.FirstName,
+			LastName:           p.LastName,
+			FullName:           p.FullName,
+			Title:              p.Title,
+			Company:            p.Company,
+			CompanyURL:         p.CompanyURL,
+			Department:         p.Department,
+			Seniority:          p.Seniority,
+			Location:           p.Location,
+			LinkedinURL:        p.LinkedinURL,
+			SalesNavURL:        p.SalesNavURL,
+			Headline:           p.Headline,
+			ConnectionDegree:   p.ConnectionDegree,
+			Sources:            p.Sources,
+			VerificationStatus: p.VerificationStatus,
+		}
+		if err := enc.Encode(jr); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "Error encoding linkedin JSON: %v\n", err)
+		}
+	}
+}

--- a/cmd/brutus/cmd_enum_linkedin_test.go
+++ b/cmd/brutus/cmd_enum_linkedin_test.go
@@ -1,0 +1,214 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/praetorian-inc/brutus/pkg/enum/phantombuster"
+)
+
+func TestResolvePhantomBusterKey(t *testing.T) {
+	tests := []struct {
+		name      string
+		flagValue string
+		envValue  string
+		wantKey   string
+		wantErr   bool
+	}{
+		{
+			name:      "flag value takes priority over env",
+			flagValue: "flag-key",
+			envValue:  "env-key",
+			wantKey:   "flag-key",
+		},
+		{
+			name:      "env var used when flag is empty",
+			flagValue: "",
+			envValue:  "env-key",
+			wantKey:   "env-key",
+		},
+		{
+			name:      "error when both empty — mentions PHANTOMBUSTER_KEY",
+			flagValue: "",
+			envValue:  "",
+			wantErr:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("PHANTOMBUSTER_KEY", tc.envValue)
+			key, err := resolvePhantomBusterKey(tc.flagValue)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "PHANTOMBUSTER_KEY",
+					"error message must mention PHANTOMBUSTER_KEY so the operator knows what to set")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantKey, key)
+		})
+	}
+}
+
+func TestClassifyPhantomBusterError(t *testing.T) {
+	tests := []struct {
+		name         string
+		err          error
+		wantContains string
+	}{
+		{
+			name:         "unauthorized",
+			err:          pb.ErrUnauthorized,
+			wantContains: "invalid or missing API key",
+		},
+		{
+			name:         "not found",
+			err:          pb.ErrNotFound,
+			wantContains: "agent not found",
+		},
+		{
+			name:         "rate limited",
+			err:          pb.ErrRateLimited,
+			wantContains: "rate limit exceeded",
+		},
+		{
+			name:         "agent failed",
+			err:          pb.ErrAgentFailed,
+			wantContains: "agent run failed",
+		},
+		{
+			name:         "unknown error passes through",
+			err:          errors.New("network timeout"),
+			wantContains: "network timeout",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := classifyPhantomBusterError(tc.err)
+			assert.Contains(t, result.Error(), tc.wantContains)
+		})
+	}
+}
+
+func TestEnumLinkedinRegistered(t *testing.T) {
+	var passive *cobra.Command
+	for _, cmd := range enumCmd.Commands() {
+		if cmd.Use == "passive" {
+			passive = cmd
+			break
+		}
+	}
+	require.NotNil(t, passive, `enumCmd must have a "passive" subcommand`)
+
+	var linkedin *cobra.Command
+	for _, cmd := range passive.Commands() {
+		if cmd.Use == "linkedin" {
+			linkedin = cmd
+			break
+		}
+	}
+	require.NotNil(t, linkedin, `"linkedin" must be a subcommand of enumPassiveCmd`)
+
+	for _, flagName := range []string{"agent-id", "api-key", "result-file", "skip-launch"} {
+		require.NotNilf(t, linkedin.Flags().Lookup(flagName),
+			"--%s flag must exist on linkedin command", flagName)
+	}
+
+	agentIDFlag := linkedin.Flags().Lookup("agent-id")
+	_, isRequired := agentIDFlag.Annotations["cobra_annotation_bash_completion_one_required_flag"]
+	assert.True(t, isRequired, "--agent-id must be marked as required")
+}
+
+func TestOutputLinkedinHuman_Table(t *testing.T) {
+	result := &pb.ScrapeResult{
+		Total: 2,
+		Profiles: []pb.Profile{
+			{
+				FullName:    "Jane Doe",
+				FirstName:   "Jane",
+				LastName:    "Doe",
+				Title:       "VP Engineering",
+				Company:     "Acme Corp",
+				LinkedinURL: "https://linkedin.com/in/janedoe",
+				Department:  "Engineering",
+			},
+			{
+				FullName:    "John Smith",
+				FirstName:   "John",
+				LastName:    "Smith",
+				Title:       "CTO",
+				Company:     "Widgets Inc",
+				LinkedinURL: "https://linkedin.com/in/johnsmith",
+			},
+		},
+	}
+	var buf bytes.Buffer
+	outputLinkedinHuman(&buf, result, false)
+	out := buf.String()
+
+	assert.Contains(t, out, "LinkedIn Sales Navigator")
+	assert.Contains(t, out, "Profiles scraped: 2")
+	assert.Contains(t, out, "Jane Doe")
+	assert.Contains(t, out, "VP Engineering")
+	assert.Contains(t, out, "Acme Corp")
+	assert.Contains(t, out, "John Smith")
+}
+
+func TestOutputLinkedinHuman_Empty(t *testing.T) {
+	result := &pb.ScrapeResult{}
+	var buf bytes.Buffer
+	outputLinkedinHuman(&buf, result, false)
+	out := buf.String()
+	assert.Contains(t, out, "No profiles found")
+}
+
+func TestOutputLinkedinJSONL(t *testing.T) {
+	result := &pb.ScrapeResult{
+		Total: 1,
+		Profiles: []pb.Profile{
+			{
+				FirstName:          "Jane",
+				LastName:           "Doe",
+				FullName:           "Jane Doe",
+				Title:              "VP Engineering",
+				Company:            "Acme Corp",
+				LinkedinURL:        "https://linkedin.com/in/janedoe",
+				Sources:            []string{"linkedin-salesnav"},
+				VerificationStatus: "unverified",
+			},
+		},
+	}
+	var buf bytes.Buffer
+	outputLinkedinJSONL(&buf, result)
+	out := buf.String()
+
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	assert.Len(t, lines, 1)
+	assert.Contains(t, out, `"type":"linkedin"`)
+	assert.Contains(t, out, `"first_name":"Jane"`)
+	assert.Contains(t, out, `"linkedin_url":"https://linkedin.com/in/janedoe"`)
+	assert.Contains(t, out, `"sources":["linkedin-salesnav"]`)
+	assert.Contains(t, out, `"verification_status":"unverified"`)
+}

--- a/cmd/brutus/cmd_enum_passive.go
+++ b/cmd/brutus/cmd_enum_passive.go
@@ -31,6 +31,7 @@ Sources:
   apollo     Discover and enrich people for a domain via Apollo.io
   lusha      Enrich a single contact (email/phone) via Lusha
   dehashed   Collect breach-exposed identity data for a domain via DeHashed
+  linkedin   Scrape LinkedIn Sales Navigator profiles via PhantomBuster
 
 These sources are standalone — they do not feed the saas enumeration pipeline.`,
 	Example: `  # Discover people via Hunter.io
@@ -43,5 +44,8 @@ These sources are standalone — they do not feed the saas enumeration pipeline.
   brutus enum passive lusha --first-name Jane --last-name Doe --company "Example Inc"
 
   # Collect breach-exposed identity data via DeHashed
-  brutus enum passive dehashed --domain example.com`,
+  brutus enum passive dehashed --domain example.com
+
+  # Scrape LinkedIn Sales Navigator profiles via PhantomBuster
+  brutus enum passive linkedin --agent-id 1234567890`,
 }

--- a/pkg/enum/phantombuster/client.go
+++ b/pkg/enum/phantombuster/client.go
@@ -1,0 +1,290 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package phantombuster provides a client for the PhantomBuster agent
+// execution API. It handles launching pre-configured agents, polling for
+// async completion, and fetching results from S3. The client is generic —
+// scraper-specific parsing (e.g. LinkedIn Sales Navigator) lives in
+// separate files.
+package phantombuster
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/praetorian-inc/brutus/pkg/enum"
+)
+
+var (
+	ErrUnauthorized = errors.New("invalid or missing PhantomBuster API key")
+	ErrNotFound     = errors.New("agent not found")
+	ErrRateLimited  = errors.New("rate limit exceeded")
+	ErrAgentFailed  = errors.New("agent run failed")
+)
+
+const (
+	defaultBaseURL   = "https://api.phantombuster.com"
+	headerAPIKey     = "X-Phantombuster-Key-1"
+	launchPath       = "/api/v2/agents/launch"
+	outputPath       = "/api/v1/agent/%s/output.json"
+	fetchPath        = "/api/v2/agents/fetch"
+	s3BaseURL        = "https://phantombuster.s3.amazonaws.com"
+	defaultPollInit  = 5 * time.Second
+	defaultPollMax   = 30 * time.Second
+	defaultPollMult  = 1.5
+	maxResponseBytes = 10 << 20 // 10 MB for S3 result files
+)
+
+// ContainerStatus values returned by the output endpoint.
+const (
+	StatusRunning    = "running"
+	StatusNotRunning = "not running"
+)
+
+// Client holds state for interacting with the PhantomBuster API.
+type Client struct {
+	apiKey     string // X-Phantombuster-Key-1 — NEVER logged (P0-1)
+	httpClient *http.Client
+	baseURL    string
+
+	pollInit time.Duration
+	pollMax  time.Duration
+	pollMult float64
+}
+
+// NewClient builds a PhantomBuster client. timeout is the per-request HTTP budget.
+func NewClient(apiKey string, timeout time.Duration) *Client {
+	return &Client{
+		apiKey:     apiKey,
+		httpClient: enum.NewEnumHTTPClient(timeout),
+		baseURL:    defaultBaseURL,
+		pollInit:   defaultPollInit,
+		pollMax:    defaultPollMax,
+		pollMult:   defaultPollMult,
+	}
+}
+
+// LaunchResult is returned by Launch.
+type LaunchResult struct {
+	ContainerID string `json:"containerId"`
+}
+
+// Launch starts a pre-configured agent. The agent must already exist in the
+// PhantomBuster UI with its script, inputs, and LinkedIn session cookie
+// configured. Returns the container ID for polling.
+func (c *Client) Launch(ctx context.Context, agentID string) (*LaunchResult, error) {
+	body := map[string]string{"id": agentID}
+	respBody, err := c.doJSON(ctx, http.MethodPost, launchPath, body)
+	if err != nil {
+		return nil, err
+	}
+
+	var result LaunchResult
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("decoding launch response: %w", err)
+	}
+	if result.ContainerID == "" {
+		return nil, fmt.Errorf("launch returned empty containerId")
+	}
+	return &result, nil
+}
+
+// OutputStatus is the parsed polling response from the output endpoint.
+type OutputStatus struct {
+	ContainerStatus string `json:"containerStatus"`
+	ExitCode        int    `json:"exitCode"`
+	ExitMessage     string `json:"exitMessage"`
+	Progress        *struct {
+		Value float64 `json:"value"`
+		Label string  `json:"label"`
+	} `json:"progress"`
+	ResultObject json.RawMessage `json:"resultObject"`
+}
+
+// PollUntilDone polls the agent output endpoint until the container finishes
+// or the context is cancelled. It uses exponential backoff between polls.
+// onProgress is called (if non-nil) on each poll with the current status,
+// allowing the caller to log progress updates.
+func (c *Client) PollUntilDone(ctx context.Context, agentID, containerID string, onProgress func(OutputStatus)) (*OutputStatus, error) {
+	path := fmt.Sprintf(outputPath, agentID)
+	if containerID != "" {
+		path += "?mode=track&containerId=" + containerID
+	}
+
+	delay := c.pollInit
+	for {
+		respBody, err := c.doJSON(ctx, http.MethodGet, path, nil)
+		if err != nil {
+			return nil, fmt.Errorf("polling agent status: %w", err)
+		}
+
+		var status OutputStatus
+		if err := json.Unmarshal(respBody, &status); err != nil {
+			return nil, fmt.Errorf("decoding output response: %w", err)
+		}
+
+		if onProgress != nil {
+			onProgress(status)
+		}
+
+		if status.ContainerStatus != StatusRunning {
+			if status.ExitCode != 0 {
+				return &status, fmt.Errorf("%w: %s (exit code %d)", ErrAgentFailed, status.ExitMessage, status.ExitCode)
+			}
+			return &status, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(delay):
+		}
+		delay = time.Duration(float64(delay) * c.pollMult)
+		if delay > c.pollMax {
+			delay = c.pollMax
+		}
+	}
+}
+
+// AgentInfo is the parsed response from the fetch endpoint, containing
+// S3 paths needed to download results.
+type AgentInfo struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	S3Folder    string `json:"s3Folder"`
+	OrgS3Folder string `json:"orgS3Folder"`
+}
+
+// FetchAgentInfo retrieves the agent's metadata including S3 folder paths.
+func (c *Client) FetchAgentInfo(ctx context.Context, agentID string) (*AgentInfo, error) {
+	path := fetchPath + "?id=" + agentID
+	respBody, err := c.doJSON(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var info AgentInfo
+	if err := json.Unmarshal(respBody, &info); err != nil {
+		return nil, fmt.Errorf("decoding agent info: %w", err)
+	}
+	return &info, nil
+}
+
+// DownloadResult fetches the result file (CSV or JSON) from the agent's
+// S3 bucket. The filename is typically "result.csv" for Sales Nav scrapers.
+func (c *Client) DownloadResult(ctx context.Context, info *AgentInfo, filename string) ([]byte, error) {
+	url := fmt.Sprintf("%s/%s/%s/%s", s3BaseURL, info.OrgS3Folder, info.S3Folder, filename)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("building S3 download request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("downloading result from S3: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("S3 download failed (HTTP %d)", resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("reading S3 result: %w", err)
+	}
+	return data, nil
+}
+
+// RunAndFetch is a convenience that launches, polls, and fetches the result
+// file in one call. It is the primary entry point for CLI usage.
+func (c *Client) RunAndFetch(ctx context.Context, agentID, resultFile string, onProgress func(OutputStatus)) ([]byte, error) {
+	launch, err := c.Launch(ctx, agentID)
+	if err != nil {
+		return nil, fmt.Errorf("launching agent: %w", err)
+	}
+
+	_, err = c.PollUntilDone(ctx, agentID, launch.ContainerID, onProgress)
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := c.FetchAgentInfo(ctx, agentID)
+	if err != nil {
+		return nil, fmt.Errorf("fetching agent info: %w", err)
+	}
+
+	return c.DownloadResult(ctx, info, resultFile)
+}
+
+// doJSON is the single choke point for authenticated API requests. It
+// JSON-encodes the body (if non-nil), sets the API key header, issues the
+// request, reads the response via a bounded reader, and maps non-2xx to
+// typed errors. The key is NEVER logged (P0-1).
+func (c *Client) doJSON(ctx context.Context, method, path string, body any) ([]byte, error) {
+	var bodyReader io.Reader
+	if body != nil {
+		payload, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("encoding request: %w", err)
+		}
+		bodyReader = bytes.NewReader(payload)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("building request: %w", err)
+	}
+	req.Header.Set(headerAPIKey, c.apiKey)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := enum.ReadResponseBody(resp, 0)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, c.classifyHTTPError(resp.StatusCode)
+	}
+
+	return respBody, nil
+}
+
+func (c *Client) classifyHTTPError(code int) error {
+	switch code {
+	case http.StatusUnauthorized:
+		return ErrUnauthorized
+	case http.StatusNotFound:
+		return ErrNotFound
+	case http.StatusTooManyRequests:
+		return ErrRateLimited
+	default:
+		return fmt.Errorf("phantombuster API error (HTTP %d)", code)
+	}
+}

--- a/pkg/enum/phantombuster/client.go
+++ b/pkg/enum/phantombuster/client.go
@@ -106,14 +106,21 @@ func (c *Client) Launch(ctx context.Context, agentID string) (*LaunchResult, err
 	return &result, nil
 }
 
+// outputV1Response wraps the v1 output endpoint's envelope format:
+// {"status":"success","data":{...actual fields...}}
+type outputV1Response struct {
+	Status string       `json:"status"`
+	Data   OutputStatus `json:"data"`
+}
+
 // OutputStatus is the parsed polling response from the output endpoint.
 type OutputStatus struct {
 	ContainerStatus string `json:"containerStatus"`
 	ExitCode        int    `json:"exitCode"`
 	ExitMessage     string `json:"exitMessage"`
 	Progress        *struct {
-		Value float64 `json:"value"`
-		Label string  `json:"label"`
+		Value json.Number `json:"value"`
+		Label string      `json:"label"`
 	} `json:"progress"`
 	ResultObject json.RawMessage `json:"resultObject"`
 }
@@ -136,7 +143,13 @@ func (c *Client) PollUntilDone(ctx context.Context, agentID, containerID string,
 		}
 
 		var status OutputStatus
-		if err := json.Unmarshal(respBody, &status); err != nil {
+		var envelope outputV1Response
+		if err := json.Unmarshal(respBody, &envelope); err != nil {
+			return nil, fmt.Errorf("decoding output response: %w", err)
+		}
+		if envelope.Data.ContainerStatus != "" {
+			status = envelope.Data
+		} else if err := json.Unmarshal(respBody, &status); err != nil {
 			return nil, fmt.Errorf("decoding output response: %w", err)
 		}
 

--- a/pkg/enum/phantombuster/client_test.go
+++ b/pkg/enum/phantombuster/client_test.go
@@ -115,7 +115,7 @@ func TestPollUntilDone_ImmediateSuccess(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/agent/agent-123/output.json", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprint(w, `{"containerStatus":"not running","exitCode":0,"exitMessage":"finished"}`)
+		_, _ = fmt.Fprint(w, `{"status":"success","data":{"containerStatus":"not running","exitCode":0,"exitMessage":"finished"}}`)
 	})
 
 	c := newTestClient(t, mux)
@@ -135,9 +135,9 @@ func TestPollUntilDone_TransitionsToComplete(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		n := calls.Add(1)
 		if n <= 2 {
-			_, _ = fmt.Fprint(w, `{"containerStatus":"running","progress":{"value":0.5,"label":"scraping"}}`)
+			_, _ = fmt.Fprint(w, `{"status":"success","data":{"containerStatus":"running","progress":{"value":"0.5","label":"scraping"}}}`)
 		} else {
-			_, _ = fmt.Fprint(w, `{"containerStatus":"not running","exitCode":0,"exitMessage":"finished"}`)
+			_, _ = fmt.Fprint(w, `{"status":"success","data":{"containerStatus":"not running","exitCode":0,"exitMessage":"finished"}}`)
 		}
 	})
 
@@ -161,7 +161,7 @@ func TestPollUntilDone_AgentFailed(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/agent/agent-123/output.json", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprint(w, `{"containerStatus":"not running","exitCode":1,"exitMessage":"agent timeout"}`)
+		_, _ = fmt.Fprint(w, `{"status":"success","data":{"containerStatus":"not running","exitCode":1,"exitMessage":"agent timeout"}}`)
 	})
 
 	c := newTestClient(t, mux)
@@ -175,7 +175,7 @@ func TestPollUntilDone_ContextCancelled(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/agent/agent-123/output.json", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprint(w, `{"containerStatus":"running"}`)
+		_, _ = fmt.Fprint(w, `{"status":"success","data":{"containerStatus":"running"}}`)
 	})
 
 	c := newTestClient(t, mux)

--- a/pkg/enum/phantombuster/client_test.go
+++ b/pkg/enum/phantombuster/client_test.go
@@ -1,0 +1,250 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package phantombuster
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func newTestClient(t *testing.T, handler http.Handler) *Client {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	c := NewClient("test-key", 5*time.Second)
+	c.baseURL = server.URL
+	c.pollInit = 10 * time.Millisecond
+	c.pollMax = 50 * time.Millisecond
+	return c
+}
+
+func TestLaunch_Success(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/agents/launch", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if got := r.Header.Get(headerAPIKey); got != "test-key" {
+			t.Errorf("expected API key header, got %q", got)
+		}
+
+		var body map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decoding request: %v", err)
+		}
+		if body["id"] != "agent-123" {
+			t.Errorf("expected agent id agent-123, got %q", body["id"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"containerId":"container-abc"}`)
+	})
+
+	c := newTestClient(t, mux)
+	result, err := c.Launch(context.Background(), "agent-123")
+	if err != nil {
+		t.Fatalf("Launch: %v", err)
+	}
+	if result.ContainerID != "container-abc" {
+		t.Errorf("expected containerId container-abc, got %q", result.ContainerID)
+	}
+}
+
+func TestLaunch_Unauthorized(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/agents/launch", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = fmt.Fprint(w, `{"error":"Unauthorized"}`)
+	})
+
+	c := newTestClient(t, mux)
+	_, err := c.Launch(context.Background(), "agent-123")
+	if !errors.Is(err, ErrUnauthorized) {
+		t.Errorf("expected ErrUnauthorized, got %v", err)
+	}
+}
+
+func TestLaunch_NotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/agents/launch", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprint(w, `{"error":"Agent not found"}`)
+	})
+
+	c := newTestClient(t, mux)
+	_, err := c.Launch(context.Background(), "bad-id")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestLaunch_EmptyContainerID(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/agents/launch", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"containerId":""}`)
+	})
+
+	c := newTestClient(t, mux)
+	_, err := c.Launch(context.Background(), "agent-123")
+	if err == nil {
+		t.Fatal("expected error for empty containerId")
+	}
+}
+
+func TestPollUntilDone_ImmediateSuccess(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/agent/agent-123/output.json", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"containerStatus":"not running","exitCode":0,"exitMessage":"finished"}`)
+	})
+
+	c := newTestClient(t, mux)
+	status, err := c.PollUntilDone(context.Background(), "agent-123", "container-abc", nil)
+	if err != nil {
+		t.Fatalf("PollUntilDone: %v", err)
+	}
+	if status.ExitMessage != "finished" {
+		t.Errorf("expected exitMessage finished, got %q", status.ExitMessage)
+	}
+}
+
+func TestPollUntilDone_TransitionsToComplete(t *testing.T) {
+	var calls atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/agent/agent-123/output.json", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		n := calls.Add(1)
+		if n <= 2 {
+			_, _ = fmt.Fprint(w, `{"containerStatus":"running","progress":{"value":0.5,"label":"scraping"}}`)
+		} else {
+			_, _ = fmt.Fprint(w, `{"containerStatus":"not running","exitCode":0,"exitMessage":"finished"}`)
+		}
+	})
+
+	c := newTestClient(t, mux)
+	var progressCalls int
+	status, err := c.PollUntilDone(context.Background(), "agent-123", "container-abc", func(_ OutputStatus) {
+		progressCalls++
+	})
+	if err != nil {
+		t.Fatalf("PollUntilDone: %v", err)
+	}
+	if status.ExitMessage != "finished" {
+		t.Errorf("expected exitMessage finished, got %q", status.ExitMessage)
+	}
+	if progressCalls < 3 {
+		t.Errorf("expected at least 3 progress callbacks, got %d", progressCalls)
+	}
+}
+
+func TestPollUntilDone_AgentFailed(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/agent/agent-123/output.json", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"containerStatus":"not running","exitCode":1,"exitMessage":"agent timeout"}`)
+	})
+
+	c := newTestClient(t, mux)
+	_, err := c.PollUntilDone(context.Background(), "agent-123", "container-abc", nil)
+	if !errors.Is(err, ErrAgentFailed) {
+		t.Errorf("expected ErrAgentFailed, got %v", err)
+	}
+}
+
+func TestPollUntilDone_ContextCancelled(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/agent/agent-123/output.json", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"containerStatus":"running"}`)
+	})
+
+	c := newTestClient(t, mux)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := c.PollUntilDone(ctx, "agent-123", "container-abc", nil)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("expected context.DeadlineExceeded, got %v", err)
+	}
+}
+
+func TestFetchAgentInfo_Success(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/agents/fetch", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("id") != "agent-123" {
+			t.Errorf("expected id=agent-123, got %q", r.URL.Query().Get("id"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"agent-123","name":"Sales Nav Scraper","s3Folder":"s3folder","orgS3Folder":"orgfolder"}`)
+	})
+
+	c := newTestClient(t, mux)
+	info, err := c.FetchAgentInfo(context.Background(), "agent-123")
+	if err != nil {
+		t.Fatalf("FetchAgentInfo: %v", err)
+	}
+	if info.S3Folder != "s3folder" || info.OrgS3Folder != "orgfolder" {
+		t.Errorf("unexpected S3 paths: %+v", info)
+	}
+}
+
+func TestDownloadResult_Success(t *testing.T) {
+	csvContent := "fullName,firstName,lastName\nJohn Smith,John,Smith\n"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/orgfolder/s3folder/result.csv", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, csvContent)
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	c := NewClient("test-key", 5*time.Second)
+	c.baseURL = server.URL
+
+	// s3BaseURL is a const so we can't override it for tests. Instead, verify
+	// the download mechanics by hitting the test server directly.
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		server.URL+"/orgfolder/s3folder/result.csv", nil)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestRateLimited(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/agents/launch", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = fmt.Fprint(w, `{"error":"Rate limited"}`)
+	})
+
+	c := newTestClient(t, mux)
+	_, err := c.Launch(context.Background(), "agent-123")
+	if !errors.Is(err, ErrRateLimited) {
+		t.Errorf("expected ErrRateLimited, got %v", err)
+	}
+}

--- a/pkg/enum/phantombuster/linkedin.go
+++ b/pkg/enum/phantombuster/linkedin.go
@@ -1,0 +1,137 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package phantombuster
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Profile is a single person scraped from LinkedIn Sales Navigator. Fields
+// align with the PhantomBuster Sales Navigator Profile Scraper output.
+// Verification-ready fields (Sources, VerificationStatus, Confidence) are
+// reserved per 10T-373 so confirmation oracles bolt on with no migration.
+type Profile struct {
+	FirstName        string `json:"firstName"`
+	LastName         string `json:"lastName"`
+	FullName         string `json:"fullName"`
+	Title            string `json:"title"`
+	Company          string `json:"company"`
+	CompanyURL       string `json:"companyUrl,omitempty"`
+	Department       string `json:"department,omitempty"`
+	Seniority        string `json:"seniority,omitempty"`
+	Location         string `json:"location,omitempty"`
+	LinkedinURL      string `json:"linkedinUrl"`
+	SalesNavURL      string `json:"salesNavUrl,omitempty"`
+	Headline         string `json:"headline,omitempty"`
+	ImageURL         string `json:"imageUrl,omitempty"`
+	ConnectionDegree string `json:"connectionDegree,omitempty"`
+
+	// Verification-ready fields (10T-373). Zero-value until confirmation
+	// oracles run; included now to avoid schema migration.
+	Sources            []string `json:"sources"`
+	VerificationStatus string   `json:"verificationStatus"`
+	Confidence         float64  `json:"confidence"`
+
+	Error error `json:"-"`
+}
+
+// ScrapeResult aggregates the parsed output from a LinkedIn Sales Navigator
+// scrape run.
+type ScrapeResult struct {
+	Profiles []Profile `json:"profiles"`
+	Total    int       `json:"total"`
+	AgentID  string    `json:"agentId"`
+}
+
+// ParseSalesNavCSV parses the CSV output from a PhantomBuster Sales Navigator
+// Profile Scraper run. The parser is lenient: missing columns map to empty
+// strings. PhantomBuster does not publish a formal CSV schema, so column
+// names are mapped best-effort from documented and observed field names.
+func ParseSalesNavCSV(data []byte) (*ScrapeResult, error) {
+	reader := csv.NewReader(strings.NewReader(string(data)))
+	reader.LazyQuotes = true
+	reader.TrimLeadingSpace = true
+
+	headers, err := reader.Read()
+	if err != nil {
+		return nil, fmt.Errorf("reading CSV headers: %w", err)
+	}
+
+	colIndex := make(map[string]int, len(headers))
+	for i, h := range headers {
+		colIndex[strings.TrimSpace(strings.ToLower(h))] = i
+	}
+
+	var profiles []Profile
+	for {
+		record, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("reading CSV row: %w", err)
+		}
+
+		p := Profile{
+			FirstName:          getField(record, colIndex, "firstname"),
+			LastName:           getField(record, colIndex, "lastname"),
+			FullName:           getField(record, colIndex, "fullname"),
+			Title:              coalesce(getField(record, colIndex, "jobtitle"), getField(record, colIndex, "job"), getField(record, colIndex, "title")),
+			Company:            coalesce(getField(record, colIndex, "companyname"), getField(record, colIndex, "company")),
+			CompanyURL:         coalesce(getField(record, colIndex, "companylinkedinurl"), getField(record, colIndex, "companyurl")),
+			Location:           coalesce(getField(record, colIndex, "location"), getField(record, colIndex, "region")),
+			LinkedinURL:        coalesce(getField(record, colIndex, "linkedinprofileurl"), getField(record, colIndex, "profileurl")),
+			SalesNavURL:        getField(record, colIndex, "salesnavigatorurl"),
+			Headline:           getField(record, colIndex, "headline"),
+			ImageURL:           getField(record, colIndex, "imgurl"),
+			ConnectionDegree:   getField(record, colIndex, "connectiondegree"),
+			Sources:            []string{"linkedin-salesnav"},
+			VerificationStatus: "unverified",
+		}
+
+		if p.FullName == "" && p.FirstName != "" {
+			p.FullName = strings.TrimSpace(p.FirstName + " " + p.LastName)
+		}
+
+		profiles = append(profiles, p)
+	}
+
+	return &ScrapeResult{
+		Profiles: profiles,
+		Total:    len(profiles),
+	}, nil
+}
+
+// getField safely retrieves a field from a CSV record by column name.
+func getField(record []string, colIndex map[string]int, name string) string {
+	idx, ok := colIndex[name]
+	if !ok || idx >= len(record) {
+		return ""
+	}
+	return strings.TrimSpace(record[idx])
+}
+
+// coalesce returns the first non-empty string from the arguments.
+func coalesce(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/pkg/enum/phantombuster/linkedin.go
+++ b/pkg/enum/phantombuster/linkedin.go
@@ -94,7 +94,7 @@ func ParseSalesNavCSV(data []byte) (*ScrapeResult, error) {
 			Title:              coalesce(getField(record, colIndex, "jobtitle"), getField(record, colIndex, "job"), getField(record, colIndex, "title")),
 			Company:            coalesce(getField(record, colIndex, "companyname"), getField(record, colIndex, "company")),
 			CompanyURL:         coalesce(getField(record, colIndex, "companylinkedinurl"), getField(record, colIndex, "companyurl")),
-			Department:         coalesce(getField(record, colIndex, "department"), getField(record, colIndex, "industry")),
+			Department:         getField(record, colIndex, "department"),
 			Seniority:          getField(record, colIndex, "seniority"),
 			Location:           coalesce(getField(record, colIndex, "location"), getField(record, colIndex, "region")),
 			LinkedinURL:        coalesce(getField(record, colIndex, "linkedinprofileurl"), getField(record, colIndex, "profileurl")),

--- a/pkg/enum/phantombuster/linkedin.go
+++ b/pkg/enum/phantombuster/linkedin.go
@@ -94,6 +94,8 @@ func ParseSalesNavCSV(data []byte) (*ScrapeResult, error) {
 			Title:              coalesce(getField(record, colIndex, "jobtitle"), getField(record, colIndex, "job"), getField(record, colIndex, "title")),
 			Company:            coalesce(getField(record, colIndex, "companyname"), getField(record, colIndex, "company")),
 			CompanyURL:         coalesce(getField(record, colIndex, "companylinkedinurl"), getField(record, colIndex, "companyurl")),
+			Department:         coalesce(getField(record, colIndex, "department"), getField(record, colIndex, "industry")),
+			Seniority:          getField(record, colIndex, "seniority"),
 			Location:           coalesce(getField(record, colIndex, "location"), getField(record, colIndex, "region")),
 			LinkedinURL:        coalesce(getField(record, colIndex, "linkedinprofileurl"), getField(record, colIndex, "profileurl")),
 			SalesNavURL:        getField(record, colIndex, "salesnavigatorurl"),
@@ -102,6 +104,16 @@ func ParseSalesNavCSV(data []byte) (*ScrapeResult, error) {
 			ConnectionDegree:   getField(record, colIndex, "connectiondegree"),
 			Sources:            []string{"linkedin-salesnav"},
 			VerificationStatus: "unverified",
+		}
+
+		if p.Department == "" || p.Seniority == "" {
+			dept, sen := inferDeptSeniority(p.Title, p.Headline)
+			if p.Department == "" {
+				p.Department = dept
+			}
+			if p.Seniority == "" {
+				p.Seniority = sen
+			}
 		}
 
 		if p.FullName == "" && p.FirstName != "" {
@@ -134,4 +146,123 @@ func coalesce(values ...string) string {
 		}
 	}
 	return ""
+}
+
+var seniorityKeywords = []struct {
+	keyword  string
+	seniority string
+}{
+	{"chief", "c-suite"},
+	{"ceo", "c-suite"},
+	{"cto", "c-suite"},
+	{"cfo", "c-suite"},
+	{"coo", "c-suite"},
+	{"ciso", "c-suite"},
+	{"cio", "c-suite"},
+	{"cmo", "c-suite"},
+	{"cpo", "c-suite"},
+	{"cro", "c-suite"},
+	{"partner", "partner"},
+	{"founder", "founder"},
+	{"co-founder", "founder"},
+	{"cofounder", "founder"},
+	{"owner", "owner"},
+	{"president", "vp"},
+	{"vice president", "vp"},
+	{"vp ", "vp"},
+	{"svp", "vp"},
+	{"evp", "vp"},
+	{"avp", "vp"},
+	{"head of", "director"},
+	{"director", "director"},
+	{"senior manager", "senior"},
+	{"sr. manager", "senior"},
+	{"sr manager", "senior"},
+	{"manager", "manager"},
+	{"principal", "senior"},
+	{"staff", "senior"},
+	{"senior", "senior"},
+	{"sr.", "senior"},
+	{"sr ", "senior"},
+	{"lead", "senior"},
+	{"junior", "entry"},
+	{"jr.", "entry"},
+	{"jr ", "entry"},
+	{"intern", "training"},
+	{"associate", "entry"},
+	{"analyst", "entry"},
+}
+
+var departmentKeywords = []struct {
+	keyword    string
+	department string
+}{
+	{"information security", "security"},
+	{"infosec", "security"},
+	{"cybersecurity", "security"},
+	{"cyber security", "security"},
+	{"security", "security"},
+	{"information technology", "it"},
+	{"software engineer", "engineering"},
+	{"software develop", "engineering"},
+	{"engineering", "engineering"},
+	{"devops", "engineering"},
+	{"sre", "engineering"},
+	{"platform", "engineering"},
+	{"infrastructure", "engineering"},
+	{"data scien", "data"},
+	{"data engineer", "data"},
+	{"machine learning", "data"},
+	{"analytics", "data"},
+	{"product manag", "product"},
+	{"product design", "product"},
+	{"product", "product"},
+	{"design", "design"},
+	{"ux", "design"},
+	{"ui", "design"},
+	{"marketing", "marketing"},
+	{"growth", "marketing"},
+	{"brand", "marketing"},
+	{"communications", "marketing"},
+	{"sales", "sales"},
+	{"account executive", "sales"},
+	{"business develop", "sales"},
+	{"customer success", "customer_success"},
+	{"support", "support"},
+	{"human resource", "hr"},
+	{"people ops", "hr"},
+	{"talent", "hr"},
+	{"recruiting", "hr"},
+	{"finance", "finance"},
+	{"accounting", "finance"},
+	{"legal", "legal"},
+	{"compliance", "legal"},
+	{"operations", "operations"},
+	{"supply chain", "operations"},
+	{"logistics", "operations"},
+	{"research", "research"},
+	{"r&d", "research"},
+}
+
+// inferDeptSeniority attempts best-effort extraction of department and
+// seniority from a LinkedIn title or headline. Returns empty strings when
+// no keywords match — callers should treat empty as "unknown".
+func inferDeptSeniority(title, headline string) (department, seniority string) {
+	combined := strings.ToLower(title + " " + headline)
+
+	for _, s := range seniorityKeywords {
+		if strings.Contains(combined, s.keyword) {
+			seniority = s.seniority
+			break
+		}
+	}
+
+	for _, d := range departmentKeywords {
+		if strings.Contains(combined, d.keyword) {
+			department = d.department
+			break
+		}
+	}
+
+	return department, seniority
 }

--- a/pkg/enum/phantombuster/linkedin_test.go
+++ b/pkg/enum/phantombuster/linkedin_test.go
@@ -159,3 +159,96 @@ func TestParseSalesNavCSV_QuotedFields(t *testing.T) {
 		t.Errorf("unexpected company: %q", p.Company)
 	}
 }
+
+func TestParseSalesNavCSV_DeptSeniorityFromCSV(t *testing.T) {
+	csv := `fullName,firstName,lastName,jobTitle,department,seniority,companyName
+Jane Doe,Jane,Doe,VP Engineering,Engineering,VP,Acme Corp
+`
+	result, err := ParseSalesNavCSV([]byte(csv))
+	if err != nil {
+		t.Fatalf("ParseSalesNavCSV: %v", err)
+	}
+	p := result.Profiles[0]
+	if p.Department != "Engineering" {
+		t.Errorf("expected department Engineering from CSV column, got %q", p.Department)
+	}
+	if p.Seniority != "VP" {
+		t.Errorf("expected seniority VP from CSV column, got %q", p.Seniority)
+	}
+}
+
+func TestParseSalesNavCSV_DeptSeniorityInferred(t *testing.T) {
+	csv := `fullName,firstName,lastName,jobTitle,companyName,headline
+Jane Doe,Jane,Doe,VP Engineering,Acme Corp,VP Engineering at Acme
+John Smith,John,Smith,CTO,Widgets Inc,CTO at Widgets
+`
+	result, err := ParseSalesNavCSV([]byte(csv))
+	if err != nil {
+		t.Fatalf("ParseSalesNavCSV: %v", err)
+	}
+
+	p0 := result.Profiles[0]
+	if p0.Seniority != "vp" {
+		t.Errorf("expected inferred seniority 'vp' for VP Engineering, got %q", p0.Seniority)
+	}
+	if p0.Department != "engineering" {
+		t.Errorf("expected inferred department 'engineering' for VP Engineering, got %q", p0.Department)
+	}
+
+	p1 := result.Profiles[1]
+	if p1.Seniority != "c-suite" {
+		t.Errorf("expected inferred seniority 'c-suite' for CTO, got %q", p1.Seniority)
+	}
+}
+
+func TestParseSalesNavCSV_CSVOverridesInference(t *testing.T) {
+	csv := `fullName,jobTitle,department,seniority,headline
+Jane Doe,VP Engineering,Ops,Executive,VP Engineering at Acme
+`
+	result, err := ParseSalesNavCSV([]byte(csv))
+	if err != nil {
+		t.Fatalf("ParseSalesNavCSV: %v", err)
+	}
+	p := result.Profiles[0]
+	if p.Department != "Ops" {
+		t.Errorf("CSV-provided department should take priority, got %q", p.Department)
+	}
+	if p.Seniority != "Executive" {
+		t.Errorf("CSV-provided seniority should take priority, got %q", p.Seniority)
+	}
+}
+
+func TestInferDeptSeniority(t *testing.T) {
+	tests := []struct {
+		title     string
+		headline  string
+		wantDept  string
+		wantSen   string
+	}{
+		{"VP Engineering", "", "engineering", "vp"},
+		{"CTO", "CTO at Acme", "", "c-suite"},
+		{"Senior Security Engineer", "", "security", "senior"},
+		{"Junior Analyst", "", "", "entry"},
+		{"Marketing Manager", "", "marketing", "manager"},
+		{"Co-Founder & CEO", "", "", "c-suite"},
+		{"", "Head of Product at Widgets", "product", "director"},
+		{"Intern", "Summer Engineering Intern", "engineering", "training"},
+		{"", "", "", ""},
+		{"Account Executive", "Account Executive at BigCo", "sales", ""},
+		{"Principal Data Scientist", "", "data", "senior"},
+		{"Staff Software Engineer", "Platform Engineering", "engineering", "senior"},
+		{"CISO", "Chief Information Security Officer", "security", "c-suite"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.title+"/"+tc.headline, func(t *testing.T) {
+			dept, sen := inferDeptSeniority(tc.title, tc.headline)
+			if dept != tc.wantDept {
+				t.Errorf("department: got %q, want %q", dept, tc.wantDept)
+			}
+			if sen != tc.wantSen {
+				t.Errorf("seniority: got %q, want %q", sen, tc.wantSen)
+			}
+		})
+	}
+}

--- a/pkg/enum/phantombuster/linkedin_test.go
+++ b/pkg/enum/phantombuster/linkedin_test.go
@@ -1,0 +1,161 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package phantombuster
+
+import (
+	"testing"
+)
+
+func TestParseSalesNavCSV_BasicFields(t *testing.T) {
+	csv := `fullName,firstName,lastName,jobTitle,companyName,location,linkedinProfileUrl,salesNavigatorUrl,headline
+Jane Doe,Jane,Doe,VP Engineering,Acme Corp,San Francisco,https://linkedin.com/in/janedoe,https://salesnavigator.linkedin.com/in/janedoe,VP Engineering at Acme
+John Smith,John,Smith,CTO,Widgets Inc,New York,https://linkedin.com/in/johnsmith,,CTO at Widgets
+`
+	result, err := ParseSalesNavCSV([]byte(csv))
+	if err != nil {
+		t.Fatalf("ParseSalesNavCSV: %v", err)
+	}
+	if result.Total != 2 {
+		t.Errorf("expected 2 profiles, got %d", result.Total)
+	}
+
+	p := result.Profiles[0]
+	if p.FirstName != "Jane" || p.LastName != "Doe" {
+		t.Errorf("unexpected name: %q %q", p.FirstName, p.LastName)
+	}
+	if p.Title != "VP Engineering" {
+		t.Errorf("expected title VP Engineering, got %q", p.Title)
+	}
+	if p.Company != "Acme Corp" {
+		t.Errorf("expected company Acme Corp, got %q", p.Company)
+	}
+	if p.LinkedinURL != "https://linkedin.com/in/janedoe" {
+		t.Errorf("unexpected LinkedIn URL: %q", p.LinkedinURL)
+	}
+	if p.Location != "San Francisco" {
+		t.Errorf("unexpected location: %q", p.Location)
+	}
+	if p.SalesNavURL != "https://salesnavigator.linkedin.com/in/janedoe" {
+		t.Errorf("unexpected Sales Nav URL: %q", p.SalesNavURL)
+	}
+
+	// Verification-ready fields.
+	if len(p.Sources) != 1 || p.Sources[0] != "linkedin-salesnav" {
+		t.Errorf("expected sources [linkedin-salesnav], got %v", p.Sources)
+	}
+	if p.VerificationStatus != "unverified" {
+		t.Errorf("expected verificationStatus unverified, got %q", p.VerificationStatus)
+	}
+}
+
+func TestParseSalesNavCSV_AlternateColumnNames(t *testing.T) {
+	csv := `fullName,firstName,lastName,job,company,region,profileUrl
+Alice Lee,Alice,Lee,Manager,BigCo,London,https://linkedin.com/in/alicelee
+`
+	result, err := ParseSalesNavCSV([]byte(csv))
+	if err != nil {
+		t.Fatalf("ParseSalesNavCSV: %v", err)
+	}
+	if result.Total != 1 {
+		t.Fatalf("expected 1 profile, got %d", result.Total)
+	}
+
+	p := result.Profiles[0]
+	if p.Title != "Manager" {
+		t.Errorf("expected title Manager (from 'job' column), got %q", p.Title)
+	}
+	if p.Company != "BigCo" {
+		t.Errorf("expected company BigCo (from 'company' column), got %q", p.Company)
+	}
+	if p.Location != "London" {
+		t.Errorf("expected location London (from 'region' column), got %q", p.Location)
+	}
+	if p.LinkedinURL != "https://linkedin.com/in/alicelee" {
+		t.Errorf("expected LinkedIn URL from 'profileUrl', got %q", p.LinkedinURL)
+	}
+}
+
+func TestParseSalesNavCSV_FullNameFallback(t *testing.T) {
+	csv := `firstName,lastName,jobTitle,companyName,linkedinProfileUrl
+Bob,Jones,Engineer,StartupXYZ,https://linkedin.com/in/bobjones
+`
+	result, err := ParseSalesNavCSV([]byte(csv))
+	if err != nil {
+		t.Fatalf("ParseSalesNavCSV: %v", err)
+	}
+	p := result.Profiles[0]
+	if p.FullName != "Bob Jones" {
+		t.Errorf("expected fullName fallback 'Bob Jones', got %q", p.FullName)
+	}
+}
+
+func TestParseSalesNavCSV_Empty(t *testing.T) {
+	csv := `fullName,firstName,lastName,jobTitle,companyName
+`
+	result, err := ParseSalesNavCSV([]byte(csv))
+	if err != nil {
+		t.Fatalf("ParseSalesNavCSV: %v", err)
+	}
+	if result.Total != 0 {
+		t.Errorf("expected 0 profiles, got %d", result.Total)
+	}
+}
+
+func TestParseSalesNavCSV_MissingColumns(t *testing.T) {
+	csv := `firstName,lastName
+Charlie,Brown
+`
+	result, err := ParseSalesNavCSV([]byte(csv))
+	if err != nil {
+		t.Fatalf("ParseSalesNavCSV: %v", err)
+	}
+	if result.Total != 1 {
+		t.Fatalf("expected 1 profile, got %d", result.Total)
+	}
+	p := result.Profiles[0]
+	if p.Title != "" {
+		t.Errorf("expected empty title for missing column, got %q", p.Title)
+	}
+	if p.Company != "" {
+		t.Errorf("expected empty company for missing column, got %q", p.Company)
+	}
+}
+
+func TestParseSalesNavCSV_NoHeaders(t *testing.T) {
+	_, err := ParseSalesNavCSV([]byte(""))
+	if err == nil {
+		t.Fatal("expected error for empty CSV")
+	}
+}
+
+func TestParseSalesNavCSV_QuotedFields(t *testing.T) {
+	csv := `fullName,firstName,lastName,jobTitle,companyName,headline
+"O'Brien, Pat",Pat,O'Brien,"Sr. Director, Engineering","Acme, Inc.","Director at Acme, Inc."
+`
+	result, err := ParseSalesNavCSV([]byte(csv))
+	if err != nil {
+		t.Fatalf("ParseSalesNavCSV: %v", err)
+	}
+	p := result.Profiles[0]
+	if p.FullName != "O'Brien, Pat" {
+		t.Errorf("unexpected fullName: %q", p.FullName)
+	}
+	if p.Title != "Sr. Director, Engineering" {
+		t.Errorf("unexpected title: %q", p.Title)
+	}
+	if p.Company != "Acme, Inc." {
+		t.Errorf("unexpected company: %q", p.Company)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `enum passive linkedin` command — launches a pre-configured PhantomBuster Sales Navigator scraper, polls until completion, downloads the CSV from S3, and parses profiles into structured output
- New `pkg/enum/phantombuster/` package: generic PB API client (launch, poll with exponential backoff, fetch from S3) + Sales Nav CSV parser with verification-ready fields (10T-373 compatible)
- Infers department (14 categories) and seniority (10 levels) from LinkedIn titles/headlines when CSV columns aren't present, with CSV values taking priority when available
- Human table output (Name/Title/Dept/Company/LinkedIn) and JSONL output with `type: "linkedin"` for downstream pipeline consumption
- API keys never logged or included in error messages (P0-1)

## Test plan
- [x] Unit tests: 25 tests across client, CSV parser, CLI wiring, and output formatting
- [x] Live test: scraped 2,499 Fox Corporation profiles via PhantomBuster against LinkedIn Sales Navigator
- [x] Verified department/seniority inference produces meaningful categorization across the result set (14 departments, 10 seniority levels)
- [x] Verified `--skip-launch` fetches results from a previous run without re-launching the phantom
- [x] Verified JSONL output includes all fields including verification-ready fields
- [ ] Verify `--json` output pipes cleanly into downstream tooling (enum generate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)