### PR TITLE
fix(enum/github): retry the join-page fetch to survive intermittent 403s

### DIFF
--- a/pkg/enum/github/existence.go
+++ b/pkg/enum/github/existence.go
@@ -136,34 +136,67 @@ func (e *Enumerator) EnumerateWith(ctx context.Context, emails []string, threads
 // Existence helpers
 // ---------------------------------------------------------------------------
 
-// establishSession GETs the join page, parses the CSRF authenticity token from
-// the auto-check[src="/email_validity_checks"] element's hidden input, and
-// captures the response cookies. The parsed token + cookies are reused across
-// all existence checks. As a sanity check it verifies that a random,
-// almost-certainly-nonexistent address returns 200 (available); if it does not,
-// the endpoint likely changed and a warning is emitted to stderr.
+// establishSession fetches the join page, parses the CSRF token, and runs the
+// sanity check, retrying on transient failures. GitHub's signup page applies
+// intermittent, rate/reputation-based bot detection that returns a token-less
+// stub (commonly HTTP 403); a single such response would otherwise fail the
+// whole run. Retries use e.existenceBackoff / e.existenceMaxRetries (tuned to a
+// short delay + higher ceiling under --rotating-proxy, where each retry egresses
+// a fresh exit IP). A 200 response whose HTML lacks the token is NOT retried —
+// that signals a genuine endpoint change, so it fails fast.
 func (e *Enumerator) establishSession(ctx context.Context) (*session, error) {
+	var lastErr error
+	for attempt := 0; ; attempt++ {
+		sess, retryable, err := e.tryEstablishSession(ctx)
+		if err == nil {
+			return sess, nil
+		}
+		lastErr = err
+		if !retryable || attempt >= e.existenceMaxRetries {
+			return nil, lastErr
+		}
+		if serr := e.sleep(ctx, e.existenceBackoff); serr != nil {
+			return nil, serr
+		}
+	}
+}
+
+// tryEstablishSession performs ONE attempt to GET the join page, parse the CSRF
+// token, and run the sanity check. The bool reports whether a non-nil error is
+// worth retrying: transport failures, non-200 responses (the intermittent bot/
+// rate block), and transient sanity-check failures are retryable; a 200 with no
+// parseable token is not (the page contract changed).
+func (e *Enumerator) tryEstablishSession(ctx context.Context) (*session, bool, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, e.webBaseURL+joinPath, http.NoBody)
 	if err != nil {
-		return nil, fmt.Errorf("github enum: creating join request: %w", err)
+		return nil, false, fmt.Errorf("github enum: creating join request: %w", err)
 	}
 
 	resp, err := e.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("github enum: join request failed: %w", err)
+		return nil, true, fmt.Errorf("github enum: join request failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		// GitHub serves a token-less stub (commonly HTTP 403) to requests its bot/
+		// rate detection dislikes. This is intermittent, so it is retryable — with
+		// --rotating-proxy each retry uses a fresh exit IP.
+		return nil, true, fmt.Errorf("github enum: join page returned HTTP %d (GitHub bot/rate detection on the signup page; intermittent — with --rotating-proxy each retry uses a fresh exit IP)", resp.StatusCode)
+	}
 
 	// Bounded read — reuses enum.ReadResponseBody (1 MB default) so a hostile or
 	// misbehaving join endpoint cannot exhaust memory via an unbounded HTML body.
 	body, err := enum.ReadResponseBody(resp, 0)
 	if err != nil {
-		return nil, fmt.Errorf("github enum: reading join page: %w", err)
+		return nil, true, fmt.Errorf("github enum: reading join page: %w", err)
 	}
 
 	csrf, err := parseCSRFToken(bytes.NewReader(body))
 	if err != nil {
-		return nil, fmt.Errorf("github enum: parsing join page: %w", err)
+		// 200 but no token: the endpoint contract likely changed. Retrying will
+		// not help, so fail fast.
+		return nil, false, fmt.Errorf("github enum: parsing join page: %w", err)
 	}
 
 	sess := &session{
@@ -176,7 +209,7 @@ func (e *Enumerator) establishSession(ctx context.Context) (*session, error) {
 	sanityEmail := e.newName() + "@foobar.com"
 	exists, err := e.postValidity(ctx, sess, sanityEmail)
 	if err != nil {
-		return nil, fmt.Errorf("github enum: sanity check failed: %w", err)
+		return nil, true, fmt.Errorf("github enum: sanity check failed: %w", err)
 	}
 	if exists {
 		fmt.Fprintf(os.Stderr,
@@ -184,7 +217,7 @@ func (e *Enumerator) establishSession(ctx context.Context) (*session, error) {
 			sanityEmail)
 	}
 
-	return sess, nil
+	return sess, false, nil
 }
 
 // checkEmail POSTs a single email to the validity endpoint and maps the result.

--- a/pkg/enum/github/github_test.go
+++ b/pkg/enum/github/github_test.go
@@ -948,3 +948,126 @@ func TestNewEnumerator_RotatingProxy(t *testing.T) {
 			"existenceMaxRetries must equal rotatingProxyMaxRetries when rotatingProxy=true")
 	})
 }
