### PR TITLE
fix(enum/github): send browser User-Agent so account existence works

### DIFF
--- a/cmd/brutus/cmd_enum_github_output.go
+++ b/cmd/brutus/cmd_enum_github_output.go
@@ -31,6 +31,14 @@ import (
 func outputGithubEnumResultLine(w io.Writer, r githubenum.Result, useColor bool) {
 	email := truncate(sanitizeTerminal(r.Email), 40)
 
+	if r.Error != nil {
+		_, _ = fmt.Fprintf(w, "  %-40s %s%s error%s %s\n",
+			email,
+			colorIf(useColor, ColorRed), SymbolError, colorIf(useColor, ColorReset),
+			dim(useColor, truncate(sanitizeTerminal(r.Error.Error()), 100)))
+		return
+	}
+
 	if !r.Exists {
 		_, _ = fmt.Fprintf(w, "  %-40s %s[ ] not found%s\n",
 			email, colorIf(useColor, ColorDim), colorIf(useColor, ColorReset))
@@ -103,9 +111,22 @@ func outputGithubEnumSummary(w io.Writer, results []githubenum.Result, useColor 
 	}
 	if errorCount > 0 {
 		_, _ = fmt.Fprintf(w, "    %sErrors:%s     %d\n", colorIf(useColor, ColorRed), colorIf(useColor, ColorReset), errorCount)
+		if msg := firstGithubEnumError(results); msg != "" {
+			_, _ = fmt.Fprintf(w, "      %s\n", dim(useColor, "e.g. "+truncate(sanitizeTerminal(msg), 120)))
+		}
 	}
 	_, _ = fmt.Fprintf(w, "    %sTotal:%s      %d\n", colorIf(useColor, ColorCyan), colorIf(useColor, ColorReset), len(results))
 	_, _ = fmt.Fprintln(w)
+}
+
+// firstGithubEnumError returns the first non-nil result error message, or "".
+func firstGithubEnumError(results []githubenum.Result) string {
+	for i := range results {
+		if results[i].Error != nil {
+			return results[i].Error.Error()
+		}
+	}
+	return ""
 }
 
 // outputGithubEnumJSONL writes one JSON object per result. encoding/json escapes

--- a/cmd/brutus/cmd_enum_github_test.go
+++ b/cmd/brutus/cmd_enum_github_test.go
@@ -17,6 +17,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -354,4 +355,101 @@ func TestOutputGithubEnumJSONL(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ---------------------------------------------------------------------------
+// outputGithubEnumResultLine
+// ---------------------------------------------------------------------------
+
+// TestOutputGithubEnumResultLine_Error verifies that a result with a non-nil
+// Error renders the dedicated error row: the red "[-]" symbol, the literal
+// word "error", and a truncated/sanitized chunk of the error message. It must
+// NOT fall through to the not-found row.
+func TestOutputGithubEnumResultLine_Error(t *testing.T) {
+	r := githubenum.Result{
+		Email: "a@x.com",
+		Error: errors.New("github enum: parsing join page: CSRF authenticity token not found on join page"),
+	}
+
+	var buf bytes.Buffer
+	outputGithubEnumResultLine(&buf, r, false)
+	out := buf.String()
+
+	assert.Contains(t, out, SymbolError, "error row must show the error symbol")
+	assert.Contains(t, out, "error", "error row must contain the literal word \"error\"")
+	assert.Contains(t, out, "CSRF authenticity token not found",
+		"error row must contain a chunk of the underlying error message")
+	assert.NotContains(t, out, "[ ] not found",
+		"a result with an error must not render as the not-found row")
+}
+
+// TestOutputGithubEnumResultLine_NotFoundStillWorks guards against
+// regressing the pre-existing not-found branch: a result with no error and
+// Exists=false must still render "[ ] not found" and must not render the
+// error row.
+func TestOutputGithubEnumResultLine_NotFoundStillWorks(t *testing.T) {
+	r := githubenum.Result{Email: "b@x.com"}
+
+	var buf bytes.Buffer
+	outputGithubEnumResultLine(&buf, r, false)
+	out := buf.String()
+
+	assert.Contains(t, out, "[ ] not found", "a result with no error/no match must render the not-found row")
+	assert.NotContains(t, out, SymbolError, "a not-found result must not show the error symbol")
+	assert.NotContains(t, out, " error ", "a not-found result must not render the error row")
+}
+
+// ---------------------------------------------------------------------------
+// outputGithubEnumSummary
+// ---------------------------------------------------------------------------
+
+// TestOutputGithubEnumSummary_ShowsRepresentativeError verifies that when
+// errored results are present, the summary shows an "Errors: N" line followed
+// by a representative "e.g. <msg>" line containing the FIRST errored
+// result's message.
+func TestOutputGithubEnumSummary_ShowsRepresentativeError(t *testing.T) {
+	results := []githubenum.Result{
+		{Email: "exists@x.com", Exists: true},
+		{Email: "missing@x.com"},
+		{Email: "err1@x.com", Error: errors.New("first distinct failure message")},
+		{Email: "err2@x.com", Error: errors.New("second distinct failure message")},
+	}
+
+	var buf bytes.Buffer
+	outputGithubEnumSummary(&buf, results, false)
+	out := buf.String()
+
+	assert.Contains(t, out, "Errors:", "summary must show an Errors line when errored results exist")
+	assert.Contains(t, out, "2", "summary must show the correct error count")
+	assert.Contains(t, out, "e.g. first distinct failure message",
+		"summary must show a representative line with the first errored result's message")
+	assert.NotContains(t, out, "second distinct failure message",
+		"summary need only show the first errored result's message, not every one")
+}
+
+// ---------------------------------------------------------------------------
+// firstGithubEnumError
+// ---------------------------------------------------------------------------
+
+// TestFirstGithubEnumError verifies that firstGithubEnumError returns the
+// first non-nil error's message, and "" when no result has an error.
+func TestFirstGithubEnumError(t *testing.T) {
+	t.Run("returns first non-nil error message", func(t *testing.T) {
+		results := []githubenum.Result{
+			{Email: "ok@x.com", Exists: true},
+			{Email: "err1@x.com", Error: errors.New("boom one")},
+			{Email: "err2@x.com", Error: errors.New("boom two")},
+		}
+
+		assert.Equal(t, "boom one", firstGithubEnumError(results))
+	})
+
+	t.Run("returns empty string when no errors present", func(t *testing.T) {
+		results := []githubenum.Result{
+			{Email: "ok@x.com", Exists: true},
+			{Email: "missing@x.com"},
+		}
+
+		assert.Equal(t, "", firstGithubEnumError(results))
+	})
 }

--- a/pkg/enum/github/github.go
+++ b/pkg/enum/github/github.go
@@ -50,6 +50,7 @@ import (
 	"golang.org/x/net/html"
 
 	"github.com/praetorian-inc/brutus/pkg/brutus"
+	"github.com/praetorian-inc/brutus/pkg/enum"
 )
 
 // Result is the outcome of checking (and optionally revealing) a single email.
@@ -142,6 +143,12 @@ func NewEnumerator(proxyURL string, timeout time.Duration, token string, rotatin
 	if err != nil {
 		return nil, fmt.Errorf("github enum: configuring HTTP client: %w", err)
 	}
+
+	// GitHub rejects Go's default "Go-http-client/…" User-Agent: github.com/join
+	// returns 403 with no CSRF token, and api.github.com requires a UA. Inject a
+	// browser UA at the transport layer so every existence and reveal request
+	// carries it (the apiClient clone below inherits this wrapped transport).
+	httpClient.Transport = enum.WithUserAgent(httpClient.Transport)
 
 	existenceBackoff := rateLimitBackoff
 	existenceMaxRetries := maxRateLimitRetries

--- a/pkg/enum/github/github_test.go
+++ b/pkg/enum/github/github_test.go
@@ -948,3 +948,69 @@ func TestNewEnumerator_RotatingProxy(t *testing.T) {
 			"existenceMaxRetries must equal rotatingProxyMaxRetries when rotatingProxy=true")
 	})
 }
+
+// TestExistence_SetsBrowserUserAgent is a regression test for the bug where the
+// existence client sent no User-Agent header, so Go defaulted to
+// "Go-http-client/…". GitHub returns HTTP 403 with a stub page (no CSRF token)
+// to that UA, so establishSession → parseCSRFToken failed with "CSRF
+// authenticity token not found on join page" on every run, recording every
+// target email as an error.
+//
+// This test's /join handler mimics GitHub: it returns 403 when the request
+// carries no User-Agent or a "Go-http-client" UA, and 200 with the CSRF-bearing
+// auto-check block otherwise. Enumeration succeeding (no error, Exists=true)
+// proves the request carried a browser UA. The test fails unless NewEnumerator
+// wraps the client transport with enum.WithUserAgent.
+func TestExistence_SetsBrowserUserAgent(t *testing.T) {
+	t.Parallel()
+
+	const csrfToken = "csrf-user-agent-test-token"
+
+	signupHTML := fmt.Sprintf(`<!DOCTYPE html><html><body>
+<auto-check src="/email_validity_checks">
+  <input type="hidden" value="%s">
+</auto-check>
+</body></html>`, csrfToken)
+
+	mux := http.NewServeMux()
+
+	// /join mimics GitHub: bot UAs (empty or "Go-http-client/…") get a 403 stub
+	// with no CSRF token; a real browser UA gets the CSRF-bearing page.
+	mux.HandleFunc("/join", func(w http.ResponseWriter, r *http.Request) {
+		ua := r.Header.Get("User-Agent")
+		if ua == "" || strings.Contains(ua, "Go-http-client") {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = fmt.Fprint(w, `<html><body>Request blocked</body></html>`)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = fmt.Fprint(w, signupHTML)
+	})
+
+	// /email_validity_checks returns 422 for the target (account exists) and 200
+	// for everything else (including the sanity-check @foobar.com address).
+	mux.HandleFunc("/email_validity_checks", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if r.FormValue("value") == "target@example.com" {
+			w.WriteHeader(http.StatusUnprocessableEntity) // 422 → exists
+		} else {
+			w.WriteHeader(http.StatusOK) // 200 → available
+		}
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	e := newTestEnumerator(t, srv, nil, "")
+
+	results := e.Enumerate(context.Background(), []string{"target@example.com"}, 1, 0, 0)
+
+	require.Len(t, results, 1)
+	require.NoError(t, results[0].Error,
+		"establishSession must succeed by sending a browser User-Agent so /join returns the CSRF token instead of a 403 stub")
+	assert.True(t, results[0].Exists,
+		"HTTP 422 from validity endpoint must map to Exists=true")
+}

--- a/pkg/enum/httpclient.go
+++ b/pkg/enum/httpclient.go
@@ -43,6 +43,20 @@ func (t *uaTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return t.base.RoundTrip(req)
 }
 
+// WithUserAgent wraps base so that requests without an explicit User-Agent get
+// the default browser UA. Enumerators that build their own client instead of
+// using NewEnumHTTPClientWithProxy (e.g. github, which must follow redirects on
+// its existence flow) call this to keep the UA behavior. Without it, Go sends
+// "Go-http-client/…", which GitHub — and other providers — reject as a bot
+// (github.com/join returns 403 with no CSRF token; api.github.com requires a UA).
+// A nil base defaults to http.DefaultTransport.
+func WithUserAgent(base http.RoundTripper) http.RoundTripper {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return &uaTransport{base: base}
+}
+
 // NewEnumHTTPClient returns an HTTP client with safe defaults for enum plugins:
 //   - No redirect following (returns last response)
 //   - Default User-Agent header


### PR DESCRIPTION
## Problem

`enum active github` failed for **every** target with `CSRF authenticity token not found on join page`, reporting `Errors == Total`. Large runs "finished" in ~1s because the failure happened once at session setup and was fanned out to all results.

## Root cause

`pkg/enum/github.NewEnumerator` builds its HTTP client via `brutus.NewHTTPClientWithProxy`, which sets **no `User-Agent`**. Go then sends `User-Agent: Go-http-client/…`. GitHub's signup flow (`/join` → `/signup`) applies bot detection there and can return **HTTP 403** with a token-less stub page, so `establishSession` → `parseCSRFToken` fails and every email is recorded as an error.

The `enum` package already injects a browser UA (`uaTransport`) for clients built with `NewEnumHTTPClientWithProxy`; google/microsoft365 get it for free. GitHub bypassed it because its existence flow must **follow redirects**, which that helper disables.

## Fix

- Export the UA behavior as `enum.WithUserAgent(base)` (`pkg/enum/httpclient.go`).
- Wrap the github client transport with it in `NewEnumerator`, **before** the `apiClient` clone, so both the existence and reveal clients carry a browser UA (`api.github.com` also requires a `User-Agent`).

A browser UA materially improves the join-page success rate and makes direct (unproxied) runs reliable.

## Also: error surfacing (this bug was invisible in human output)

In human (non-JSON) mode, errored results rendered as `[ ] not found` and the summary showed only `Errors: N` with no message — the actual error was visible only via `--json`.

- `outputGithubEnumResultLine` now renders a distinct `[-] error <msg>` row for errored results.
- The summary prints one representative error message beneath the `Errors:` count.

## Note on the signup page's bot detection (not a bug in this repo)

GitHub applies **adaptive, rate/reputation-based** bot detection to the `/signup` HTML page (keyed on IP reputation + request rate + User-Agent). It is **not** a hard block of any IP class. Measured on a rotating datacenter proxy with a browser UA, success was intermittent and time-varying (e.g. 2/3, then 0/12, then 1/1 within minutes), while direct connections were reliably 200. The 403, when it occurs, originates from GitHub (`server: github.com`), not from the proxy.

Because `establishSession` fetches `/join` exactly once with no retry, a single 403 currently fails the whole run. A follow-up to retry the join fetch on non-200 (leveraging `--rotating-proxy`'s fresh-IP-per-retry) would make proxied runs resilient to this flakiness; not included here.

## Tests

- `TestExistence_SetsBrowserUserAgent` — `/join` handler that 403s a Go/empty UA and 200s a browser UA; fails without the fix, passes with it.
- `TestOutputGithubEnumResultLine_Error`, `TestOutputGithubEnumResultLine_NotFoundStillWorks`, `TestOutputGithubEnumSummary_ShowsRepresentativeError`, `TestFirstGithubEnumError` — display behavior.

`go build ./...`, `go vet`, and the full `cmd/brutus` + `pkg/enum/...` suites are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
