### PR TITLE
feat(enum/gravatar): add Gravatar email-registration oracle

### DIFF
--- a/cmd/brutus/cmd_enum_active.go
+++ b/cmd/brutus/cmd_enum_active.go
@@ -34,6 +34,7 @@ Sources:
   kerberos     Enumerate Active Directory users via Kerberos AS-REQ
   teams        Authenticate with Microsoft Entra ID via device code flow
   github       Enumerate GitHub accounts by email (existence + username reveal)
+  gravatar     Enumerate accounts with a registered Gravatar (by email)
   custom       Enumerate against a user-supplied oracle definition`,
 	Example: `  # Account-existence oracle enumeration
   brutus enum active oracles --domain example.com --known-valid admin@example.com
@@ -52,6 +53,9 @@ Sources:
 
   # GitHub account enumeration by email
   brutus enum active github -e alice@example.com,bob@example.com
+
+  # Gravatar account enumeration by email
+  brutus enum active gravatar -e alice@example.com,bob@example.com
 
   # Enumerate against a custom oracle definition
   brutus enum active custom -f oracle.json -e jsmith,asmith`,

--- a/cmd/brutus/cmd_enum_gravatar.go
+++ b/cmd/brutus/cmd_enum_gravatar.go
@@ -1,0 +1,242 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"slices"
+	"strings"
+	"syscall"
+
+	"github.com/spf13/cobra"
+
+	"github.com/praetorian-inc/brutus/pkg/enum"
+	"github.com/praetorian-inc/brutus/pkg/enum/gravatar"
+)
+
+// File-local flag variables for the "enum gravatar" subcommand. A separate block
+// avoids cross-command flag-state bleed with the other enum subcommands.
+var (
+	flagGravatarEnumEmails    string
+	flagGravatarEnumEmailFile string
+	flagGravatarEnumDomain    string
+	flagGravatarEnumFormat    string
+	flagGravatarEnumLimit     int
+)
+
+var enumGravatarCmd = &cobra.Command{
+	Use:   "gravatar",
+	Short: "Enumerate accounts with a registered Gravatar (by email)",
+	Long: `Check whether email addresses have a registered Gravatar, using the public
+avatar endpoint as an account-existence oracle. Each email is normalized
+(lower-cased and trimmed) and MD5-hashed, then the avatar is requested with
+d=404 so a missing avatar returns 404 rather than a default image: HTTP 200
+means a Gravatar exists for that address, 404 means none is registered. Both
+outcomes are definitive.
+
+Provide targets directly with --emails/-e or --email-file/-E, or pass --domain
+to generate the candidate wordlist internally from a bundled, frequency-ranked
+list of statistically-likely first/last name combinations (the same generator
+as "enum generate") — no piping required. --format selects the username layout
+and --limit caps generation to the first N (most-likely) candidates. --domain
+may be combined with -e/-E.
+
+This enumeration is unauthenticated: no token, credential store, or sign-in is
+required.`,
+	Example: `  # Enumerate a couple of emails
+  brutus enum active gravatar -e alice@example.com,bob@example.com
+
+  # Generate candidate emails for a domain and enumerate the 5000 most likely
+  brutus enum active gravatar --domain target.com --format first.last --limit 5000
+
+  # Enumerate emails from a file
+  brutus enum active gravatar -E emails.txt
+
+  # Route through a SOCKS5 proxy and raise concurrency
+  brutus enum active gravatar -E emails.txt --proxy socks5://127.0.0.1:1080 --threads 20`,
+	RunE: runEnumGravatar,
+}
+
+func init() {
+	f := enumGravatarCmd.Flags()
+	f.StringVarP(&flagGravatarEnumEmails, "emails", "e", "", "Comma-separated email addresses to check")
+	f.StringVarP(&flagGravatarEnumEmailFile, "email-file", "E", "", "File of email addresses, one per line (\"-\" for stdin)")
+	f.StringVarP(&flagGravatarEnumDomain, "domain", "d", "", "Generate candidate emails for this domain (statistically-likely first/last combos)")
+	f.StringVar(&flagGravatarEnumFormat, "format", "first.last", "Username format for --domain generation (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first)")
+	f.IntVar(&flagGravatarEnumLimit, "limit", 0, "When generating with --domain, cap to the first N (most-likely) candidates (0 = all)")
+	// NOTE: no -t shorthand: it collides with the global persistent --threads/-t
+	// flag, which cobra merges into this subcommand at execute time.
+	//
+	// gravatar lives under "active". init() runs after all package-level command
+	// vars are initialized and AddCommand only needs the vars to exist, so it is
+	// safe to reference enumActiveCmd (defined in cmd_enum_active.go) here.
+	enumActiveCmd.AddCommand(enumGravatarCmd)
+}
+
+// runEnumGravatar implements the "enum gravatar" subcommand.
+func runEnumGravatar(cmd *cobra.Command, args []string) error {
+	useColor := isColorEnabled(flagNoColor)
+
+	jsonWriter, forceJSON, closeOutput, err := setupOutputWriter(flagOutputFile)
+	if err != nil {
+		return err
+	}
+	defer closeOutput()
+	if forceJSON {
+		flagJSON = true
+	}
+
+	emails, err := gravatarEnumTargets()
+	if err != nil {
+		return err
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	proxyURL, err := resolveProxyURL()
+	if err != nil {
+		return err
+	}
+
+	checker, err := gravatar.NewChecker("", proxyURL, flagTimeout)
+	if err != nil {
+		return fmt.Errorf("gravatar: %w", err)
+	}
+
+	if !flagQuiet && !flagJSON {
+		fmt.Fprintf(os.Stderr, "%s Enumerating %d email(s) against Gravatar...\n",
+			dim(useColor, SymbolInfo), len(emails))
+		_, _ = fmt.Fprintf(os.Stdout, "\n%s %s\n\n", dim(useColor, SymbolInfo), heading(useColor, "Gravatar Account Enumeration"))
+	}
+
+	// Stream each completed result live (the callback is invoked serialized under
+	// the checker's results mutex, so output never interleaves and never races
+	// the results slice). Human mode prints only EXISTS rows unless --verbose;
+	// JSON mode streams a JSONL line per result. A live progress bar goes to
+	// stderr (suppressed under --quiet/--json); on a TTY it redraws in place with
+	// percent/rate/elapsed/ETA, off-TTY it emits throttled newline lines.
+	total := len(emails)
+	progress := newProgressReporter(os.Stderr, total, !flagQuiet && !flagJSON, useColor)
+	progress.Start()
+	var processed, found int
+	onResult := func(res gravatar.Result) {
+		processed++
+		if res.Exists {
+			found++
+		}
+
+		if flagJSON {
+			outputGravatarEnumJSONL(jsonWriter, []gravatar.Result{res})
+		} else if res.Exists || flagVerbose {
+			// Clear the in-place bar before printing a result row so the bar's
+			// partial line doesn't corrupt it; the bar redraws on the next tick.
+			progress.Clear()
+			outputGravatarEnumResultLine(os.Stdout, res, useColor)
+		}
+
+		progress.Update(processed, fmt.Sprintf("%d found", found))
+	}
+
+	results := checker.EnumerateWith(ctx, emails, flagThreads, flagRateLimit, flagJitter, onResult)
+	progress.Stop()
+
+	if !flagJSON {
+		outputGravatarEnumSummary(os.Stdout, results, useColor)
+	}
+	return nil
+}
+
+// gravatarEnumTargets parses, trims, lower-cases, and dedups the email targets
+// from --emails and --email-file, plus any --domain-generated candidates. It
+// errors when no targets are supplied.
+func gravatarEnumTargets() ([]string, error) {
+	var raw []string
+	if flagGravatarEnumEmails != "" {
+		raw = append(raw, strings.Split(flagGravatarEnumEmails, ",")...)
+	}
+	if flagGravatarEnumEmailFile != "" {
+		lines, err := loadLinesFromFile(flagGravatarEnumEmailFile)
+		if err != nil {
+			return nil, fmt.Errorf("reading --email-file: %w", err)
+		}
+		raw = append(raw, lines...)
+	}
+
+	// --domain generates the candidate wordlist internally (reusing the same
+	// ranked first/last generator as "enum generate"), so no piping is needed.
+	// Generated candidates are appended to any -e/-E targets and flow through
+	// the same dedup + enumeration path.
+	if flagGravatarEnumDomain != "" {
+		generated, err := gravatarEnumGenerate()
+		if err != nil {
+			return nil, err
+		}
+		raw = append(raw, generated...)
+	}
+
+	seen := make(map[string]struct{})
+	var emails []string
+	for _, e := range raw {
+		e = strings.ToLower(strings.TrimSpace(e))
+		if e == "" {
+			continue
+		}
+		if _, ok := seen[e]; ok {
+			continue
+		}
+		seen[e] = struct{}{}
+		emails = append(emails, e)
+	}
+
+	if len(emails) == 0 {
+		return nil, fmt.Errorf("provide --emails/-e, --email-file/-E, or --domain")
+	}
+	return emails, nil
+}
+
+// gravatarEnumGenerate produces the candidate email wordlist for --domain by
+// reusing the shared, frequency-ranked generator (enum.GenerateEmails) and the
+// shared capResults helper — no duplicated generation logic. The requested
+// format is validated against enum.ListFormats() first, because GenerateEmails
+// silently yields an empty list for an unknown format. A status line goes to
+// stderr (never stdout, so --json/-o output stays clean) unless quiet or JSON.
+func gravatarEnumGenerate() ([]string, error) {
+	if !slices.Contains(enum.ListFormats(), flagGravatarEnumFormat) {
+		return nil, fmt.Errorf("invalid --format %q; valid formats: %s",
+			flagGravatarEnumFormat, strings.Join(enum.ListFormats(), ", "))
+	}
+
+	generated, err := enum.GenerateEmails(flagGravatarEnumFormat, flagGravatarEnumDomain)
+	if err != nil {
+		return nil, fmt.Errorf("generating candidate emails: %w", err)
+	}
+	generated = capResults(generated, flagGravatarEnumLimit)
+
+	if !flagQuiet && !flagJSON {
+		useColor := isColorEnabled(flagNoColor)
+		fmt.Fprintf(os.Stderr, "%s Generating %s candidates for %s (%d emails)...\n",
+			dim(useColor, SymbolInfo), flagGravatarEnumFormat, sanitizeTerminal(flagGravatarEnumDomain), len(generated))
+		if flagGravatarEnumLimit == 0 {
+			fmt.Fprintf(os.Stderr, "%s (no --limit; generating the full ~%d-candidate list — pass --limit to cap)\n",
+				dim(useColor, SymbolInfo), len(generated))
+		}
+	}
+
+	return generated, nil
+}

--- a/cmd/brutus/cmd_enum_gravatar_output.go
+++ b/cmd/brutus/cmd_enum_gravatar_output.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/praetorian-inc/brutus/pkg/enum/gravatar"
+)
+
+// ---------------------------------------------------------------------------
+// Gravatar account enumeration output functions
+// ---------------------------------------------------------------------------
+
+// outputGravatarEnumResultLine prints ONE Gravatar enumeration result row.
+// EXISTS rows show the email and an "[+] EXISTS" label; not-found rows render as
+// "[ ] not found". Callers decide which results to print (e.g. EXISTS only,
+// unless verbose); this helper renders whatever it is given.
+func outputGravatarEnumResultLine(w io.Writer, r gravatar.Result, useColor bool) {
+	email := truncate(sanitizeTerminal(r.Email), 40)
+
+	if !r.Exists {
+		_, _ = fmt.Fprintf(w, "  %-40s %s[ ] not found%s\n",
+			email, colorIf(useColor, ColorDim), colorIf(useColor, ColorReset))
+		return
+	}
+
+	_, _ = fmt.Fprintf(w, "  %-40s %s%s EXISTS%s\n",
+		email,
+		colorIf(useColor, ColorGreen), SymbolSuccess, colorIf(useColor, ColorReset))
+}
+
+// outputGravatarEnumSummary prints the counts-by-status summary block for a set
+// of Gravatar enumeration results: found / not found / errors / total.
+func outputGravatarEnumSummary(w io.Writer, results []gravatar.Result, useColor bool) {
+	var foundCount, notFoundCount, errorCount int
+	for i := range results {
+		switch {
+		case results[i].Error != nil:
+			errorCount++
+		case results[i].Exists:
+			foundCount++
+		default:
+			notFoundCount++
+		}
+	}
+
+	_, _ = fmt.Fprintf(w, "\n  %s\n", heading(useColor, "Summary"))
+	if foundCount > 0 {
+		_, _ = fmt.Fprintf(w, "    %sExists:%s     %d\n", colorIf(useColor, ColorGreen), colorIf(useColor, ColorReset), foundCount)
+	}
+	if notFoundCount > 0 {
+		_, _ = fmt.Fprintf(w, "    %sNot found:%s  %d\n", colorIf(useColor, ColorDim), colorIf(useColor, ColorReset), notFoundCount)
+	}
+	if errorCount > 0 {
+		_, _ = fmt.Fprintf(w, "    %sErrors:%s     %d\n", colorIf(useColor, ColorRed), colorIf(useColor, ColorReset), errorCount)
+	}
+	_, _ = fmt.Fprintf(w, "    %sTotal:%s      %d\n", colorIf(useColor, ColorCyan), colorIf(useColor, ColorReset), len(results))
+	_, _ = fmt.Fprintln(w)
+}
+
+// gravatarEnumJSON is the JSONL row shape for a Gravatar enumeration result. The
+// avatar URL is derived from the hash for convenience.
+type gravatarEnumJSON struct {
+	Email     string `json:"email"`
+	Hash      string `json:"hash"`
+	Exists    bool   `json:"exists"`
+	AvatarURL string `json:"avatar_url"`
+	Error     string `json:"error,omitempty"`
+}
+
+// encodeGravatarEnumResult maps a gravatar.Result to its JSONL row.
+func encodeGravatarEnumResult(r gravatar.Result) gravatarEnumJSON {
+	jr := gravatarEnumJSON{
+		Email:     r.Email,
+		Hash:      r.Hash,
+		Exists:    r.Exists,
+		AvatarURL: fmt.Sprintf("https://www.gravatar.com/avatar/%s", r.Hash),
+	}
+	if r.Error != nil {
+		jr.Error = r.Error.Error()
+	}
+	return jr
+}
+
+// outputGravatarEnumJSONL writes one JSON object per result. encoding/json
+// escapes control characters, so no sanitization is needed.
+func outputGravatarEnumJSONL(w io.Writer, results []gravatar.Result) {
+	enc := json.NewEncoder(w)
+	for i := range results {
+		if err := enc.Encode(encodeGravatarEnumResult(results[i])); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "Error encoding gravatar enum JSON: %v\n", err)
+		}
+	}
+}