+
+// ---------------------------------------------------------------------------
+// establishSession retry behavior: /join non-200 is retried, 200-no-token fails fast
+// ---------------------------------------------------------------------------
+
+// TestSession_RetriesOn403ThenSucceeds verifies that establishSession retries
+// the /join fetch when GitHub's bot/rate detection returns a non-200 (e.g.
+// HTTP 403) stub, and succeeds once /join starts returning the CSRF-bearing
+// page.
+func TestSession_RetriesOn403ThenSucceeds(t *testing.T) {
+	t.Parallel()
+
+	const csrfToken = "csrf-403-retry-token"
+	var joinCalls atomic.Int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/join", func(w http.ResponseWriter, _ *http.Request) {
+		n := joinCalls.Add(1)
+		if n <= 2 {
+			// Bot/rate-detection stub: non-200, no token.
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = fmt.Fprint(w, `<!DOCTYPE html><html><body>blocked</body></html>`)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = fmt.Fprintf(w, `<!DOCTYPE html><html><body>
+<auto-check src="/email_validity_checks">
+  <input type="hidden" value="%s">
+</auto-check>
+</body></html>`, csrfToken)
+	})
+	mux.HandleFunc("/email_validity_checks", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		email := r.FormValue("value")
+		if email == "target@example.com" {
+			w.WriteHeader(http.StatusUnprocessableEntity) // 422 → exists
+		} else {
+			w.WriteHeader(http.StatusOK) // 200 → available (sanity-check passes)
+		}
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	e := newTestEnumerator(t, srv, nil, "")
+
+	results := e.Enumerate(context.Background(), []string{"target@example.com"}, 1, 0, 0)
+
+	require.Len(t, results, 1)
+	require.NoError(t, results[0].Error, "establishSession must succeed after retrying past the 403 stubs")
+	assert.True(t, results[0].Exists, "HTTP 422 from validity endpoint must map to Exists=true")
+	assert.Equal(t, int32(3), joinCalls.Load(), "/join must be hit 3 times: 2 failed 403 attempts + 1 success")
+}
+
+// TestSession_403ExhaustsRetries verifies that when /join always returns a
+// non-200 response, establishSession exhausts existenceMaxRetries and every
+// email's Result carries an error mentioning the HTTP status. The session is
+// established once per Enumerate batch, so /join must be hit exactly
+// existenceMaxRetries+1 times regardless of how many emails are enumerated.
+func TestSession_403ExhaustsRetries(t *testing.T) {
+	t.Parallel()
+
+	var joinCalls atomic.Int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/join", func(w http.ResponseWriter, _ *http.Request) {
+		joinCalls.Add(1)
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = fmt.Fprint(w, `<!DOCTYPE html><html><body>blocked</body></html>`)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	e := newTestEnumerator(t, srv, nil, "")
+	e.existenceMaxRetries = 2
+
+	results := e.Enumerate(context.Background(), []string{"a@x.com", "b@x.com"}, 2, 0, 0)
+
+	require.Len(t, results, 2)
+	for i, r := range results {
+		assert.Error(t, r.Error, "result[%d] must carry an error when /join always returns 403", i)
+		if r.Error != nil {
+			assert.Contains(t, r.Error.Error(), "join page returned HTTP 403",
+				"result[%d] error must mention the join page HTTP status", i)
+		}
+	}
+	assert.Equal(t, int32(3), joinCalls.Load(),
+		"/join must be hit existenceMaxRetries+1=3 times total (session established once per batch, not per email)")
+}
+
+// TestSession_200NoTokenNotRetried verifies that a 200 response from /join
+// whose HTML lacks a parseable CSRF token is NOT retried — it fails fast
+// after a single attempt, since the endpoint contract has changed rather than
+// GitHub applying transient bot/rate detection.
+func TestSession_200NoTokenNotRetried(t *testing.T) {
+	t.Parallel()
+
+	var joinCalls atomic.Int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/join", func(w http.ResponseWriter, _ *http.Request) {
+		joinCalls.Add(1)
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = fmt.Fprint(w, `<!DOCTYPE html><html><body><p>no auto-check here</p></body></html>`)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	e := newTestEnumerator(t, srv, nil, "")
+
+	results := e.Enumerate(context.Background(), []string{"a@x.com"}, 1, 0, 0)
+
+	require.Len(t, results, 1)
+	assert.Error(t, results[0].Error, "a 200 join page with no CSRF token must produce an error")
+	if results[0].Error != nil {
+		assert.Contains(t, results[0].Error.Error(), "parsing join page",
+			"error must mention join-page parsing failure")
+	}
+	assert.Equal(t, int32(1), joinCalls.Load(),
+		"/join must be hit exactly once — a 200-with-no-token response must fail fast, not retry")
+}


