### PR TITLE
feat(enum): "Top errors:" breakdown in enum active summaries

### DIFF
--- a/cmd/brutus/cmd_enum_github_output.go
+++ b/cmd/brutus/cmd_enum_github_output.go
@@ -74,13 +74,16 @@ func outputGithubEnumUsernames(w io.Writer, results []githubenum.Result, useColo
 }
 
 // outputGithubEnumSummary prints the counts-by-status summary block: found /
-// revealed / not found / errors / total.
+// revealed / not found / errors / total, followed by a "Top errors" breakdown
+// when any result errored.
 func outputGithubEnumSummary(w io.Writer, results []githubenum.Result, useColor bool) {
 	var foundCount, revealedCount, notFoundCount, errorCount int
+	var errMsgs []string
 	for i := range results {
 		switch {
 		case results[i].Error != nil:
 			errorCount++
+			errMsgs = append(errMsgs, results[i].Error.Error())
 		case results[i].Exists:
 			foundCount++
 			if results[i].Username != "" {
@@ -105,6 +108,7 @@ func outputGithubEnumSummary(w io.Writer, results []githubenum.Result, useColor 
 		_, _ = fmt.Fprintf(w, "    %sErrors:%s     %d\n", colorIf(useColor, ColorRed), colorIf(useColor, ColorReset), errorCount)
 	}
 	_, _ = fmt.Fprintf(w, "    %sTotal:%s      %d\n", colorIf(useColor, ColorCyan), colorIf(useColor, ColorReset), len(results))
+	outputEnumErrorBreakdown(w, errMsgs, useColor)
 	_, _ = fmt.Fprintln(w)
 }
 

--- a/cmd/brutus/cmd_enum_output.go
+++ b/cmd/brutus/cmd_enum_output.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -634,6 +635,7 @@ func outputTeamsEnumResultLine(w io.Writer, r *teams.EnumResult, useColor bool) 
 // reported as before.
 func outputTeamsEnumSummary(w io.Writer, results []teams.EnumResult, useColor bool) {
 	var withDetailsCount, restrictedCount, notFoundCount, errorCount int
+	var errMsgs []string
 	for i := range results {
 		switch results[i].Exists {
 		case teams.ExistenceYes:
@@ -644,6 +646,9 @@ func outputTeamsEnumSummary(w io.Writer, results []teams.EnumResult, useColor bo
 			notFoundCount++
 		default:
 			errorCount++
+			if results[i].Error != nil {
+				errMsgs = append(errMsgs, results[i].Error.Error())
+			}
 		}
 	}
 	existsCount := withDetailsCount + restrictedCount
@@ -661,6 +666,7 @@ func outputTeamsEnumSummary(w io.Writer, results []teams.EnumResult, useColor bo
 		_, _ = fmt.Fprintf(w, "    %sErrors:%s     %d\n", colorIf(useColor, ColorRed), colorIf(useColor, ColorReset), errorCount)
 	}
 	_, _ = fmt.Fprintf(w, "    %sTotal:%s      %d\n", colorIf(useColor, ColorCyan), colorIf(useColor, ColorReset), len(results))
+	outputEnumErrorBreakdown(w, errMsgs, useColor)
 	_, _ = fmt.Fprintln(w)
 }
 
@@ -1004,14 +1010,79 @@ func outputGoogleEnumResultLine(w io.Writer, r google.Result, useColor bool) {
 		dim(useColor, note))
 }
 
+// enumErrorBreakdownTopN caps how many distinct error groups the "Top errors"
+// breakdown lists; any remainder collapses into a single "… and K more" line.
+const enumErrorBreakdownTopN = 5
+
+// enumErrorGroup is one distinct error message and the number of results that
+// failed with it, used to render an enum summary's "Top errors" breakdown.
+type enumErrorGroup struct {
+	msg   string
+	count int
+}
+
+// outputEnumErrorBreakdown renders the "Top errors" section of an enum summary:
+// a concise breakdown of the DISTINCT error messages in errMsgs with per-message
+// counts, so a bare "Errors: 100" becomes actionable (e.g. every request failing
+// the same proxy CONNECT collapses to one "100×" row). Messages are grouped by
+// their full string — deliberately NOT normalized, so distinct failure modes
+// (407 / 403 / TLS / context deadline exceeded) stay separate; every enum target
+// hits the same endpoint, so there is no volatile per-request URL to trim.
+// Groups are sorted by count (descending, then message ascending for stable ties),
+// at most enumErrorBreakdownTopN are shown, and the rest collapse into
+// "… and K more". Each message is sanitized (P0-4) before rendering. Prints
+// nothing when errMsgs is empty, so callers may invoke it unconditionally.
+func outputEnumErrorBreakdown(w io.Writer, errMsgs []string, useColor bool) {
+	if len(errMsgs) == 0 {
+		return
+	}
+
+	counts := make(map[string]int)
+	var order []string
+	for _, m := range errMsgs {
+		m = sanitizeTerminal(m)
+		if _, seen := counts[m]; !seen {
+			order = append(order, m)
+		}
+		counts[m]++
+	}
+
+	groups := make([]enumErrorGroup, 0, len(order))
+	for _, m := range order {
+		groups = append(groups, enumErrorGroup{msg: m, count: counts[m]})
+	}
+	sort.SliceStable(groups, func(i, j int) bool {
+		if groups[i].count != groups[j].count {
+			return groups[i].count > groups[j].count
+		}
+		return groups[i].msg < groups[j].msg
+	})
+
+	_, _ = fmt.Fprintf(w, "    %sTop errors:%s\n", colorIf(useColor, ColorRed), colorIf(useColor, ColorReset))
+	shown := groups
+	if len(shown) > enumErrorBreakdownTopN {
+		shown = shown[:enumErrorBreakdownTopN]
+	}
+	for _, g := range shown {
+		_, _ = fmt.Fprintf(w, "      %d×  %s\n", g.count, g.msg)
+	}
+	if remaining := len(groups) - len(shown); remaining > 0 {
+		_, _ = fmt.Fprintf(w, "      %s… and %d more%s\n",
+			colorIf(useColor, ColorDim), remaining, colorIf(useColor, ColorReset))
+	}
+}
+
 // outputGoogleEnumSummary prints the counts-by-status summary block for a set
-// of Google enumeration results: found / not found / errors / total.
+// of Google enumeration results: found / not found / errors / total, followed by
+// a "Top errors" breakdown when any result errored.
 func outputGoogleEnumSummary(w io.Writer, results []google.Result, useColor bool) {
 	var foundCount, notFoundCount, errorCount int
+	var errMsgs []string
 	for i := range results {
 		switch {
 		case results[i].Error != nil:
 			errorCount++
+			errMsgs = append(errMsgs, results[i].Error.Error())
 		case results[i].Exists:
 			foundCount++
 		default:
@@ -1030,6 +1101,7 @@ func outputGoogleEnumSummary(w io.Writer, results []google.Result, useColor bool
 		_, _ = fmt.Fprintf(w, "    %sErrors:%s     %d\n", colorIf(useColor, ColorRed), colorIf(useColor, ColorReset), errorCount)
 	}
 	_, _ = fmt.Fprintf(w, "    %sTotal:%s      %d\n", colorIf(useColor, ColorCyan), colorIf(useColor, ColorReset), len(results))
+	outputEnumErrorBreakdown(w, errMsgs, useColor)
 	_, _ = fmt.Fprintln(w)
 }
 
@@ -1139,13 +1211,17 @@ func outputMicrosoft365EnumResultLine(w io.Writer, r m365.Result, useColor bool)
 
 // outputMicrosoft365EnumSummary prints the counts-by-status summary block for a
 // set of Microsoft 365 enumeration results: found / federated / not found /
-// errors / total.
+// errors / total, followed by a "Top errors" breakdown when any result errored
+// (so a proxy/transport failure that errors every request is diagnosable from
+// the summary instead of showing only "Errors: N").
 func outputMicrosoft365EnumSummary(w io.Writer, results []m365.Result, useColor bool) {
 	var foundCount, federatedCount, notFoundCount, errorCount int
+	var errMsgs []string
 	for i := range results {
 		switch {
 		case results[i].Error != nil:
 			errorCount++
+			errMsgs = append(errMsgs, results[i].Error.Error())
 		case results[i].Exists:
 			foundCount++
 			if results[i].Federated {
@@ -1170,6 +1246,7 @@ func outputMicrosoft365EnumSummary(w io.Writer, results []m365.Result, useColor 
 		_, _ = fmt.Fprintf(w, "    %sErrors:%s     %d\n", colorIf(useColor, ColorRed), colorIf(useColor, ColorReset), errorCount)
 	}
 	_, _ = fmt.Fprintf(w, "    %sTotal:%s      %d\n", colorIf(useColor, ColorCyan), colorIf(useColor, ColorReset), len(results))
+	outputEnumErrorBreakdown(w, errMsgs, useColor)
 	_, _ = fmt.Fprintln(w)
 }
 

--- a/cmd/brutus/cmd_enum_output_error_breakdown_test.go
+++ b/cmd/brutus/cmd_enum_output_error_breakdown_test.go
@@ -1,0 +1,180 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	m365 "github.com/praetorian-inc/brutus/pkg/enum/microsoft365"
+)
+
+// ---------------------------------------------------------------------------
+// Test: outputEnumErrorBreakdown — empty input prints nothing
+// ---------------------------------------------------------------------------
+
+func TestOutputEnumErrorBreakdown_EmptyPrintsNothing(t *testing.T) {
+	t.Run("nil slice", func(t *testing.T) {
+		var buf bytes.Buffer
+		outputEnumErrorBreakdown(&buf, nil, false /* useColor */)
+		assert.Empty(t, buf.String(), "nil errMsgs must produce no output")
+	})
+
+	t.Run("empty slice", func(t *testing.T) {
+		var buf bytes.Buffer
+		outputEnumErrorBreakdown(&buf, []string{}, false /* useColor */)
+		assert.Empty(t, buf.String(), "empty errMsgs must produce no output")
+		assert.NotContains(t, buf.String(), "Top errors:")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Test: outputEnumErrorBreakdown — groups identical messages with correct counts
+// ---------------------------------------------------------------------------
+
+func TestOutputEnumErrorBreakdown_GroupingAndCounts(t *testing.T) {
+	errMsgs := []string{
+		"proxy: 407 Proxy Authentication Required",
+		"proxy: 407 Proxy Authentication Required",
+		"proxy: 407 Proxy Authentication Required",
+		"context deadline exceeded",
+		"context deadline exceeded",
+		"tls: handshake failure",
+	}
+
+	var buf bytes.Buffer
+	outputEnumErrorBreakdown(&buf, errMsgs, false /* useColor */)
+	out := buf.String()
+
+	assert.Contains(t, out, "Top errors:")
+	assert.Contains(t, out, "3×  proxy: 407 Proxy Authentication Required",
+		"the 407 message must be grouped and counted 3 times")
+	assert.Contains(t, out, "2×  context deadline exceeded",
+		"the deadline message must be grouped and counted 2 times")
+	assert.Contains(t, out, "1×  tls: handshake failure",
+		"the tls message must appear once")
+}
+
+// ---------------------------------------------------------------------------
+// Test: outputEnumErrorBreakdown — sort order (count desc, message asc tie-break)
+// ---------------------------------------------------------------------------
+
+func TestOutputEnumErrorBreakdown_SortOrder(t *testing.T) {
+	t.Run("higher count sorts before lower count", func(t *testing.T) {
+		errMsgs := []string{
+			"low count error",
+			"high count error", "high count error", "high count error",
+		}
+
+		var buf bytes.Buffer
+		outputEnumErrorBreakdown(&buf, errMsgs, false /* useColor */)
+		out := buf.String()
+
+		highIdx := strings.Index(out, "high count error")
+		lowIdx := strings.Index(out, "low count error")
+		assert.Greater(t, highIdx, -1, "high count message must appear")
+		assert.Greater(t, lowIdx, -1, "low count message must appear")
+		assert.Less(t, highIdx, lowIdx,
+			"higher-count group must appear before lower-count group")
+	})
+
+	t.Run("equal counts tie-break by message ascending", func(t *testing.T) {
+		errMsgs := []string{"zebra error", "alpha error"}
+
+		var buf bytes.Buffer
+		outputEnumErrorBreakdown(&buf, errMsgs, false /* useColor */)
+		out := buf.String()
+
+		alphaIdx := strings.Index(out, "alpha error")
+		zebraIdx := strings.Index(out, "zebra error")
+		assert.Greater(t, alphaIdx, -1, "alpha error must appear")
+		assert.Greater(t, zebraIdx, -1, "zebra error must appear")
+		assert.Less(t, alphaIdx, zebraIdx,
+			"equal-count groups must tie-break by message ascending")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Test: outputEnumErrorBreakdown — top-N cap and "… and K more" remainder
+// ---------------------------------------------------------------------------
+
+func TestOutputEnumErrorBreakdown_TopNCapAndRemainder(t *testing.T) {
+	// 8 distinct messages, each appearing once (equal counts -> alphabetic
+	// tie-break), so exactly the first 5 alphabetically are shown and the
+	// remaining 3 distinct messages collapse into "… and 3 more".
+	errMsgs := []string{
+		"error-a", "error-b", "error-c", "error-d",
+		"error-e", "error-f", "error-g", "error-h",
+	}
+
+	var buf bytes.Buffer
+	outputEnumErrorBreakdown(&buf, errMsgs, false /* useColor */)
+	out := buf.String()
+
+	rowCount := strings.Count(out, "1×  error-")
+	assert.Equal(t, enumErrorBreakdownTopN, rowCount,
+		"exactly enumErrorBreakdownTopN rows must be printed")
+
+	wantRemaining := len(errMsgs) - enumErrorBreakdownTopN // 8 distinct - 5 shown = 3
+	assert.Contains(t, out, fmt.Sprintf("… and %d more", wantRemaining),
+		"remainder line must report the number of distinct messages not shown")
+
+	// The alphabetically-last messages (f, g, h) must not have their own row.
+	assert.NotContains(t, out, "1×  error-f")
+	assert.NotContains(t, out, "1×  error-g")
+	assert.NotContains(t, out, "1×  error-h")
+}
+
+// ---------------------------------------------------------------------------
+// Test: outputEnumErrorBreakdown — single error, no remainder line
+// ---------------------------------------------------------------------------
+
+func TestOutputEnumErrorBreakdown_SingleError(t *testing.T) {
+	var buf bytes.Buffer
+	outputEnumErrorBreakdown(&buf, []string{"only error"}, false /* useColor */)
+	out := buf.String()
+
+	assert.Contains(t, out, "Top errors:")
+	assert.Contains(t, out, "1×  only error")
+	assert.NotContains(t, out, "more",
+		"a single distinct error must not print a remainder line")
+}
+
+// ---------------------------------------------------------------------------
+// Test: outputMicrosoft365EnumSummary — full summary renders the error
+// breakdown block for erroring results.
+// ---------------------------------------------------------------------------
+
+func TestOutputMicrosoft365EnumSummary_IncludesErrorBreakdown(t *testing.T) {
+	results := []m365.Result{
+		{Email: "a@contoso.com", Exists: false, Error: errors.New("proxy: 407 Proxy Authentication Required")},
+		{Email: "b@contoso.com", Exists: false, Error: errors.New("proxy: 407 Proxy Authentication Required")},
+		{Email: "c@contoso.com", Exists: false, Error: errors.New("context deadline exceeded")},
+	}
+
+	var buf bytes.Buffer
+	outputMicrosoft365EnumSummary(&buf, results, false /* useColor */)
+	out := buf.String()
+
+	assert.Contains(t, out, "Errors:")
+	assert.Contains(t, out, "Top errors:")
+	assert.Contains(t, out, "2×  proxy: 407 Proxy Authentication Required")
+	assert.Contains(t, out, "1×  context deadline exceeded")
+}


### PR DESCRIPTION
## Summary

Stacked on `feat/enum-active-microsoft365`. When an `enum active <oracle>` run fails (e.g. a proxy zone rejecting the CONNECT to the target endpoint), the human summary printed only a bare count:

```
  Summary
    Errors:     100
    Total:      100
```

The per-request `Result.Error` was captured by the checker but thrown away when rendering the summary — so a 100%-proxy-failure was indistinguishable from a healthy run that legitimately found nothing. (This directly cost hours diagnosing M365 through a Bright Data **datacenter** proxy zone: Microsoft's `GetCredentialType` blocks datacenter IPs, every request 407/errored, and the summary just said "Errors: 100".)

## Change (presentation-only)

- New shared helper `outputEnumErrorBreakdown(w, errMsgs, useColor)` in `cmd/brutus/cmd_enum_output.go`: groups by full error string, sorts by count desc (message asc tie-break), prints the top 5 as `N×  <message>` under a `Top errors:` heading, collapses the rest into `… and K more`, prints nothing when there are no errors.
- Wired into all four `enum active` summary renderers: `outputMicrosoft365EnumSummary`, `outputGoogleEnumSummary`, `outputTeamsEnumSummary`, `outputGithubEnumSummary`.
- Reads the already-populated `Result.Error`; no checker/transport/enumeration logic touched; `--json`/`--verbose` unchanged.

Example through a dead proxy:
```
  Summary
    Errors:     3
    Total:      3
    Top errors:
      3×  request failed: Post "https://login.microsoftonline.com/common/GetCredentialType": ... connection refused
```

## Tests

New `cmd/brutus/cmd_enum_output_error_breakdown_test.go`: empty→no-op, grouping/counts, sort order + tie-break, top-N cap + `… and K more`, single error, and an integration assertion that `outputMicrosoft365EnumSummary` emits the block. `go test ./cmd/brutus/...` green; existing `TestOutputTeamsEnumSummary` unaffected (its unknown result has a nil `Error`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)