### PR TITLE
feat(enum/dehashed): --detailed JSON export with full per-contact records

### DIFF
--- a/cmd/brutus/cmd_enum_dehashed.go
+++ b/cmd/brutus/cmd_enum_dehashed.go
@@ -22,6 +22,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -40,6 +41,8 @@ var (
 	flagDehashedNoCredentials     bool
 	flagDehashedSources           []string
 	flagDehashedNoRepair          bool
+	flagDehashedDetailed          bool
+	flagDehashedWithCredentials   bool
 )
 
 // newEnumDehashedCmd builds the "dehashed" command. A fresh instance is
@@ -79,6 +82,12 @@ enforced client-side. Truncated email local-parts (a leading character or two
 dropped by broker/aggregator sources) are repaired using each record's name data
 by default; use --no-repair-emails to disable that repair.
 
+Use --detailed to emit a single structured JSON document per domain (run metadata
+plus every contact with all available fields: ip addresses, addresses, dates of
+birth, and breach obtained-dates). In --detailed mode passwords are OFF by
+default; add --with-credentials to include the breach-exposed plaintext passwords
+(hashes are never included, and --no-credentials still wins as a safety override).
+
 Requires a DeHashed API key via the DEHASHED_API_KEY environment variable
 (or the --api-key flag).
 
@@ -99,6 +108,12 @@ to bound the number of results (and therefore credits) per run.`,
   # Disable truncated-email repair (repair is on by default)
   brutus enum passive dehashed -d example.com --no-repair-emails
 
+  # Emit one structured JSON document with full per-contact detail + run metadata
+  brutus enum passive dehashed -d example.com --detailed -o breaches.json
+
+  # Same detailed export, including breach-exposed plaintext passwords
+  brutus enum passive dehashed -d example.com --detailed --with-credentials -o breaches.json
+
   # Provide the key explicitly (note: visible in process list / shell history)
   brutus enum passive dehashed -d example.com --api-key abc123
 
@@ -118,6 +133,8 @@ to bound the number of results (and therefore credits) per run.`,
 	f.BoolVar(&flagDehashedNoCredentials, "no-credentials", false, "Suppress breach-exposed plaintext passwords from the output")
 	f.StringSliceVar(&flagDehashedSources, "sources", nil, "Restrict results to these DeHashed source databases (comma-separated, exact names)")
 	f.BoolVar(&flagDehashedNoRepair, "no-repair-emails", false, "Do not repair truncated email local-parts using record name data (repair is on by default)")
+	f.BoolVar(&flagDehashedDetailed, "detailed", false, "Emit a single structured JSON document with full per-contact detail (ip addresses, addresses, dobs, obtained dates) and run metadata")
+	f.BoolVar(&flagDehashedWithCredentials, "with-credentials", false, "Include breach-exposed plaintext passwords in --detailed output (off by default; hashes are never included)")
 	_ = cmd.MarkFlagRequired("domain")
 
 	return cmd
@@ -195,6 +212,18 @@ func runEnumDehashed(cmd *cobra.Command, args []string) error {
 		len(result.Records), len(entries), result.Total, result.Balance)
 
 	showCredentials := !flagDehashedNoCredentials
+
+	// --detailed takes precedence over the human/JSONL branch. It reuses the same
+	// output-file plumbing as JSON (jsonWriter is the file when -o is set, else
+	// os.Stdout). Passwords are OFF by default here; --with-credentials opts in,
+	// but --no-credentials always wins as a safety override.
+	if flagDehashedDetailed {
+		detailedShowCreds := flagDehashedWithCredentials && !flagDehashedNoCredentials
+		if err := outputDehashedDetailedJSON(jsonWriter, flagDehashedDomain, len(result.Records), result.Total, result.Balance, entries, detailedShowCreds, time.Now()); err != nil {
+			return fmt.Errorf("writing detailed dehashed output: %w", err)
+		}
+		return nil
+	}
 
 	if flagJSON {
 		outputDehashedJSONL(jsonWriter, entries, showCredentials)

--- a/cmd/brutus/cmd_enum_dehashed_output.go
+++ b/cmd/brutus/cmd_enum_dehashed_output.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/praetorian-inc/brutus/pkg/enum/dehashed"
 )
