### PR TITLE
fix(plugins/rdp): route sticky-keys/utilman detection probes through --proxy

### DIFF
--- a/internal/plugins/rdp/detect.go
+++ b/internal/plugins/rdp/detect.go
@@ -49,7 +49,7 @@ func DetectStickyKeys(ctx context.Context, target string, connectTimeout, timeou
 	if fast {
 		budget = FastBudget
 	}
-	stickyResult := plugin.RunStickyKeysCheck(ctx, target, connectTimeout, timeout, noVision, budget, fast)
+	stickyResult := plugin.RunStickyKeysCheck(ctx, target, "", connectTimeout, timeout, noVision, budget, fast)
 	result := mapStickyResult(stickyResult, username)
 	result.Target = target
 	return result
@@ -126,7 +126,7 @@ func DetectUtilman(ctx context.Context, target string, connectTimeout, timeout t
 	if fast {
 		budget = FastBudget
 	}
-	utilmanResult := plugin.RunUtilmanCheck(ctx, target, connectTimeout, timeout, noVision, budget, fast)
+	utilmanResult := plugin.RunUtilmanCheck(ctx, target, "", connectTimeout, timeout, noVision, budget, fast)
 	result := mapUtilmanResult(utilmanResult, username)
 	result.Target = target
 	return result
@@ -198,7 +198,7 @@ func mapUtilmanResult(utilmanResult *UtilmanResult, username string) *brutus.Res
 // RunStickyKeysCheck performs sticky keys detection on a separate connection.
 // The noVision flag disables Vision API confirmation. budget selects the settle
 // profile; fast enforces the never-clean invariant.
-func (p *Plugin) RunStickyKeysCheck(ctx context.Context, target string, connectTimeout, timeout time.Duration, noVision bool, budget SettleBudget, fast bool) *StickyKeysResult {
+func (p *Plugin) RunStickyKeysCheck(ctx context.Context, target string, proxyURL string, connectTimeout, timeout time.Duration, noVision bool, budget SettleBudget, fast bool) *StickyKeysResult {
 	host, port := brutus.ParseTarget(target, "3389")
 	addr := net.JoinHostPort(host, port)
 
@@ -207,8 +207,7 @@ func (p *Plugin) RunStickyKeysCheck(ctx context.Context, target string, connectT
 		return &StickyKeysResult{Performed: false, SkipReason: fmt.Sprintf("wasm init: %v", err)}
 	}
 
-	dialer := &net.Dialer{Timeout: connectTimeout}
-	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	conn, err := brutus.DialWithProxy(ctx, "tcp", addr, connectTimeout, proxyURL)
 	if err != nil {
 		return &StickyKeysResult{Performed: false, Unreachable: true, SkipReason: fmt.Sprintf("connection failed: %v", err)}
 	}
@@ -230,7 +229,7 @@ func (p *Plugin) RunStickyKeysCheck(ctx context.Context, target string, connectT
 
 // RunUtilmanCheck performs utilman backdoor detection on a separate connection.
 // budget selects the settle profile; fast enforces the never-clean invariant.
-func (p *Plugin) RunUtilmanCheck(ctx context.Context, target string, connectTimeout, timeout time.Duration, noVision bool, budget SettleBudget, fast bool) *UtilmanResult {
+func (p *Plugin) RunUtilmanCheck(ctx context.Context, target string, proxyURL string, connectTimeout, timeout time.Duration, noVision bool, budget SettleBudget, fast bool) *UtilmanResult {
 	host, port := brutus.ParseTarget(target, "3389")
 	addr := net.JoinHostPort(host, port)
 
@@ -239,8 +238,7 @@ func (p *Plugin) RunUtilmanCheck(ctx context.Context, target string, connectTime
 		return &UtilmanResult{Performed: false, SkipReason: fmt.Sprintf("wasm init: %v", err)}
 	}
 
-	dialer := &net.Dialer{Timeout: connectTimeout}
-	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	conn, err := brutus.DialWithProxy(ctx, "tcp", addr, connectTimeout, proxyURL)
 	if err != nil {
 		return &UtilmanResult{Performed: false, Unreachable: true, SkipReason: fmt.Sprintf("connection failed: %v", err)}
 	}

--- a/internal/plugins/rdp/rdp.go
+++ b/internal/plugins/rdp/rdp.go
@@ -146,7 +146,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	if !pluginCfg.NoStickyKeys {
 		// Creds path (brutus rdp): one-shot, human-driven, no bulk-scan dead-host
 		// amplification — keep --timeout for the dial (connectTimeout == timeout).
-		stickyResult := p.RunStickyKeysCheck(ctx, target, timeout, timeout, pluginCfg.NoVision, CarefulBudget, false)
+		stickyResult := p.RunStickyKeysCheck(ctx, target, pluginCfg.ProxyURL, timeout, timeout, pluginCfg.NoVision, CarefulBudget, false)
 		if stickyResult != nil {
 			result.Banner = formatStickyKeysBanner(result.Banner, stickyResult)
 		}
@@ -154,7 +154,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 
 	// Utilman detection: same approach as sticky keys but uses Win+U trigger.
 	if !pluginCfg.NoStickyKeys {
-		utilmanResult := p.RunUtilmanCheck(ctx, target, timeout, timeout, pluginCfg.NoVision, CarefulBudget, false)
+		utilmanResult := p.RunUtilmanCheck(ctx, target, pluginCfg.ProxyURL, timeout, timeout, pluginCfg.NoVision, CarefulBudget, false)
 		if utilmanResult != nil {
 			result.Banner = formatUtilmanBanner(result.Banner, utilmanResult)
 		}


### PR DESCRIPTION
## Problem

The RDP plugin's main auth connection dials via `brutus.DialWithProxy(..., pluginCfg.ProxyURL)`, but the pre-auth sticky-keys/utilman **detection probes** (`RunStickyKeysCheck` / `RunUtilmanCheck`) dialed with a bare `net.Dialer` and never received the proxy. With `--proxy` set, those side connections bypassed the proxy and **leaked the real source IP**.

## Fix (contained)

`RunStickyKeysCheck`/`RunUtilmanCheck` are shared with the logon subsystem (via `DetectStickyKeys`/`DetectUtilman`). To avoid altering logon behavior, I:

- Added a `proxyURL` parameter to the two `Run*Check` functions and dial via `brutus.DialWithProxy`.
- RDP credential-scan callers (`rdp.go`) now pass `pluginCfg.ProxyURL`.
- The `Detect*` wrappers pass `""` — an empty proxy is a timeout-aware **direct** dial, identical to the previous `net.Dialer` behavior — so the logon path is unchanged.

## Testing

No new unit test: exercising the proxied dial requires a proxy interceptor around the WASM detection engine, for which the plugin exposes no seam. The parameter threading is compiler-verified, and the `""` wrappers preserve the direct path exactly. Verified via `go build ./...`, `go vet`, and the existing `rdp` + `logon` suites (green).

Found during a broader review for proxy-consistency tweaks. (Note: whether the logon-family detection dials should *also* honor `--proxy` is a separate, larger question left out of scope here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)