### PR TITLE
fix(plugins): bound SSH and VNC handshakes with an I/O deadline

### DIFF
--- a/internal/plugins/ssh/ssh.go
+++ b/internal/plugins/ssh/ssh.go
@@ -80,6 +80,11 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	}
 	defer func() { _ = conn.Close() }()
 
+	// Bound the SSH handshake: ssh.ClientConfig.Timeout only covers ssh.Dial's
+	// internal dial, not NewClientConn on an already-dialed conn, so without this
+	// a server that stalls the handshake hangs the worker.
+	_ = conn.SetDeadline(time.Now().Add(timeout))
+
 	// Perform SSH handshake
 	sshConn, chans, reqs, err := ssh.NewClientConn(conn, target, config)
 	if err != nil {
@@ -152,6 +157,11 @@ func (p *Plugin) TestKey(ctx context.Context, target, username string, key []byt
 		return result
 	}
 	defer func() { _ = conn.Close() }()
+
+	// Bound the SSH handshake: ssh.ClientConfig.Timeout only covers ssh.Dial's
+	// internal dial, not NewClientConn on an already-dialed conn, so without this
+	// a server that stalls the handshake hangs the worker.
+	_ = conn.SetDeadline(time.Now().Add(timeout))
 
 	// Perform SSH handshake
 	sshConn, chans, reqs, err := ssh.NewClientConn(conn, target, config)

--- a/internal/plugins/ssh/ssh_key_test.go
+++ b/internal/plugins/ssh/ssh_key_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/praetorian-inc/brutus/pkg/badkeys"
 	"github.com/praetorian-inc/brutus/pkg/brutus"
 )
@@ -192,6 +194,34 @@ func TestPlugin_TestKey_ContextCancellation(t *testing.T) {
 	if result.Error == nil {
 		t.Error("expected Error!=nil for canceled context")
 	}
+}
+
+// TestPlugin_TestKey_StalledHandshakeDoesNotHang is a regression test proving
+// that a server which accepts the TCP connection but never speaks (no SSH
+// banner) does not hang TestKey() forever. Without SetDeadline on the dialed
+// conn, the SSH handshake would block indefinitely on the stalled read.
+func TestPlugin_TestKey_StalledHandshakeDoesNotHang(t *testing.T) {
+	plugin := &Plugin{}
+	target := startStallingServer(t)
+	validKey := generateTestKey(t)
+
+	done := make(chan struct{})
+	var result *brutus.Result
+	go func() {
+		result = plugin.TestKey(context.Background(), target, "testuser", validKey, 500*time.Millisecond, brutus.PluginConfig{})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// completed - good
+	case <-time.After(5 * time.Second):
+		t.Fatal("TestKey() did not return within 5s - handshake deadline missing (regressed)")
+	}
+
+	assert.NotNil(t, result)
+	assert.False(t, result.Success)
+	assert.Error(t, result.Error)
 }
 
 // getKeyTestConfig returns test configuration from environment variables.

--- a/internal/plugins/ssh/ssh_test.go
+++ b/internal/plugins/ssh/ssh_test.go
@@ -15,13 +15,59 @@
 package ssh
 
 import (
+	"context"
 	"errors"
+	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/praetorian-inc/brutus/pkg/brutus"
 )
