### PR TITLE
feat(enum/microsoft365): add batch Enumerate/EnumerateWith to Checker

### DIFF
--- a/pkg/enum/microsoft365/microsoft365.go
+++ b/pkg/enum/microsoft365/microsoft365.go
@@ -23,8 +23,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"net/http"
+	"os"
+	"runtime/debug"
+	"sync"
 	"time"
+
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/time/rate"
 
 	"github.com/praetorian-inc/brutus/pkg/enum"
 )
@@ -90,6 +97,105 @@ func NewChecker(baseURL, proxyURL string, timeout time.Duration) (*Checker, erro
 		timeout: timeout,
 		client:  client,
 	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Enumeration
+// ---------------------------------------------------------------------------
+
+// Enumerate looks up each email using a bounded worker pool, applying rate
+// limiting and jitter when rateLimit > 0. Results preserve input order. It is a
+// thin wrapper around EnumerateWith with no per-result callback.
+func (c *Checker) Enumerate(ctx context.Context, emails []string, threads int, rateLimit float64, jitter time.Duration) []Result {
+	return c.EnumerateWith(ctx, emails, threads, rateLimit, jitter, nil)
+}
+
+// EnumerateWith runs enumeration with bounded concurrency and invokes onResult
+// (if non-nil) for each completed result, serialized so callers can print/stream
+// safely. It still returns all results in input order.
+//
+// onResult is called under the same mutex that guards the results slice, so
+// callback invocations never interleave and never race the slice. The callback
+// must therefore be cheap and self-contained: it may write to an io.Writer or
+// update counters, but it must NOT call back into the Checker (doing so risks
+// deadlock and defeats the serialization guarantee).
+func (c *Checker) EnumerateWith(ctx context.Context, emails []string, threads int, rateLimit float64, jitter time.Duration, onResult func(Result)) []Result {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(threads)
+
+	var limiter *rate.Limiter
+	if rateLimit > 0 {
+		limiter = rate.NewLimiter(rate.Limit(rateLimit), 1)
+	}
+
+	results := make([]Result, len(emails))
+	var mu sync.Mutex
+
+	// record stores a completed result and, under the same lock, invokes the
+	// caller's callback so streamed output is serialized and slice-safe.
+	record := func(i int, res Result) {
+		mu.Lock()
+		defer mu.Unlock()
+		results[i] = res
+		if onResult != nil {
+			onResult(res)
+		}
+	}
+
+	for i, email := range emails {
+		i, email := i, email
+		g.Go(func() error {
+			defer func() {
+				if r := recover(); r != nil {
+					fmt.Fprintf(os.Stderr, "microsoft365 enum: panic checking %s: %v\n%s\n", email, r, debug.Stack())
+					record(i, Result{
+						Email: email,
+						Error: fmt.Errorf("microsoft365 enum: panicked: %v", r),
+					})
+				}
+			}()
+
+			select {
+			case <-ctx.Done():
+				return nil
+			default:
+			}
+
+			if limiter != nil {
+				if err := limiter.Wait(ctx); err != nil {
+					return nil
+				}
+				if jitter > 0 {
+					delay := time.Duration(rand.Int63n(int64(jitter)))
+					select {
+					case <-time.After(delay):
+					case <-ctx.Done():
+						return nil
+					}
+				}
+			}
+
+			r := c.CheckAccount(ctx, email)
+			if r == nil {
+				record(i, Result{
+					Email: email,
+					Error: fmt.Errorf("microsoft365 enum: nil result for %s", email),
+				})
+				return nil
+			}
+			record(i, *r)
+			return nil
+		})
+	}
+
+	// Discarding g.Wait()'s error is deliberate: worker goroutines never return
+	// a non-nil error (per-email failures are encoded in each Result), so the
+	// returned error is always nil.
+	_ = g.Wait()
+	return results
 }
 
 // CheckAccount tests if an email account exists on Microsoft 365 via the

--- a/pkg/enum/microsoft365/microsoft365_test.go
+++ b/pkg/enum/microsoft365/microsoft365_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -307,4 +308,115 @@ func TestCheckAccount_FallsBackToOwnClientWithoutContextClient(t *testing.T) {
 
 	require.NoError(t, result.Error)
 	assert.True(t, result.Exists)
+}
+
+// ---------------------------------------------------------------------------
+// TestEnumerateWith_Callback
+// 6 emails, threads=4, onResult callback appends under a mutex.
+// After the run:
+//   - callback invoked exactly once per email
+//   - returned slice len == 6
+//   - set of emails from callback matches input set
+//   - results are in input order
+//
+// Run the package under -race (go test -race ./pkg/enum/microsoft365/) to
+// verify the callback serialization guarantee.
+// ---------------------------------------------------------------------------
+
+func TestEnumerateWith_Callback(t *testing.T) {
+	t.Parallel()
+
+	srv := newMockServer(t)
+	t.Cleanup(srv.Close)
+
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
+
+	emails := []string{
+		"exists@example.com",
+		"notexists@example.com",
+		"difftenant@example.com",
+		"domainhint@example.com",
+		"federated@example.com",
+		"unknown@example.com",
+	}
+
+	var mu sync.Mutex
+	var callbackResults []Result
+
+	results := c.EnumerateWith(
+		context.Background(),
+		emails,
+		4, // threads
+		0, // rateLimit (no throttle)
+		0, // jitter
+		func(r Result) {
+			mu.Lock()
+			callbackResults = append(callbackResults, r)
+			mu.Unlock()
+		},
+	)
+
+	// Returned slice must have exactly one entry per input email.
+	require.Len(t, results, len(emails),
+		"EnumerateWith must return one Result per email")
+
+	// Callback must be invoked exactly once per email.
+	assert.Len(t, callbackResults, len(emails),
+		"onResult callback must be invoked exactly once per email")
+
+	// The set of emails seen by the callback must equal the input set.
+	cbEmails := make(map[string]struct{}, len(callbackResults))
+	for _, r := range callbackResults {
+		cbEmails[r.Email] = struct{}{}
+	}
+	for _, email := range emails {
+		assert.Contains(t, cbEmails, email,
+			"onResult callback must have been called for email %q", email)
+	}
+
+	// Returned results must preserve input order.
+	for i, r := range results {
+		assert.Equal(t, emails[i], r.Email,
+			"results[%d] must correspond to emails[%d]", i, i)
+	}
+
+	// Spot-check known-exists emails.
+	byEmail := make(map[string]Result, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	for _, email := range []string{"exists@example.com", "difftenant@example.com", "domainhint@example.com", "federated@example.com"} {
+		r := byEmail[email]
+		assert.NoError(t, r.Error, "email %q must not have an error", email)
+		assert.True(t, r.Exists, "email %q must be Exists=true", email)
+	}
+
+	for _, email := range []string{"notexists@example.com", "unknown@example.com"} {
+		r := byEmail[email]
+		assert.NoError(t, r.Error, "email %q must not have an error", email)
+		assert.False(t, r.Exists, "email %q must be Exists=false", email)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestEnumerateWith_NilCallback
+// Passing nil as the callback must not panic and must return one result per
+// email.
+// ---------------------------------------------------------------------------
+
+func TestEnumerateWith_NilCallback(t *testing.T) {
+	t.Parallel()
+
+	srv := newMockServer(t)
+	t.Cleanup(srv.Close)
+
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
+
+	emails := []string{"exists@example.com", "notexists@example.com", "unknown@example.com"}
+
+	results := c.EnumerateWith(context.Background(), emails, 2, 0, 0, nil)
+	require.Len(t, results, len(emails), "nil callback must not panic; must return one result per email")
 }


### PR DESCRIPTION
## What
Give the Microsoft 365 `Checker` the same batch interface the Google/GitHub enumerators already have: `Enumerate` / `EnumerateWith`.

## Why
M365 only offered single-account `CheckAccount`, so callers (e.g. Guard's OSINT collection) had to hand-roll their own worker pool to enumerate thousands of candidates. Google/GitHub expose a batched `EnumerateWith` with built-in concurrency; this brings M365 to the same uniform interface so consumers can treat all three oracles identically.

## Changes
- `(*Checker) EnumerateWith(ctx, emails []string, threads int, rateLimit float64, jitter time.Duration, onResult func(Result)) []Result` and `(*Checker) Enumerate(...)` — a line-for-line mirror of `google.EnumerateWith`: `errgroup` with `SetLimit(threads)`, optional `rate.Limiter` + jitter, results returned in input order, `onResult` serialized under the results mutex, per-worker panic recovery. The per-email op is the existing `CheckAccount` (guards a nil `*Result`).
- `CheckAccount`, `NewChecker`, and `Result` are unchanged.

## Tests
`TestEnumerateWith_Callback` (once-per-email callback, input-order preservation, per-category Exists/Error spot-checks) and `TestEnumerateWith_NilCallback`. `go test -race ./pkg/enum/microsoft365/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)