--- a/cmd/brutus/cmd_enum_gravatar_test.go
+++ b/cmd/brutus/cmd_enum_gravatar_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/brutus/pkg/enum"
+)
+
+// ---------------------------------------------------------------------------
+// TestGravatarEnumTargets
+// Exercises gravatarEnumTargets() using the file-local flag variables
+// directly, saving and restoring them with defer (mirrors
+// TestGoogleEnumTargets_InlineEmails).
+// ---------------------------------------------------------------------------
+
+func resetGravatarEnumFlags() (restore func()) {
+	origEmails := flagGravatarEnumEmails
+	origEmailFile := flagGravatarEnumEmailFile
+	origDomain := flagGravatarEnumDomain
+	origFormat := flagGravatarEnumFormat
+	origLimit := flagGravatarEnumLimit
+	return func() {
+		flagGravatarEnumEmails = origEmails
+		flagGravatarEnumEmailFile = origEmailFile
+		flagGravatarEnumDomain = origDomain
+		flagGravatarEnumFormat = origFormat
+		flagGravatarEnumLimit = origLimit
+	}
+}
+
+func TestGravatarEnumTargets_InlineEmails(t *testing.T) {
+	defer resetGravatarEnumFlags()()
+
+	flagGravatarEnumEmails = "Alice@Example.com, Bob@Example.com ,alice@example.com"
+	flagGravatarEnumEmailFile = ""
+	flagGravatarEnumDomain = ""
+
+	emails, err := gravatarEnumTargets()
+	require.NoError(t, err)
+
+	// Deduplication (case-insensitive) and lower-casing/trimming: Alice and
+	// alice must collapse to one lower-cased, trimmed entry.
+	assert.Len(t, emails, 2, "deduplication must collapse case-insensitive duplicate emails")
+	assert.Contains(t, emails, "alice@example.com")
+	assert.Contains(t, emails, "bob@example.com")
+}
+
+func TestGravatarEnumTargets_NoSource(t *testing.T) {
+	defer resetGravatarEnumFlags()()
+
+	flagGravatarEnumEmails = ""
+	flagGravatarEnumEmailFile = ""
+	flagGravatarEnumDomain = ""
+
+	_, err := gravatarEnumTargets()
+	require.Error(t, err, "gravatarEnumTargets must fail when no source is supplied")
+	assert.Contains(t, err.Error(), "provide",
+		"error message must guide the user to supply a target source")
+}
+
+// ---------------------------------------------------------------------------
+// TestGravatarEnumGenerate
+// ---------------------------------------------------------------------------
+
+func TestGravatarEnumGenerate_ProducesCandidatesForDomain(t *testing.T) {
+	defer resetGravatarEnumFlags()()
+
+	flagGravatarEnumDomain = "target.com"
+	flagGravatarEnumFormat = "first.last"
+	flagGravatarEnumLimit = 0
+
+	generated, err := gravatarEnumGenerate()
+	require.NoError(t, err)
+
+	want, err := enum.GenerateEmails("first.last", "target.com")
+	require.NoError(t, err)
+
+	assert.Equal(t, want, generated,
+		"gravatarEnumGenerate must reuse enum.GenerateEmails and return the same candidates")
+	for _, e := range generated {
+		assert.Contains(t, e, "@target.com", "every generated candidate must be for the requested domain")
+	}
+}
+
+func TestGravatarEnumGenerate_RespectsLimit(t *testing.T) {
+	defer resetGravatarEnumFlags()()
+
+	flagGravatarEnumDomain = "target.com"
+	flagGravatarEnumFormat = "first.last"
+	flagGravatarEnumLimit = 3
+
+	generated, err := gravatarEnumGenerate()
+	require.NoError(t, err)
+
+	assert.Len(t, generated, 3, "--limit must cap the number of generated candidates")
+
+	want, err := enum.GenerateEmails("first.last", "target.com")
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(want), 3, "full generated list must have at least 3 candidates for this assertion to be meaningful")
+	assert.Equal(t, want[:3], generated, "--limit must keep the first (most-likely) N candidates")
+}
+
+func TestGravatarEnumGenerate_InvalidFormatRejected(t *testing.T) {
+	defer resetGravatarEnumFlags()()
+
+	flagGravatarEnumDomain = "target.com"
+	flagGravatarEnumFormat = "not-a-real-format"
+	flagGravatarEnumLimit = 0
+
+	_, err := gravatarEnumGenerate()
+	require.Error(t, err, "an invalid --format must be rejected")
+	assert.Contains(t, err.Error(), "invalid --format")
+}