+
+// startStallingServer starts a TCP listener that accepts connections but
+// never writes anything (no protocol banner), simulating a server that
+// stalls the handshake. It returns the listener's address as the target.
+func startStallingServer(t *testing.T) string {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start stalling server: %v", err)
+	}
+
+	stop := make(chan struct{})
+	t.Cleanup(func() {
+		close(stop)
+		_ = ln.Close()
+	})
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer func() { _ = c.Close() }()
+				buf := make([]byte, 1)
+				for {
+					select {
+					case <-stop:
+						return
+					default:
+					}
+					if _, err := c.Read(buf); err != nil {
+						return
+					}
+				}
+			}(conn)
+		}
+	}()
+
+	return ln.Addr().String()
+}
 
 func TestPlugin_Name(t *testing.T) {
 	p := &Plugin{}
@@ -96,6 +142,33 @@ func TestClassifyAuthError(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestPlugin_Test_StalledHandshakeDoesNotHang is a regression test proving that
+// a server which accepts the TCP connection but never speaks (no SSH banner)
+// does not hang Test() forever. Without SetDeadline on the dialed conn, the
+// SSH handshake would block indefinitely on the stalled read.
+func TestPlugin_Test_StalledHandshakeDoesNotHang(t *testing.T) {
+	plugin := &Plugin{}
+	target := startStallingServer(t)
+
+	done := make(chan struct{})
+	var result *brutus.Result
+	go func() {
+		result = plugin.Test(context.Background(), target, "testuser", "testpass", 500*time.Millisecond, brutus.PluginConfig{})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// completed - good
+	case <-time.After(5 * time.Second):
+		t.Fatal("Test() did not return within 5s - handshake deadline missing (regressed)")
+	}
+
+	assert.NotNil(t, result)
+	assert.False(t, result.Success)
+	assert.Error(t, result.Error)
 }
 
 // Integration test for password authentication - requires real SSH server (skipped by default)

--- a/internal/plugins/vnc/vnc.go
+++ b/internal/plugins/vnc/vnc.go
@@ -67,6 +67,10 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	}
 	defer func() { _ = conn.Close() }()
 
+	// Bound the VNC handshake so a server that stalls after connect cannot hang
+	// the worker (vnc.Client performs blocking reads with no timeout of its own).
+	_ = conn.SetDeadline(time.Now().Add(timeout))
+
 	// Create VNC client configuration
 	cfg := &vnc.ClientConfig{
 		Auth: []vnc.ClientAuth{

--- a/internal/plugins/vnc/vnc_test.go
+++ b/internal/plugins/vnc/vnc_test.go
@@ -16,6 +16,7 @@ package vnc
 
 import (
 	"context"
+	"net"
 	"testing"
 	"time"
 
@@ -23,6 +24,49 @@ import (
 
 	"github.com/praetorian-inc/brutus/pkg/brutus"
 )
+
+// startStallingServer starts a TCP listener that accepts connections but
+// never writes anything (no protocol banner), simulating a server that
+// stalls the handshake. It returns the listener's address as the target.
+func startStallingServer(t *testing.T) string {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start stalling server: %v", err)
+	}
+
+	stop := make(chan struct{})
+	t.Cleanup(func() {
+		close(stop)
+		_ = ln.Close()
+	})
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer func() { _ = c.Close() }()
+				buf := make([]byte, 1)
+				for {
+					select {
+					case <-stop:
+						return
+					default:
+					}
+					if _, err := c.Read(buf); err != nil {
+						return
+					}
+				}
+			}(conn)
+		}
+	}()
+
+	return ln.Addr().String()
+}
 
 func TestPlugin_Name(t *testing.T) {
 	p := &Plugin{}
@@ -98,6 +142,33 @@ func TestPlugin_Test_ContextCancellation(t *testing.T) {
 	assert.NotNil(t, result)
 	assert.False(t, result.Success)
 	assert.NotNil(t, result.Error)
+}
+
+// TestPlugin_Test_StalledHandshakeDoesNotHang is a regression test proving
+// that a server which accepts the TCP connection but never speaks (no VNC
+// protocol banner) does not hang Test() forever. Without SetDeadline on the
+// dialed conn, vnc.Client's blocking read would stall indefinitely.
+func TestPlugin_Test_StalledHandshakeDoesNotHang(t *testing.T) {
+	p := &Plugin{}
+	target := startStallingServer(t)
+
+	done := make(chan struct{})
+	var result *brutus.Result
+	go func() {
+		result = p.Test(context.Background(), target, "", "password", 500*time.Millisecond, brutus.PluginConfig{})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// completed - good
+	case <-time.After(5 * time.Second):
+		t.Fatal("Test() did not return within 5s - handshake deadline missing (regressed)")
+	}
+
+	assert.NotNil(t, result)
+	assert.False(t, result.Success)
+	assert.Error(t, result.Error)
 }
 
 func TestPlugin_Test_Timeout(t *testing.T) {


### PR DESCRIPTION
## Problem

SSH (`Test`, `TestKey`) and VNC (`Test`) performed their protocol handshake on an already-dialed conn with **no I/O deadline**. `ssh.ClientConfig.Timeout` only bounds `ssh.Dial`'s internal dial — **not** `ssh.NewClientConn` on an existing conn — so a server that completes the TCP connect but then stalls the handshake **hangs the worker forever**. VNC's `vnc.Client` has the same blocking-read behavior. Every other raw-TCP plugin (pop3, ftp, telnet) already sets a deadline right after dialing.

## Fix

Add `_ = conn.SetDeadline(time.Now().Add(timeout))` immediately after each dial (2 sites in ssh.go, 1 in vnc.go), matching the sibling idiom.

## Tests

Regression tests start a TCP listener that accepts but never writes a banner, then assert the credential check returns (with an error) within a generous bound instead of hanging — guarded by a `select`/`time.After` so a regression fails cleanly rather than hanging the suite. Confirmed RED without the fix and GREEN with it.

Found during a broader review for small correctness/hygiene tweaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)