### PR TITLE
fix(cli): scope --rotating-proxy to the github enum commands

### DIFF
--- a/cmd/brutus/cmd_enum_github.go
+++ b/cmd/brutus/cmd_enum_github.go
@@ -98,6 +98,10 @@ func init() {
 	f.BoolVar(&flagGithubEnumNoReveal, "no-reveal", false, "Skip username reveal after existence enumeration (existence-only; no token used, no temp repo created)")
 	// NOTE: no -t shorthand: it collides with the global persistent --threads/-t
 	// flag, which cobra merges into this subcommand at execute time.
+	// --rotating-proxy is only meaningful for GitHub existence enumeration, so it
+	// lives here (persistent, inherited by the `map` subcommand) rather than as a
+	// global root flag that would surface — doing nothing — on every other command.
+	enumGithubCmd.PersistentFlags().BoolVar(&flagRotatingProxy, "rotating-proxy", false, "Signal that --proxy rotates exit IPs (e.g. Bright Data): reduces per-IP rate-limit backoff during GitHub existence enumeration (short retry delay, higher retry ceiling). No effect on token-rate-limited reveal.")
 	enumActiveCmd.AddCommand(enumGithubCmd)
 }
 

--- a/cmd/brutus/flags.go
+++ b/cmd/brutus/flags.go
@@ -128,7 +128,6 @@ func registerSharedFlags(cmd *cobra.Command) {
 	// Proxy
 	pf.StringVar(&flagProxy, "proxy", "", "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080")
 	pf.StringVar(&flagProxyUser, "proxy-user", "", "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.")
-	pf.BoolVar(&flagRotatingProxy, "rotating-proxy", false, "Signal that --proxy rotates exit IPs (e.g. Bright Data): reduces per-IP rate-limit backoff during GitHub existence enumeration (short retry delay, higher retry ceiling). No effect on token-rate-limited reveal.")
 
 	// Output
 	pf.BoolVar(&flagJSON, "json", false, "JSON output format")

--- a/cmd/brutus/rotating_proxy_flag_wiring_test.go
+++ b/cmd/brutus/rotating_proxy_flag_wiring_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Tests that the --rotating-proxy flag is registered only on the GitHub enum
+// command (and inherited by its map subcommand), and is NOT a root persistent
+// flag or reachable from sibling enum/scan commands. Regression guard for the
+// flag move off of rootCmd's persistent flags onto enumGithubCmd.
+func TestRotatingProxyFlag_ScopedToGithubEnum(t *testing.T) {
+	t.Run("not a root persistent flag", func(t *testing.T) {
+		assert.Nil(t, rootCmd.PersistentFlags().Lookup("rotating-proxy"))
+	})
+
+	t.Run("present on github enum command", func(t *testing.T) {
+		assert.NotNil(t, enumGithubCmd.PersistentFlags().Lookup("rotating-proxy"))
+	})
+
+	t.Run("inherited by github map subcommand", func(t *testing.T) {
+		assert.NotNil(t, enumGithubMapCmd.InheritedFlags().Lookup("rotating-proxy"))
+	})
+
+	t.Run("not reachable from sibling enum command (google)", func(t *testing.T) {
+		assert.Nil(t, enumGoogleCmd.InheritedFlags().Lookup("rotating-proxy"))
+		assert.Nil(t, enumGoogleCmd.Flags().Lookup("rotating-proxy"))
+	})
+
+	t.Run("not reachable from scan command (creds)", func(t *testing.T) {
+		assert.Nil(t, credsCmd.InheritedFlags().Lookup("rotating-proxy"))
+		assert.Nil(t, credsCmd.Flags().Lookup("rotating-proxy"))
+	})
+}


### PR DESCRIPTION
## Problem

`--rotating-proxy` was a `rootCmd` persistent flag, so every command inherited it — but only the github enum path reads `flagRotatingProxy` (`cmd_enum_github.go` and `cmd_enum_github_map.go` pass it to `githubenum.NewEnumerator`). Its help is GitHub-specific ("…during GitHub existence enumeration … No effect on token-rate-limited reveal"), so under `creds`/`web`/other enum sources it appeared as a usable global flag that did nothing. Same archetype as #243/#244.

## Fix

Move it off root onto `enumGithubCmd.PersistentFlags()`, so only `enum active github` and its `map` subcommand (which also reads it and inherits persistent flags) expose it.

## Verification

`creds`, `enum active google` no longer show it; `enum active github` and `enum active github map` do; passing it to github still works. Wiring test asserts it's off `rootCmd`, on the github command, inherited by github `map`, and unreachable from a sibling enum command (google) and a scan command (creds). Build/vet/full `cmd/brutus` suite green.

> Note: touches `registerSharedFlags` in `flags.go`, as does the still-open #244 (different line). Whichever merges first, the other needs a trivial rebase.

Found during a broader review for small CLI-hygiene tweaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)