### PR DESCRIPTION
## Problem

`establishSession` fetched `github.com/join` **exactly once**. GitHub's signup page applies adaptive, rate/reputation-based bot detection that intermittently returns **HTTP 403** with a token-less stub page. A single 403 on that one fetch failed the **entire** enumeration run — every target came back as an error.

This is time-varying: the same source swings between mostly-200 and mostly-403 within minutes, and a shared datacenter proxy pool's standing with GitHub fluctuates over hours/days (which is why proxied enum "works some days, not others").

## Fix

Wrap the join fetch + CSRF parse in a bounded retry loop using the **existing** `existenceBackoff` / `existenceMaxRetries` knobs — already tuned to a short delay + higher ceiling when `--rotating-proxy` is set, where **each retry egresses a fresh exit IP**. So when the pool's success rate is nonzero, a few retries land a 200 and the run proceeds.

Retry policy:
- Non-200 responses (the intermittent 403), transport failures, and transient sanity-check failures → **retried**.
- A **200 with no parseable CSRF token** → **not retried** (genuine endpoint change; fails fast).
- Bounded (`existenceMaxRetries`, +1 total attempts) and ctx-aware via `e.sleep`, so cancellation aborts promptly.
- `establishSession` runs once per `Enumerate` batch, so retries are per-run, not per-email.

The non-200 error now names the status — `join page returned HTTP 403 (GitHub bot/rate detection on the signup page; intermittent — with --rotating-proxy each retry uses a fresh exit IP)` — instead of the old, misleading `CSRF authenticity token not found on join page`.

## Relationship to #241

Independent and complementary. #241 fixes the missing `User-Agent` (necessary for the join page to return a token at all) and makes errors visible in human output. This PR adds resilience to the *intermittent* bot-detection 403s on top of that. Neither depends on the other's code; this branch is cut from `main`.

**Note:** when the source IP / proxy pool is *fully* burned (≈0% success), no amount of retrying recovers it — that needs a fresh/residential IP source and/or request pacing. This PR maximizes recovery whenever success is intermittent rather than zero.

## Tests

- `TestSession_RetriesOn403ThenSucceeds` — `/join` 403s twice then 200s; run recovers, `/join` hit 3×.
- `TestSession_403ExhaustsRetries` — always 403; bounded attempts (`existenceMaxRetries+1`), error names `HTTP 403`.
- `TestSession_200NoTokenNotRetried` — 200 with no token fails fast, `/join` hit exactly once (no retry).

`go build ./...`, `go vet`, and the full `cmd/brutus` + `pkg/enum/github` suites are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
