### PR TITLE
style(lint): resolve all golangci-lint findings (CI Lint green)

### DIFF
--- a/cmd/brutus/browser.go
+++ b/cmd/brutus/browser.go
@@ -58,7 +58,7 @@ func isAllowedVerificationURL(raw string) bool {
 
 // browserCommand returns the executable and args to open rawURL on the given
 // GOOS. It is pure (executes nothing) so it can be unit-tested across platforms.
-func browserCommand(goos, rawURL string) (string, []string, error) {
+func browserCommand(goos, rawURL string) (executable string, args []string, err error) {
 	switch goos {
 	case "darwin":
 		return "open", []string{rawURL}, nil

--- a/cmd/brutus/cmd_enum_github_map_test.go
+++ b/cmd/brutus/cmd_enum_github_map_test.go
@@ -82,13 +82,13 @@ func TestEnumGithubMapCmd_WiredUnderGithub(t *testing.T) {
 // no-source sentinel error path.
 func TestCollectGithubEmails(t *testing.T) {
 	tests := []struct {
-		name         string
-		emailsCSV    string
-		emailFile    string
-		generated    []string
-		noSourceErr  error
-		wantEmails   []string
-		wantErrIs    error // non-nil → expect an error satisfying errors.Is
+		name        string
+		emailsCSV   string
+		emailFile   string
+		generated   []string
+		noSourceErr error
+		wantEmails  []string
+		wantErrIs   error // non-nil → expect an error satisfying errors.Is
 	}{
 		{
 			name:        "CSV dedup + trim + order",

--- a/cmd/brutus/cmd_enum_github_output.go
+++ b/cmd/brutus/cmd_enum_github_output.go
@@ -51,14 +51,14 @@ func outputGithubEnumResultLine(w io.Writer, r githubenum.Result, useColor bool)
 // outputGithubEnumUsernames prints the resolved username:email mappings for
 // results that have a revealed username, under a small heading.
 func outputGithubEnumUsernames(w io.Writer, results []githubenum.Result, useColor bool) {
-	var any bool
+	var anyMatch bool
 	for i := range results {
 		if results[i].Username != "" {
-			any = true
+			anyMatch = true
 			break
 		}
 	}
-	if !any {
+	if !anyMatch {
 		return
 	}
 

--- a/cmd/brutus/cmd_enum_google_test.go
+++ b/cmd/brutus/cmd_enum_google_test.go
@@ -17,7 +17,6 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -254,7 +253,7 @@ func TestOutputGoogleEnumResultLine(t *testing.T) {
 	t.Run("malicious IdP with ANSI escape is sanitized", func(t *testing.T) {
 		// A server-controlled IdP that injects a raw ESC (0x1B) byte. The output
 		// layer must strip it before rendering (P0-4 requirement).
-		maliciousIdP := fmt.Sprintf("login.okta.com\x1b[31mINJECTED\x1b[0m")
+		maliciousIdP := "login.okta.com\x1b[31mINJECTED\x1b[0m"
 		r := google.Result{
 			Email:  "user@example.com",
 			Exists: true,

--- a/cmd/brutus/cmd_enum_lusha.go
+++ b/cmd/brutus/cmd_enum_lusha.go
@@ -168,7 +168,7 @@ func runEnumLusha(cmd *cobra.Command, args []string) error {
 		reveal = lusha.RevealOptions{Email: true, Phone: false}
 	}
 
-	contact, err := client.Enrich(ctx, query, reveal)
+	contact, err := client.Enrich(ctx, &query, reveal)
 	if err != nil {
 		return classifyLushaError(err)
 	}

--- a/cmd/brutus/cmd_enum_oracles.go
+++ b/cmd/brutus/cmd_enum_oracles.go
@@ -601,7 +601,7 @@ func confirmTeamsOracle(ctx context.Context, knownValid string, useColor bool) s
 	}
 
 	res := enumerator.EnumerateOne(ctx, knownValid)
-	return teamsDiscoverLine(res)
+	return teamsDiscoverLine(&res)
 }
 
 // resolveTeamsConfirmToken resolves a Teams token opportunistically for the
@@ -634,7 +634,7 @@ func resolveTeamsConfirmToken(useColor bool) (accessToken, refreshToken string, 
 // teamsDiscoverLine maps a Teams enumeration result to a discover-style status
 // line. A 403/blocked result is still a working oracle (it distinguishes real
 // from fake accounts). Token values never appear in the returned string.
-func teamsDiscoverLine(res teams.EnumResult) string {
+func teamsDiscoverLine(res *teams.EnumResult) string {
 	switch res.Exists {
 	case teams.ExistenceYes:
 		line := "teams: working (corporate account resolved)"

--- a/cmd/brutus/cmd_enum_oracles_teams_test.go
+++ b/cmd/brutus/cmd_enum_oracles_teams_test.go
@@ -353,7 +353,7 @@ func TestTeamsDiscoverLine_Mapping(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			line := teamsDiscoverLine(tc.result)
+			line := teamsDiscoverLine(&tc.result)
 
 			for _, want := range tc.wantContains {
 				assert.Contains(t, line, want,

--- a/cmd/brutus/cmd_enum_output.go
+++ b/cmd/brutus/cmd_enum_output.go
@@ -595,7 +595,7 @@ func outputTeamsEnumHuman(w io.Writer, results []teams.EnumResult, useColor bool
 // are sanitized via sanitizeTerminal (P0-4). Token values are never printed.
 // Callers decide which results to print (e.g. positive signals only, unless
 // verbose); this helper renders whatever it is given.
-func outputTeamsEnumResultLine(w io.Writer, r teams.EnumResult, useColor bool) {
+func outputTeamsEnumResultLine(w io.Writer, r *teams.EnumResult, useColor bool) {
 	statusCol, statusColor := teamsEnumStatusLabel(r.Exists)
 	email := truncate(sanitizeTerminal(r.Email), 32)
 	name := truncate(sanitizeTerminal(r.DisplayName), 28)
@@ -745,7 +745,7 @@ func outputTeamsEnumJSONL(w io.Writer, results []teams.EnumResult) {
 // The "External / cross-tenant chat: ALLOWED" line is a finding and is colored
 // red when open, green when blocked, and dim when unknown. The server-derived
 // coexistence mode is sanitized via sanitizeTerminal (P0-4).
-func outputTeamsPostureHuman(w io.Writer, p teams.TenantPosture, useColor bool) {
+func outputTeamsPostureHuman(w io.Writer, p *teams.TenantPosture, useColor bool) {
 	_, _ = fmt.Fprintf(w, "\n%s %s\n", dim(useColor, SymbolInfo),
 		heading(useColor, "Teams posture: "+sanitizeTerminal(p.Domain)))
 
@@ -778,7 +778,7 @@ func outputTeamsPostureHuman(w io.Writer, p teams.TenantPosture, useColor bool) 
 
 // outputTeamsPostureJSONL writes the tenant posture as a single JSON object.
 // encoding/json escapes control characters, so no sanitization is needed.
-func outputTeamsPostureJSONL(w io.Writer, p teams.TenantPosture) {
+func outputTeamsPostureJSONL(w io.Writer, p *teams.TenantPosture) {
 	type teamsPostureJSON struct {
 		Type                string `json:"type"`
 		Domain              string `json:"domain"`
@@ -826,7 +826,7 @@ const auditEvidenceMaxRunes = 200
 // severity-appropriate color, followed by indented Evidence and Remediation
 // lines, and the run ends with a counts-by-severity summary. The posture block
 // is always printed first for context.
-func outputTeamsAuditHuman(w io.Writer, domain string, posture teams.TenantPosture, findings []teams.Finding, useColor bool) {
+func outputTeamsAuditHuman(w io.Writer, domain string, posture *teams.TenantPosture, findings []teams.Finding, useColor bool) {
 	_, _ = fmt.Fprintf(w, "\n%s\n", heading(useColor, "=== Teams Audit: "+sanitizeTerminal(domain)+" ==="))
 
 	outputTeamsPostureHuman(w, posture, useColor)

--- a/cmd/brutus/cmd_enum_output_teams_test.go
+++ b/cmd/brutus/cmd_enum_output_teams_test.go
@@ -94,7 +94,7 @@ func TestOutputTeamsEnumResultLine_AccountType(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			outputTeamsEnumResultLine(&buf, tc.result, false /* useColor */)
+			outputTeamsEnumResultLine(&buf, &tc.result, false /* useColor */)
 			out := buf.String()
 
 			if tc.wantContain != "" {
@@ -152,7 +152,7 @@ func TestOutputTeamsEnumResultLine_Sanitizes(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			outputTeamsEnumResultLine(&buf, tc.result, false)
+			outputTeamsEnumResultLine(&buf, &tc.result, false)
 			out := buf.String()
 
 			assert.NotContains(t, out, "\x1b",

--- a/cmd/brutus/cmd_enum_teams.go
+++ b/cmd/brutus/cmd_enum_teams.go
@@ -287,7 +287,7 @@ func runEnumTeamsAuth(cmd *cobra.Command, args []string) error {
 	outputTeamsDeviceCodeHuman(os.Stderr, dc, useColor)
 
 	if !flagTeamsNoBrowser {
-		if err := openBrowser(dc.VerificationURI); err != nil {
+		if openErr := openBrowser(dc.VerificationURI); openErr != nil {
 			if !flagQuiet && !flagJSON {
 				fmt.Fprintf(os.Stderr, "%s Couldn't open a browser automatically — open the URL above manually.\n", dim(useColor, SymbolInfo))
 			}
@@ -368,7 +368,7 @@ func runEnumTeamsUsers(cmd *cobra.Command, args []string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	accessToken, refreshToken, err := teamsEnumResolveTokens(ctx, teamsTokenSource{
+	accessToken, refreshToken, err := teamsEnumResolveTokens(ctx, &teamsTokenSource{
 		accessToken:  flagTeamsEnumAccessToken,
 		refreshToken: flagTeamsEnumRefreshToken,
 		tokenFile:    flagTeamsEnumTokenFile,
@@ -441,12 +441,12 @@ func runEnumTeamsUsers(cmd *cobra.Command, args []string) error {
 				// Positive signals always print. Clear the in-place bar first so
 				// its partial line doesn't corrupt the row; it redraws next tick.
 				progress.Clear()
-				outputTeamsEnumResultLine(os.Stdout, res, useColor)
+				outputTeamsEnumResultLine(os.Stdout, &res, useColor)
 			default:
 				// ExistenceNo / ExistenceUnknown are suppressed unless --verbose.
 				if flagVerbose {
 					progress.Clear()
-					outputTeamsEnumResultLine(os.Stdout, res, useColor)
+					outputTeamsEnumResultLine(os.Stdout, &res, useColor)
 				}
 			}
 		}
@@ -460,10 +460,10 @@ func runEnumTeamsUsers(cmd *cobra.Command, args []string) error {
 	posture := teams.DerivePosture(teamsEnumDomain(emails), results)
 
 	if flagJSON {
-		outputTeamsPostureJSONL(jsonWriter, posture)
+		outputTeamsPostureJSONL(jsonWriter, &posture)
 	} else {
 		outputTeamsEnumSummary(os.Stdout, results, useColor)
-		outputTeamsPostureHuman(os.Stdout, posture, useColor)
+		outputTeamsPostureHuman(os.Stdout, &posture, useColor)
 	}
 	return nil
 }
@@ -489,7 +489,7 @@ func runEnumTeamsAudit(cmd *cobra.Command, args []string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	accessToken, refreshToken, err := teamsEnumResolveTokens(ctx, teamsTokenSource{
+	accessToken, refreshToken, err := teamsEnumResolveTokens(ctx, &teamsTokenSource{
 		accessToken:  flagTeamsAuditAccessToken,
 		refreshToken: flagTeamsAuditRefreshToken,
 		tokenFile:    flagTeamsAuditTokenFile,
@@ -537,7 +537,7 @@ func runEnumTeamsAudit(cmd *cobra.Command, args []string) error {
 	result := enumerator.EnumerateOne(ctx, seedEmail)
 	domain := teamsEnumDomain([]string{seedEmail})
 	posture := teams.DerivePosture(domain, []teams.EnumResult{result})
-	findings := teams.Audit(domain, seedEmail, result, posture, presenceChecked)
+	findings := teams.Audit(domain, seedEmail, &result, &posture, presenceChecked)
 
 	// Warn (to stderr, never stdout) when the seed didn't resolve, so the user
 	// knows findings are limited — but still emit whatever we gathered.
@@ -548,7 +548,7 @@ func runEnumTeamsAudit(cmd *cobra.Command, args []string) error {
 	if flagJSON {
 		outputTeamsAuditJSONL(jsonWriter, findings)
 	} else {
-		outputTeamsAuditHuman(os.Stdout, domain, posture, findings, useColor)
+		outputTeamsAuditHuman(os.Stdout, domain, &posture, findings, useColor)
 	}
 	return nil
 }
@@ -671,7 +671,7 @@ type teamsTokenSource struct {
 // teamsEnumResolveTokens determines the access (and optional refresh) token from
 // the three mutually exclusive sources in src: --token-file, --access-token, or
 // an inline device-code flow. Token values are never logged.
-func teamsEnumResolveTokens(ctx context.Context, src teamsTokenSource, useColor bool) (accessToken, refreshToken string, err error) {
+func teamsEnumResolveTokens(ctx context.Context, src *teamsTokenSource, useColor bool) (accessToken, refreshToken string, err error) {
 	if src.tokenFile != "" && src.accessToken != "" {
 		return "", "", fmt.Errorf("--token-file and --access-token are mutually exclusive")
 	}
@@ -708,7 +708,7 @@ func teamsEnumLoadDefaultTokens(useColor bool) (accessToken, refreshToken string
 	if err != nil {
 		return "", "", false
 	}
-	if _, err := os.Stat(path); err != nil {
+	if _, statErr := os.Stat(path); statErr != nil {
 		return "", "", false
 	}
 
@@ -749,7 +749,7 @@ func teamsEnumReadTokenFile(path string) (accessToken, refreshToken string, err 
 
 // teamsEnumDeviceCodeTokens runs the interactive device-code flow inline and
 // returns the resulting access and refresh tokens.
-func teamsEnumDeviceCodeTokens(ctx context.Context, src teamsTokenSource, useColor bool) (accessToken, refreshToken string, err error) {
+func teamsEnumDeviceCodeTokens(ctx context.Context, src *teamsTokenSource, useColor bool) (accessToken, refreshToken string, err error) {
 	proxyURL, err := resolveProxyURL()
 	if err != nil {
 		return "", "", err

--- a/cmd/brutus/cmd_enum_teams_audit_test.go
+++ b/cmd/brutus/cmd_enum_teams_audit_test.go
@@ -196,7 +196,7 @@ func TestOutputTeamsAuditHuman_Sanitizes(t *testing.T) {
 		}
 
 		var buf bytes.Buffer
-		outputTeamsAuditHuman(&buf, "contoso.com", posture, findings, false /* useColor */)
+		outputTeamsAuditHuman(&buf, "contoso.com", &posture, findings, false /* useColor */)
 		out := buf.String()
 
 		// The raw ESC byte (0x1B) must not appear in the output.
@@ -230,7 +230,7 @@ func TestOutputTeamsAuditHuman_Sanitizes(t *testing.T) {
 		}
 
 		var buf bytes.Buffer
-		outputTeamsAuditHuman(&buf, "contoso.com", posture, findings, false)
+		outputTeamsAuditHuman(&buf, "contoso.com", &posture, findings, false)
 		out := buf.String()
 
 		// The full 300-character string must not appear; truncation cuts it at
@@ -248,7 +248,7 @@ func TestOutputTeamsAuditHuman_Sanitizes(t *testing.T) {
 			ExternalChatAllowed: "blocked",
 		}
 		var buf bytes.Buffer
-		outputTeamsAuditHuman(&buf, "contoso.com", posture, nil, false)
+		outputTeamsAuditHuman(&buf, "contoso.com", &posture, nil, false)
 		out := buf.String()
 		assert.Contains(t, out, "No findings",
 			"empty findings must print the no-findings message")
@@ -359,7 +359,7 @@ func TestOutputTeamsAuditHuman_SeverityLabels(t *testing.T) {
 				},
 			}
 			var buf bytes.Buffer
-			outputTeamsAuditHuman(&buf, "contoso.com", posture, findings, false)
+			outputTeamsAuditHuman(&buf, "contoso.com", &posture, findings, false)
 			out := buf.String()
 			assert.Contains(t, out, tc.label,
 				"human output must contain severity label %q for severity %q", tc.label, tc.severity)
@@ -396,7 +396,7 @@ func TestOutputTeamsAuditHuman_NoTokens(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	outputTeamsAuditHuman(&buf, "contoso.com", posture, findings, false)
+	outputTeamsAuditHuman(&buf, "contoso.com", &posture, findings, false)
 	out := buf.String()
 
 	assert.NotContains(t, out, accessTokenSentinel,

--- a/cmd/brutus/cmd_enum_teams_test.go
+++ b/cmd/brutus/cmd_enum_teams_test.go
@@ -375,7 +375,7 @@ func TestOutputTeamsPostureJSONL(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	outputTeamsPostureJSONL(&buf, posture)
+	outputTeamsPostureJSONL(&buf, &posture)
 
 	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
 	require.Len(t, lines, 1, "outputTeamsPostureJSONL must emit exactly 1 JSONL line")
@@ -506,7 +506,7 @@ func TestOutputTeamsPostureHuman_SanitizesCoExistenceMode(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	outputTeamsPostureHuman(&buf, posture, false /* useColor */)
+	outputTeamsPostureHuman(&buf, &posture, false /* useColor */)
 	out := buf.String()
 
 	// Raw ESC must be absent — sanitizeTerminal strips it.

--- a/cmd/brutus/exit_code_test.go
+++ b/cmd/brutus/exit_code_test.go
@@ -86,7 +86,7 @@ func TestScanExitError(t *testing.T) {
 	}
 }
 
-// TestScanExitError_UnreachableIsExitZero locks in the cardinal-rule behaviour:
+// TestScanExitError_UnreachableIsExitZero locks in the cardinal-rule behavior:
 // an unreachable result is terminal & non-retryable (Indeterminate=false), so
 // scanExitError must return nil (exit 0), NOT errIndeterminate (exit 2).
 //

--- a/cmd/brutus/runner.go
+++ b/cmd/brutus/runner.go
@@ -576,7 +576,7 @@ func runScanTargetsConcurrentCtx(ctx context.Context, targets []string, base *ru
 		g.Go(func() error {
 			if limiter != nil {
 				if err := limiter.Wait(ctx); err != nil {
-					// Context cancelled while queued: the host never ran, so it
+					// Context canceled while queued: the host never ran, so it
 					// must read as INDETERMINATE, never silently disappear.
 					perTarget[idx] = logon.CancelledResults(target)
 					success[idx] = false

--- a/cmd/brutus/runner_cancel_test.go
+++ b/cmd/brutus/runner_cancel_test.go
@@ -27,8 +27,8 @@ import (
 
 // TestRunScanTargetsConcurrent_CancelledIndexIndeterminate verifies that every
 // target emits non-nil, INDETERMINATE results when the context is already
-// cancelled on entry — no target may silently vanish (emit nil/empty results)
-// when the run is cancelled (invariant I5/I6).
+// canceled on entry — no target may silently vanish (emit nil/empty results)
+// when the run is canceled (invariant I5/I6).
 //
 // This test is RED until the developer adds an injectable-context entry point:
 //
@@ -68,12 +68,12 @@ func TestRunScanTargetsConcurrent_CancelledIndexIndeterminate(t *testing.T) {
 	// Every result must be INDETERMINATE — hosts never ran.
 	for i, r := range results {
 		assert.True(t, r.Indeterminate,
-			"result[%d] (target %s) must be Indeterminate (scan was cancelled)", i, r.Target)
+			"result[%d] (target %s) must be Indeterminate (scan was canceled)", i, r.Target)
 		assert.False(t, r.Success,
-			"result[%d] must not be Success (scan was cancelled)", i)
+			"result[%d] must not be Success (scan was canceled)", i)
 	}
 
-	assert.False(t, hasSuccess, "cancelled scan must not report success")
+	assert.False(t, hasSuccess, "canceled scan must not report success")
 	assert.False(t, scanInvoked,
-		"scanTargetFn must not be invoked when context is cancelled before any target runs")
+		"scanTargetFn must not be invoked when context is canceled before any target runs")
 }

--- a/examples/enum-custom-demo/main.go
+++ b/examples/enum-custom-demo/main.go
@@ -46,7 +46,7 @@ func main() {
 	addr := flag.String("addr", ":8080", "listen address (host:port)")
 	flag.Parse()
 
-	// PORT env overrides the default port when -addr was not customised, so the
+	// PORT env overrides the default port when -addr was not customized, so the
 	// demo runs unchanged on platforms that inject a PORT.
 	if port := os.Getenv("PORT"); port != "" && *addr == ":8080" {
 		*addr = ":" + port

--- a/internal/plugins/browser/chrome_test.go
+++ b/internal/plugins/browser/chrome_test.go
@@ -127,4 +127,3 @@ func TestBrowser_Navigate(t *testing.T) {
 		t.Errorf("Navigate failed: %v", err)
 	}
 }
-

--- a/internal/plugins/http/llm_integration_test.go
+++ b/internal/plugins/http/llm_integration_test.go
@@ -324,12 +324,12 @@ func TestHTTPWithLLM_BruteAPI(t *testing.T) {
 
 	// Use the Brute() API with LLM config
 	cfg := &brutus.Config{
-		Target:        target,
-		Protocol:      "http",
-		Usernames:     []string{"admin"},
-		Passwords:     []string{"wrong1", "wrong2"}, // Wrong passwords - LLM should find the right one
-		Timeout:       10 * time.Second,
-		Threads:       1,
+		Target:    target,
+		Protocol:  "http",
+		Usernames: []string{"admin"},
+		Passwords: []string{"wrong1", "wrong2"}, // Wrong passwords - LLM should find the right one
+		Timeout:   10 * time.Second,
+		Threads:   1,
 		LLMConfig: &brutus.LLMConfig{
 			Enabled:  true,
 			Provider: provider,

--- a/internal/plugins/rdp/analyze_test.go
+++ b/internal/plugins/rdp/analyze_test.go
@@ -200,7 +200,7 @@ func TestDetectChangedRectangle_ReturnsBox(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // paintBox fills a rectangular region of an RGBA buffer with the given gray value.
-func paintBox(buf []byte, w int, x0, y0, x1, y1 int, gray byte) {
+func paintBox(buf []byte, w, x0, y0, x1, y1 int, gray byte) {
 	for y := y0; y < y1; y++ {
 		for x := x0; x < x1; x++ {
 			idx := (y*w + x) * 4
@@ -211,7 +211,7 @@ func paintBox(buf []byte, w int, x0, y0, x1, y1 int, gray byte) {
 
 // paintBoxRGB fills a rectangular region with explicit RGB values.
 // Used for themed-console tests (e.g. PowerShell blue, brightness ~31).
-func paintBoxRGB(buf []byte, w int, x0, y0, x1, y1 int, r, g, b byte) {
+func paintBoxRGB(buf []byte, w, x0, y0, x1, y1 int, r, g, b byte) {
 	for y := y0; y < y1; y++ {
 		for x := x0; x < x1; x++ {
 			idx := (y*w + x) * 4
@@ -257,10 +257,10 @@ func TestClassifyRegion_Unknown(t *testing.T) {
 
 func TestDecideVerdict(t *testing.T) {
 	tests := []struct {
-		name      string
-		verdict   string
-		keepHigh  bool
-		want      string
+		name     string
+		verdict  string
+		keepHigh bool
+		want     string
 	}{
 		// Real console — keepHigh=true → kept as backdoor_likely.
 		{"backdoor_likely keepHigh=true → backdoor_likely", "backdoor_likely", true, "backdoor_likely"},

--- a/internal/plugins/rdp/detect.go
+++ b/internal/plugins/rdp/detect.go
@@ -43,7 +43,7 @@ const unreachableScanBanner = "[INFO] unreachable (no RDP/TCP connection to host
 // This function wraps RunStickyKeysCheck and interprets the StickyKeysResult into
 // a standardized Result format suitable for CLI output. fast selects the short
 // FastBudget settle profile and enforces the never-clean invariant.
-func DetectStickyKeys(ctx context.Context, target string, connectTimeout, timeout time.Duration, username string, noVision bool, fast bool) *brutus.Result {
+func DetectStickyKeys(ctx context.Context, target string, connectTimeout, timeout time.Duration, username string, noVision, fast bool) *brutus.Result {
 	plugin := &Plugin{}
 	budget := CarefulBudget
 	if fast {
@@ -120,7 +120,7 @@ func mapStickyResult(stickyResult *StickyKeysResult, username string) *brutus.Re
 // This function wraps RunUtilmanCheck and interprets the UtilmanResult into
 // a standardized Result format suitable for CLI output. fast selects the short
 // FastBudget settle profile and enforces the never-clean invariant.
-func DetectUtilman(ctx context.Context, target string, connectTimeout, timeout time.Duration, username string, noVision bool, fast bool) *brutus.Result {
+func DetectUtilman(ctx context.Context, target string, connectTimeout, timeout time.Duration, username string, noVision, fast bool) *brutus.Result {
 	plugin := &Plugin{}
 	budget := CarefulBudget
 	if fast {

--- a/internal/plugins/rdp/detect_test.go
+++ b/internal/plugins/rdp/detect_test.go
@@ -222,8 +222,8 @@ func TestMapUtilmanResult(t *testing.T) {
 // of the fast-mode plan (Phase 2).
 //
 // RED until the developer:
-//   1. Adds `fast bool` parameter to stabilizedVerdict (detect.go:381)
-//   2. Implements: if verdict == "clean" && (!stabilized || fast) { return verdictIndeterminate }
+//  1. Adds `fast bool` parameter to stabilizedVerdict (detect.go:381)
+//  2. Implements: if verdict == "clean" && (!stabilized || fast) { return verdictIndeterminate }
 func TestStabilizedVerdict(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -550,7 +550,7 @@ func TestMapStickyResult_WasmFailure_StaysIndeterminate(t *testing.T) {
 }
 
 // TestMapUtilmanResult_Unreachable_Terminal verifies the same terminal-unreachable
-// behaviour for the utilman mapper.
+// behavior for the utilman mapper.
 func TestMapUtilmanResult_Unreachable_Terminal(t *testing.T) {
 	r := mapUtilmanResult(&UtilmanResult{Performed: false, Unreachable: true, SkipReason: "connection failed: refused"}, "(utilman)")
 	assert.False(t, r.Indeterminate)

--- a/internal/plugins/rdp/nego_test.go
+++ b/internal/plugins/rdp/nego_test.go
@@ -61,8 +61,8 @@ func TestNegoBuildNegReq(t *testing.T) {
 func ccWithNeg(negType byte, payload uint32) []byte {
 	buf := make([]byte, 19)
 	// TPKT header
-	buf[0] = 0x03 // version
-	buf[1] = 0x00 // reserved
+	buf[0] = 0x03                            // version
+	buf[1] = 0x00                            // reserved
 	binary.BigEndian.PutUint16(buf[2:4], 19) // total length = 19
 	// X.224 Connection Confirm body
 	buf[4] = 0x0E  // LI = 14
@@ -74,8 +74,8 @@ func ccWithNeg(negType byte, payload uint32) []byte {
 	buf[10] = 0x00 // class/options
 	// 8-byte negotiation trailer at bytes 11-18
 	buf[11] = negType
-	buf[12] = 0x00 // flags
-	binary.LittleEndian.PutUint16(buf[13:15], 8) // length (LE) = 8
+	buf[12] = 0x00                               // flags
+	binary.LittleEndian.PutUint16(buf[13:15], 8) // length (LE): 8
 	binary.LittleEndian.PutUint32(buf[15:19], payload)
 	return buf
 }
@@ -192,10 +192,10 @@ func (fc *fakeConn) Read(b []byte) (int, error)  { return fc.readBuf.Read(b) }
 func (fc *fakeConn) Write(b []byte) (int, error) { return fc.written.Write(b) }
 func (fc *fakeConn) Close() error                { return nil }
 
-func (fc *fakeConn) LocalAddr() net.Addr              { return &net.TCPAddr{} }
-func (fc *fakeConn) RemoteAddr() net.Addr             { return &net.TCPAddr{} }
-func (fc *fakeConn) SetDeadline(t time.Time) error    { return nil }
-func (fc *fakeConn) SetReadDeadline(t time.Time) error { return nil }
+func (fc *fakeConn) LocalAddr() net.Addr                { return &net.TCPAddr{} }
+func (fc *fakeConn) RemoteAddr() net.Addr               { return &net.TCPAddr{} }
+func (fc *fakeConn) SetDeadline(t time.Time) error      { return nil }
+func (fc *fakeConn) SetReadDeadline(t time.Time) error  { return nil }
 func (fc *fakeConn) SetWriteDeadline(t time.Time) error { return nil }
 
 // TestProbeNLA_ScannableSSL verifies that a NEG_RSP selecting PROTOCOL_SSL

--- a/internal/plugins/rdp/session.go
+++ b/internal/plugins/rdp/session.go
@@ -140,6 +140,8 @@ var MinViableTimeout = CarefulBudget.minPump + CarefulBudget.quietWindow
 // Returns (baseline_rgba, response_rgba, width, height, stabilized, error).
 // stabilized reflects whether the response pump observed a settled framebuffer.
 // timeout is the per-host budget applied to each pump phase (baseline and response).
+//
+//nolint:gocritic // cohesive multi-return (baseline+response frames, width, height, stabilized, err); a result struct would churn ~20 return sites in this WASM path for no behavior change
 func (p *Plugin) runSession(ctx context.Context, inst *wasmInstance, connHandle uint32,
 	width, height uint32, timeout time.Duration, budget SettleBudget) (baselineRGBA, responseRGBA []byte, outWidth, outHeight uint32, stabilized bool, err error) {
 
@@ -220,6 +222,8 @@ func (p *Plugin) runSession(ctx context.Context, inst *wasmInstance, connHandle 
 // Returns (baseline_rgba, response_rgba, width, height, stabilized, error).
 // stabilized reflects whether the response pump observed a settled framebuffer.
 // timeout is the per-host budget applied to each pump phase (baseline and response).
+//
+//nolint:gocritic // cohesive multi-return (baseline+response frames, width, height, stabilized, err); a result struct would churn ~20 return sites in this WASM path for no behavior change
 func (p *Plugin) runUtilmanSession(ctx context.Context, inst *wasmInstance, connHandle uint32,
 	width, height uint32, timeout time.Duration, budget SettleBudget) (baselineRGBA, responseRGBA []byte, outWidth, outHeight uint32, stabilized bool, err error) {
 
@@ -382,7 +386,7 @@ func readRDPFrame(r io.Reader) ([]byte, error) {
 // changed-pixel count used to decide whether a frame is quiet (see framesQuiet).
 // Returns false if the deadline cut it off while frames were still changing (or
 // it never settled).
-func (p *Plugin) pumpSession(ctx context.Context, inst *wasmInstance, sessHandle uint32, width, height uint32, timeout time.Duration, budget SettleBudget) (stabilized bool, err error) {
+func (p *Plugin) pumpSession(ctx context.Context, inst *wasmInstance, sessHandle, width, height uint32, timeout time.Duration, budget SettleBudget) (stabilized bool, err error) {
 	callCtx := inst.callCtx(ctx)
 	sessionStepFn := inst.mod.ExportedFunction("session_step")
 	if sessionStepFn == nil {

--- a/pkg/brutus/logon/admission.go
+++ b/pkg/brutus/logon/admission.go
@@ -122,10 +122,10 @@ var runDetection = func(ctx context.Context, target string, connectTimeout, time
 }
 
 // CancelledResults returns the sticky + utilman result pair for a host whose
-// decode slot was never acquired (context cancelled while queued). The host did
+// decode slot was never acquired (context canceled while queued). The host did
 // not run, so it must read as INDETERMINATE — never silently clean.
 func CancelledResults(target string) []brutus.Result {
-	const banner = "[WARN] %s check INDETERMINATE (scan cancelled before start — rerun)"
+	const banner = "[WARN] %s check INDETERMINATE (scan canceled before start — rerun)"
 	return []brutus.Result{
 		{
 			Protocol:      "rdp",

--- a/pkg/brutus/logon/logon.go
+++ b/pkg/brutus/logon/logon.go
@@ -71,7 +71,7 @@ func DetectBackdoors(ctx context.Context, target string, connectTimeout, timeout
 
 	// STAGE 2 — existing decode-slot-gated WASM pipeline.
 	if err := decodeSlots.Acquire(ctx, 1); err != nil {
-		// Context cancelled while queued: the host never ran, so it must read
+		// Context canceled while queued: the host never ran, so it must read
 		// as indeterminate, never silently clean.
 		return CancelledResults(target), false
 	}
@@ -104,13 +104,13 @@ func anyIndeterminate(results []brutus.Result) bool {
 }
 
 // retryBackoff sleeps a capped exponential delay before a retry attempt,
-// returning early if the context is cancelled. attempt is 1-based.
+// returning early if the context is canceled. attempt is 1-based.
 func retryBackoff(ctx context.Context, attempt int) {
 	const base = 100 * time.Millisecond
-	const cap = 2 * time.Second
+	const maxDelay = 2 * time.Second
 	delay := base << (attempt - 1)
-	if delay > cap || delay <= 0 {
-		delay = cap
+	if delay > maxDelay || delay <= 0 {
+		delay = maxDelay
 	}
 	select {
 	case <-time.After(delay):

--- a/pkg/brutus/logon/logon_cancel_test.go
+++ b/pkg/brutus/logon/logon_cancel_test.go
@@ -29,21 +29,21 @@ import (
 
 // TestDetectBackdoors_CancelledWhileQueued verifies the cardinal-property
 // protection at the admission-control gate: when the context is already
-// cancelled before DetectBackdoors is called, the semaphore Acquire fails and
+// canceled before DetectBackdoors is called, the semaphore Acquire fails and
 // the host must read as INDETERMINATE — never silently clean or empty.
 //
 // This covers the previously-uncovered branch at logon.go:50-53.
 func TestDetectBackdoors_CancelledWhileQueued(t *testing.T) {
 	// Use the minimum semaphore size (1 slot) so Acquire is always attempted,
-	// giving us a deterministic cancelled-acquire on the pre-cancelled context.
+	// giving us a deterministic canceled-acquire on the pre-canceled context.
 	withDecodeSlots(t, 1)
 
 	// Swap runDetection with a fake that records whether it was ever invoked.
-	// The cardinal property requires it is NOT invoked when the ctx is cancelled
+	// The cardinal property requires it is NOT invoked when the ctx is canceled
 	// before the Acquire — the host never ran, so no detection work happens.
-	// Stub the NLA probe to return NegoScannable. The cancelled context causes the
+	// Stub the NLA probe to return NegoScannable. The canceled context causes the
 	// decode-slot Acquire to fail before runDetection is ever called, so we need the
-	// probe stub to ensure the probe itself also receives the cancelled context.
+	// probe stub to ensure the probe itself also receives the canceled context.
 	origProbe := nlaProbe
 	nlaProbe = func(ctx context.Context, target string, connectTimeout, readDeadline time.Duration, proxyURL string) rdp.NegoClass {
 		return rdp.NegoScannable
@@ -66,7 +66,7 @@ func TestDetectBackdoors_CancelledWhileQueued(t *testing.T) {
 	results, hasSuccess := DetectBackdoors(ctx, "1.2.3.4:3389", 3*time.Second, 5*time.Second, false, 0, CheckBoth, "", false, false)
 
 	// The host never ran; both results must be INDETERMINATE.
-	require.Len(t, results, 2, "cancelled context must produce exactly 2 results (sticky + utilman)")
+	require.Len(t, results, 2, "canceled context must produce exactly 2 results (sticky + utilman)")
 	assert.False(t, hasSuccess, "no scan ran; hasSuccess must be false")
 
 	for i, r := range results {
@@ -77,12 +77,12 @@ func TestDetectBackdoors_CancelledWhileQueued(t *testing.T) {
 	// The detection body must NEVER have been called — cancellation must
 	// short-circuit before any RDP work begins.
 	assert.False(t, detectionInvoked.Load(),
-		"runDetection must not be invoked when context is cancelled before Acquire")
+		"runDetection must not be invoked when context is canceled before Acquire")
 }
 
 // TestCancelledResults verifies the full content of the CancelledResults helper:
 // 2 results, correct ScanType/username/protocol/target/Indeterminate/Success,
-// and banners that carry both "INDETERMINATE" and "cancelled" (the rerun signal).
+// and banners that carry both "INDETERMINATE" and "canceled" (the rerun signal).
 // Testing content (not just length) satisfies the avoiding-low-value-tests
 // requirement — length-only assertions would miss a regression that drops
 // Indeterminate: true.
@@ -116,14 +116,14 @@ func TestCancelledResults(t *testing.T) {
 	assert.False(t, sticky.Success, "sticky result must not be Success")
 	assert.False(t, utilman.Success, "utilman result must not be Success")
 
-	// Banners must carry both "INDETERMINATE" (cardinal signal) and "cancelled"
+	// Banners must carry both "INDETERMINATE" (cardinal signal) and "canceled"
 	// (the rerun signal that tells the operator why the host was not scanned).
 	assert.Contains(t, sticky.Banner, "INDETERMINATE",
 		"sticky banner must contain INDETERMINATE")
-	assert.Contains(t, sticky.Banner, "cancelled",
-		"sticky banner must contain cancelled (rerun signal)")
+	assert.Contains(t, sticky.Banner, "canceled",
+		"sticky banner must contain canceled (rerun signal)")
 	assert.Contains(t, utilman.Banner, "INDETERMINATE",
 		"utilman banner must contain INDETERMINATE")
-	assert.Contains(t, utilman.Banner, "cancelled",
-		"utilman banner must contain cancelled (rerun signal)")
+	assert.Contains(t, utilman.Banner, "canceled",
+		"utilman banner must contain canceled (rerun signal)")
 }

--- a/pkg/brutus/proxy_test.go
+++ b/pkg/brutus/proxy_test.go
@@ -293,7 +293,7 @@ func TestProxyTransport(t *testing.T) {
 		assert.Nil(t, transport.DialContext, "expected DialContext to be nil for http scheme")
 
 		// Call transport.Proxy with a sample request and assert the returned URL host/user.
-		req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+		req := httptest.NewRequest(http.MethodGet, "http://example.com", http.NoBody)
 		proxyURL, err := transport.Proxy(req)
 		require.NoError(t, err)
 		require.NotNil(t, proxyURL)

--- a/pkg/enum/apollo/apollo.go
+++ b/pkg/enum/apollo/apollo.go
@@ -283,7 +283,7 @@ func (c *Client) RevealEmails(ctx context.Context, result *DomainResult) error {
 	}
 	for i := range result.People {
 		if m, ok := byID[result.People[i].ID]; ok {
-			mergeReveal(&result.People[i], *m)
+			mergeReveal(&result.People[i], m)
 		}
 	}
 	result.CreditsCharged = len(enriched)
@@ -384,11 +384,35 @@ func (c *Client) do(ctx context.Context, method, path string, body any) ([]byte,
 	return respBody, nil
 }
 
+type apolloPerson struct {
+	ID           string             `json:"id"`
+	FirstName    string             `json:"first_name"`
+	LastName     string             `json:"last_name"`
+	Name         string             `json:"name"`
+	Title        string             `json:"title"`
+	Seniority    string             `json:"seniority"`
+	Departments  []string           `json:"departments"`
+	Organization apolloOrganization `json:"organization"`
+	// Availability flags from people-search (no credits). has_email is a bool;
+	// has_direct_phone is a STRING ("Yes" / "Maybe: ...") — verified live
+	// 2026-06-26, hence the string type and the =="Yes" mapping in toPerson.
+	HasEmail          bool                    `json:"has_email"`
+	HasDirectPhone    string                  `json:"has_direct_phone"`
+	Email             string                  `json:"email"`
+	EmailStatus       string                  `json:"email_status"`
+	LinkedinURL       string                  `json:"linkedin_url"`
+	TwitterURL        string                  `json:"twitter_url"`
+	City              string                  `json:"city"`
+	State             string                  `json:"state"`
+	Country           string                  `json:"country"`
+	EmploymentHistory []apolloEmploymentEntry `json:"employment_history"`
+}
+
 // toPerson converts the API person struct to the public Person type, mapping
 // every field present in the payload. The search response is thin (reveal-only
 // fields are null/empty and map to zero values); the match response populates
 // the full record. Revealed is NOT set here — the caller owns that flag.
-func (p apolloPerson) toPerson() Person {
+func (p *apolloPerson) toPerson() Person {
 	dept := ""
 	if len(p.Departments) > 0 {
 		dept = p.Departments[0]
@@ -431,7 +455,7 @@ func (p apolloPerson) toPerson() Person {
 // discovered person, overwriting the obfuscated/empty search-tier last name and
 // filling in the reveal-only fields. Search-tier identity fields already on p
 // (ID, Name, Title, Organization) are left intact.
-func mergeReveal(p *Person, m Person) {
+func mergeReveal(p, m *Person) {
 	p.LastName = m.LastName
 	p.Email = m.Email
 	p.EmailStatus = m.EmailStatus
@@ -477,30 +501,6 @@ type apolloMatchRequest struct {
 
 type apolloMatchResponse struct {
 	Person apolloPerson `json:"person"`
-}
-
-type apolloPerson struct {
-	ID           string             `json:"id"`
-	FirstName    string             `json:"first_name"`
-	LastName     string             `json:"last_name"`
-	Name         string             `json:"name"`
-	Title        string             `json:"title"`
-	Seniority    string             `json:"seniority"`
-	Departments  []string           `json:"departments"`
-	Organization apolloOrganization `json:"organization"`
-	// Availability flags from people-search (no credits). has_email is a bool;
-	// has_direct_phone is a STRING ("Yes" / "Maybe: ...") — verified live
-	// 2026-06-26, hence the string type and the =="Yes" mapping in toPerson.
-	HasEmail          bool                    `json:"has_email"`
-	HasDirectPhone    string                  `json:"has_direct_phone"`
-	Email             string                  `json:"email"`
-	EmailStatus       string                  `json:"email_status"`
-	LinkedinURL       string                  `json:"linkedin_url"`
-	TwitterURL        string                  `json:"twitter_url"`
-	City              string                  `json:"city"`
-	State             string                  `json:"state"`
-	Country           string                  `json:"country"`
-	EmploymentHistory []apolloEmploymentEntry `json:"employment_history"`
 }
 
 type apolloEmploymentEntry struct {

--- a/pkg/enum/dehashed/dehashed_test.go
+++ b/pkg/enum/dehashed/dehashed_test.go
@@ -485,7 +485,7 @@ func TestIsCombolist(t *testing.T) {
 // makePagedServer builds an httptest server that serves DeHashed-shaped POST
 // responses. It reads the page number from the decoded JSON body (not a query
 // param — DeHashed uses POST with JSON body). An atomic counter tracks calls.
-func makePagedServer(t *testing.T, allEntries []apiEntry, total, pageSize int, midErr429AtPage int) (*httptest.Server, *atomic.Int32) {
+func makePagedServer(t *testing.T, allEntries []apiEntry, total, pageSize, midErr429AtPage int) (*httptest.Server, *atomic.Int32) {
 	t.Helper()
 	var requestCount atomic.Int32
 

--- a/pkg/enum/generate_test.go
+++ b/pkg/enum/generate_test.go
@@ -251,7 +251,7 @@ func TestGenerateUsernames_AllFormatsBoundedAndNonEmpty(t *testing.T) {
 // TestGenerateUsernames_UnknownFormat
 // ---------------------------------------------------------------------------
 
-// TestGenerateUsernames_UnknownFormat verifies that an unrecognised format
+// TestGenerateUsernames_UnknownFormat verifies that an unrecognized format
 // string causes all pairs to be skipped (formatUsername returns "" for the
 // default branch), producing an empty result with no error.
 func TestGenerateUsernames_UnknownFormat(t *testing.T) {
@@ -405,16 +405,4 @@ func TestGenerateEmails_FirstUnderLast(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, len(usernames), len(emails),
 		"GenerateEmails must produce the same count as GenerateUsernames for first_last")
-}
-
-// ---------------------------------------------------------------------------
-// helpers
-// ---------------------------------------------------------------------------
-
-// min returns the smaller of a and b.
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
 }

--- a/pkg/enum/github/github.go
+++ b/pkg/enum/github/github.go
@@ -39,9 +39,9 @@ package github
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
 	"io"
-	"math/rand"
 	"net/http"
 	"strconv"
 	"strings"
@@ -112,7 +112,7 @@ type Enumerator struct {
 	// them, giving GitHub time to resolve author logins. Overridable by tests.
 	settleDelay time.Duration
 
-	// sleep waits for d or until ctx is cancelled; overridable by tests to avoid
+	// sleep waits for d or until ctx is canceled; overridable by tests to avoid
 	// real delays. newName generates a random hex name for repos and files;
 	// overridable by tests for determinism.
 	sleep   func(ctx context.Context, d time.Duration) error
@@ -270,8 +270,8 @@ func cookieHeader(cookies []*http.Cookie) string {
 // reference's binascii.b2a_hex(os.urandom(15)).
 func randomHexName() string {
 	b := make([]byte, 15)
-	// math/rand is sufficient here: these names only need to be unique within a
-	// single run, not cryptographically unpredictable.
+	// crypto/rand.Read is used for name uniqueness within a single run; it never
+	// fails on the platforms we target, so the error is intentionally ignored.
 	_, _ = rand.Read(b)
 	var sb strings.Builder
 	for _, x := range b {
@@ -281,7 +281,7 @@ func randomHexName() string {
 	return sb.String()
 }
 
-// sleepCtx waits for d or returns ctx.Err() if ctx is cancelled first.
+// sleepCtx waits for d or returns ctx.Err() if ctx is canceled first.
 func sleepCtx(ctx context.Context, d time.Duration) error {
 	if d <= 0 {
 		return nil

--- a/pkg/enum/github/github_test.go
+++ b/pkg/enum/github/github_test.go
@@ -46,15 +46,6 @@ func noopSleep(_ context.Context, _ time.Duration) error { return nil }
 // call should use a counter-based newName.
 func deterministicName() string { return "test-repo-name" }
 
-// counterName returns a newName func that returns "name-N" (N=0,1,2,...),
-// which is useful when pushCommit calls newName multiple times.
-func counterName() func() string {
-	var n atomic.Int64
-	return func() string {
-		return fmt.Sprintf("name-%d", n.Add(1))
-	}
-}
-
 // webMux builds an http.ServeMux that fakes the GitHub web flow. The statusFor
 // map controls which HTTP status the /email_validity_checks POST returns per
 // email value (default 200 = available).
@@ -137,10 +128,7 @@ func apiMux(t *testing.T, token string, emailToLogin map[string]*string, deleteS
 	checkAuth := func(t *testing.T, r *http.Request) bool {
 		t.Helper()
 		auth := r.Header.Get("Authorization")
-		if auth != "Bearer "+token {
-			return false
-		}
-		return true
+		return auth == "Bearer "+token
 	}
 
 	mux.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
@@ -225,9 +213,6 @@ func newTestEnumerator(t *testing.T, webSrv, apiSrv *httptest.Server, token stri
 	e.newName = deterministicName
 	return e
 }
-
-// strPtr returns a pointer to s, used to build emailToLogin maps.
-func strPtr(s string) *string { return &s }
 
 // ---------------------------------------------------------------------------
 // Existence tests: 422 → Exists=true, 200 → Exists=false

--- a/pkg/enum/github/reveal.go
+++ b/pkg/enum/github/reveal.go
@@ -89,16 +89,16 @@ func (e *Enumerator) RevealWith(ctx context.Context, emails []string, onProgress
 	}()
 
 	for i, email := range emails {
-		if err = e.pushCommit(ctx, login, repo, email); err != nil {
-			return nil, err
+		if perr := e.pushCommit(ctx, login, repo, email); perr != nil {
+			return nil, perr
 		}
 		if onProgress != nil {
 			onProgress(i+1, len(emails))
 		}
 	}
 
-	if err = e.sleep(ctx, e.settleDelay); err != nil {
-		return nil, err
+	if serr := e.sleep(ctx, e.settleDelay); serr != nil {
+		return nil, serr
 	}
 
 	mapping, err = e.listCommitLogins(ctx, login, repo, branch)
@@ -144,7 +144,7 @@ func (e *Enumerator) getAuthUser(ctx context.Context) (string, error) {
 
 // createRepo POSTs {api}/user/repos to create a private throwaway repo, returning
 // its name and default branch (falling back to "main" when absent).
-func (e *Enumerator) createRepo(ctx context.Context) (repo string, branch string, err error) {
+func (e *Enumerator) createRepo(ctx context.Context) (repo, branch string, err error) {
 	name := e.newName()
 	payload := map[string]any{"name": name, "private": true}
 

--- a/pkg/enum/google/google.go
+++ b/pkg/enum/google/google.go
@@ -241,7 +241,7 @@ func (e *Enumerator) CheckAccount(ctx context.Context, email string) Result {
 // The shared proxied client follows redirects by default, so a per-request
 // clone with CheckRedirect=ErrUseLastResponse is used to inspect the 302
 // Location header while keeping the proxy transport.
-func (e *Enumerator) checkAccountChooser(ctx context.Context, email string) (bool, string, error) {
+func (e *Enumerator) checkAccountChooser(ctx context.Context, email string) (federated bool, host string, err error) {
 	u := e.accountChooserBaseURL + "/AccountChooser?Email=" + url.QueryEscape(email) + "&continue=https://mail.google.com/mail/"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, http.NoBody)
 	if err != nil {

--- a/pkg/enum/lusha/lusha.go
+++ b/pkg/enum/lusha/lusha.go
@@ -193,7 +193,7 @@ func NewClient(apiKey string, timeout time.Duration, proxyURL string) (*Client, 
 
 // Enrich resolves one identity to an enriched contact via v3 search-and-enrich.
 // A 200 with no datapoints returns a *Contact with empty slices (not an error).
-func (c *Client) Enrich(ctx context.Context, q ContactQuery, r RevealOptions) (*Contact, error) {
+func (c *Client) Enrich(ctx context.Context, q *ContactQuery, r RevealOptions) (*Contact, error) {
 	body := buildEnrichRequest(q, r)
 	raw, err := c.do(ctx, http.MethodPost, enrichPath, body)
 	if err != nil {
@@ -333,7 +333,7 @@ func (c *Client) do(ctx context.Context, method, path string, body any) ([]byte,
 // values ("emails"/"phones") are UNVERIFIED against a live key — they are
 // isolated here so a single edit corrects any mismatch without touching control
 // flow.
-func buildEnrichRequest(q ContactQuery, r RevealOptions) lushaEnrichRequest {
+func buildEnrichRequest(q *ContactQuery, r RevealOptions) lushaEnrichRequest {
 	var reveal []string
 	if r.Email {
 		reveal = append(reveal, "emails")

--- a/pkg/enum/lusha/lusha_test.go
+++ b/pkg/enum/lusha/lusha_test.go
@@ -223,7 +223,7 @@ func TestEnrich_Success(t *testing.T) {
 		CompanyName: "AnalyticalCo",
 	}
 	r := RevealOptions{Email: true, Phone: true}
-	contact, err := c.Enrich(context.Background(), q, r)
+	contact, err := c.Enrich(context.Background(), &q, r)
 	require.NoError(t, err)
 
 	// API key set as header, not in URL.
@@ -305,7 +305,7 @@ func TestBuildEnrichRequest(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := buildEnrichRequest(tc.query, tc.reveal)
+			got := buildEnrichRequest(&tc.query, tc.reveal)
 			// Must be a batch with exactly one contact.
 			require.Len(t, got.Contacts, 1, "batch must have exactly one contact")
 			assert.Equal(t, tc.wantContact, got.Contacts[0])
@@ -322,7 +322,7 @@ func TestEnrich_401ErrUnauthorized(t *testing.T) {
 	defer srv.Close()
 
 	c := newTestClient(srv.URL)
-	_, err := c.Enrich(context.Background(), ContactQuery{Email: "a@b.com"}, RevealOptions{Email: true})
+	_, err := c.Enrich(context.Background(), &ContactQuery{Email: "a@b.com"}, RevealOptions{Email: true})
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrUnauthorized))
 }
@@ -335,7 +335,7 @@ func TestEnrich_402ErrNoCredits(t *testing.T) {
 	defer srv.Close()
 
 	c := newTestClient(srv.URL)
-	_, err := c.Enrich(context.Background(), ContactQuery{Email: "a@b.com"}, RevealOptions{Email: true})
+	_, err := c.Enrich(context.Background(), &ContactQuery{Email: "a@b.com"}, RevealOptions{Email: true})
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrNoCredits))
 
@@ -352,7 +352,7 @@ func TestEnrich_429ErrRateLimited(t *testing.T) {
 	defer srv.Close()
 
 	c := newTestClient(srv.URL)
-	_, err := c.Enrich(context.Background(), ContactQuery{Email: "a@b.com"}, RevealOptions{Email: true})
+	_, err := c.Enrich(context.Background(), &ContactQuery{Email: "a@b.com"}, RevealOptions{Email: true})
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrRateLimited))
 }
@@ -367,7 +367,7 @@ func TestEnrich_EmptyMatch(t *testing.T) {
 	defer srv.Close()
 
 	c := newTestClient(srv.URL)
-	contact, err := c.Enrich(context.Background(), ContactQuery{Email: "nobody@example.com"}, RevealOptions{Email: true})
+	contact, err := c.Enrich(context.Background(), &ContactQuery{Email: "nobody@example.com"}, RevealOptions{Email: true})
 	require.NoError(t, err, "empty 200 must not return an error")
 	require.NotNil(t, contact)
 	assert.Empty(t, contact.Emails)
@@ -382,7 +382,7 @@ func TestEnrich_MalformedJSON(t *testing.T) {
 	defer srv.Close()
 
 	c := newTestClient(srv.URL)
-	_, err := c.Enrich(context.Background(), ContactQuery{Email: "a@b.com"}, RevealOptions{Email: true})
+	_, err := c.Enrich(context.Background(), &ContactQuery{Email: "a@b.com"}, RevealOptions{Email: true})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "decoding lusha response")
 }
@@ -401,7 +401,7 @@ func TestEnrich_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 
-	_, err := c.Enrich(ctx, ContactQuery{Email: "a@b.com"}, RevealOptions{Email: true})
+	_, err := c.Enrich(ctx, &ContactQuery{Email: "a@b.com"}, RevealOptions{Email: true})
 	require.Error(t, err, "context cancellation must produce an error")
 }
 
@@ -427,34 +427,6 @@ type prospectSearchBody struct {
 type prospectEnrichBody struct {
 	RequestID  string   `json:"requestId"`
 	ContactIDs []string `json:"contactIds"`
-}
-
-// newProspectServer builds an httptest.Server that handles the two prospecting
-// endpoints via a router. The search handler is called once (page 0); the enrich
-// handler is called once with the page's requestId + contactIds.
-func newProspectServer(t *testing.T, searchResp, enrichResp interface{}, captureSearch, captureEnrich *[]byte) *httptest.Server {
-	t.Helper()
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
-
-		switch r.URL.Path {
-		case prospectSearchPath:
-			if captureSearch != nil {
-				*captureSearch = body
-			}
-			w.Header().Set("Content-Type", "application/json")
-			require.NoError(t, json.NewEncoder(w).Encode(searchResp))
-		case prospectEnrichPath:
-			if captureEnrich != nil {
-				*captureEnrich = body
-			}
-			w.Header().Set("Content-Type", "application/json")
-			require.NoError(t, json.NewEncoder(w).Encode(enrichResp))
-		default:
-			http.NotFound(w, r)
-		}
-	}))
 }
 
 func TestSearchDomain_Success(t *testing.T) {
@@ -550,7 +522,7 @@ func TestSearchDomain_Success(t *testing.T) {
 	assert.Equal(t, 2, result.Total, "Total must equal totalResults from search page")
 	require.Len(t, result.Contacts, 2)
 
-	// Credits: 1 (search) + 2 (enrich) = 3
+	// Credits: 1 for search plus 2 for enrich, totaling 3
 	assert.Equal(t, 3, result.CreditsCharged, "CreditsCharged must sum search+enrich billing")
 
 	// ---- Bruna White (first contact) ----

--- a/pkg/enum/teams/audit.go
+++ b/pkg/enum/teams/audit.go
@@ -56,7 +56,7 @@ type Finding struct {
 // actually gathered. Findings are returned ordered by
 // severity (high -> info) then by ID, for stable output. Token values never
 // appear in any field.
-func Audit(domain, seedEmail string, result EnumResult, posture TenantPosture, presenceChecked bool) []Finding {
+func Audit(domain, seedEmail string, result *EnumResult, posture *TenantPosture, presenceChecked bool) []Finding {
 	var findings []Finding
 
 	if posture.ExternalChatAllowed == "open" {
@@ -91,7 +91,7 @@ func Audit(domain, seedEmail string, result EnumResult, posture TenantPosture, p
 // externalAccessFinding reports that external / cross-tenant Teams chat is
 // enabled: the externalsearchv3 endpoint resolved the seed user to this tenant
 // from an external context.
-func externalAccessFinding(domain string, result EnumResult) Finding {
+func externalAccessFinding(domain string, result *EnumResult) Finding {
 	evidence := "externalsearchv3 returned the user to an external tenant"
 	if posture := externalAccessSignals(result); posture != "" {
 		evidence += " (" + posture + ")"
@@ -124,7 +124,7 @@ func userEnumerationFinding(domain, seedEmail string) Finding {
 
 // presenceFinding reports that the seed user's Teams presence (availability /
 // device type) was disclosed to an external requester.
-func presenceFinding(domain, seedEmail string, result EnumResult) Finding {
+func presenceFinding(domain, seedEmail string, result *EnumResult) Finding {
 	evidence := "presence availability returned: " + result.Availability
 	if result.DeviceType != "" {
 		evidence += " (device: " + result.DeviceType + ")"
@@ -143,7 +143,7 @@ func presenceFinding(domain, seedEmail string, result EnumResult) Finding {
 // oofFinding reports that the seed user's out-of-office note was disclosed to an
 // external requester. The raw note is stored in Evidence; the caller sanitizes
 // and truncates it for terminal output.
-func oofFinding(domain, seedEmail string, result EnumResult) Finding {
+func oofFinding(domain, seedEmail string, result *EnumResult) Finding {
 	return Finding{
 		ID:          "teams-oof-disclosure",
 		Title:       "Out-of-office note disclosed to external users",
@@ -157,7 +157,7 @@ func oofFinding(domain, seedEmail string, result EnumResult) Finding {
 
 // metadataFinding reports that account metadata (UPN, objectId, tenantId,
 // coexistence mode) was disclosed to an external party via externalsearchv3.
-func metadataFinding(domain, seedEmail string, result EnumResult) Finding {
+func metadataFinding(domain, seedEmail string, result *EnumResult) Finding {
 	var fields []string
 	if result.UserPrincipalName != "" {
 		fields = append(fields, "userPrincipalName")
@@ -189,7 +189,7 @@ func metadataFinding(domain, seedEmail string, result EnumResult) Finding {
 // externalAccessSignals describes any federation/type signal observed on the
 // seed result, for inclusion in the external-access evidence string. It returns
 // "" when no such signal is present.
-func externalAccessSignals(result EnumResult) string {
+func externalAccessSignals(result *EnumResult) string {
 	var parts []string
 	if result.Type != "" {
 		parts = append(parts, "type="+result.Type)

--- a/pkg/enum/teams/audit_test.go
+++ b/pkg/enum/teams/audit_test.go
@@ -51,7 +51,7 @@ func TestAudit_ExternalAccessOpen(t *testing.T) {
 
 	t.Run("posture open emits teams-external-access Medium", func(t *testing.T) {
 		posture := TenantPosture{ExternalChatAllowed: "open"}
-		findings := Audit("contoso.com", "alice@contoso.com", baseResult, posture, false)
+		findings := Audit("contoso.com", "alice@contoso.com", &baseResult, &posture, false)
 
 		f, ok := findFinding(findings, "teams-external-access")
 		require.True(t, ok, "teams-external-access finding must be present when ExternalChatAllowed==\"open\"")
@@ -61,14 +61,14 @@ func TestAudit_ExternalAccessOpen(t *testing.T) {
 
 	t.Run("posture blocked omits teams-external-access", func(t *testing.T) {
 		posture := TenantPosture{ExternalChatAllowed: "blocked"}
-		findings := Audit("contoso.com", "alice@contoso.com", baseResult, posture, false)
+		findings := Audit("contoso.com", "alice@contoso.com", &baseResult, &posture, false)
 		assert.False(t, hasFinding(findings, "teams-external-access"),
 			"teams-external-access must be absent when ExternalChatAllowed==\"blocked\"")
 	})
 
 	t.Run("posture unknown omits teams-external-access", func(t *testing.T) {
 		posture := TenantPosture{ExternalChatAllowed: "unknown"}
-		findings := Audit("contoso.com", "alice@contoso.com", baseResult, posture, false)
+		findings := Audit("contoso.com", "alice@contoso.com", &baseResult, &posture, false)
 		assert.False(t, hasFinding(findings, "teams-external-access"),
 			"teams-external-access must be absent when ExternalChatAllowed==\"unknown\"")
 	})
@@ -83,7 +83,7 @@ func TestAudit_UserEnumeration(t *testing.T) {
 
 	t.Run("ExistenceYes emits teams-user-enumeration Info", func(t *testing.T) {
 		result := EnumResult{Exists: ExistenceYes}
-		findings := Audit("contoso.com", "alice@contoso.com", result, posture, false)
+		findings := Audit("contoso.com", "alice@contoso.com", &result, &posture, false)
 
 		f, ok := findFinding(findings, "teams-user-enumeration")
 		require.True(t, ok, "teams-user-enumeration must be present when Exists==ExistenceYes")
@@ -93,7 +93,7 @@ func TestAudit_UserEnumeration(t *testing.T) {
 
 	t.Run("ExistenceBlocked emits teams-user-enumeration Info", func(t *testing.T) {
 		result := EnumResult{Exists: ExistenceBlocked}
-		findings := Audit("contoso.com", "alice@contoso.com", result, posture, false)
+		findings := Audit("contoso.com", "alice@contoso.com", &result, &posture, false)
 
 		f, ok := findFinding(findings, "teams-user-enumeration")
 		require.True(t, ok, "teams-user-enumeration must be present when Exists==ExistenceBlocked")
@@ -103,14 +103,14 @@ func TestAudit_UserEnumeration(t *testing.T) {
 
 	t.Run("ExistenceNo omits teams-user-enumeration", func(t *testing.T) {
 		result := EnumResult{Exists: ExistenceNo}
-		findings := Audit("contoso.com", "alice@contoso.com", result, posture, false)
+		findings := Audit("contoso.com", "alice@contoso.com", &result, &posture, false)
 		assert.False(t, hasFinding(findings, "teams-user-enumeration"),
 			"teams-user-enumeration must be absent when Exists==ExistenceNo")
 	})
 
 	t.Run("ExistenceUnknown omits teams-user-enumeration", func(t *testing.T) {
 		result := EnumResult{Exists: ExistenceUnknown}
-		findings := Audit("contoso.com", "alice@contoso.com", result, posture, false)
+		findings := Audit("contoso.com", "alice@contoso.com", &result, &posture, false)
 		assert.False(t, hasFinding(findings, "teams-user-enumeration"),
 			"teams-user-enumeration must be absent when Exists==ExistenceUnknown")
 	})
@@ -129,7 +129,7 @@ func TestAudit_PresenceAndOOF_GatedByPresenceChecked(t *testing.T) {
 			Availability:    "Busy",
 			OutOfOfficeNote: "Back Monday call Jane",
 		}
-		findings := Audit("contoso.com", "alice@contoso.com", result, posture, false /* presenceChecked */)
+		findings := Audit("contoso.com", "alice@contoso.com", &result, &posture, false /* presenceChecked */)
 
 		assert.False(t, hasFinding(findings, "teams-presence-disclosure"),
 			"teams-presence-disclosure must be absent when presenceChecked==false")
@@ -142,7 +142,7 @@ func TestAudit_PresenceAndOOF_GatedByPresenceChecked(t *testing.T) {
 			Exists:       ExistenceYes,
 			Availability: "Busy",
 		}
-		findings := Audit("contoso.com", "alice@contoso.com", result, posture, true /* presenceChecked */)
+		findings := Audit("contoso.com", "alice@contoso.com", &result, &posture, true /* presenceChecked */)
 
 		f, ok := findFinding(findings, "teams-presence-disclosure")
 		require.True(t, ok, "teams-presence-disclosure must be present when presenceChecked==true and Availability is set")
@@ -156,7 +156,7 @@ func TestAudit_PresenceAndOOF_GatedByPresenceChecked(t *testing.T) {
 			Exists:          ExistenceYes,
 			OutOfOfficeNote: oooNote,
 		}
-		findings := Audit("contoso.com", "alice@contoso.com", result, posture, true /* presenceChecked */)
+		findings := Audit("contoso.com", "alice@contoso.com", &result, &posture, true /* presenceChecked */)
 
 		f, ok := findFinding(findings, "teams-oof-disclosure")
 		require.True(t, ok, "teams-oof-disclosure must be present when presenceChecked==true and OutOfOfficeNote is set")
@@ -171,7 +171,7 @@ func TestAudit_PresenceAndOOF_GatedByPresenceChecked(t *testing.T) {
 			Exists:       ExistenceYes,
 			Availability: "", // empty
 		}
-		findings := Audit("contoso.com", "alice@contoso.com", result, posture, true)
+		findings := Audit("contoso.com", "alice@contoso.com", &result, &posture, true)
 		assert.False(t, hasFinding(findings, "teams-presence-disclosure"),
 			"teams-presence-disclosure must be absent when Availability is empty even if presenceChecked==true")
 	})
@@ -181,7 +181,7 @@ func TestAudit_PresenceAndOOF_GatedByPresenceChecked(t *testing.T) {
 			Exists:          ExistenceYes,
 			OutOfOfficeNote: "", // empty
 		}
-		findings := Audit("contoso.com", "alice@contoso.com", result, posture, true)
+		findings := Audit("contoso.com", "alice@contoso.com", &result, &posture, true)
 		assert.False(t, hasFinding(findings, "teams-oof-disclosure"),
 			"teams-oof-disclosure must be absent when OutOfOfficeNote is empty even if presenceChecked==true")
 	})
@@ -199,7 +199,7 @@ func TestAudit_MetadataDisclosure(t *testing.T) {
 			Exists:            ExistenceYes,
 			UserPrincipalName: "alice@contoso.com",
 		}
-		findings := Audit("contoso.com", "alice@contoso.com", result, posture, false)
+		findings := Audit("contoso.com", "alice@contoso.com", &result, &posture, false)
 
 		f, ok := findFinding(findings, "teams-metadata-disclosure")
 		require.True(t, ok, "teams-metadata-disclosure must be present when UserPrincipalName is set")
@@ -212,7 +212,7 @@ func TestAudit_MetadataDisclosure(t *testing.T) {
 			Exists:   ExistenceYes,
 			ObjectID: "o-456",
 		}
-		findings := Audit("contoso.com", "alice@contoso.com", result, posture, false)
+		findings := Audit("contoso.com", "alice@contoso.com", &result, &posture, false)
 
 		_, ok := findFinding(findings, "teams-metadata-disclosure")
 		require.True(t, ok, "teams-metadata-disclosure must be present when ObjectID is set")
@@ -223,7 +223,7 @@ func TestAudit_MetadataDisclosure(t *testing.T) {
 			Exists:   ExistenceYes,
 			TenantID: "t-123",
 		}
-		findings := Audit("contoso.com", "alice@contoso.com", result, posture, false)
+		findings := Audit("contoso.com", "alice@contoso.com", &result, &posture, false)
 
 		_, ok := findFinding(findings, "teams-metadata-disclosure")
 		require.True(t, ok, "teams-metadata-disclosure must be present when TenantID is set")
@@ -236,7 +236,7 @@ func TestAudit_MetadataDisclosure(t *testing.T) {
 			ObjectID:          "",
 			TenantID:          "",
 		}
-		findings := Audit("contoso.com", "alice@contoso.com", result, posture, false)
+		findings := Audit("contoso.com", "alice@contoso.com", &result, &posture, false)
 		assert.False(t, hasFinding(findings, "teams-metadata-disclosure"),
 			"teams-metadata-disclosure must be absent when all metadata fields are empty")
 	})
@@ -247,7 +247,7 @@ func TestAudit_MetadataDisclosure(t *testing.T) {
 			Exists:            ExistenceBlocked,
 			UserPrincipalName: "alice@contoso.com",
 		}
-		findings := Audit("contoso.com", "alice@contoso.com", result, posture, false)
+		findings := Audit("contoso.com", "alice@contoso.com", &result, &posture, false)
 		assert.False(t, hasFinding(findings, "teams-metadata-disclosure"),
 			"teams-metadata-disclosure must be absent when Exists!=ExistenceYes")
 	})
@@ -268,7 +268,7 @@ func TestAudit_Ordering(t *testing.T) {
 	}
 	posture := TenantPosture{ExternalChatAllowed: "open"}
 
-	findings := Audit("contoso.com", "alice@contoso.com", result, posture, true /* presenceChecked */)
+	findings := Audit("contoso.com", "alice@contoso.com", &result, &posture, true /* presenceChecked */)
 
 	require.GreaterOrEqual(t, len(findings), 3,
 		"expected at least 3 findings for ordering test: Medium + Low + Info")
@@ -332,7 +332,7 @@ func TestAudit_Ordering_WithinSeverityByID(t *testing.T) {
 	}
 	posture := TenantPosture{ExternalChatAllowed: "blocked"}
 
-	findings := Audit("contoso.com", "alice@contoso.com", result, posture, true /* presenceChecked */)
+	findings := Audit("contoso.com", "alice@contoso.com", &result, &posture, true /* presenceChecked */)
 
 	var lowFindings []Finding
 	var infoFindings []Finding
@@ -391,7 +391,7 @@ func TestAudit_NoTokensInFindings(t *testing.T) {
 	}
 	posture := TenantPosture{ExternalChatAllowed: "open"}
 
-	findings := Audit("contoso.com", "alice@contoso.com", result, posture, true)
+	findings := Audit("contoso.com", "alice@contoso.com", &result, &posture, true)
 	require.NotEmpty(t, findings, "expect at least one finding")
 
 	// The refresh token sentinel must NEVER appear in any field.
@@ -443,7 +443,7 @@ func TestAudit_EmptyResult(t *testing.T) {
 
 	var findings []Finding
 	require.NotPanics(t, func() {
-		findings = Audit("contoso.com", "", result, posture, false)
+		findings = Audit("contoso.com", "", &result, &posture, false)
 	}, "Audit must not panic on zero-value inputs")
 
 	// Audit returns nil (not an initialized empty slice) when no rules fire — this
@@ -464,7 +464,7 @@ func TestAudit_FindingFieldsNonEmpty(t *testing.T) {
 	}
 	posture := TenantPosture{ExternalChatAllowed: "open"}
 
-	findings := Audit("contoso.com", "alice@contoso.com", result, posture, true)
+	findings := Audit("contoso.com", "alice@contoso.com", &result, &posture, true)
 	require.NotEmpty(t, findings)
 
 	for _, f := range findings {
@@ -487,7 +487,7 @@ func TestAudit_AffectedContainsDomain(t *testing.T) {
 	result := EnumResult{Exists: ExistenceYes, UserPrincipalName: "alice@contoso.com"}
 	posture := TenantPosture{ExternalChatAllowed: "open"}
 
-	findings := Audit("contoso.com", "alice@contoso.com", result, posture, false)
+	findings := Audit("contoso.com", "alice@contoso.com", &result, &posture, false)
 	require.NotEmpty(t, findings)
 
 	for _, f := range findings {
@@ -510,7 +510,7 @@ func TestAudit_PresenceEvidenceContainsAvailability(t *testing.T) {
 		Availability: "DoNotDisturb",
 	}
 	posture := TenantPosture{ExternalChatAllowed: "blocked"}
-	findings := Audit("contoso.com", "alice@contoso.com", result, posture, true)
+	findings := Audit("contoso.com", "alice@contoso.com", &result, &posture, true)
 
 	f, ok := findFinding(findings, "teams-presence-disclosure")
 	require.True(t, ok, "teams-presence-disclosure must be present")
@@ -528,7 +528,7 @@ func TestAudit_MetadataEvidenceListsFields(t *testing.T) {
 		TenantID:          "",
 	}
 	posture := TenantPosture{ExternalChatAllowed: "open"}
-	findings := Audit("contoso.com", "alice@contoso.com", result, posture, false)
+	findings := Audit("contoso.com", "alice@contoso.com", &result, &posture, false)
 
 	f, ok := findFinding(findings, "teams-metadata-disclosure")
 	require.True(t, ok)

--- a/pkg/enum/teams/auth_test.go
+++ b/pkg/enum/teams/auth_test.go
@@ -390,13 +390,13 @@ func TestWaitForToken_AccessDenied(t *testing.T) {
 }
 
 func TestWaitForToken_ContextCancellation(t *testing.T) {
-	// Server blocks until the request context is cancelled (client hung up),
+	// Server blocks until the request context is canceled (client hung up),
 	// then returns without writing a response.  This ensures the handler exits
 	// promptly so srv.Close() is never blocked waiting for an active connection.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		select {
 		case <-r.Context().Done():
-			// Client cancelled — handler exits immediately.
+			// Client canceled — handler exits immediately.
 			return
 		case <-time.After(10 * time.Second):
 			w.WriteHeader(http.StatusOK)
@@ -404,7 +404,7 @@ func TestWaitForToken_ContextCancellation(t *testing.T) {
 	}))
 	// CloseClientConnections forcibly terminates any open keep-alive connections
 	// before Close() waits for handlers to finish, eliminating the 5-second
-	// "blocked in Close" warning that occurs when a context-cancelled request
+	// "blocked in Close" warning that occurs when a context-canceled request
 	// leaves a TCP connection in the active state.
 	defer func() {
 		srv.CloseClientConnections()

--- a/pkg/enum/teams/enum_test.go
+++ b/pkg/enum/teams/enum_test.go
@@ -525,7 +525,7 @@ func TestEnumerate_ConcurrentRefreshNoRace(t *testing.T) {
 	var refreshCount atomic.Int32
 
 	// Server: first call → 401, all subsequent → 200 with a valid user.
-	// Using an atomic counter makes the behaviour deterministic across
+	// Using an atomic counter makes the behavior deterministic across
 	// goroutines without any mutex in the handler.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		n := reqCount.Add(1)
@@ -842,7 +842,7 @@ func TestEnumerateOne_TokenSafetyTable(t *testing.T) {
 			e.searchBaseURL = srv.URL + "/%s"
 			// No refresh function to keep test deterministic.
 
-			res := e.EnumerateOne(context.Background(), fmt.Sprintf("user@contoso.com"))
+			res := e.EnumerateOne(context.Background(), "user@contoso.com")
 
 			if res.Error != nil {
 				assert.NotContains(t, res.Error.Error(), accessToken,


### PR DESCRIPTION
## Summary

Clears the ~85 pre-existing golangci-lint findings so the **CI Lint** check goes green. No behavior changes — pure lint cleanup.

## What changed (40 files)
- **gocritic**: `hugeParam` heavy value params → pointers (all call sites, incl. tests, updated); `paramTypeCombine`, `unnamedResult`, `builtinShadow` (`any`→`anyMatch`, `cap`→`maxDelay`), `sloppyReassign`, `typeDefFirst`, `commentedOutCode`. Two cohesive 6-return WASM detection funcs kept with a justified `//nolint:gocritic` rather than a risky struct refactor.
- **govet**: resolved 2 `err` shadows.
- **staticcheck**: `math/rand.Read`→`crypto/rand.Read` (SA1019), removed needless `fmt.Sprintf` (S1039), simplified return (S1008).
- **unused**: removed dead test helpers.
- **misspell**: `cancelled`→`canceled`, `behaviour`→`behavior`, etc. (comments/strings only).
- **gofmt**: formatted several previously-unformatted test files.

## Verification
- `golangci-lint run --max-same-issues=0 --max-issues-per-linter=0 ./...` → **0 findings**
- `go build ./...` — clean
- `go test ./... -count=1` — all pass
- `gofmt -l .` — empty

## Scope
Lint/style only; no logic changes. Split-verified via backend-developer (production) + backend-tester (tests) with build+test gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)