### PR TITLE
fix(enum/google): send a browser User-Agent for account existence checks

### DIFF
--- a/pkg/enum/google/google.go
+++ b/pkg/enum/google/google.go
@@ -36,6 +36,7 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/praetorian-inc/brutus/pkg/brutus"
+	"github.com/praetorian-inc/brutus/pkg/enum"
 )
 
 // Method identifies which oracle confirmed an account's existence.
@@ -95,6 +96,12 @@ func NewEnumerator(proxyURL string, timeout time.Duration) (*Enumerator, error) 
 	if err != nil {
 		return nil, fmt.Errorf("google enum: configuring HTTP client: %w", err)
 	}
+
+	// Providers' anti-automation reject Go's default "Go-http-client" User-Agent
+	// (the same failure the github enumerator hit). Inject a browser UA at the
+	// transport layer so every request — including the client clone in
+	// checkAccountChooser, which shares this transport — carries it.
+	httpClient.Transport = enum.WithUserAgent(httpClient.Transport)
 
 	return &Enumerator{
 		httpClient:            httpClient,

--- a/pkg/enum/google/google_test.go
+++ b/pkg/enum/google/google_test.go
@@ -394,6 +394,48 @@ func TestEnumerateWith_ZeroOrNegativeThreadsDoesNotHang(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// TestCheckAccount_SendsBrowserUserAgent
+// Regression guard: NewEnumerator wraps its transport with enum.WithUserAgent
+// so outbound requests carry a browser User-Agent instead of Go's default
+// "Go-http-client/1.1". Captures the User-Agent seen by both the
+// AccountChooser and GXLU endpoints and asserts it looks like a browser UA.
+// ---------------------------------------------------------------------------
+
+func TestCheckAccount_SendsBrowserUserAgent(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var capturedUA string
+
+	captureUA := func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		capturedUA = r.Header.Get("User-Agent")
+		mu.Unlock()
+		w.Header().Set("Location", "https://accounts.google.com/ServiceLogin")
+		w.WriteHeader(http.StatusFound)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/AccountChooser", captureUA)
+	mux.HandleFunc("/mail/gxlu", captureUA)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	e := newTestEnumerator(t, srv)
+	res := e.CheckAccount(context.Background(), "user@gmail.com")
+
+	require.NoError(t, res.Error)
+
+	mu.Lock()
+	ua := capturedUA
+	mu.Unlock()
+
+	require.NotEmpty(t, ua, "the account-check must issue at least one request")
+	assert.NotContains(t, ua, "Go-http-client", "requests must not carry Go's default User-Agent")
+	assert.Contains(t, ua, "Mozilla", "requests must carry a browser User-Agent")
+}
+
+// ---------------------------------------------------------------------------
 // idpHost helper (unit coverage for the unexported helper)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

`pkg/enum/google/NewEnumerator` built its HTTP client via `brutus.NewHTTPClientWithProxy`, which sets **no** `User-Agent` — so every account-existence request egressed as `Go-http-client/1.1`. Same bug class as the recently-fixed github enumerator (#241): providers' anti-automation can 403 or silently alter the redirect `Location` / `GMAIL_AT` cookie signals these checks depend on, breaking enumeration with no useful diagnostic. github.go's own comment notes it "Mirrors pkg/enum/google/google.go", so google carried the identical latent gap.

## Fix

Wrap the client transport with the shared `enum.WithUserAgent` helper (added in #241) in `NewEnumerator`, so every request — including the client clone in `checkAccountChooser`, which shares this transport — carries a browser UA.

## Test

`TestCheckAccount_SendsBrowserUserAgent` captures the outbound `User-Agent` at a mock server and asserts it's a `Mozilla/...` UA, never `Go-http-client`. `go build ./...`, `go vet`, and the full `pkg/enum/google` suite are green.

Found during a broader review for the same class of issue as #241–#244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)