--- a/cmd/brutus/cmd_enum_oracles.go
+++ b/cmd/brutus/cmd_enum_oracles.go
@@ -146,7 +146,7 @@ func teamsOracleAvailable(result *enum.DNSReconResult) bool {
 // (GitHub account existence is checkable for any address; there is no per-tenant
 // DNS TXT record to discover). They are unioned into the auto-discovered oracle
 // set in runEnumOracles so the oracle check covers them.
-var domainIndependentOracles = []string{"github"}
+var domainIndependentOracles = []string{"github", "gravatar"}
 
 // addDomainIndependentOracles appends any registered domain-independent oracles
 // (see domainIndependentOracles) to services that are not already present. It is

--- a/internal/enumplugins/gravatar/gravatar.go
+++ b/internal/enumplugins/gravatar/gravatar.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package gravatar registers the Gravatar account-existence oracle. The
+// detection logic lives in pkg/enum/gravatar (the single source of truth, also
+// consumable via the Brutus API); this plugin is a thin adapter that maps a
+// gravatar.Result to an enum.Result.
+package gravatar
+
+import (
+	"context"
+	"time"
+
+	"github.com/praetorian-inc/brutus/pkg/enum"
+	gravatarenum "github.com/praetorian-inc/brutus/pkg/enum/gravatar"
+)
+
+func init() {
+	enum.Register("gravatar", func() enum.Plugin {
+		return &Plugin{}
+	})
+}
+
+// Plugin checks Gravatar account existence via the shared pkg/enum/gravatar
+// checker (avatar endpoint with d=404). Proxy support is preserved: the checker
+// honors the per-run enum HTTP client carried on ctx.
+type Plugin struct{}
+
+func (p *Plugin) Name() string { return "gravatar" }
+
+// Check tests if an email has a registered Gravatar. Both outcomes are
+// definitive (200 -> exists, 404 -> not registered), so a clean check reports
+// ConfidenceHigh in either case; a service error leaves Exists=false and
+// propagates the error.
+func (p *Plugin) Check(ctx context.Context, email string, timeout time.Duration) *enum.Result {
+	start := time.Now()
+	result := &enum.Result{
+		Service: p.Name(),
+		Email:   email,
+	}
+
+	checker, err := gravatarenum.NewChecker("", "", timeout)
+	if err != nil {
+		result.Error = err
+		result.Duration = time.Since(start)
+		return result
+	}
+	res := checker.CheckAccount(ctx, email)
+
+	result.Exists = res.Exists
+	result.Error = res.Error
+	result.Duration = time.Since(start)
+
+	if res.Error != nil {
+		return result
+	}
+
+	result.Confidence = enum.ConfidenceHigh
+	return result
+}

--- a/internal/enumplugins/gravatar/gravatar_test.go
+++ b/internal/enumplugins/gravatar/gravatar_test.go
@@ -1,0 +1,134 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gravatar
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/brutus/pkg/enum"
+)
+
+// roundTripFunc adapts a function to http.RoundTripper so tests can stub the
+// avatar endpoint response without making a real network call. The checker's
+// baseURL is irrelevant here — the request never leaves this process because
+// the enum HTTP client carried on ctx (see enum.WithHTTPClient) is what
+// pkg/enum/gravatar.CheckAccount uses.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+// contextWithStatus returns a context carrying an enum HTTP client that
+// answers any request with the given status code.
+func contextWithStatus(status int) context.Context {
+	client := &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: status,
+				Body:       io.NopCloser(bytes.NewReader(nil)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+	return enum.WithHTTPClient(context.Background(), client)
+}
+
+func TestName(t *testing.T) {
+	t.Parallel()
+	p := &Plugin{}
+	assert.Equal(t, "gravatar", p.Name())
+}
+
+// TestCheck verifies the adapter's mapping from gravatar.Result to
+// enum.Result — logic that lives in this thin adapter, not in the shared
+// pkg/enum/gravatar library (which is covered by its own tests).
+func TestCheck(t *testing.T) {
+	tests := []struct {
+		name           string
+		status         int
+		wantExists     bool
+		wantConfidence enum.Confidence
+	}{
+		{
+			name:           "200 -> exists, high confidence",
+			status:         http.StatusOK,
+			wantExists:     true,
+			wantConfidence: enum.ConfidenceHigh,
+		},
+		{
+			name:           "404 -> not exists, high confidence",
+			status:         http.StatusNotFound,
+			wantExists:     false,
+			wantConfidence: enum.ConfidenceHigh,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := contextWithStatus(tc.status)
+
+			p := &Plugin{}
+			result := p.Check(ctx, "user@example.com", 5*time.Second)
+
+			require.NoError(t, result.Error)
+			assert.Equal(t, "gravatar", result.Service)
+			assert.Equal(t, "user@example.com", result.Email)
+			assert.Equal(t, tc.wantExists, result.Exists)
+			assert.Equal(t, tc.wantConfidence, result.Confidence)
+		})
+	}
+}
+
+// TestCheck_PropagatesTransportError verifies that a transport/5xx-level
+// error from the shared checker is surfaced on enum.Result.Error without a
+// Confidence assignment.
+func TestCheck_PropagatesTransportError(t *testing.T) {
+	client := &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("connection refused")
+		}),
+	}
+	ctx := enum.WithHTTPClient(context.Background(), client)
+
+	p := &Plugin{}
+	result := p.Check(ctx, "user@example.com", 5*time.Second)
+
+	require.Error(t, result.Error)
+	assert.False(t, result.Exists)
+	assert.Empty(t, result.Confidence)
+}
+
+// TestCheck_PropagatesServerError verifies that a non-200/404 status (a
+// service error per pkg/enum/gravatar.CheckAccount) is surfaced on
+// enum.Result.Error without a Confidence assignment.
+func TestCheck_PropagatesServerError(t *testing.T) {
+	ctx := contextWithStatus(http.StatusInternalServerError)
+
+	p := &Plugin{}
+	result := p.Check(ctx, "user@example.com", 5*time.Second)
+
+	require.Error(t, result.Error)
+	assert.False(t, result.Exists)
+	assert.Empty(t, result.Confidence)
+}