@@ -139,4 +140,74 @@ func outputDehashedJSONL(w io.Writer, entries []dehashed.Entry, showCredentials 
 			_, _ = fmt.Fprintf(os.Stderr, "Error encoding dehashed JSON: %v\n", err)
 		}
 	}
+}
+
+// outputDehashedDetailedJSON writes ONE structured JSON document (indented,
+// 2-space) describing the whole collection: run metadata plus every refined
+// contact carrying ALL available fields (ip addresses, addresses, dobs, obtained
+// dates). When showCredentials is true each entry includes the breach-exposed
+// plaintext "passwords" (omitempty); when false the key is omitted entirely
+// (never an empty array). The hashed_password field is never present (P0-SCOPE).
+// encoding/json escapes control characters, so no sanitization is needed (same
+// rationale as outputDehashedJSONL). collectedAt is taken as a parameter
+// (emitted as UTC RFC3339) so the output is deterministic and testable. The
+// encoder error is returned so the caller/tests can assert on it.
+func outputDehashedDetailedJSON(w io.Writer, domain string, rawFetched, total, balance int, entries []dehashed.Entry, showCredentials bool, collectedAt time.Time) error {
+	type detailedEntry struct {
+		Email         string   `json:"email"`
+		Names         []string `json:"names,omitempty"`
+		Usernames     []string `json:"usernames,omitempty"`
+		Phones        []string `json:"phones,omitempty"`
+		IPAddresses   []string `json:"ip_addresses,omitempty"`
+		Addresses     []string `json:"addresses,omitempty"`
+		DOBs          []string `json:"dobs,omitempty"`
+		ObtainedDates []string `json:"obtained_dates,omitempty"`
+		Databases     []string `json:"databases"`
+		Count         int      `json:"count"`
+		Passwords     []string `json:"passwords,omitempty"`
+	}
+	type detailedDocument struct {
+		Type           string          `json:"type"`
+		Domain         string          `json:"domain"`
+		CollectedAt    string          `json:"collected_at"`
+		TotalAvailable int             `json:"total_available"`
+		RecordsFetched int             `json:"records_fetched"`
+		UniqueContacts int             `json:"unique_contacts"`
+		Balance        int             `json:"balance"`
+		Entries        []detailedEntry `json:"entries"`
+	}
+
+	doc := detailedDocument{
+		Type:           "dehashed_collection",
+		Domain:         domain,
+		CollectedAt:    collectedAt.UTC().Format(time.RFC3339),
+		TotalAvailable: total,
+		RecordsFetched: rawFetched,
+		UniqueContacts: len(entries),
+		Balance:        balance,
+		Entries:        make([]detailedEntry, 0, len(entries)),
+	}
+	for i := range entries {
+		e := &entries[i]
+		de := detailedEntry{
+			Email:         e.Email,
+			Names:         e.Names,
+			Usernames:     e.Usernames,
+			Phones:        e.Phones,
+			IPAddresses:   e.IPAddresses,
+			Addresses:     e.Addresses,
+			DOBs:          e.DOBs,
+			ObtainedDates: e.ObtainedDates,
+			Databases:     e.Databases,
+			Count:         e.Count,
+		}
+		if showCredentials {
+			de.Passwords = e.Passwords
+		}
+		doc.Entries = append(doc.Entries, de)
+	}
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(doc)
 }

