### PR TITLE
fix(enum/github): delete reveal repo even when the ctx is cancelled

### DIFF
--- a/pkg/enum/github/github_test.go
+++ b/pkg/enum/github/github_test.go
@@ -488,6 +488,69 @@ func TestReveal_DeleteAlwaysAttempted(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Reveal: repo cleanup (DELETE) survives a cancelled reveal context
+// ---------------------------------------------------------------------------
+
+// TestReveal_DeletesEvenWhenContextCancelled verifies that the deferred repo
+// DELETE is still sent even when the reveal ctx is cancelled mid-flow. The
+// settle-delay sleep cancels the ctx and returns context.Canceled, after
+// createRepo and pushCommit succeed but before listCommitLogins runs, so the
+// deferred cleanup fires with an already-cancelled ctx. Because cleanup runs on
+// a context detached from cancellation, the DELETE must still reach the API.
+// Pre-fix (deferred deleteRepo reused the cancelled ctx) => deleteCount == 0;
+// with the fix => deleteCount == 1.
+func TestReveal_DeletesEvenWhenContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	const token = "ghp-test-token-cancelled-cleanup"
+
+	var deleteCount atomic.Int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/user", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprintf(w, `{"login":"testowner"}`)
+	})
+	mux.HandleFunc("/user/repos", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprintf(w, `{"name":"test-repo-name","default_branch":"main"}`)
+	})
+	mux.HandleFunc("/repos/", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodDelete:
+			deleteCount.Add(1)
+			w.WriteHeader(http.StatusNoContent)
+		case http.MethodPut:
+			w.WriteHeader(http.StatusCreated)
+		case http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, `[]`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	apiSrv := httptest.NewServer(mux)
+	t.Cleanup(apiSrv.Close)
+
+	e, err := NewEnumerator("", 5*time.Second, token, false)
+	require.NoError(t, err)
+	e.apiBaseURL = apiSrv.URL
+	e.newName = deterministicName
+	e.settleDelay = 0
+
+	ctx, cancel := context.WithCancel(context.Background())
+	e.sleep = func(_ context.Context, _ time.Duration) error {
+		cancel()
+		return context.Canceled
+	}
+
+	_, revErr := e.Reveal(ctx, []string{"alice@example.com"})
+	require.Error(t, revErr)
+
+	assert.Equal(t, int32(1), deleteCount.Load(),
+		"repo DELETE must still be sent even though the reveal ctx was cancelled")
+}
+
+// ---------------------------------------------------------------------------
 // Auth header: PAT is sent as Bearer <token> on every API call
 // ---------------------------------------------------------------------------
 

--- a/pkg/enum/github/reveal.go
+++ b/pkg/enum/github/reveal.go
@@ -22,9 +22,16 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/praetorian-inc/brutus/pkg/enum"
 )
+
+// cleanupTimeout bounds the deferred throwaway-repo deletion in RevealWith. The
+// deletion runs on a context detached from the reveal ctx (which may already be
+// cancelled or past its deadline), so it needs its own deadline to guarantee it
+// cannot hang.
+const cleanupTimeout = 30 * time.Second
 
 // ---------------------------------------------------------------------------
 // Username reveal (authenticated)
@@ -78,7 +85,15 @@ func (e *Enumerator) RevealWith(ctx context.Context, emails []string, onProgress
 	// it manually; if the function already failed, the original error is joined
 	// (not overwritten). The token is never included in the error.
 	defer func() {
-		if delErr := e.deleteRepo(ctx, login, repo); delErr != nil {
+		// Detach cleanup from ctx's cancellation/deadline: reveal's ctx may
+		// already be cancelled or timed out (e.g. a caller deadline, or the
+		// settle-delay sleep returning early), and reusing it here would make
+		// the DELETE fail to send and orphan the throwaway private repo under
+		// the operator's account. context.WithoutCancel keeps ctx's values
+		// while dropping cancellation; a fresh short timeout bounds the delete.
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cleanupTimeout)
+		defer cancel()
+		if delErr := e.deleteRepo(cleanupCtx, login, repo); delErr != nil {
 			repoURL := login + "/" + repo
 			if err != nil {
 				err = fmt.Errorf("%w; ADDITIONALLY failed to delete temp repo %q (delete it manually): %v", err, repoURL, delErr)


### PR DESCRIPTION
## Problem

`RevealWith` creates a throwaway private repo, and defers its DELETE cleanup. The deferred delete reused the **same context** that carries the reveal deadline. On a mid-flow cancellation/timeout — a caller deadline, or the settle-delay sleep returning early — that deferred `DELETE` was built with an already-cancelled context, so the request failed to send and the **private repo was orphaned** under the operator's account.

## Fix

Run the deferred cleanup on a context detached from cancellation (`context.WithoutCancel(ctx)`) with its own bounded `cleanupTimeout`, so the DELETE always reaches the API even after the reveal ctx is done.

## Test

Adds `TestReveal_DeletesEvenWhenContextCancelled`: the settle-delay sleep cancels the reveal ctx (after createRepo + pushCommit succeed, before listCommitLogins), then asserts the DELETE was still sent. Verified RED (pre-fix: `deleteCount == 0`) / GREEN (post-fix: `deleteCount == 1`). Full package suite (18 tests) + `gofmt`/`go vet`/`go build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)