### PR TITLE
feat(enum/lusha): expose FirstName/LastName on Contact

### DIFF
--- a/pkg/enum/lusha/lusha.go
+++ b/pkg/enum/lusha/lusha.go
@@ -109,6 +109,8 @@ type EmploymentEntry struct {
 // Contact is the enriched result for one identity.
 type Contact struct {
 	Name          string
+	FirstName     string
+	LastName      string
 	JobTitle      string
 	Company       string
 	CompanyDomain string
@@ -373,6 +375,8 @@ func toContact(resp *lushaEnrichResponse) *Contact {
 
 	c := &Contact{
 		Name:          name,
+		FirstName:     r.FirstName,
+		LastName:      r.LastName,
 		JobTitle:      r.JobTitle.Title,
 		Company:       r.Company.Name,
 		CompanyDomain: r.Company.Domain,
@@ -490,6 +494,8 @@ func toProspectContact(d *prospectEnrichData) Contact {
 
 	c := Contact{
 		Name:        name,
+		FirstName:   d.FirstName,
+		LastName:    d.LastName,
 		JobTitle:    d.JobTitle,
 		Company:     d.CompanyName,
 		LinkedIn:    d.SocialLinks.Linkedin,

--- a/pkg/enum/lusha/lusha_test.go
+++ b/pkg/enum/lusha/lusha_test.go
@@ -96,6 +96,8 @@ func TestToContact(t *testing.T) {
 	}
 	got := toContact(resp)
 	assert.Equal(t, "Ada Lovelace", got.Name)
+	assert.Equal(t, "Ada", got.FirstName)
+	assert.Equal(t, "Lovelace", got.LastName)
 	assert.Equal(t, "Mathematician", got.JobTitle)
 	assert.Equal(t, "Analytical Engine Co", got.Company)
 	assert.Equal(t, "analytical.example.com", got.CompanyDomain)
@@ -866,6 +868,8 @@ func TestSearchDomain_ContextCancellation(t *testing.T) {
 // (emailAddresses, phoneNumbers, seniority[].value differ from single-identity).
 func TestToProspectContact(t *testing.T) {
 	d := &prospectEnrichData{
+		FirstName:   "Bruna",
+		LastName:    "White",
 		FullName:    "Bruna White",
 		JobTitle:    "Assistant Director",
 		CompanyName: "Fox",
@@ -896,6 +900,8 @@ func TestToProspectContact(t *testing.T) {
 
 	got := toProspectContact(d)
 	assert.Equal(t, "Bruna White", got.Name)
+	assert.Equal(t, "Bruna", got.FirstName)
+	assert.Equal(t, "White", got.LastName)
 	assert.Equal(t, "Assistant Director", got.JobTitle)
 	assert.Equal(t, "Fox", got.Company)
 	assert.Equal(t, "United States", got.Location)


### PR DESCRIPTION
## What
Add `FirstName` and `LastName` to the exported `lusha.Contact` type and populate them in both converters (`toContact`, `toProspectContact`).

## Why
`Contact` only exposed a combined `Name`, so downstream consumers can't populate a person's first/last name separately (e.g. a roster that renders `FirstName`/`LastName` columns). The v3 enrich and prospect wire responses already carry `firstName`/`lastName` — the converters concatenated them into `Name` and dropped the split. This surfaces the data that's already fetched, with no new API calls.

## Changes
- `Contact` gains `FirstName string` / `LastName string` (after `Name`).
- `toContact` sets them from `resp.Results[0].FirstName/LastName`.
- `toProspectContact` sets them from `prospectEnrichData.FirstName/LastName`.
- `Name` behavior is unchanged; existing emails/phones/employment mapping untouched.

## Tests
`TestToContact` and `TestToProspectContact` assert the split names flow through. `go test ./pkg/enum/lusha/...` passes; `gofmt`/`go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)