### PR TITLE
ci(integration): pin openssh-server to last-good 10.2 (unbreak SSH key tests)

### DIFF
--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -16,9 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     environment: internal
     services:
+      # SSH servers are pinned to a digest (not :latest). The linuxserver
+      # openssh-server 10.3 build (ls230, published 2026-07-08) regressed
+      # key-based auth for the Vagrant insecure key, turning TestPlugin_TestKey_*
+      # red on every main push since 2026-07-09. 10.2 (ls229) is the last
+      # known-good build. Bump deliberately and confirm integration tests stay
+      # green before moving off this pin.
       # SSH server for password testing
       ssh:
-        image: linuxserver/openssh-server:latest
+        image: linuxserver/openssh-server:10.2_p1-r0-ls229@sha256:67d4c3a1402179a6579aa217a38b52ced557eb8a0c17a8e32fe986a4549fdee4
         env:
           PUID: 1000
           PGID: 1000
@@ -30,7 +36,7 @@ jobs:
 
       # SSH server for key-based auth testing (using Vagrant insecure key)
       ssh-key:
-        image: linuxserver/openssh-server:latest
+        image: linuxserver/openssh-server:10.2_p1-r0-ls229@sha256:67d4c3a1402179a6579aa217a38b52ced557eb8a0c17a8e32fe986a4549fdee4
         env:
           PUID: 1000
           PGID: 1000


### PR DESCRIPTION
## Summary

The **Integration Tests** workflow has failed on **every `main` push since 2026-07-09**. The only failing package is `internal/plugins/ssh` — specifically `TestPlugin_TestKey_KeySpraying` and `TestPlugin_TestKey_BadKeysIntegration`, where the embedded Vagrant insecure RSA key authenticates for **no** username.

## Root cause: `:latest` image drift, not a Brutus regression

The `ssh` / `ssh-key` service containers used the moving tag `linuxserver/openssh-server:latest`. The timeline is exact:

| Event | Time (UTC) |
|---|---|
| Last **green** integration run (#224) | 2026-07-08 **13:42** |
| OpenSSH **10.3** image (`ls230`) published | 2026-07-08 **21:26** |
| First **red** run (#211 merge) | 2026-07-09 **07:40** |

The last green run used OpenSSH **10.2** (`ls229`); the first red run used **10.3** (`ls230`). The Brutus merge at the boundary only added LinkedIn/phantombuster enum code — it was coincidental.

Evidence it's the image, not our code:
- `internal/plugins/ssh`, `pkg/badkeys`, `pkg/brutus`, and `go.mod` are **byte-identical** between the last-good commit and the first-red merge.
- The Vagrant private key in `pkg/badkeys` derives to **exactly** the public key the container is provisioned with (`ssh-keygen -y` match).
- `golang.org/x/crypto v0.53.0` already negotiates `rsa-sha2-256/512`, and the [OpenSSH 10.3 release notes](https://www.openssh.com/txt/release-10.3) contain **no** RSA / `ssh-rsa` / `PubkeyAcceptedAlgorithms` changes. So this is **not** SHA-1 deprecation — it's a packaging regression in the `ls230` build (every key fails, consistent with broken `authorized_keys` provisioning).

## Fix

Pin both SSH services to the last known-good build `10.2_p1-r0-ls229`, by **digest**:

```
linuxserver/openssh-server:10.2_p1-r0-ls229@sha256:67d4c3a1402179a6579aa217a38b52ced557eb8a0c17a8e32fe986a4549fdee4
```

Digest-pinning matches the repo's existing action-pinning convention and removes future `:latest` drift. (A server-side `ssh-rsa` re-enable was considered but is inapplicable here — the evidence shows it's not a SHA-1 problem — and cannot be cleanly injected into a `services:` block anyway.)

## Verification

⚠️ `ci-integration.yml` triggers only on **`push` to `main`**, not on pull requests — so this fix **cannot be confirmed green on the PR itself**; it will run on the merge commit. YAML validated locally (`yaml.safe_load` OK).

### Follow-up suggestion (not in this PR)
Consider adding a `pull_request` trigger (or a manual `workflow_dispatch` with the service matrix) so integration regressions are catchable **before** merge rather than only after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)