--- a/cmd/brutus/cmd_enum_dehashed_test.go
+++ b/cmd/brutus/cmd_enum_dehashed_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -456,4 +457,78 @@ func TestEnumDehashedRegistered(t *testing.T) {
 	require.NotNil(t, alias, `hidden "dehashed" alias must be registered directly under enumCmd`)
 	assert.True(t, alias.Hidden, "back-compat dehashed alias must be Hidden")
 	assert.NotEmpty(t, alias.Deprecated, "back-compat dehashed alias must be Deprecated")
+}
+
+// ---------------------------------------------------------------------------
+// outputDehashedDetailedJSON
+// ---------------------------------------------------------------------------
+
+func TestOutputDehashedDetailedJSON(t *testing.T) {
+	collectedAt := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	entries := []dehashed.Entry{
+		{
+			Email:         "alice@example.com",
+			Names:         []string{"Alice Smith"},
+			Usernames:     []string{"alice"},
+			Phones:        []string{"+1-555-0100"},
+			Passwords:     []string{"secret123"},
+			Databases:     []string{"breach-db"},
+			Count:         3,
+			IPAddresses:   []string{"1.2.3.4"},
+			Addresses:     []string{"123 Main St"},
+			DOBs:          []string{"1990-01-01"},
+			ObtainedDates: []string{"2021-01"},
+		},
+	}
+
+	t.Run("showCredentials=false: full shape, metadata, no passwords key, no hashes", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := outputDehashedDetailedJSON(&buf, "example.com", 5, 100, 9000, entries, false, collectedAt)
+		require.NoError(t, err)
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &obj))
+		assert.Equal(t, "dehashed_collection", obj["type"])
+		assert.Equal(t, "example.com", obj["domain"])
+		assert.Equal(t, "2026-01-02T03:04:05Z", obj["collected_at"])
+		assert.Equal(t, float64(100), obj["total_available"])
+		assert.Equal(t, float64(5), obj["records_fetched"])
+		assert.Equal(t, float64(1), obj["unique_contacts"])
+		assert.Equal(t, float64(9000), obj["balance"])
+		arr, ok := obj["entries"].([]interface{})
+		require.True(t, ok)
+		require.Len(t, arr, 1)
+		entry := arr[0].(map[string]interface{})
+		assert.Equal(t, "alice@example.com", entry["email"])
+		assert.Equal(t, "1.2.3.4", entry["ip_addresses"].([]interface{})[0])
+		assert.Equal(t, "123 Main St", entry["addresses"].([]interface{})[0])
+		assert.Equal(t, "1990-01-01", entry["dobs"].([]interface{})[0])
+		assert.Equal(t, "2021-01", entry["obtained_dates"].([]interface{})[0])
+		assert.Equal(t, "breach-db", entry["databases"].([]interface{})[0])
+		assert.Equal(t, float64(3), entry["count"])
+		_, hasPw := entry["passwords"]
+		assert.False(t, hasPw, "passwords key must be ABSENT when showCredentials=false")
+		low := strings.ToLower(buf.String())
+		assert.NotContains(t, low, "secret123")
+		assert.NotContains(t, low, "hashed_password")
+		assert.NotContains(t, low, `"hash"`)
+	})
+
+	t.Run("showCredentials=true: passwords key PRESENT with values, still no hashes", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := outputDehashedDetailedJSON(&buf, "example.com", 5, 100, 9000, entries, true, collectedAt)
+		require.NoError(t, err)
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &obj))
+		entry := obj["entries"].([]interface{})[0].(map[string]interface{})
+		pw, ok := entry["passwords"].([]interface{})
+		require.True(t, ok, "passwords key must be PRESENT when showCredentials=true")
+		assert.Equal(t, "secret123", pw[0])
+		assert.NotContains(t, strings.ToLower(buf.String()), "hashed_password")
+	})
+
+	t.Run("output is indented with 2 spaces", func(t *testing.T) {
+		var buf bytes.Buffer
+		require.NoError(t, outputDehashedDetailedJSON(&buf, "example.com", 5, 100, 9000, entries, false, collectedAt))
+		assert.Contains(t, buf.String(), "\n  \"type\"", "document must be 2-space indented")
+	})
 }

