### PR TITLE
chore: gitignore agent scaffolding + local recon scratch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,9 +27,15 @@ Thumbs.db
 
 # Local development artifacts
 .claude/
+# Agent / feature-workflow scaffolding (design notes, plans, reviews — never committed)
+.feature-development/
 
 # Git worktrees
 .worktrees/
+
+# Local scratch & operator recon output (machine/engagement-specific, keep out of VCS)
+/demos/
+*-users.txt
 
 # Terraform
 *.tfstate


### PR DESCRIPTION
## Summary

Hardens `.gitignore` so the artifacts that were accidentally committed to `dev` can't recur. Follows the just-completed history scrub of `.feature-development/` from `dev` and 21 branches.

New ignore rules (added beside the existing `.claude/` entry):
- `.feature-development/` — AI **feature-workflow scaffolding** (design notes, plans, reviews). This is the directory that leaked; it's internal/local-only and never belongs in the repo.
- `/demos/` — root-anchored local scratch demos. Deliberately anchored so it does **not** touch the tracked `examples/` or `testdata/demo/` dirs.
- `*-users.txt` — operator recon output (e.g. `fox-users.txt`, `km-users.txt`) — engagement-specific target/user lists that shouldn't be public.

## Verification

`git check-ignore` confirms the new patterns match `.feature-development/plan.md`, `demos/x.txt`, `fox-users.txt`, `km-users.txt`, while `examples/enum-custom-demo/main.go` and `testdata/demo/Dockerfile.ssh` remain **tracked** (not ignored). No currently-tracked file matches any new pattern.

Targeting `dev` (the active integration branch where the leak occurred); it reaches `main` via #214.

🤖 Generated with [Claude Code](https://claude.com/claude-code)