### PR TITLE
feat(enum/microsoft365): add rotating-proxy support to NewChecker

### DIFF
--- a/internal/enumplugins/microsoft365/microsoft365.go
+++ b/internal/enumplugins/microsoft365/microsoft365.go
@@ -46,7 +46,12 @@ func (p *Plugin) Check(ctx context.Context, email string, timeout time.Duration)
 		Email:   email,
 	}
 
-	checker := ms365.NewChecker("", timeout)
+	checker, err := ms365.NewChecker("", "", timeout)
+	if err != nil {
+		result.Error = err
+		result.Duration = time.Since(start)
+		return result
+	}
 	res := checker.CheckAccount(ctx, email)
 
 	result.Exists = res.Exists

--- a/pkg/enum/microsoft365/microsoft365.go
+++ b/pkg/enum/microsoft365/microsoft365.go
@@ -70,16 +70,26 @@ type Checker struct {
 }
 
 // NewChecker creates a Checker with the given timeout. Pass "" for baseURL to
-// use the default Microsoft login endpoint.
-func NewChecker(baseURL string, timeout time.Duration) *Checker {
+// use the default Microsoft login endpoint. Pass "" for proxyURL for a direct
+// (non-proxied) client; when proxyURL is non-empty the checker's client routes
+// through it (honoring the --proxy flag), mirroring the Google enumerator.
+func NewChecker(baseURL, proxyURL string, timeout time.Duration) (*Checker, error) {
 	if baseURL == "" {
 		baseURL = DefaultBaseURL
+	}
+	client := enum.NewEnumHTTPClient(timeout)
+	if proxyURL != "" {
+		c, err := enum.NewEnumHTTPClientWithProxy(timeout, proxyURL)
+		if err != nil {
+			return nil, fmt.Errorf("microsoft365: configuring proxy: %w", err)
+		}
+		client = c
 	}
 	return &Checker{
 		baseURL: baseURL,
 		timeout: timeout,
-		client:  enum.NewEnumHTTPClient(timeout),
-	}
+		client:  client,
+	}, nil
 }
 
 // CheckAccount tests if an email account exists on Microsoft 365 via the

