### PR TITLE
fix(cli): stop registering scan target-input flags on the enum subtree

### DIFF
--- a/cmd/brutus/flags.go
+++ b/cmd/brutus/flags.go
@@ -119,12 +119,6 @@ var flagVersion bool
 func registerSharedFlags(cmd *cobra.Command) {
 	pf := cmd.PersistentFlags()
 
-	// Target
-	pf.StringVar(&flagTarget, "target", "", "Target host:port")
-	pf.StringVar(&flagTargetsFile, "targets-file", "", "File of targets to test, one host:port per line (fingerprints with Nerva unless --protocol is set)")
-	pf.StringVar(&flagNmapFile, "nmap-file", "", "Nmap XML file (-oX output) to import targets from")
-	pf.StringVar(&flagMasscanFile, "masscan-file", "", "Masscan JSON file (-oJ output) to import targets from")
-
 	// Performance
 	pf.IntVarP(&flagThreads, "threads", "t", 10, "Number of concurrent threads")
 	pf.DurationVar(&flagTimeout, "timeout", 10*time.Second, "Per-target timeout")
@@ -148,6 +142,18 @@ func registerSharedFlags(cmd *cobra.Command) {
 	pf.BoolVar(&flagNoColor, "no-color", false, "Disable colored output")
 	pf.BoolVarP(&flagQuiet, "quiet", "q", false, "Quiet mode - only show successful credentials")
 	pf.BoolVarP(&flagVerbose, "verbose", "v", false, "Verbose mode - show detailed progress to stderr")
+}
+
+// registerScanTargetFlags registers the host:port target-input flags as
+// persistent flags on a target-based scan command. These are intentionally NOT
+// rootCmd-persistent: the enum subtree operates on emails/domains, so it must
+// not inherit --target/--targets-file/--nmap-file/--masscan-file.
+func registerScanTargetFlags(cmd *cobra.Command) {
+	pf := cmd.PersistentFlags()
+	pf.StringVar(&flagTarget, "target", "", "Target host:port")
+	pf.StringVar(&flagTargetsFile, "targets-file", "", "File of targets to test, one host:port per line (fingerprints with Nerva unless --protocol is set)")
+	pf.StringVar(&flagNmapFile, "nmap-file", "", "Nmap XML file (-oX output) to import targets from")
+	pf.StringVar(&flagMasscanFile, "masscan-file", "", "Masscan JSON file (-oJ output) to import targets from")
 }
 
 // registerCredentialFlags registers credential and brute-force strategy flags

--- a/cmd/brutus/root.go
+++ b/cmd/brutus/root.go
@@ -59,6 +59,13 @@ func init() {
 	registerSharedFlags(rootCmd)
 	registerRootFlags(rootCmd)
 
+	// Target-input flags are scan-only; register them on the target-based scan
+	// commands rather than rootCmd so the enum subtree (emails/domains) does not
+	// inherit them.
+	for _, c := range []*cobra.Command{credsCmd, webCmd, snmpCmd, badkeysCmd, logonCmd, stickykeysCmd, utilmanCmd} {
+		registerScanTargetFlags(c)
+	}
+
 	// Validate shared flags before any subcommand runs.
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
 		// SNMP has its own tier names (extended, full) that predate the global

--- a/cmd/brutus/scan_target_flags_wiring_test.go
+++ b/cmd/brutus/scan_target_flags_wiring_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+// Tests that the host:port target-input flags are registered on the scan
+// commands and NOT globally on rootCmd, so the enum subtree does not inherit
+// them. Regression guard for the flag move out of registerSharedFlags.
+
+func TestScanTargetFlags_NotOnRoot(t *testing.T) {
+	names := []string{"target", "targets-file", "nmap-file", "masscan-file"}
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			assert.Nil(t, rootCmd.PersistentFlags().Lookup(name))
+		})
+	}
+}
+
+func TestScanTargetFlags_OnScanCommands(t *testing.T) {
+	names := []string{"target", "targets-file", "nmap-file", "masscan-file"}
+	commands := map[string]*cobra.Command{
+		"creds":      credsCmd,
+		"web":        webCmd,
+		"snmp":       snmpCmd,
+		"badkeys":    badkeysCmd,
+		"logon":      logonCmd,
+		"stickykeys": stickykeysCmd,
+		"utilman":    utilmanCmd,
+	}
+	for name, cmd := range commands {
+		t.Run(name, func(t *testing.T) {
+			for _, flagName := range names {
+				assert.NotNil(t, cmd.PersistentFlags().Lookup(flagName), "expected flag %q on command %q", flagName, name)
+			}
+		})
+	}
+}
+
+func TestScanTargetFlags_NotInheritedByEnumLeaf(t *testing.T) {
+	names := []string{"target", "targets-file", "nmap-file", "masscan-file"}
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			assert.Nil(t, enumGithubCmd.InheritedFlags().Lookup(name))
+			assert.Nil(t, enumGithubCmd.Flags().Lookup(name))
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The host:port **target-input** flags — `--target`, `--targets-file`, `--nmap-file`, `--masscan-file` — are registered as `rootCmd` persistent flags, so **every** subcommand inherits them. That includes the `enum` tree, which enumerates email accounts against SaaS services and **never reads any of them** (verified: no `enum` code path references `flagTarget`/`flagTargetsFile`/`flagNmapFile`/`flagMasscanFile`, and `enum` doesn't call `buildBaseConfig`). They appeared under `brutus enum --help` (and every enum subcommand) as usable global flags that silently did nothing.

## Fix

Move the four flags off `rootCmd` onto the target-based scan commands (`creds`, `web`, `snmp`, `badkeys`, `logon`, `stickykeys`, `utilman`) via a new `registerScanTargetFlags` helper called from `root.go`'s `init()`.

- Behavior for the scan commands is unchanged: same flag names, same global variables, still read by `runSubcommand`.
- `enum` no longer inherits them → they're gone from its help and rejected as unknown flags (`Error: unknown flag: --nmap-file`).
- **Minor intended side effect:** the bare root command (no subcommand) no longer accepts these flags either — it only ever handled `--version`, so this is a no-op in practice.

## Verification

```
$ brutus enum active github --help        # (target-input flags absent)
$ brutus creds --help
      --masscan-file string   Masscan JSON file (-oJ output) to import targets from
      --nmap-file string      Nmap XML file (-oX output) to import targets from
      --target string         Target host:port
      --targets-file string   File of targets to test, one host:port per line ...
$ brutus enum active github --nmap-file /tmp/x -e a@b.com
Error: unknown flag: --nmap-file
```

Regression test `scan_target_flags_wiring_test.go` asserts the four flags are absent from `rootCmd`'s persistent set, present on each scan command, and neither inherited nor locally defined on an enum leaf command. `go build ./...`, `go vet`, and the full `cmd/brutus` suite are green.

## Part of a pair

Companion PR handles the scan-**tuning** flags (`--connect-timeout`, `--mode`, `--retries`) that leak into `enum` the same way. Both are cut from `main`; whichever merges first, the other needs a trivial rebase (both edit `registerSharedFlags` / `root.go init`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