--- a/internal/enumplugins/init.go
+++ b/internal/enumplugins/init.go
@@ -18,5 +18,6 @@ package enumplugins
 import (
 	_ "github.com/praetorian-inc/brutus/internal/enumplugins/github"
 	_ "github.com/praetorian-inc/brutus/internal/enumplugins/google"
+	_ "github.com/praetorian-inc/brutus/internal/enumplugins/gravatar"
 	_ "github.com/praetorian-inc/brutus/internal/enumplugins/microsoft365"
 )

--- a/pkg/enum/gravatar/gravatar.go
+++ b/pkg/enum/gravatar/gravatar.go
@@ -1,0 +1,255 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package gravatar provides email-account enumeration via the Gravatar avatar
+// endpoint. This is the single source of truth for the Gravatar
+// account-existence check, reused by the internal enum oracle plugin and
+// consumable via the Brutus API.
+package gravatar
+
+import (
+	"context"
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"os"
+	"runtime/debug"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/time/rate"
+
+	"github.com/praetorian-inc/brutus/pkg/enum"
+)
+
+const DefaultBaseURL = "https://www.gravatar.com"
+
+// HashEmail returns the Gravatar hash of email: the MD5 hex digest of the
+// normalized (lower-cased, whitespace-trimmed) address, as required by the
+// Gravatar avatar API.
+func HashEmail(email string) string {
+	normalized := strings.ToLower(strings.TrimSpace(email))
+	sum := md5.Sum([]byte(normalized))
+	return hex.EncodeToString(sum[:])
+}
+
+// Result is the outcome of checking a single email against the Gravatar avatar
+// endpoint.
+type Result struct {
+	Email    string
+	Hash     string
+	Exists   bool
+	Error    error
+	Duration time.Duration
+}
+
+// Checker performs Gravatar account-existence checks via the avatar endpoint.
+// It is safe for concurrent use.
+type Checker struct {
+	baseURL string
+	timeout time.Duration
+	client  *http.Client
+}
+
+// NewChecker creates a Checker with the given timeout. Pass "" for baseURL to
+// use the default Gravatar endpoint. Pass "" for proxyURL for a direct
+// (non-proxied) client; when proxyURL is non-empty the checker's client routes
+// through it (honoring the --proxy flag), mirroring the Microsoft 365 checker.
+func NewChecker(baseURL, proxyURL string, timeout time.Duration) (*Checker, error) {
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
+	baseURL = strings.TrimSuffix(baseURL, "/")
+	client := enum.NewEnumHTTPClient(timeout)
+	if proxyURL != "" {
+		c, err := enum.NewEnumHTTPClientWithProxy(timeout, proxyURL)
+		if err != nil {
+			return nil, fmt.Errorf("gravatar: configuring proxy: %w", err)
+		}
+		client = c
+	}
+	return &Checker{
+		baseURL: baseURL,
+		timeout: timeout,
+		client:  client,
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Enumeration
+// ---------------------------------------------------------------------------
+
+// Enumerate looks up each email using a bounded worker pool, applying rate
+// limiting and jitter when rateLimit > 0. Results preserve input order. It is a
+// thin wrapper around EnumerateWith with no per-result callback.
+func (c *Checker) Enumerate(ctx context.Context, emails []string, threads int, rateLimit float64, jitter time.Duration) []Result {
+	return c.EnumerateWith(ctx, emails, threads, rateLimit, jitter, nil)
+}
+
+// EnumerateWith runs enumeration with bounded concurrency and invokes onResult
+// (if non-nil) for each completed result, serialized so callers can print/stream
+// safely. It still returns all results in input order.
+//
+// onResult is called under the same mutex that guards the results slice, so
+// callback invocations never interleave and never race the slice. The callback
+// must therefore be cheap and self-contained: it may write to an io.Writer or
+// update counters, but it must NOT call back into the Checker (doing so risks
+// deadlock and defeats the serialization guarantee).
+func (c *Checker) EnumerateWith(ctx context.Context, emails []string, threads int, rateLimit float64, jitter time.Duration, onResult func(Result)) []Result {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	g, ctx := errgroup.WithContext(ctx)
+	// Normalize thread count: 0 would deadlock errgroup.SetLimit (no goroutine
+	// can ever run) and a negative value means unbounded. Clamp to a safe
+	// positive default of 1 (serial execution).
+	if threads <= 0 {
+		threads = 1
+	}
+	g.SetLimit(threads)
+
+	var limiter *rate.Limiter
+	if rateLimit > 0 {
+		limiter = rate.NewLimiter(rate.Limit(rateLimit), 1)
+	}
+
+	results := make([]Result, len(emails))
+	var mu sync.Mutex
+
+	// record stores a completed result and, under the same lock, invokes the
+	// caller's callback so streamed output is serialized and slice-safe.
+	record := func(i int, res Result) {
+		mu.Lock()
+		defer mu.Unlock()
+		results[i] = res
+		if onResult != nil {
+			onResult(res)
+		}
+	}
+
+	for i, email := range emails {
+		i, email := i, email
+		g.Go(func() error {
+			defer func() {
+				if r := recover(); r != nil {
+					fmt.Fprintf(os.Stderr, "gravatar enum: panic checking %s: %v\n%s\n", email, r, debug.Stack())
+					record(i, Result{
+						Email: email,
+						Hash:  HashEmail(email),
+						Error: fmt.Errorf("gravatar enum: panicked: %v", r),
+					})
+				}
+			}()
+
+			select {
+			case <-ctx.Done():
+				// Record before returning so every index is filled and the callback fires exactly once per email.
+				record(i, Result{Email: email, Hash: HashEmail(email), Error: ctx.Err()})
+				return nil
+			default:
+			}
+
+			if limiter != nil {
+				if err := limiter.Wait(ctx); err != nil {
+					// Record before returning so every index is filled and the callback fires exactly once per email.
+					record(i, Result{Email: email, Hash: HashEmail(email), Error: err})
+					return nil
+				}
+				if jitter > 0 {
+					delay := time.Duration(rand.Int63n(int64(jitter)))
+					select {
+					case <-time.After(delay):
+					case <-ctx.Done():
+						// Record before returning so every index is filled and the callback fires exactly once per email.
+						record(i, Result{Email: email, Hash: HashEmail(email), Error: ctx.Err()})
+						return nil
+					}
+				}
+			}
+
+			r := c.CheckAccount(ctx, email)
+			if r == nil {
+				record(i, Result{
+					Email: email,
+					Hash:  HashEmail(email),
+					Error: fmt.Errorf("gravatar enum: nil result for %s", email),
+				})
+				return nil
+			}
+			record(i, *r)
+			return nil
+		})
+	}
+
+	// Discarding g.Wait()'s error is deliberate: worker goroutines never return
+	// a non-nil error (per-email failures are encoded in each Result), so the
+	// returned error is always nil.
+	_ = g.Wait()
+	return results
+}
+
+// CheckAccount tests if an email account has a registered Gravatar by requesting
+// the avatar for its hash with d=404 (so a missing avatar returns 404 rather
+// than a default image). HTTP 200 means the account exists, 404 means it does
+// not, and any other status is treated as a service error.
+//
+// If ctx carries a shared enum HTTP client (via enum.WithHTTPClient — set for a
+// run to honor --proxy and connection pooling), that client is used; otherwise
+// the Checker's own client is used.
+func (c *Checker) CheckAccount(ctx context.Context, email string) *Result {
+	start := time.Now()
+	hash := HashEmail(email)
+	result := &Result{Email: email, Hash: hash}
+	defer func() { result.Duration = time.Since(start) }()
+
+	url := fmt.Sprintf("%s/avatar/%s?d=404&s=1", c.baseURL, hash)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		result.Error = fmt.Errorf("creating request: %w", err)
+		return result
+	}
+
+	client := enum.HTTPClientFromContext(ctx)
+	if client == nil {
+		client = c.client
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		result.Error = fmt.Errorf("request failed: %w", err)
+		return result
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Drain the body (within the shared read limit) so the connection can be
+	// reused; the status code alone determines existence.
+	if _, err := enum.ReadResponseBody(resp, 0); err != nil {
+		result.Error = fmt.Errorf("reading response: %w", err)
+		return result
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		result.Exists = true
+	case http.StatusNotFound:
+		result.Exists = false
+	default:
+		result.Error = fmt.Errorf("unexpected status: %d", resp.StatusCode)
+	}
+
+	return result
+}

--- a/pkg/enum/gravatar/gravatar_test.go
+++ b/pkg/enum/gravatar/gravatar_test.go
@@ -1,0 +1,443 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gravatar
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/brutus/pkg/enum"
+)
+
+// roundTripFunc adapts a function to http.RoundTripper so tests can stub the
+// avatar endpoint response without a real network call.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+// ---------------------------------------------------------------------------
+// TestHashEmail
+// ---------------------------------------------------------------------------
+
+func TestHashEmail(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "492a8a929d007d94c91cfc1e780aeab3", HashEmail("john.smith@mckesson.com"))
+	assert.Equal(t, "a6aaaaf5d124132f358752c7d72d4b44", HashEmail("noreply@example.com"))
+
+	// Mixed case and surrounding whitespace must normalize to the same hash.
+	assert.Equal(t, HashEmail("john.smith@mckesson.com"), HashEmail("  John.Smith@McKesson.com  "))
+}
+
+// ---------------------------------------------------------------------------
+// TestCheckAccount — mock server keyed by hash, mirroring microsoft365's
+// newMockServer pattern.
+// ---------------------------------------------------------------------------
+
+// registeredEmail is the email whose Gravatar hash the mock server treats as
+// "registered" (200); every other hash 404s.
+const registeredEmail = "exists@example.com"
+
+func newMockServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	registeredHash := HashEmail(registeredEmail)
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wantPrefix := "/avatar/"
+		if !strings.HasPrefix(r.URL.Path, wantPrefix) {
+			http.NotFound(w, r)
+			return
+		}
+		hash := strings.TrimPrefix(r.URL.Path, wantPrefix)
+
+		assert.Equal(t, "404", r.URL.Query().Get("d"), "gravatar request must set d=404")
+
+		if hash == registeredHash {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+}
+
+func TestCheckAccount_Exists(t *testing.T) {
+	t.Parallel()
+	srv := newMockServer(t)
+	t.Cleanup(srv.Close)
+
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
+	result := c.CheckAccount(context.Background(), registeredEmail)
+
+	require.NoError(t, result.Error)
+	assert.True(t, result.Exists)
+	assert.Equal(t, registeredEmail, result.Email)
+	assert.Equal(t, HashEmail(registeredEmail), result.Hash)
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
+}
+
+func TestCheckAccount_NotExists(t *testing.T) {
+	t.Parallel()
+	srv := newMockServer(t)
+	t.Cleanup(srv.Close)
+
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
+	result := c.CheckAccount(context.Background(), "notexists@example.com")
+
+	require.NoError(t, result.Error)
+	assert.False(t, result.Exists)
+	assert.Equal(t, "notexists@example.com", result.Email)
+	assert.Equal(t, HashEmail("notexists@example.com"), result.Hash)
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
+}
+
+func TestCheckAccount_ServerError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
+	result := c.CheckAccount(context.Background(), "test@example.com")
+
+	require.Error(t, result.Error)
+	assert.Contains(t, result.Error.Error(), "unexpected status")
+	assert.False(t, result.Exists)
+	assert.Equal(t, "test@example.com", result.Email)
+	assert.Equal(t, HashEmail("test@example.com"), result.Hash)
+	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
+}
+
+func TestCheckAccount_ContextCancelled(t *testing.T) {
+	t.Parallel()
+	srv := newMockServer(t)
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
+	result := c.CheckAccount(ctx, registeredEmail)
+
+	require.Error(t, result.Error)
+	assert.False(t, result.Exists)
+}
+
+// ---------------------------------------------------------------------------
+// TestNewChecker — default baseURL is asserted indirectly by pointing the
+// checker at a test server and verifying it can be constructed with an empty
+// baseURL/proxyURL without error (baseURL is unexported, so behavior is
+// verified via CheckAccount against a real server rather than field access).
+// ---------------------------------------------------------------------------
+
+func TestNewChecker_DefaultBaseURLUsedWhenEmpty(t *testing.T) {
+	t.Parallel()
+	c, err := NewChecker("", "", 5*time.Second)
+	require.NoError(t, err)
+	require.NotNil(t, c)
+
+	// Exercise CheckAccount against the real default endpoint's context-carried
+	// client stub to confirm the checker is usable without hitting the network:
+	// injecting a context client proves NewChecker("", ...) produced a working
+	// Checker whose CheckAccount constructs a valid request against
+	// DefaultBaseURL (the request must at least be well-formed; a malformed
+	// baseURL would fail request construction).
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			assert.True(t, strings.HasPrefix(req.URL.String(), DefaultBaseURL+"/avatar/"),
+				"request URL must be built from DefaultBaseURL when baseURL is empty")
+			return &http.Response{
+				StatusCode: http.StatusNotFound,
+				Body:       io.NopCloser(bytes.NewReader(nil)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+	ctx := enum.WithHTTPClient(context.Background(), client)
+	result := c.CheckAccount(ctx, "someone@example.com")
+	require.NoError(t, result.Error)
+	assert.False(t, result.Exists)
+}
+
+func TestNewChecker_WithProxyURL(t *testing.T) {
+	t.Parallel()
+	c, err := NewChecker("", "http://user:pass@127.0.0.1:1/", 5*time.Second)
+	require.NoError(t, err)
+	assert.NotNil(t, c)
+}
+
+// ---------------------------------------------------------------------------
+// enum.HTTPClientFromContext precedence: CheckAccount must prefer a shared
+// enum HTTP client carried on ctx (set via enum.WithHTTPClient) over the
+// Checker's own client, and fall back to its own client when ctx carries
+// none.
+// ---------------------------------------------------------------------------
+
+func TestCheckAccount_UsesHTTPClientFromContext(t *testing.T) {
+	t.Parallel()
+
+	// baseURL points at a server that always 500s. If the request reaches this
+	// server, the test fails via "unexpected status" — proving the
+	// context-carried client (which never dials this server at all) was used
+	// instead.
+	failing := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(failing.Close)
+
+	c, err := NewChecker(failing.URL, "", 5*time.Second)
+	require.NoError(t, err)
+
+	contextClient := &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(nil)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+	ctx := enum.WithHTTPClient(context.Background(), contextClient)
+
+	result := c.CheckAccount(ctx, registeredEmail)
+
+	require.NoError(t, result.Error)
+	assert.True(t, result.Exists, "the context-carried client's response must be used, not the failing server's")
+}
+
+func TestCheckAccount_FallsBackToOwnClientWithoutContextClient(t *testing.T) {
+	t.Parallel()
+	srv := newMockServer(t)
+	t.Cleanup(srv.Close)
+
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
+
+	// No enum.WithHTTPClient on this context — CheckAccount must fall back to
+	// the Checker's own client and still reach srv successfully.
+	result := c.CheckAccount(context.Background(), registeredEmail)
+
+	require.NoError(t, result.Error)
+	assert.True(t, result.Exists)
+}
+
+// ---------------------------------------------------------------------------
+// TestEnumerateWith_Callback
+// 4 emails, threads=4, onResult callback appends under a mutex.
+// After the run:
+//   - callback invoked exactly once per email
+//   - returned slice len == 4
+//   - set of emails from callback matches input set
+//   - results are in input order
+//
+// Run the package under -race (go test -race ./pkg/enum/gravatar/) to verify
+// the callback serialization guarantee.
+// ---------------------------------------------------------------------------
+
+func TestEnumerateWith_Callback(t *testing.T) {
+	t.Parallel()
+
+	srv := newMockServer(t)
+	t.Cleanup(srv.Close)
+
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
+
+	emails := []string{
+		registeredEmail,
+		"notexists@example.com",
+		"another@example.com",
+		"nobody@example.com",
+	}
+
+	var mu sync.Mutex
+	var callbackResults []Result
+
+	results := c.EnumerateWith(
+		context.Background(),
+		emails,
+		4, // threads
+		0, // rateLimit (no throttle)
+		0, // jitter
+		func(r Result) {
+			mu.Lock()
+			callbackResults = append(callbackResults, r)
+			mu.Unlock()
+		},
+	)
+
+	// Returned slice must have exactly one entry per input email.
+	require.Len(t, results, len(emails), "EnumerateWith must return one Result per email")
+
+	// Callback must be invoked exactly once per email.
+	assert.Len(t, callbackResults, len(emails), "onResult callback must be invoked exactly once per email")
+
+	// The set of emails seen by the callback must equal the input set.
+	cbEmails := make(map[string]struct{}, len(callbackResults))
+	for _, r := range callbackResults {
+		cbEmails[r.Email] = struct{}{}
+	}
+	for _, email := range emails {
+		assert.Contains(t, cbEmails, email, "onResult callback must have been called for email %q", email)
+	}
+
+	// Returned results must preserve input order.
+	for i, r := range results {
+		assert.Equal(t, emails[i], r.Email, "results[%d] must correspond to emails[%d]", i, i)
+	}
+
+	byEmail := make(map[string]Result, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	existsResult := byEmail[registeredEmail]
+	assert.NoError(t, existsResult.Error)
+	assert.True(t, existsResult.Exists)
+
+	for _, email := range []string{"notexists@example.com", "another@example.com", "nobody@example.com"} {
+		r := byEmail[email]
+		assert.NoError(t, r.Error, "email %q must not have an error", email)
+		assert.False(t, r.Exists, "email %q must be Exists=false", email)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestEnumerateWith_NilCallback
+// Passing nil as the callback must not panic and must return one result per
+// email.
+// ---------------------------------------------------------------------------
+
+func TestEnumerateWith_NilCallback(t *testing.T) {
+	t.Parallel()
+
+	srv := newMockServer(t)
+	t.Cleanup(srv.Close)
+
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
+
+	emails := []string{registeredEmail, "notexists@example.com"}
+
+	results := c.EnumerateWith(context.Background(), emails, 2, 0, 0, nil)
+	require.Len(t, results, len(emails), "nil callback must not panic; must return one result per email")
+}
+
+// ---------------------------------------------------------------------------
+// TestEnumerateWith_CanceledContextRecordsAllSlots
+// Regression guard: with an already-canceled context, every worker hits the
+// <-ctx.Done() guard before the HTTP call. Each guard must still record
+// before returning, so every index is filled (Email set, input order
+// preserved) and the callback fires exactly once per email.
+// ---------------------------------------------------------------------------
+
+func TestEnumerateWith_CanceledContextRecordsAllSlots(t *testing.T) {
+	t.Parallel()
+
+	srv := newMockServer(t)
+	t.Cleanup(srv.Close)
+
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
+
+	emails := []string{registeredEmail, "notexists@example.com", "nobody@example.com"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var mu sync.Mutex
+	var cbResults []Result
+
+	results := c.EnumerateWith(ctx, emails, 4, 0, 0, func(r Result) {
+		mu.Lock()
+		cbResults = append(cbResults, r)
+		mu.Unlock()
+	})
+
+	require.Len(t, results, len(emails), "every slot must be filled even when ctx is already canceled")
+
+	for i := range emails {
+		assert.Equal(t, emails[i], results[i].Email,
+			"results[%d].Email must be set (input order preserved), not left as a dropped zero-value", i)
+		assert.Error(t, results[i].Error, "results[%d] must carry the ctx.Done() error, not be silently dropped", i)
+		assert.True(t, errors.Is(results[i].Error, context.Canceled),
+			"results[%d].Error must be context.Canceled from the <-ctx.Done() guard", i)
+	}
+
+	assert.Len(t, cbResults, len(emails), "onResult callback must fire exactly once per email, even on the canceled-context path")
+}
+
+// ---------------------------------------------------------------------------
+// TestEnumerateWith_ZeroOrNegativeThreadsDoesNotHang
+// Regression guard: threads<=0 must be normalized to 1 before g.SetLimit.
+// SetLimit(0) would permit zero concurrent goroutines, so no worker could
+// ever run and EnumerateWith would hang forever.
+// ---------------------------------------------------------------------------
+
+func TestEnumerateWith_ZeroOrNegativeThreadsDoesNotHang(t *testing.T) {
+	tests := []struct {
+		name    string
+		threads int
+	}{
+		{"zero", 0},
+		{"negative", -1},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := newMockServer(t)
+			t.Cleanup(srv.Close)
+
+			c, err := NewChecker(srv.URL, "", 5*time.Second)
+			require.NoError(t, err)
+
+			emails := []string{registeredEmail, "notexists@example.com"}
+
+			done := make(chan []Result, 1)
+			go func() {
+				done <- c.EnumerateWith(context.Background(), emails, tc.threads, 0, 0, nil)
+			}()
+
+			select {
+			case results := <-done:
+				require.Len(t, results, len(emails), "threads=%d must still return one result per email", tc.threads)
+				for i := range emails {
+					assert.Equal(t, emails[i], results[i].Email,
+						"results[%d] must preserve input order under normalized serial execution", i)
+					assert.NoError(t, results[i].Error, "results[%d] must succeed against the mock server", i)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatalf("EnumerateWith hung with threads=%d", tc.threads)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds `gravatar` as an unauthenticated email account-enumeration oracle, following the microsoft365/google plugin pattern across all three layers.

**Technique:** normalize email (lower + trim) → MD5 hex → `GET https://www.gravatar.com/avatar/<md5>?d=404&s=1`. HTTP **200 = the email has a registered Gravatar**, **404 = none**. Passing `?d=404` turns the usual default-placeholder `200` into a definitive `404`, so both outcomes are authoritative → the adapter reports `ConfidenceHigh` on any clean check.

```
brutus enum active gravatar -e john.smith@example.com
brutus enum active gravatar -d example.com --format first.last --limit 500 --json
```

## How

| Layer | File |
|---|---|
| Engine (reusable) | `pkg/enum/gravatar/gravatar.go` — `HashEmail`, `Checker`/`NewChecker`, `CheckAccount`, `Enumerate`/`EnumerateWith` |
| Adapter (`enum.Plugin`) | `internal/enumplugins/gravatar/gravatar.go` — registers `"gravatar"`, maps to `enum.Result` |
| CLI | `cmd/brutus/cmd_enum_gravatar.go` + `cmd_enum_gravatar_output.go` — `enum active gravatar` with the standard `-e/-E/-d/--format/--limit` flags and human/JSONL output |
| Wiring | `internal/enumplugins/init.go` (blank import); `cmd_enum_oracles.go` (added to `domainIndependentOracles` — no DNS footprint, keyed per-email like `github`); `cmd_enum_active.go` (help listing) |

- Honors the context-carried (proxied) HTTP client so the `enum active oracles` path reuses the shared client; the standalone CLI falls back to its own proxied client.
- Body drained/limited via `enum.ReadResponseBody`; redirects disabled by the shared enum client.
- **First oracle that hashes emails** — the md5 normalization lives in the engine (single source of truth); CLI/adapter stay thin.

## Scope

Existence-only, matching microsoft365/google. Gravatar's free `/<hash>.json` profile (display name, bio, verified accounts) is a deliberate non-goal / possible follow-up.

## Testing

- Unit tests for engine (hash vectors, 200/404/error, context-client precedence, `EnumerateWith` order/cancellation/threads), adapter (name, confidence mapping, error propagation), and CLI (target parsing/dedup, generation, invalid format) — all pass under `-race`.
- `gofmt`, `go vet`, `golangci-lint` clean.
- **Live check:** `matt@automattic.com` → `exists:true`; an unregistered address → `exists:false`.

## Reviews

Code review and security review both APPROVED (no P0/P1). Applied two P2 hardening fixes: `sanitizeTerminal` on the operator-supplied `--domain` before terminal output, and `http.NoBody` for lint parity with the google/github engines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)