### PR TITLE
fix(enum/teams): send UA on presence requests; fix stale teams parent help

### DIFF
--- a/cmd/brutus/cmd_enum_active.go
+++ b/cmd/brutus/cmd_enum_active.go
@@ -32,7 +32,7 @@ Sources:
   google       Enumerate Google Workspace accounts (existence + SSO/IdP)
   microsoft365 Enumerate Microsoft 365 accounts (existence + federation/tenant)
   kerberos     Enumerate Active Directory users via Kerberos AS-REQ
-  teams        Authenticate with Microsoft Entra ID via device code flow
+  teams        Microsoft Teams: auth, user enumeration, and tenant posture audit
   github       Enumerate GitHub accounts by email (existence + username reveal)
   gravatar     Enumerate accounts with a registered Gravatar (by email)
   custom       Enumerate against a user-supplied oracle definition`,

--- a/cmd/brutus/cmd_enum_teams.go
+++ b/cmd/brutus/cmd_enum_teams.go
@@ -77,16 +77,16 @@ var (
 
 var enumTeamsCmd = &cobra.Command{
 	Use:   "teams",
-	Short: "Authenticate with Microsoft Entra ID via device code flow",
-	Long: `Authenticate with Microsoft Entra ID (Azure AD) using the OAuth2 device
-code flow. The device code flow is designed for input-constrained or headless
-environments: brutus requests a short user code, you visit the verification URL
-in any browser and enter that code, and brutus polls until you finish signing
-in. On success it returns an access token (and, when offline_access is in the
-requested scope, a refresh token).
+	Short: "Microsoft Teams: device-code auth, user enumeration, and tenant posture audit",
+	Long: `Microsoft Teams enumeration and auditing. This is a parent command; use one
+of its subcommands:
 
-See the auth subcommand for details:
-  brutus enum active teams auth --help`,
+  auth   Obtain a Microsoft access/refresh token via the OAuth2 device code flow
+  users  Enumerate corporate Microsoft Teams users by email address
+  audit  Audit a Microsoft Teams tenant's external posture into graded findings
+
+See each subcommand's --help for details, e.g.:
+  brutus enum active teams users --help`,
 }
 
 var enumTeamsAuthCmd = &cobra.Command{

--- a/pkg/enum/teams/enum.go
+++ b/pkg/enum/teams/enum.go
@@ -467,6 +467,8 @@ func (e *Enumerator) getPresence(ctx context.Context, mri string) (presenceInfo,
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+e.token())
+	req.Header.Set("X-Ms-Client-Version", clientVersion)
+	req.Header.Set("User-Agent", enumUserAgent)
 
 	resp, err := e.httpClient.Do(req)
 	if err != nil {

--- a/pkg/enum/teams/enum_test.go
+++ b/pkg/enum/teams/enum_test.go
@@ -454,6 +454,44 @@ func TestEnumerateOne_PresenceRequestAssertions(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Test: getPresence sends a browser User-Agent — regression for presence
+// requests going out as the default Go-http-client UA (which Teams silently
+// rejects), mirroring the browser UA already sent by search().
+// ---------------------------------------------------------------------------
+
+func TestGetPresence_SendsBrowserUserAgent(t *testing.T) {
+	searchSrv := searchServerReturning(http.StatusOK,
+		`[{"displayName":"Carol","mri":"8:orgid:carol"}]`)
+	defer searchSrv.Close()
+
+	var mu sync.Mutex
+	var capturedUserAgent string
+
+	presenceSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		capturedUserAgent = r.Header.Get("User-Agent")
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[{"presence":{"availability":"Available","deviceType":"Desktop"}}]`))
+	}))
+	defer presenceSrv.Close()
+
+	e := newTestEnumerator(t, searchSrv, presenceSrv, true /* presence enabled */)
+	_ = e.EnumerateOne(context.Background(), "carol@contoso.com")
+
+	mu.Lock()
+	ua := capturedUserAgent
+	mu.Unlock()
+
+	require.NotEmpty(t, ua, "presence request must have reached the server with a User-Agent header")
+	assert.Contains(t, ua, "Mozilla",
+		"presence request User-Agent must look like a browser (contain \"Mozilla\")")
+	assert.NotContains(t, ua, "Go-http-client",
+		"presence request must not go out with the default Go-http-client User-Agent")
+}
+
+// ---------------------------------------------------------------------------
 // Test 12: Concurrency — Enumerate over 6 emails with threads=2
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Two small fixes in the Teams enumeration path.

## 1. Presence request missing its User-Agent

`getPresence` set only `Content-Type` + `Authorization`, while its sibling `search()` also sets `X-Ms-Client-Version` and `User-Agent` (the `enumUserAgent` const's own comment says it exists "so requests are not rejected"). Presence is best-effort — it returns `ok=false` on any failure — so a rejection **silently** under-reported `Availability`/`DeviceType`/OOO posture for valid users. Now sets both headers to match `search()`.

## 2. Stale `teams` parent-command help

`teams` is a parent command with three subcommands (`auth`, `users`, `audit`), but its `Short`/`Long` described it as auth-only, so the `users` (user enumeration) and `audit` (tenant posture) capabilities were undiscoverable from the parent help. Rewrote `Short`/`Long` to list all three, and updated the matching stale line in the `enum active` Sources block.

## Test

`TestGetPresence_SendsBrowserUserAgent` captures the presence request's UA and asserts it's a `Mozilla/...` UA, never `Go-http-client` — verified RED before the header fix, GREEN after. Build/vet/full `pkg/enum/teams` + `cmd/brutus` suites green.

Found during a broader review for small correctness/UX tweaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)