### PR TITLE
fix(plugins/imap): honor the connect timeout on the direct (non-proxy) dial

### DIFF
--- a/internal/plugins/imap/imap.go
+++ b/internal/plugins/imap/imap.go
@@ -69,23 +69,16 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	// Create options
 	options := &imapclient.Options{}
 
-	// Dial IMAP server (proxy-aware)
-	var client *imapclient.Client
-	if pluginCfg.ProxyURL != "" {
-		conn, dialErr := brutus.DialWithProxy(dialCtx, "tcp", addr, timeout, pluginCfg.ProxyURL)
-		if dialErr != nil {
-			result.Error = classifyError(dialErr)
-			return result
-		}
-		client = imapclient.New(conn, options)
-	} else {
-		var dialErr error
-		client, dialErr = imapclient.DialInsecure(addr, options)
-		if dialErr != nil {
-			result.Error = classifyError(dialErr)
-			return result
-		}
+	// Dial IMAP server. brutus.DialWithProxy honors the connect timeout and,
+	// with an empty ProxyURL, does a direct timeout-aware dial — so both the
+	// proxied and direct paths are bounded identically (the previous
+	// imapclient.DialInsecure direct path ignored the timeout).
+	conn, dialErr := brutus.DialWithProxy(dialCtx, "tcp", addr, timeout, pluginCfg.ProxyURL)
+	if dialErr != nil {
+		result.Error = classifyError(dialErr)
+		return result
 	}
+	client := imapclient.New(conn, options)
 	defer func() { _ = client.Close() }()
 
 	// Check if context was canceled during dial


### PR DESCRIPTION
## Problem

The IMAP plugin dialed inconsistently between its two branches: the proxy branch used `brutus.DialWithProxy` (timeout-aware), but the direct branch used `imapclient.DialInsecure`, which does a plain `net.Dial` with **no timeout and no context**. The surrounding `dialCtx`/`timeout` was only checked *after* the blocking dial returned, so it couldn't bound it — a slow/unresponsive host could stall the direct path past the configured timeout.

## Fix

Unify both branches through `brutus.DialWithProxy` (empty `ProxyURL` = direct, timeout-aware dial — exactly how every other raw-TCP plugin dials), then wrap the conn with `imapclient.New` as the proxy branch already did. No TLS or other behavior change.

## Testing

No new unit test: a connect timeout needs a black-hole address to exercise reliably (environment-dependent and flaky), and the change routes through the already-tested shared `DialWithProxy` path used by every other plugin. Verified via `go build ./...`, `go vet`, and the existing `imap` suite.

Found during a broader review for small correctness/consistency tweaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)