### PR TITLE
fix(enum): record results on early return + clamp threads<=0 in batch EnumerateWith

### DIFF
--- a/pkg/enum/google/google.go
+++ b/pkg/enum/google/google.go
@@ -128,6 +128,12 @@ func (e *Enumerator) EnumerateWith(ctx context.Context, emails []string, threads
 	defer cancel()
 
 	g, ctx := errgroup.WithContext(ctx)
+	// Normalize thread count: 0 would deadlock errgroup.SetLimit (no goroutine
+	// can ever run) and a negative value means unbounded. Clamp to a safe
+	// positive default of 1 (serial execution).
+	if threads <= 0 {
+		threads = 1
+	}
 	g.SetLimit(threads)
 
 	var limiter *rate.Limiter
@@ -164,12 +170,16 @@ func (e *Enumerator) EnumerateWith(ctx context.Context, emails []string, threads
 
 			select {
 			case <-ctx.Done():
+				// Record before returning so every index is filled and the callback fires exactly once per email.
+				record(i, Result{Email: email, Error: ctx.Err()})
 				return nil
 			default:
 			}
 
 			if limiter != nil {
 				if err := limiter.Wait(ctx); err != nil {
+					// Record before returning so every index is filled and the callback fires exactly once per email.
+					record(i, Result{Email: email, Error: err})
 					return nil
 				}
 				if jitter > 0 {
@@ -177,6 +187,8 @@ func (e *Enumerator) EnumerateWith(ctx context.Context, emails []string, threads
 					select {
 					case <-time.After(delay):
 					case <-ctx.Done():
+						// Record before returning so every index is filled and the callback fires exactly once per email.
+						record(i, Result{Email: email, Error: ctx.Err()})
 						return nil
 					}
 				}

--- a/pkg/enum/google/google_test.go
+++ b/pkg/enum/google/google_test.go
@@ -19,6 +19,7 @@ package google
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -296,6 +297,100 @@ func TestEnumerateWith_NilCallback(t *testing.T) {
 
 	results := e.EnumerateWith(context.Background(), emails, 2, 0, 0, nil)
 	require.Len(t, results, len(emails), "nil callback must not panic; must return one result per email")
+}
+
+// ---------------------------------------------------------------------------
+// TestEnumerateWith_CanceledContextRecordsAllSlots
+// Regression guard: with an already-canceled context, every worker hits the
+// <-ctx.Done() guard before any HTTP call. Each guard must still call
+// record(i, ...) before returning, so every index is filled (Email set, input
+// order preserved) and the callback fires exactly once per email. Reverting
+// that record() call leaves the dropped slots as zero-value Result{} (empty
+// Email, nil Error) and skips the callback for those emails.
+// ---------------------------------------------------------------------------
+
+func TestEnumerateWith_CanceledContextRecordsAllSlots(t *testing.T) {
+	t.Parallel()
+
+	srv := newMockServer(t)
+	t.Cleanup(srv.Close)
+
+	e := newTestEnumerator(t, srv)
+
+	emails := []string{"saml@example.com", "gmail@example.com", "unknown@example.com"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var mu sync.Mutex
+	var cbResults []Result
+
+	results := e.EnumerateWith(ctx, emails, 4, 0, 0, func(r Result) {
+		mu.Lock()
+		cbResults = append(cbResults, r)
+		mu.Unlock()
+	})
+
+	require.Len(t, results, len(emails), "every slot must be filled even when ctx is already canceled")
+
+	for i := range emails {
+		assert.Equal(t, emails[i], results[i].Email,
+			"results[%d].Email must be set (input order preserved), not left as a dropped zero-value", i)
+		assert.Error(t, results[i].Error, "results[%d] must carry the ctx.Done() error, not be silently dropped", i)
+		assert.True(t, errors.Is(results[i].Error, context.Canceled),
+			"results[%d].Error must be context.Canceled from the <-ctx.Done() guard", i)
+	}
+
+	assert.Len(t, cbResults, len(emails), "onResult callback must fire exactly once per email, even on the canceled-context path")
+}
+
+// ---------------------------------------------------------------------------
+// TestEnumerateWith_ZeroOrNegativeThreadsDoesNotHang
+// Regression guard: threads<=0 must be normalized to 1 before g.SetLimit.
+// SetLimit(0) would permit zero concurrent goroutines, so no worker could ever
+// run and EnumerateWith would hang forever. Guarded by a timeout rather than
+// relying solely on `go test -timeout`, so failure is immediate and specific.
+// ---------------------------------------------------------------------------
+
+func TestEnumerateWith_ZeroOrNegativeThreadsDoesNotHang(t *testing.T) {
+	tests := []struct {
+		name    string
+		threads int
+	}{
+		{"zero", 0},
+		{"negative", -1},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := newMockServer(t)
+			t.Cleanup(srv.Close)
+
+			e := newTestEnumerator(t, srv)
+
+			emails := []string{"saml@example.com", "gmail@example.com"}
+
+			done := make(chan []Result, 1)
+			go func() {
+				done <- e.EnumerateWith(context.Background(), emails, tc.threads, 0, 0, nil)
+			}()
+
+			select {
+			case results := <-done:
+				require.Len(t, results, len(emails), "threads=%d must still return one result per email", tc.threads)
+				for i := range emails {
+					assert.Equal(t, emails[i], results[i].Email,
+						"results[%d] must preserve input order under normalized serial execution", i)
+					assert.NoError(t, results[i].Error, "results[%d] must succeed against the mock server", i)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatalf("EnumerateWith hung with threads=%d", tc.threads)
+			}
+		})
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/enum/microsoft365/microsoft365.go
+++ b/pkg/enum/microsoft365/microsoft365.go
@@ -124,6 +124,12 @@ func (c *Checker) EnumerateWith(ctx context.Context, emails []string, threads in
 	defer cancel()
 
 	g, ctx := errgroup.WithContext(ctx)
+	// Normalize thread count: 0 would deadlock errgroup.SetLimit (no goroutine
+	// can ever run) and a negative value means unbounded. Clamp to a safe
+	// positive default of 1 (serial execution).
+	if threads <= 0 {
+		threads = 1
+	}
 	g.SetLimit(threads)
 
 	var limiter *rate.Limiter
@@ -160,12 +166,16 @@ func (c *Checker) EnumerateWith(ctx context.Context, emails []string, threads in
 
 			select {
 			case <-ctx.Done():
+				// Record before returning so every index is filled and the callback fires exactly once per email.
+				record(i, Result{Email: email, Error: ctx.Err()})
 				return nil
 			default:
 			}
 
 			if limiter != nil {
 				if err := limiter.Wait(ctx); err != nil {
+					// Record before returning so every index is filled and the callback fires exactly once per email.
+					record(i, Result{Email: email, Error: err})
 					return nil
 				}
 				if jitter > 0 {
@@ -173,6 +183,8 @@ func (c *Checker) EnumerateWith(ctx context.Context, emails []string, threads in
 					select {
 					case <-time.After(delay):
 					case <-ctx.Done():
+						// Record before returning so every index is filled and the callback fires exactly once per email.
+						record(i, Result{Email: email, Error: ctx.Err()})
 						return nil
 					}
 				}

--- a/pkg/enum/microsoft365/microsoft365_test.go
+++ b/pkg/enum/microsoft365/microsoft365_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -419,4 +420,100 @@ func TestEnumerateWith_NilCallback(t *testing.T) {
 
 	results := c.EnumerateWith(context.Background(), emails, 2, 0, 0, nil)
 	require.Len(t, results, len(emails), "nil callback must not panic; must return one result per email")
+}
+
+// ---------------------------------------------------------------------------
+// TestEnumerateWith_CanceledContextRecordsAllSlots
+// Regression guard: with an already-canceled context, every worker hits the
+// <-ctx.Done() guard before the HTTP call. Each guard must still call
+// record(i, ...) before returning, so every index is filled (Email set, input
+// order preserved) and the callback fires exactly once per email. Reverting
+// that record() call leaves the dropped slots as zero-value Result{} (empty
+// Email, nil Error) and skips the callback for those emails.
+// ---------------------------------------------------------------------------
+
+func TestEnumerateWith_CanceledContextRecordsAllSlots(t *testing.T) {
+	t.Parallel()
+
+	srv := newMockServer(t)
+	t.Cleanup(srv.Close)
+
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
+
+	emails := []string{"exists@example.com", "notexists@example.com", "unknown@example.com"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var mu sync.Mutex
+	var cbResults []Result
+
+	results := c.EnumerateWith(ctx, emails, 4, 0, 0, func(r Result) {
+		mu.Lock()
+		cbResults = append(cbResults, r)
+		mu.Unlock()
+	})
+
+	require.Len(t, results, len(emails), "every slot must be filled even when ctx is already canceled")
+
+	for i := range emails {
+		assert.Equal(t, emails[i], results[i].Email,
+			"results[%d].Email must be set (input order preserved), not left as a dropped zero-value", i)
+		assert.Error(t, results[i].Error, "results[%d] must carry the ctx.Done() error, not be silently dropped", i)
+		assert.True(t, errors.Is(results[i].Error, context.Canceled),
+			"results[%d].Error must be context.Canceled from the <-ctx.Done() guard", i)
+	}
+
+	assert.Len(t, cbResults, len(emails), "onResult callback must fire exactly once per email, even on the canceled-context path")
+}
+
+// ---------------------------------------------------------------------------
+// TestEnumerateWith_ZeroOrNegativeThreadsDoesNotHang
+// Regression guard: threads<=0 must be normalized to 1 before g.SetLimit.
+// SetLimit(0) would permit zero concurrent goroutines, so no worker could ever
+// run and EnumerateWith would hang forever. Guarded by a timeout rather than
+// relying solely on `go test -timeout`, so failure is immediate and specific.
+// ---------------------------------------------------------------------------
+
+func TestEnumerateWith_ZeroOrNegativeThreadsDoesNotHang(t *testing.T) {
+	tests := []struct {
+		name    string
+		threads int
+	}{
+		{"zero", 0},
+		{"negative", -1},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := newMockServer(t)
+			t.Cleanup(srv.Close)
+
+			c, err := NewChecker(srv.URL, "", 5*time.Second)
+			require.NoError(t, err)
+
+			emails := []string{"exists@example.com", "notexists@example.com"}
+
+			done := make(chan []Result, 1)
+			go func() {
+				done <- c.EnumerateWith(context.Background(), emails, tc.threads, 0, 0, nil)
+			}()
+
+			select {
+			case results := <-done:
+				require.Len(t, results, len(emails), "threads=%d must still return one result per email", tc.threads)
+				for i := range emails {
+					assert.Equal(t, emails[i], results[i].Email,
+						"results[%d] must preserve input order under normalized serial execution", i)
+					assert.NoError(t, results[i].Error, "results[%d] must succeed against the mock server", i)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatalf("EnumerateWith hung with threads=%d", tc.threads)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Follow-up to #221. That PR added the batch `EnumerateWith` to the microsoft365 checker (mirroring google), and three independent reviewers flagged two latent robustness bugs that shipped with the merge. Both bugs exist identically in **microsoft365** and **google** (the two enumerators share the same worker-pool shape), so this fixes both.

### Bug 1 — `threads == 0` deadlock
`EnumerateWith` calls `g.SetLimit(threads)` on an `errgroup.Group`. `SetLimit(0)` means no goroutine can ever acquire a slot → permanent deadlock; a negative value means unbounded. A caller passing `0` (a natural "use a default" value) would hang forever.

**Fix:** clamp before `SetLimit`:
```go
if threads <= 0 {
    threads = 1
}
```

### Bug 2 — early-return paths silently dropped results
The per-email worker returned `nil` **without recording a result** on three early-exit paths: the `<-ctx.Done()` guard, the `limiter.Wait(ctx)` error path, and the jitter-cancel `<-ctx.Done()` path. Because results are written into a fixed-size slice by index with an ordered per-index callback, dropped indices left zero-value `Result{}` slots (empty `Email`) and skipped the callback for that email — violating the "one ordered result + one callback per input email" contract.

**Fix:** each early-return path now records `Result{Email: email, Error: ...}` before returning, so every index is filled and the callback fires exactly once.

## Tests
Race-enabled regression tests added to both packages:
- `TestEnumerateWith_CanceledContextRecordsAllSlots` — an already-canceled context still fills every slot in input order, each `Error` wraps `context.Canceled`, and the callback fires once per email.
- `TestEnumerateWith_ZeroOrNegativeThreadsDoesNotHang` — table-driven (`threads=0`, `threads=-1`), runs in a goroutine with a 5s hang guard, asserts full ordered error-free results.

Reverting Fix 2 regresses the first test (empty `Email` / missing callbacks); reverting Fix 1 hangs the second (caught by the timeout guard).

## Verification
- `gofmt -l` → clean
- `go vet ./pkg/enum/microsoft365/... ./pkg/enum/google/...` → clean
- `go build -race` + `go test -race` both packages → all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)