--- a/pkg/enum/dehashed/dehashed.go
+++ b/pkg/enum/dehashed/dehashed.go
@@ -100,13 +100,17 @@ type RefineOptions struct {
 
 // Entry is a refined (optionally merged) output row.
 type Entry struct {
-	Email     string
-	Names     []string
-	Usernames []string
-	Phones    []string
-	Passwords []string // breach-exposed plaintext passwords for this entry
-	Databases []string // distinct source DBs contributing to this entry
-	Count     int      // number of raw breach records merged into this entry
+	Email         string
+	Names         []string
+	Usernames     []string
+	Phones        []string
+	Passwords     []string // breach-exposed plaintext passwords for this entry
+	Databases     []string // distinct source DBs contributing to this entry
+	Count         int      // number of raw breach records merged into this entry
+	IPAddresses   []string // distinct IP addresses across merged records
+	Addresses     []string // distinct physical addresses
+	DOBs          []string // distinct dates of birth
+	ObtainedDates []string // distinct breach obtained-dates
 }
 
 // Refine applies the filtering/merging pipeline to raw breach records and
@@ -157,13 +161,17 @@ func Refine(records []Record, opts RefineOptions) []Entry {
 		}
 
 		entries = append(entries, Entry{
-			Email:     email,
-			Names:     dedupStrings(r.Name),
-			Usernames: dedupStrings(r.Username),
-			Phones:    dedupStrings(r.Phone),
-			Passwords: dedupStrings(r.Passwords),
-			Databases: dedupStrings([]string{r.Database}),
-			Count:     1,
+			Email:         email,
+			Names:         dedupStrings(r.Name),
+			Usernames:     dedupStrings(r.Username),
+			Phones:        dedupStrings(r.Phone),
+			Passwords:     dedupStrings(r.Passwords),
+			Databases:     dedupStrings([]string{r.Database}),
+			Count:         1,
+			IPAddresses:   dedupStrings(r.IPAddress),
+			Addresses:     dedupStrings(r.Address),
+			DOBs:          dedupStrings(r.DOB),
+			ObtainedDates: dedupStrings([]string{r.ObtainedDate}),
 		})
 	}
 
@@ -503,6 +511,10 @@ func mergeEntry(entries *[]Entry, indexByEmail map[string]int, email string, r *
 	e.Phones = dedupStrings(append(e.Phones, r.Phone...))
 	e.Passwords = dedupStrings(append(e.Passwords, r.Passwords...))
 	e.Databases = dedupStrings(append(e.Databases, r.Database))
+	e.IPAddresses = dedupStrings(append(e.IPAddresses, r.IPAddress...))
+	e.Addresses = dedupStrings(append(e.Addresses, r.Address...))
+	e.DOBs = dedupStrings(append(e.DOBs, r.DOB...))
+	e.ObtainedDates = dedupStrings(append(e.ObtainedDates, r.ObtainedDate))
 	e.Count++
 }
 

--- a/pkg/enum/dehashed/dehashed_test.go
+++ b/pkg/enum/dehashed/dehashed_test.go
@@ -878,3 +878,53 @@ func TestSearchWithOptions_Sources(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, res2.Records, 1, "limit bounds matching records")
 }
