### PR TITLE
style(lint): fix golangci-lint failures blocking CI

### DIFF
--- a/cmd/brutus/cmd_enum_linkedin.go
+++ b/cmd/brutus/cmd_enum_linkedin.go
@@ -109,7 +109,8 @@ func runEnumLinkedin(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(os.Stderr, "%s Fetching results from previous run (agent %s)...\n",
 				dim(useColor, SymbolInfo), flagLinkedinAgentID)
 		}
-		info, err := client.FetchAgentInfo(ctx, flagLinkedinAgentID)
+		var info *pb.AgentInfo
+		info, err = client.FetchAgentInfo(ctx, flagLinkedinAgentID)
 		if err != nil {
 			return classifyPhantomBusterError(err)
 		}

--- a/pkg/enum/github/github_test.go
+++ b/pkg/enum/github/github_test.go
@@ -488,21 +488,21 @@ func TestReveal_DeleteAlwaysAttempted(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Reveal: repo cleanup (DELETE) survives a cancelled reveal context
+// Reveal: repo cleanup (DELETE) survives a canceled reveal context
 // ---------------------------------------------------------------------------
 
 // TestReveal_DeletesEvenWhenContextCancelled verifies that the deferred repo
-// DELETE is still sent even when the reveal ctx is cancelled mid-flow. The
+// DELETE is still sent even when the reveal ctx is canceled mid-flow. The
 // settle-delay sleep cancels the ctx and returns context.Canceled, after
 // createRepo and pushCommit succeed but before listCommitLogins runs, so the
-// deferred cleanup fires with an already-cancelled ctx. Because cleanup runs on
+// deferred cleanup fires with an already-canceled ctx. Because cleanup runs on
 // a context detached from cancellation, the DELETE must still reach the API.
-// Pre-fix (deferred deleteRepo reused the cancelled ctx) => deleteCount == 0;
+// Pre-fix (deferred deleteRepo reused the canceled ctx) => deleteCount == 0;
 // with the fix => deleteCount == 1.
 func TestReveal_DeletesEvenWhenContextCancelled(t *testing.T) {
 	t.Parallel()
 
-	const token = "ghp-test-token-cancelled-cleanup"
+	const token = "ghp-test-token-canceled-cleanup"
 
 	var deleteCount atomic.Int32
 
@@ -547,7 +547,7 @@ func TestReveal_DeletesEvenWhenContextCancelled(t *testing.T) {
 	require.Error(t, revErr)
 
 	assert.Equal(t, int32(1), deleteCount.Load(),
-		"repo DELETE must still be sent even though the reveal ctx was cancelled")
+		"repo DELETE must still be sent even though the reveal ctx was canceled")
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/enum/github/reveal.go
+++ b/pkg/enum/github/reveal.go
@@ -29,7 +29,7 @@ import (
 
 // cleanupTimeout bounds the deferred throwaway-repo deletion in RevealWith. The
 // deletion runs on a context detached from the reveal ctx (which may already be
-// cancelled or past its deadline), so it needs its own deadline to guarantee it
+// canceled or past its deadline), so it needs its own deadline to guarantee it
 // cannot hang.
 const cleanupTimeout = 30 * time.Second
 
@@ -86,7 +86,7 @@ func (e *Enumerator) RevealWith(ctx context.Context, emails []string, onProgress
 	// (not overwritten). The token is never included in the error.
 	defer func() {
 		// Detach cleanup from ctx's cancellation/deadline: reveal's ctx may
-		// already be cancelled or timed out (e.g. a caller deadline, or the
+		// already be canceled or timed out (e.g. a caller deadline, or the
 		// settle-delay sleep returning early), and reusing it here would make
 		// the DELETE fail to send and orphan the throwaway private repo under
 		// the operator's account. context.WithoutCancel keeps ctx's values

--- a/pkg/enum/phantombuster/client.go
+++ b/pkg/enum/phantombuster/client.go
@@ -126,7 +126,7 @@ type OutputStatus struct {
 }
 
 // PollUntilDone polls the agent output endpoint until the container finishes
-// or the context is cancelled. It uses exponential backoff between polls.
+// or the context is canceled. It uses exponential backoff between polls.
 // onProgress is called (if non-nil) on each poll with the current status,
 // allowing the caller to log progress updates.
 func (c *Client) PollUntilDone(ctx context.Context, agentID, containerID string, onProgress func(OutputStatus)) (*OutputStatus, error) {
@@ -205,7 +205,7 @@ func (c *Client) FetchAgentInfo(ctx context.Context, agentID string) (*AgentInfo
 func (c *Client) DownloadResult(ctx context.Context, info *AgentInfo, filename string) ([]byte, error) {
 	url := fmt.Sprintf("%s/%s/%s/%s", s3BaseURL, info.OrgS3Folder, info.S3Folder, filename)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("building S3 download request: %w", err)
 	}

--- a/pkg/enum/phantombuster/client_test.go
+++ b/pkg/enum/phantombuster/client_test.go
@@ -224,7 +224,7 @@ func TestDownloadResult_Success(t *testing.T) {
 	// s3BaseURL is a const so we can't override it for tests. Instead, verify
 	// the download mechanics by hitting the test server directly.
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
-		server.URL+"/orgfolder/s3folder/result.csv", nil)
+		server.URL+"/orgfolder/s3folder/result.csv", http.NoBody)
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		t.Fatalf("download: %v", err)


### PR DESCRIPTION
## Summary

The **CI `Lint` job (golangci-lint) has been failing on `main`** for a while — every recent push/PR shows a red `ci / Lint` while build and tests pass. This PR fixes all reported issues so CI goes green.

## What was failing

Running the repo's own `.golangci.yml` config surfaced 3 issues at first, but golangci-lint's default `max-same-issues: 3` was **masking duplicate `misspell` hits**. Re-running with caps disabled revealed the full set:

| Linter | Issue | Locations |
|--------|-------|-----------|
| `govet` (shadow) | `err` shadowed a prior declaration | `cmd/brutus/cmd_enum_linkedin.go` |
| `gocritic` (httpNoBody) | `nil` request body should be `http.NoBody` | `pkg/enum/phantombuster/client.go`, `client_test.go` |
| `misspell` (US) | `cancelled` → `canceled` | `pkg/enum/github/reveal.go`, `github_test.go` (×6), `pkg/enum/phantombuster/client.go` |

## Fixes

- **shadow:** declare `var info *pb.AgentInfo` and reuse the outer `err` in `runEnumLinkedin`.
- **httpNoBody:** use `http.NoBody` instead of `nil` (semantically identical empty body).
- **misspell:** `cancelled` → `canceled` in comments, one assertion message, and one test token literal (a named `const`, so the change is local).

No behavior change — comments, a test token string, and a `nil`→`http.NoBody` swap.

## Verification

```
$ golangci-lint run --max-same-issues=0 --max-issues-per-linter=0 ./...
0 issues.

$ golangci-lint run ./...        # exact CI config
0 issues.  (exit 0)

$ go build ./...                 # exit 0
$ go test ./pkg/enum/github/... ./pkg/enum/phantombuster/...   # ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)