--- a/pkg/enum/microsoft365/microsoft365_test.go
+++ b/pkg/enum/microsoft365/microsoft365_test.go
@@ -93,7 +93,8 @@ func TestCheckAccount_Exists(t *testing.T) {
 	srv := newMockServer(t)
 	t.Cleanup(srv.Close)
 
-	c := NewChecker(srv.URL, 5*time.Second)
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
 	result := c.CheckAccount(context.Background(), "exists@example.com")
 
 	require.NoError(t, result.Error)
@@ -108,7 +109,8 @@ func TestCheckAccount_NotExists(t *testing.T) {
 	srv := newMockServer(t)
 	t.Cleanup(srv.Close)
 
-	c := NewChecker(srv.URL, 5*time.Second)
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
 	result := c.CheckAccount(context.Background(), "notexists@example.com")
 
 	require.NoError(t, result.Error)
@@ -121,7 +123,8 @@ func TestCheckAccount_DifferentTenant(t *testing.T) {
 	srv := newMockServer(t)
 	t.Cleanup(srv.Close)
 
-	c := NewChecker(srv.URL, 5*time.Second)
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
 	result := c.CheckAccount(context.Background(), "difftenant@example.com")
 
 	require.NoError(t, result.Error)
@@ -134,7 +137,8 @@ func TestCheckAccount_DomainHint(t *testing.T) {
 	srv := newMockServer(t)
 	t.Cleanup(srv.Close)
 
-	c := NewChecker(srv.URL, 5*time.Second)
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
 	result := c.CheckAccount(context.Background(), "domainhint@example.com")
 
 	require.NoError(t, result.Error)
@@ -147,7 +151,8 @@ func TestCheckAccount_UnknownResult(t *testing.T) {
 	srv := newMockServer(t)
 	t.Cleanup(srv.Close)
 
-	c := NewChecker(srv.URL, 5*time.Second)
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
 	result := c.CheckAccount(context.Background(), "unknown@example.com")
 
 	require.NoError(t, result.Error)
@@ -160,7 +165,8 @@ func TestCheckAccount_Throttled(t *testing.T) {
 	srv := newMockServer(t)
 	t.Cleanup(srv.Close)
 
-	c := NewChecker(srv.URL, 5*time.Second)
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
 	result := c.CheckAccount(context.Background(), "throttled@example.com")
 
 	require.Error(t, result.Error)
@@ -173,7 +179,8 @@ func TestCheckAccount_Federated(t *testing.T) {
 	srv := newMockServer(t)
 	t.Cleanup(srv.Close)
 
-	c := NewChecker(srv.URL, 5*time.Second)
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
 	result := c.CheckAccount(context.Background(), "federated@example.com")
 
 	require.NoError(t, result.Error)
@@ -189,7 +196,8 @@ func TestCheckAccount_ServerError(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	c := NewChecker(srv.URL, 5*time.Second)
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
 	result := c.CheckAccount(context.Background(), "test@example.com")
 
 	require.Error(t, result.Error)
@@ -204,7 +212,8 @@ func TestCheckAccount_BadJSON(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	c := NewChecker(srv.URL, 5*time.Second)
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
 	result := c.CheckAccount(context.Background(), "test@example.com")
 
 	require.Error(t, result.Error)
@@ -219,7 +228,8 @@ func TestCheckAccount_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	c := NewChecker(srv.URL, 5*time.Second)
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
 	result := c.CheckAccount(ctx, "exists@example.com")
 
 	require.Error(t, result.Error)
@@ -228,8 +238,16 @@ func TestCheckAccount_ContextCancelled(t *testing.T) {
 
 func TestNewChecker_DefaultBaseURL(t *testing.T) {
 	t.Parallel()
-	c := NewChecker("", 5*time.Second)
+	c, err := NewChecker("", "", 5*time.Second)
+	require.NoError(t, err)
 	assert.Equal(t, DefaultBaseURL, c.baseURL)
+}
+
+func TestNewChecker_WithProxyURL(t *testing.T) {
+	t.Parallel()
+	c, err := NewChecker("", "http://user:pass@127.0.0.1:1/", 5*time.Second)
+	require.NoError(t, err)
+	assert.NotNil(t, c)
 }
 
 // ---------------------------------------------------------------------------
@@ -252,7 +270,8 @@ func TestCheckAccount_UsesHTTPClientFromContext(t *testing.T) {
 	}))
 	t.Cleanup(failing.Close)
 
-	c := NewChecker(failing.URL, 5*time.Second)
+	c, err := NewChecker(failing.URL, "", 5*time.Second)
+	require.NoError(t, err)
 
 	body, err := json.Marshal(credTypeResponse{IfExistsResult: IfExistsResultExists})
 	require.NoError(t, err)
@@ -279,7 +298,8 @@ func TestCheckAccount_FallsBackToOwnClientWithoutContextClient(t *testing.T) {
 	srv := newMockServer(t)
 	t.Cleanup(srv.Close)
 
-	c := NewChecker(srv.URL, 5*time.Second)
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
 
 	// No enum.WithHTTPClient on this context — CheckAccount must fall back
 	// to the Checker's own client and still reach srv successfully.


### PR DESCRIPTION
## What
`microsoft365.NewChecker` now accepts a `proxyURL` and returns an error, mirroring `google.NewEnumerator` / the GitHub enumerator.

## Why
The M365 checker built a direct HTTP client with no proxy option, so account enumeration egressed from the caller's single IP — a rate-limit and attribution risk against `login.microsoftonline.com` at scale. Consumers (e.g. Guard's OSINT collection) need to route M365 existence checks through a rotating proxy like the GitHub/Google oracles already do.

## Changes
- `NewChecker(baseURL string, timeout time.Duration) *Checker` → `NewChecker(baseURL, proxyURL string, timeout time.Duration) (*Checker, error)`. Non-empty `proxyURL` builds the client via `enum.NewEnumHTTPClientWithProxy`; empty keeps the direct `enum.NewEnumHTTPClient`. Proxy-config errors are wrapped and returned.
- Updated the in-repo `internal/enumplugins/microsoft365` caller (passes `""`; that path proxies via `HTTPClientFromContext` inside `CheckAccount`).
- Updated the 13 `microsoft365_test.go` call-sites to the new signature + added a test that a proxy URL parses.

Note: single-account `CheckAccount` is unchanged (no batch method added — out of scope); callers own their own concurrency.

## Tests
`go test ./pkg/enum/microsoft365/...` → 14 pass; `go vet`/`gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)