+
+// ---------------------------------------------------------------------------
+// Refine — detailed fields (IPAddresses, Addresses, DOBs, ObtainedDates)
+// ---------------------------------------------------------------------------
+
+func TestRefine_DetailedFields(t *testing.T) {
+	t.Run("non-dedup single record populates ip/address/dob/obtained (deduped)", func(t *testing.T) {
+		records := []Record{
+			{
+				Email:        []string{"alice@example.com"},
+				IPAddress:    []string{"1.2.3.4", "1.2.3.4"},
+				Address:      []string{"123 Main St"},
+				DOB:          []string{"1990-01-01"},
+				Database:     "DB-A",
+				ObtainedDate: "2021-01",
+			},
+		}
+		got := Refine(records, RefineOptions{Domain: "example.com"})
+		require.Len(t, got, 1)
+		e := got[0]
+		assert.Equal(t, []string{"1.2.3.4"}, e.IPAddresses)
+		assert.Equal(t, []string{"123 Main St"}, e.Addresses)
+		assert.Equal(t, []string{"1990-01-01"}, e.DOBs)
+		assert.Equal(t, []string{"2021-01"}, e.ObtainedDates)
+	})
+
+	t.Run("non-dedup empty obtained date dropped", func(t *testing.T) {
+		records := []Record{
+			{Email: []string{"a@example.com"}, Database: "DB", ObtainedDate: ""},
+		}
+		got := Refine(records, RefineOptions{Domain: "example.com"})
+		require.Len(t, got, 1)
+		assert.Empty(t, got[0].ObtainedDates, "empty obtained date must be dropped")
+	})
+
+	t.Run("dedup unions and dedups ip/address/dob/obtained across records", func(t *testing.T) {
+		records := []Record{
+			{Email: []string{"alice@example.com"}, IPAddress: []string{"1.1.1.1"}, Address: []string{"Addr A"}, DOB: []string{"1990-01-01"}, ObtainedDate: "2021-01", Database: "DB-A"},
+			{Email: []string{"alice@example.com"}, IPAddress: []string{"2.2.2.2", "1.1.1.1"}, Address: []string{"Addr B"}, DOB: []string{"1990-01-01"}, ObtainedDate: "2022-06", Database: "DB-B"},
+			{Email: []string{"alice@example.com"}, IPAddress: []string{""}, Address: []string{""}, DOB: []string{""}, ObtainedDate: "", Database: "DB-C"},
+		}
+		got := Refine(records, RefineOptions{Domain: "example.com", Dedup: true})
+		require.Len(t, got, 1)
+		e := got[0]
+		assert.ElementsMatch(t, []string{"1.1.1.1", "2.2.2.2"}, e.IPAddresses)
+		assert.ElementsMatch(t, []string{"Addr A", "Addr B"}, e.Addresses)
+		assert.Equal(t, []string{"1990-01-01"}, e.DOBs)
+		assert.ElementsMatch(t, []string{"2021-01", "2022-06"}, e.ObtainedDates)
+	})
+}


### PR DESCRIPTION
## What
A `--detailed` CLI mode for the DeHashed command that emits **one structured JSON document per domain** — built for running breach-data collections against companies and getting clean, parseable JSON.

Surfaces the richer per-record fields the existing JSONL output dropped: **IP addresses, physical addresses, DOB, obtained-dates**.

> **Stacked on #252** (source-selection + email-repair) — base is `feat/enum-dehashed-sources-repair`, so this PR's diff is only the detailed-export delta. Merge #252 first.

### Output shape
```json
{
  "type": "dehashed_collection",
  "domain": "example.com",
  "collected_at": "2026-01-02T03:04:05Z",
  "total_available": 1234,
  "records_fetched": 100,
  "unique_contacts": 87,
  "balance": 9000,
  "entries": [
    {
      "email": "...", "names": [...], "usernames": [...], "phones": [...],
      "ip_addresses": [...], "addresses": [...], "dobs": [...],
      "obtained_dates": [...], "databases": [...], "count": 3
    }
  ]
}
```

### Changes
- **`Entry` enriched (additive):** `IPAddresses`, `Addresses`, `DOBs`, `ObtainedDates`, populated in `Refine` on both the non-dedup and dedup (unioned) paths using the existing `dedupStrings` pattern. Existing fields/behavior unchanged.
- **`outputDehashedDetailedJSON`:** single 2-space-indented document; returns the encoder error to the caller (no stderr swallowing). Existing `outputDehashedJSONL`/`outputDehashedHuman` untouched.
- **CLI:** `--detailed` (precedence over human/JSONL, reuses the `-o` writer) and `--with-credentials`.

### Credentials
Passwords are **off by default** in the detailed export — the `passwords` key is omitted entirely unless `--with-credentials` is passed, and `--no-credentials` always wins (`detailedShowCreds = withCredentials && !noCredentials`). Password **hashes are never present** (unchanged invariant; the field doesn't exist upstream in `Record`).

## Compatibility
Additive only — four fields appended to the end of `Entry`, no existing signature changed. Guard's pinned import stays compatible.

## Testing
`go test ./pkg/enum/dehashed/... ./cmd/brutus/...` green — `Refine` field population/union, and golden detailed-JSON (fixed timestamp) asserting shape, metadata, credential gating, and absence of any hash field. Build + vet + gofmt clean. Reviewed by backend-reviewer: REVIEW_APPROVED (security invariants, non-breaking API, correctness confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)