### PR TITLE
feat(enum/oracles): default --domain to the --known-valid email's domain

### DIFF
--- a/cmd/brutus/cmd_enum_oracles.go
+++ b/cmd/brutus/cmd_enum_oracles.go
@@ -181,9 +181,7 @@ func runEnumOracles(cmd *cobra.Command, args []string) error {
 	// known-valid address (e.g. `--known-valid admin@example.com` is enough to
 	// drive DNS recon and email generation for example.com). An explicit
 	// --domain still wins.
-	if flagEnumDomain == "" {
-		flagEnumDomain = emailDomain(flagOraclesKnownValid)
-	}
+	flagEnumDomain = resolveOraclesDomain(flagEnumDomain, flagOraclesKnownValid)
 
 	if flagEnumDomain == "" && flagOraclesEmails == "" && flagOraclesEmailFile == "" {
 		return fmt.Errorf("--domain, --emails/-e, or --email-file/-E is required (or pass a --known-valid address with a domain)")
@@ -703,4 +701,16 @@ func emailDomain(email string) string {
 		return ""
 	}
 	return email[at+1:]
+}
+
+// resolveOraclesDomain returns the effective org domain for the oracles command.
+// An explicit --domain always wins; otherwise it falls back to the domain of the
+// required --known-valid email (see emailDomain). Returns "" when neither yields
+// a domain. Kept as a pure function so the precedence (explicit over derived) is
+// unit-testable without running runEnumOracles' network path.
+func resolveOraclesDomain(domain, knownValid string) string {
+	if domain != "" {
+		return domain
+	}
+	return emailDomain(knownValid)
 }

--- a/cmd/brutus/cmd_enum_oracles.go
+++ b/cmd/brutus/cmd_enum_oracles.go
@@ -45,7 +45,8 @@ var enumOraclesCmd = &cobra.Command{
 	Long: `Identify which unauthenticated account-existence oracles (e.g. microsoft365,
 google) — plus the Microsoft Teams oracle — work for an organization, validate
 them against a known-valid user, then enumerate candidate emails against the
-working oracles.
+working oracles. The org domain defaults to the --known-valid email's domain, so
+an explicit --domain is only needed to target a different domain.
 
 DNS TXT recon surfaces the candidate oracles for the org; the validation step
 (against --known-valid) is the headline: it reports, per oracle, whether the
@@ -54,11 +55,12 @@ against the oracles that confirm it (including the Microsoft Teams oracle when
 applicable).
 
 Modes:
-  Oracle check only:  brutus enum active oracles --domain example.com --known-valid admin@example.com
-  Enumerate emails:   brutus enum active oracles --domain example.com -e user@example.com --known-valid admin@example.com
-  Generate + enum:    brutus enum active oracles --domain example.com --generate --format flast --known-valid admin@example.com`,
-	Example: `  # Discover candidate oracles via DNS and report which ones work (validated against --known-valid)
-  brutus enum active oracles --domain praetorian.com --known-valid admin@praetorian.com
+  Oracle check only:  brutus enum active oracles --known-valid admin@example.com
+  Enumerate emails:   brutus enum active oracles -e user@example.com --known-valid admin@example.com
+  Generate + enum:    brutus enum active oracles --generate --format flast --known-valid admin@example.com`,
+	Example: `  # Discover candidate oracles via DNS and report which ones work
+  # (domain defaults to the --known-valid email's domain)
+  brutus enum active oracles --known-valid admin@praetorian.com
 
   # Enumerate specific emails against the working oracles
   brutus enum active oracles --domain praetorian.com -e test@praetorian.com,admin@praetorian.com --known-valid admin@praetorian.com
@@ -102,7 +104,7 @@ func init() {
 // registerOraclesFlags registers flags for the oracles subcommand.
 func registerOraclesFlags(cmd *cobra.Command) {
 	f := cmd.Flags()
-	f.StringVarP(&flagEnumDomain, "domain", "d", "", "Domain to enumerate (used for DNS recon and email generation)")
+	f.StringVarP(&flagEnumDomain, "domain", "d", "", "Domain to enumerate for DNS recon and email generation (defaults to the --known-valid email's domain)")
 	f.StringVarP(&flagOraclesEmails, "emails", "e", "", "Comma-separated emails to enumerate")
 	f.StringVarP(&flagOraclesEmailFile, "email-file", "E", "", "File of emails to enumerate (one per line, use - for stdin)")
 	f.StringVarP(&flagOraclesServices, "services", "s", "", "Comma-separated oracles to check (default: all discovered/registered)")
@@ -174,8 +176,17 @@ func addDomainIndependentOracles(services []string, registeredSet map[string]boo
 func runEnumOracles(cmd *cobra.Command, args []string) error {
 	useColor := isColorEnabled(flagNoColor)
 
+	// --domain defaults to the domain of the required --known-valid email, so
+	// callers don't have to repeat a domain they already supplied in the
+	// known-valid address (e.g. `--known-valid admin@example.com` is enough to
+	// drive DNS recon and email generation for example.com). An explicit
+	// --domain still wins.
+	if flagEnumDomain == "" {
+		flagEnumDomain = emailDomain(flagOraclesKnownValid)
+	}
+
 	if flagEnumDomain == "" && flagOraclesEmails == "" && flagOraclesEmailFile == "" {
-		return fmt.Errorf("--domain, --emails/-e, or --email-file/-E is required")
+		return fmt.Errorf("--domain, --emails/-e, or --email-file/-E is required (or pass a --known-valid address with a domain)")
 	}
 
 	// Setup output writer
@@ -680,4 +691,16 @@ func oracleCheckLabel(emails []string) string {
 		return strings.Join(emails, ", ")
 	}
 	return "(no targets)"
+}
+
+// emailDomain returns the domain portion of an email address: the substring
+// after the last "@". It returns "" when the value has no usable domain part
+// (no "@", or "@" is the final character). Used so --domain can default to the
+// domain of the required --known-valid email.
+func emailDomain(email string) string {
+	at := strings.LastIndex(email, "@")
+	if at < 0 || at == len(email)-1 {
+		return ""
+	}
+	return email[at+1:]
 }

--- a/cmd/brutus/cmd_enum_oracles_test.go
+++ b/cmd/brutus/cmd_enum_oracles_test.go
@@ -182,3 +182,35 @@ func TestAddDomainIndependentOracles(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// TestEmailDomain
+// ---------------------------------------------------------------------------
+
+// TestEmailDomain covers the helper that extracts the domain portion of an
+// email address (the substring after the last "@"), used so --domain can
+// default to the domain of the required --known-valid email. It confirms the
+// normal case, subdomains, the last-"@"-wins rule, and the empty-domain cases
+// (no "@", trailing "@", empty string) all resolve as documented.
+func TestEmailDomain(t *testing.T) {
+	tests := []struct {
+		name  string
+		email string
+		want  string
+	}{
+		{name: "normal address", email: "admin@example.com", want: "example.com"},
+		{name: "subdomain address", email: "a@mail.corp.example.com", want: "mail.corp.example.com"},
+		{name: "multiple @ uses the last one", email: `"a@b"@example.com`, want: "example.com"},
+		{name: "no @ returns empty", email: "notanemail", want: ""},
+		{name: "trailing @ returns empty", email: "user@", want: ""},
+		{name: "empty string returns empty", email: "", want: ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := emailDomain(tc.email)
+			assert.Equal(t, tc.want, got,
+				"emailDomain(%q) = %q; want %q", tc.email, got, tc.want)
+		})
+	}
+}

--- a/cmd/brutus/cmd_enum_oracles_test.go
+++ b/cmd/brutus/cmd_enum_oracles_test.go
@@ -214,3 +214,62 @@ func TestEmailDomain(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// TestResolveOraclesDomain
+// ---------------------------------------------------------------------------
+
+// TestResolveOraclesDomain covers the helper that decides the effective org
+// domain for the oracles command. It confirms the precedence the fix relies on:
+// an explicit --domain always wins, and when it is absent the domain is derived
+// from the required --known-valid email — so `--known-valid admin@example.com`
+// alone yields a domain and satisfies the required-one-of gate. When neither
+// yields a domain, it returns "".
+func TestResolveOraclesDomain(t *testing.T) {
+	tests := []struct {
+		name       string
+		domain     string
+		knownValid string
+		want       string
+	}{
+		{
+			name:       "explicit domain wins over known-valid",
+			domain:     "explicit.com",
+			knownValid: "admin@derived.com",
+			want:       "explicit.com",
+		},
+		{
+			name:       "explicit domain wins even when known-valid has no domain",
+			domain:     "explicit.com",
+			knownValid: "notanemail",
+			want:       "explicit.com",
+		},
+		{
+			name:       "no domain derives from known-valid",
+			domain:     "",
+			knownValid: "admin@derived.com",
+			want:       "derived.com",
+		},
+		{
+			name:       "no domain and known-valid without @ yields empty",
+			domain:     "",
+			knownValid: "notanemail",
+			want:       "",
+		},
+		{
+			name:       "both empty yields empty",
+			domain:     "",
+			knownValid: "",
+			want:       "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveOraclesDomain(tc.domain, tc.knownValid)
+			assert.Equal(t, tc.want, got,
+				"resolveOraclesDomain(%q, %q) = %q; want %q",
+				tc.domain, tc.knownValid, got, tc.want)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`brutus enum active oracles` required one of `--domain`, `--emails/-e`, or `--email-file/-E` — even though `--known-valid` is always a required flag and always carries a domain. So the natural invocation errored:

```
$ brutus enum active oracles --known-valid admin@example.com
[-] Error: --domain, --emails/-e, or --email-file/-E is required
```

This PR makes `--domain` **default to the domain of the `--known-valid` email** when it isn't given explicitly (an explicit `--domain` still wins). The known-valid address alone now drives DNS recon and email generation, matching what users already expect from passing the domain twice.

## Changes

- **`cmd/brutus/cmd_enum_oracles.go`**
  - New `emailDomain(email)` helper — substring after the last `@`, `""` when there's no usable domain part.
  - `runEnumOracles` derives `flagEnumDomain` from `--known-valid` before the required-one-of gate.
  - Updated the `--domain` flag help and the command `Long`/`Example` docs to reflect that `--domain` is optional; refreshed the error message.
- **`cmd/brutus/cmd_enum_oracles_test.go`**
  - Added `TestEmailDomain` (normal, subdomain, last-`@`-wins, no `@`, trailing `@`, empty).

Scope kept tight: the `discover` subcommand and the `--generate requires --domain` safety net are untouched.

## Testing

- `go build ./...` — OK
- `go test ./cmd/brutus/` (`TestEmailDomain`, `TestEnumOracles*`, `TestAddDomainIndependentOracles`) — pass; `gofmt` clean.
- Verified against the real binary: `enum active oracles --known-valid admin@example.com` now proceeds into DNS recon + oracle check instead of erroring; omitting `--known-valid` entirely still fails with cobra's required-flag error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)