### PR TITLE
fix(cli): stop registering scan-tuning flags on the enum subtree

### DIFF
--- a/cmd/brutus/flags.go
+++ b/cmd/brutus/flags.go
@@ -122,14 +122,8 @@ func registerSharedFlags(cmd *cobra.Command) {
 	// Performance
 	pf.IntVarP(&flagThreads, "threads", "t", 10, "Number of concurrent threads")
 	pf.DurationVar(&flagTimeout, "timeout", 10*time.Second, "Per-target timeout")
-	pf.DurationVar(&flagConnectTimeout, "connect-timeout", 3*time.Second,
-		"TCP connect timeout for scan dials (separate from --scan-timeout, which is the per-host settle deadline). A reachable host completes the handshake in ~1 RTT, so the short default only accelerates dead-host rejection; raise it for high-latency target sets.")
 	pf.Float64Var(&flagRateLimit, "rate-limit", 0, "Max requests per second (0 = unlimited)")
 	pf.DurationVar(&flagJitter, "jitter", 0, "Random delay variance for rate limiting")
-	pf.IntVar(&flagRetries, "retries", 2, "Max retries on connection error (0 = disabled)")
-
-	// Mode
-	pf.StringVarP(&flagMode, "mode", "m", "default", "Aggressiveness tier: cautious, default, aggressive")
 
 	// Proxy
 	pf.StringVar(&flagProxy, "proxy", "", "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080")
@@ -154,6 +148,18 @@ func registerScanTargetFlags(cmd *cobra.Command) {
 	pf.StringVar(&flagTargetsFile, "targets-file", "", "File of targets to test, one host:port per line (fingerprints with Nerva unless --protocol is set)")
 	pf.StringVar(&flagNmapFile, "nmap-file", "", "Nmap XML file (-oX output) to import targets from")
 	pf.StringVar(&flagMasscanFile, "masscan-file", "", "Masscan JSON file (-oJ output) to import targets from")
+}
+
+// registerScanTuningFlags registers the scan-tuning flags as persistent flags on
+// a target-based scan command. Like the target-input flags, these are NOT
+// rootCmd-persistent: the enum subtree never reads --connect-timeout/--mode/
+// --retries (and never applies --mode presets), so it must not inherit them.
+func registerScanTuningFlags(cmd *cobra.Command) {
+	pf := cmd.PersistentFlags()
+	pf.DurationVar(&flagConnectTimeout, "connect-timeout", 3*time.Second,
+		"TCP connect timeout for scan dials (separate from --scan-timeout, which is the per-host settle deadline). A reachable host completes the handshake in ~1 RTT, so the short default only accelerates dead-host rejection; raise it for high-latency target sets.")
+	pf.StringVarP(&flagMode, "mode", "m", "default", "Aggressiveness tier: cautious, default, aggressive")
+	pf.IntVar(&flagRetries, "retries", 2, "Max retries on connection error (0 = disabled)")
 }
 
 // registerCredentialFlags registers credential and brute-force strategy flags

--- a/cmd/brutus/root.go
+++ b/cmd/brutus/root.go
@@ -59,11 +59,12 @@ func init() {
 	registerSharedFlags(rootCmd)
 	registerRootFlags(rootCmd)
 
-	// Target-input flags are scan-only; register them on the target-based scan
-	// commands rather than rootCmd so the enum subtree (emails/domains) does not
-	// inherit them.
+	// Target-input and scan-tuning flags are scan-only; register them on the
+	// target-based scan commands rather than rootCmd so the enum subtree
+	// (emails/domains) does not inherit them.
 	for _, c := range []*cobra.Command{credsCmd, webCmd, snmpCmd, badkeysCmd, logonCmd, stickykeysCmd, utilmanCmd} {
 		registerScanTargetFlags(c)
+		registerScanTuningFlags(c)
 	}
 
 	// Validate shared flags before any subcommand runs.

--- a/cmd/brutus/scan_tuning_flags_wiring_test.go
+++ b/cmd/brutus/scan_tuning_flags_wiring_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+// scanTuningFlagNames lists the flags moved off rootCmd's persistent flags
+// onto each target-based scan command via registerScanTuningFlags, so that
+// the enum subtree does not inherit them.
+var scanTuningFlagNames = []string{"connect-timeout", "mode", "retries"}
+
+// TestScanTuningFlags_NotOnRoot verifies that --connect-timeout, --mode, and
+// --retries (and the -m shorthand) are no longer registered as persistent
+// flags on rootCmd.
+func TestScanTuningFlags_NotOnRoot(t *testing.T) {
+	for _, name := range scanTuningFlagNames {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			assert.Nil(t, rootCmd.PersistentFlags().Lookup(name),
+				"rootCmd must not have --%s as a persistent flag", name)
+		})
+	}
+
+	assert.Nil(t, rootCmd.PersistentFlags().ShorthandLookup("m"),
+		"rootCmd must not have -m as a persistent flag shorthand")
+}
+
+// TestScanTuningFlags_OnScanCommands verifies that each target-based scan
+// command registers all three scan-tuning flags via registerScanTuningFlags.
+func TestScanTuningFlags_OnScanCommands(t *testing.T) {
+	scanCmds := map[string]*cobra.Command{
+		"creds":      credsCmd,
+		"web":        webCmd,
+		"snmp":       snmpCmd,
+		"badkeys":    badkeysCmd,
+		"logon":      logonCmd,
+		"stickykeys": stickykeysCmd,
+		"utilman":    utilmanCmd,
+	}
+
+	for cmdName, cmd := range scanCmds {
+		cmdName, cmd := cmdName, cmd
+		t.Run(cmdName, func(t *testing.T) {
+			for _, name := range scanTuningFlagNames {
+				assert.NotNil(t, cmd.PersistentFlags().Lookup(name),
+					"%s command must register --%s via registerScanTuningFlags", cmdName, name)
+			}
+		})
+	}
+}
+
+// TestScanTuningFlags_NotInheritedByEnumLeaf verifies that an enum leaf
+// command (enumGithubCmd) neither inherits nor directly registers any of the
+// scan-tuning flags, confirming the enum subtree is isolated from them.
+func TestScanTuningFlags_NotInheritedByEnumLeaf(t *testing.T) {
+	for _, name := range scanTuningFlagNames {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			assert.Nil(t, enumGithubCmd.InheritedFlags().Lookup(name),
+				"enumGithubCmd must not inherit --%s", name)
+			assert.Nil(t, enumGithubCmd.Flags().Lookup(name),
+				"enumGithubCmd must not directly register --%s", name)
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The scan-**tuning** flags `--connect-timeout`, `--mode`/`-m`, and `--retries` are registered as `rootCmd` persistent flags, so the `enum` command tree inherits them despite never using them: no `enum` code path reads `flagConnectTimeout`/`flagMode`/`flagRetries`, and `enum` never calls `buildBaseConfig`, so the `--mode` aggressiveness presets were never applied to it. They appeared under `brutus enum --help` as usable global flags that silently did nothing.

## Fix

Move the three flags off `rootCmd` onto the target-based scan commands (`creds`, `web`, `snmp`, `badkeys`, `logon`, `stickykeys`, `utilman`) via a new `registerScanTuningFlags` helper called from `root.go`'s `init()`.

- `rootCmd.PersistentPreRunE` still validates `--mode` (unchanged): `flagMode` is a global defaulting to `"default"` (valid) for enum invocations that no longer register the flag, and is still set + validated for scan invocations.
- Scan-command behavior is unchanged; `enum` now rejects these as unknown flags and omits them from help.

## Verification

```
$ brutus enum active github --help        # (--connect-timeout / -m,--mode / --retries absent)
$ brutus creds --help
      --connect-timeout duration   TCP connect timeout for scan dials ...
  -m, --mode string                Aggressiveness tier: cautious, default, aggressive (default "default")
      --retries int                Max retries on connection error (0 = disabled) (default 2)
$ brutus enum active github --mode aggressive -e a@b.com
Error: unknown flag: --mode
$ brutus creds --mode bogus --target 127.0.0.1:22
Error: invalid --mode "bogus" (valid: cautious, default, aggressive)   # PersistentPreRunE still fires
```

Regression test `scan_tuning_flags_wiring_test.go` asserts the three flags (and the `-m` shorthand) are absent from `rootCmd`, present on each scan command, and neither inherited nor locally defined on an enum leaf command. `go build ./...`, `go vet`, and the full `cmd/brutus` suite are green.

## Part of a pair

Companion PR handles the scan target-**input** flags (`--target`, `--targets-file`, `--nmap-file`, `--masscan-file`) that leak into `enum` the same way. Both are cut from `main`; whichever merges first, the other needs a trivial rebase (both edit `registerSharedFlags` / `root.go init`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
