### PR TITLE
fix(plugins): close idle HTTP connections after credential attempts

### DIFF
--- a/internal/plugins/couchdb/couchdb.go
+++ b/internal/plugins/couchdb/couchdb.go
@@ -64,6 +64,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		result.Error = brutus.WrapConnError(err)
 		return result
 	}
+	defer client.CloseIdleConnections()
 
 	// Create request
 	req, err := http.NewRequestWithContext(ctx, "GET", url, http.NoBody)

--- a/internal/plugins/docker/docker.go
+++ b/internal/plugins/docker/docker.go
@@ -63,6 +63,7 @@ func (c *Checker) CheckUnauth(ctx context.Context, target string, timeout time.D
 	if err != nil {
 		return result
 	}
+	defer client.CloseIdleConnections()
 	resp, err := client.Do(req)
 	if err != nil {
 		return result

--- a/internal/plugins/elasticsearch/elasticsearch.go
+++ b/internal/plugins/elasticsearch/elasticsearch.go
@@ -75,6 +75,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		result.Error = brutus.WrapConnError(err)
 		return result
 	}
+	defer client.CloseIdleConnections()
 
 	// Execute request
 	resp, err := client.Do(req)
@@ -124,6 +125,7 @@ func (p *Plugin) CheckUnauth(ctx context.Context, target string, timeout time.Du
 	if err != nil {
 		return result
 	}
+	defer client.CloseIdleConnections()
 	resp, err := client.Do(req)
 	if err != nil {
 		return result

--- a/internal/plugins/influxdb/influxdb.go
+++ b/internal/plugins/influxdb/influxdb.go
@@ -76,6 +76,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		result.Error = brutus.WrapConnError(err)
 		return result
 	}
+	defer client.CloseIdleConnections()
 
 	// Send HTTP request
 	resp, err := client.Do(req)

--- a/internal/plugins/kubernetes/kubernetes.go
+++ b/internal/plugins/kubernetes/kubernetes.go
@@ -58,6 +58,7 @@ func (c *Checker) CheckUnauth(ctx context.Context, target string, timeout time.D
 	if err != nil {
 		return result
 	}
+	defer client.CloseIdleConnections()
 	scheme := brutus.SchemeFromTLSMode(tlsMode)
 
 	// For kubelet (port 10250), check the /pods endpoint directly


### PR DESCRIPTION
## Problem

The `elasticsearch`, `couchdb`, `influxdb`, `docker`, and `kubernetes` plugins each build a fresh `*http.Client` per credential attempt via `brutus.NewHTTPClientWithProxy` but never call `CloseIdleConnections()`. The shared transport sets no `IdleConnTimeout` (0 = never expire), so every attempt leaves a keep-alive socket open for the life of the process — a real fd/connection leak in a tool that can make thousands of attempts. The `http` plugin already guards this with `defer client.CloseIdleConnections()`; these five siblings did not.

## Fix

Add the same `defer client.CloseIdleConnections()` at each of the six client-build sites (elasticsearch has two: `Test` and `CheckUnauth`). No behavior change beyond releasing idle sockets when the attempt function returns.

## Testing

No new unit test: idle-connection release isn't meaningfully assertable without a client-injection seam these plugins don't expose, and the change mirrors the existing, already-tested `http`-plugin pattern verbatim. Verified via `go build ./...`, `go vet ./internal/plugins/...`, and the existing per-plugin suites (all green).

Found during a broader review for small correctness/hygiene tweaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)