### PR TITLE
fix(lint): resolve all errcheck findings (unblock CI Lint for v1.7.0)

### DIFF
--- a/cmd/brutus/cmd_enum_github.go
+++ b/cmd/brutus/cmd_enum_github.go
@@ -139,7 +139,7 @@ func runEnumGithub(cmd *cobra.Command, args []string) error {
 	if !flagQuiet && !flagJSON {
 		fmt.Fprintf(os.Stderr, "%s Enumerating %d email(s) against GitHub...\n",
 			dim(useColor, SymbolInfo), len(emails))
-		fmt.Fprintf(os.Stdout, "\n%s %s\n\n", dim(useColor, SymbolInfo), heading(useColor, "GitHub Account Enumeration"))
+		_, _ = fmt.Fprintf(os.Stdout, "\n%s %s\n\n", dim(useColor, SymbolInfo), heading(useColor, "GitHub Account Enumeration"))
 	}
 
 	// Stream each completed result live. Human mode prints only EXISTS rows

--- a/cmd/brutus/cmd_enum_github_map.go
+++ b/cmd/brutus/cmd_enum_github_map.go
@@ -113,7 +113,7 @@ func runEnumGithubMap(cmd *cobra.Command, args []string) error {
 	if !flagQuiet && !flagJSON {
 		fmt.Fprintf(os.Stderr, "%s Correlating %d email(s) to GitHub accounts via a temporary private repo (deleted afterward)...\n",
 			dim(useColor, SymbolInfo), len(emails))
-		fmt.Fprintf(os.Stdout, "\n%s %s\n\n",
+		_, _ = fmt.Fprintf(os.Stdout, "\n%s %s\n\n",
 			dim(useColor, SymbolInfo), heading(useColor, "GitHub Email → Account Correlation"))
 	}
 

--- a/cmd/brutus/cmd_enum_google.go
+++ b/cmd/brutus/cmd_enum_google.go
@@ -122,7 +122,7 @@ func runEnumGoogle(cmd *cobra.Command, args []string) error {
 	if !flagQuiet && !flagJSON {
 		fmt.Fprintf(os.Stderr, "%s Enumerating %d email(s) against Google Workspace...\n",
 			dim(useColor, SymbolInfo), len(emails))
-		fmt.Fprintf(os.Stdout, "\n%s %s\n\n", dim(useColor, SymbolInfo), heading(useColor, "Google Workspace Account Enumeration"))
+		_, _ = fmt.Fprintf(os.Stdout, "\n%s %s\n\n", dim(useColor, SymbolInfo), heading(useColor, "Google Workspace Account Enumeration"))
 	}
 
 	// Stream each completed result live (the callback is invoked serialized under

--- a/cmd/brutus/cmd_enum_lusha_test.go
+++ b/cmd/brutus/cmd_enum_lusha_test.go
@@ -78,13 +78,15 @@ func TestOutputLushaJSONL(t *testing.T) {
 		emails, ok := obj["emails"].([]interface{})
 		require.True(t, ok, "emails must be a JSON array")
 		require.Len(t, emails, 1)
-		email := emails[0].(map[string]interface{})
+		email, ok := emails[0].(map[string]interface{})
+		require.True(t, ok)
 		assert.Equal(t, "ada@example.com", email["address"])
 
 		phones, ok := obj["phones"].([]interface{})
 		require.True(t, ok, "phones must be a JSON array")
 		require.Len(t, phones, 1)
-		phone := phones[0].(map[string]interface{})
+		phone, ok := phones[0].(map[string]interface{})
+		require.True(t, ok)
 		// do_not_call bool must always be emitted (P0-DNC).
 		doNotCall, exists := phone["do_not_call"]
 		require.True(t, exists, "do_not_call field must always be present")
@@ -119,8 +121,10 @@ func TestOutputLushaJSONL(t *testing.T) {
 
 		var obj map[string]interface{}
 		require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &obj))
-		phones := obj["phones"].([]interface{})
-		phone := phones[0].(map[string]interface{})
+		phones, ok := obj["phones"].([]interface{})
+		require.True(t, ok)
+		phone, ok := phones[0].(map[string]interface{})
+		require.True(t, ok)
 		// do_not_call bool is always emitted — must be false here.
 		doNotCall, exists := phone["do_not_call"]
 		require.True(t, exists, "do_not_call field must always be emitted")
@@ -507,7 +511,8 @@ func TestOutputLushaDomainJSONL(t *testing.T) {
 		phones, ok := obj0["phones"].([]interface{})
 		require.True(t, ok, "phones must be a JSON array")
 		require.Len(t, phones, 1)
-		phone := phones[0].(map[string]interface{})
+		phone, ok := phones[0].(map[string]interface{})
+		require.True(t, ok)
 		doNotCall, exists := phone["do_not_call"]
 		require.True(t, exists, "do_not_call field must always be present (P0-DNC)")
 		assert.Equal(t, true, doNotCall, "DNC flag must be true")

--- a/cmd/brutus/cmd_enum_teams.go
+++ b/cmd/brutus/cmd_enum_teams.go
@@ -410,7 +410,7 @@ func runEnumTeamsUsers(cmd *cobra.Command, args []string) error {
 	if !flagQuiet && !flagJSON {
 		fmt.Fprintf(os.Stderr, "%s Enumerating %d email(s) against Microsoft Teams...\n",
 			dim(useColor, SymbolInfo), len(emails))
-		fmt.Fprintf(os.Stdout, "\n%s %s\n\n", dim(useColor, SymbolInfo), heading(useColor, "Teams User Enumeration"))
+		_, _ = fmt.Fprintf(os.Stdout, "\n%s %s\n\n", dim(useColor, SymbolInfo), heading(useColor, "Teams User Enumeration"))
 	}
 
 	// Stream each completed result live (the callback is invoked serialized under

--- a/cmd/brutus/progress.go
+++ b/cmd/brutus/progress.go
@@ -160,7 +160,7 @@ func (p *progressReporter) Clear() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.onScreen {
-		fmt.Fprint(p.w, "\r\033[K")
+		_, _ = fmt.Fprint(p.w, "\r\033[K")
 		p.onScreen = false
 	}
 }
@@ -199,15 +199,15 @@ func (p *progressReporter) flush(final bool) {
 	line := dim(p.useColor, progressLine(p.processed, p.total, elapsed, p.metrics))
 
 	if p.isTTY {
-		fmt.Fprint(p.w, "\r\033[K"+line)
+		_, _ = fmt.Fprint(p.w, "\r\033[K"+line)
 		p.onScreen = true
 		if final {
-			fmt.Fprint(p.w, "\n")
+			_, _ = fmt.Fprint(p.w, "\n")
 			p.onScreen = false
 		}
 		return
 	}
-	fmt.Fprint(p.w, line+"\n")
+	_, _ = fmt.Fprint(p.w, line+"\n")
 }
 
 // progressLine builds the human-readable progress content (no color, no

--- a/examples/enum-custom-demo/main.go
+++ b/examples/enum-custom-demo/main.go
@@ -134,7 +134,7 @@ func handleIndex(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	fmt.Fprint(w, indexText)
+	_, _ = fmt.Fprint(w, indexText)
 }
 
 // =============================================================================

--- a/internal/plugins/rdp/realframes_test.go
+++ b/internal/plugins/rdp/realframes_test.go
@@ -40,7 +40,7 @@ func loadFrameRGBA(t *testing.T, name string) (pix []byte, width, height uint32)
 	path := filepath.Join("testdata", "realframes", name)
 	f, err := os.Open(path)
 	require.NoError(t, err, "open fixture %s", path)
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	img, format, err := image.Decode(f)
 	require.NoError(t, err, "decode fixture %s", path)

--- a/pkg/enum/github/github_test.go
+++ b/pkg/enum/github/github_test.go
@@ -70,7 +70,7 @@ func webMux(t *testing.T, csrfToken string, statusFor map[string]int) *http.Serv
 	// /join returns a minimal HTML page with the auto-check block.
 	mux.HandleFunc("/join", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
-		fmt.Fprintf(w, `<!DOCTYPE html><html><body>
+		_, _ = fmt.Fprintf(w, `<!DOCTYPE html><html><body>
 <auto-check src="/email_validity_checks">
   <input type="hidden" value="%s">
 </auto-check>
@@ -281,7 +281,7 @@ func TestExistence_429_RetryThenSucceed(t *testing.T) {
 	var callCount atomic.Int32
 	mux := http.NewServeMux()
 	mux.HandleFunc("/join", func(w http.ResponseWriter, _ *http.Request) {
-		fmt.Fprintf(w, `<!DOCTYPE html><html><body>
+		_, _ = fmt.Fprintf(w, `<!DOCTYPE html><html><body>
 <auto-check src="/email_validity_checks">
   <input type="hidden" value="csrf-abc">
 </auto-check>
@@ -333,7 +333,7 @@ func TestSessionParseFail_JoinPageMissingAutoCheck(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == joinPath {
 			// HTML without the auto-check element.
-			fmt.Fprint(w, `<!DOCTYPE html><html><body><p>no auto-check here</p></body></html>`)
+			_, _ = fmt.Fprint(w, `<!DOCTYPE html><html><body><p>no auto-check here</p></body></html>`)
 		}
 	}))
 	t.Cleanup(srv.Close)
@@ -778,7 +778,7 @@ func TestExistence_FollowsJoinRedirectForCSRF(t *testing.T) {
 	// must land on after following the redirect.
 	mux.HandleFunc("/signup", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
-		fmt.Fprint(w, signupHTML)
+		_, _ = fmt.Fprint(w, signupHTML)
 	})
 
 	// /email_validity_checks returns 422 for the target email (account exists)

--- a/pkg/enum/google/google_test.go
+++ b/pkg/enum/google/google_test.go
@@ -196,7 +196,7 @@ func TestCheckAccount_TransportError(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	closedAddr := "http://" + ln.Addr().String()
-	ln.Close()
+	_ = ln.Close()
 
 	e, err := NewEnumerator("", 2*time.Second)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Makes CI **Lint** green so we can cut **v1.7.0**. The dev→main merge (#214) surfaced `errcheck` failures (golangci-lint, `check-type-assertions: true`). This resolves **all** errcheck findings repo-wide.

## Changes (errcheck only)
- Discard intentional `fmt.Fprint*` writes to stdout / `io.Writer` with `_, _ =` (`cmd_enum_github.go`, `cmd_enum_github_map.go`, `cmd_enum_google.go`, `cmd_enum_teams.go`, `progress.go`, `examples/enum-custom-demo/main.go`)
- Guard test-side type assertions with `require.True(t, ok)` (`cmd_enum_lusha_test.go`)
- Check `Close()` returns (`realframes_test.go`, `google_test.go`)
- Discard `fmt.Fprint*` writes to `httptest` response writers (`github_test.go`)

## Verification
- `golangci-lint run --max-same-issues=0 --max-issues-per-linter=0 ./...` → **0 errcheck findings** (verified locally with a go1.26-built golangci-lint v2.12.1, matching CI's config)
- `go build ./...` — clean
- `go test ./...` — passing
- `gofmt` — clean

## Scope note
**errcheck only.** The repo has ~48 pre-existing `gocritic`/`misspell`/`unused`/`staticcheck` findings that CI tolerates (it runs golangci-lint in only-new-issues mode). Those are intentionally left untouched to avoid unrelated churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)