### PR TITLE
chore(cmd): remove two dead enum-output funcs, retarget tests to live funcs

### DIFF
--- a/cmd/brutus/cmd_enum_microsoft365_test.go
+++ b/cmd/brutus/cmd_enum_microsoft365_test.go
@@ -92,12 +92,12 @@ func TestEnumMicrosoft365Cmd_RegisteredUnderActiveCmd(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// TestOutputMicrosoft365EnumJSONL
+// TestEncodeMicrosoft365EnumResult
 // Feeds m365.Result values and asserts the type/if_exists_result/federation
 // fields, including omitempty behavior.
 // ---------------------------------------------------------------------------
 
-func TestOutputMicrosoft365EnumJSONL(t *testing.T) {
+func TestEncodeMicrosoft365EnumResult(t *testing.T) {
 	tests := []struct {
 		name              string
 		result            m365.Result
@@ -155,10 +155,11 @@ func TestOutputMicrosoft365EnumJSONL(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			outputMicrosoft365EnumJSONL(&buf, []m365.Result{tc.result})
+			enc := json.NewEncoder(&buf)
+			encodeMicrosoft365EnumResult(enc, tc.result)
 
 			line := strings.TrimSpace(buf.String())
-			require.NotEmpty(t, line, "outputMicrosoft365EnumJSONL must produce a JSONL line")
+			require.NotEmpty(t, line, "encodeMicrosoft365EnumResult must produce a JSONL line")
 
 			var obj map[string]interface{}
 			require.NoError(t, json.Unmarshal([]byte(line), &obj),
@@ -217,10 +218,11 @@ func TestOutputMicrosoft365EnumJSONL(t *testing.T) {
 		}
 
 		var buf bytes.Buffer
-		outputMicrosoft365EnumJSONL(&buf, []m365.Result{result})
+		enc := json.NewEncoder(&buf)
+		encodeMicrosoft365EnumResult(enc, result)
 
 		line := strings.TrimSpace(buf.String())
-		require.NotEmpty(t, line, "outputMicrosoft365EnumJSONL must produce a JSONL line")
+		require.NotEmpty(t, line, "encodeMicrosoft365EnumResult must produce a JSONL line")
 
 		var obj map[string]interface{}
 		require.NoError(t, json.Unmarshal([]byte(line), &obj),

--- a/cmd/brutus/cmd_enum_output.go
+++ b/cmd/brutus/cmd_enum_output.go
@@ -523,74 +523,9 @@ func outputTeamsTokenJSONL(w io.Writer, tok *teams.TokenSet) {
 // Teams user enumeration output functions
 // ---------------------------------------------------------------------------
 
-// outputTeamsEnumHuman renders Teams user enumeration results as an aligned
-// table. All server-provided strings are sanitized via sanitizeTerminal (P0-4).
-// The presence columns (Availability, Device) are shown only when at least one
-// result carries presence data.
-func outputTeamsEnumHuman(w io.Writer, results []teams.EnumResult, useColor bool) {
-	_, _ = fmt.Fprintf(w, "\n%s %s\n", dim(useColor, SymbolInfo), heading(useColor, "Teams User Enumeration"))
-
-	showPresence := false
-	for i := range results {
-		if results[i].Availability != "" || results[i].DeviceType != "" {
-			showPresence = true
-			break
-		}
-	}
-
-	// Header row.
-	if showPresence {
-		_, _ = fmt.Fprintf(w, "\n  %s%-32s %-12s %-28s %-40s %-14s %-12s%s\n",
-			colorIf(useColor, ColorBold),
-			"Email", "Status", "Display Name", "MRI", "Availability", "Device",
-			colorIf(useColor, ColorReset))
-	} else {
-		_, _ = fmt.Fprintf(w, "\n  %s%-32s %-12s %-28s %-40s%s\n",
-			colorIf(useColor, ColorBold),
-			"Email", "Status", "Display Name", "MRI",
-			colorIf(useColor, ColorReset))
-	}
-
-	for i := range results {
-		r := &results[i]
-		switch r.Exists {
-		case teams.ExistenceNo:
-			if flagQuiet {
-				continue
-			}
-		case teams.ExistenceUnknown:
-			if !flagVerbose {
-				continue
-			}
-		}
-
-		statusCol, statusColor := teamsEnumStatusLabel(r.Exists)
-		email := truncate(sanitizeTerminal(r.Email), 32)
-		name := truncate(sanitizeTerminal(r.DisplayName), 28)
-		mri := truncate(sanitizeTerminal(r.MRI), 40)
-
-		if showPresence {
-			_, _ = fmt.Fprintf(w, "  %-32s %s%-12s%s %-28s %-40s %-14s %-12s\n",
-				email,
-				colorIf(useColor, statusColor), statusCol, colorIf(useColor, ColorReset),
-				name, mri,
-				truncate(sanitizeTerminal(r.Availability), 14),
-				truncate(sanitizeTerminal(r.DeviceType), 12))
-		} else {
-			_, _ = fmt.Fprintf(w, "  %-32s %s%-12s%s %-28s %-40s\n",
-				email,
-				colorIf(useColor, statusColor), statusCol, colorIf(useColor, ColorReset),
-				name, mri)
-		}
-	}
-
-	outputTeamsEnumSummary(w, results, useColor)
-}
-
-// outputTeamsEnumResultLine prints ONE Teams enumeration result row in the same
-// visual style as outputTeamsEnumHuman's per-row rendering: Email, status label,
-// Display Name, and MRI, with the account type appended for EXISTS rows (e.g.
-// "(corporate)" or "(consumer)") via teams.AccountType. A 403/blocked result is
+// outputTeamsEnumResultLine prints ONE Teams enumeration result row: Email,
+// status label, Display Name, and MRI, with the account type appended for EXISTS
+// "(corporate)" or "(consumer)" via teams.AccountType. A 403/blocked result is
 // a confirmed hit whose details the tenant withholds, so it renders as an
 // "[+] EXISTS" row with a "(details restricted)" qualifier and no
 // DisplayName/MRI/account-type (a 403 carries none). All server-provided strings
@@ -1210,15 +1145,5 @@ func encodeMicrosoft365EnumResult(enc *json.Encoder, r m365.Result) { //nolint:g
 	}
 	if err := enc.Encode(jr); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Error encoding microsoft365 enum JSON: %v\n", err)
-	}
-}
-
-// outputMicrosoft365EnumJSONL writes one JSON object per result, reusing a
-// single encoder. encoding/json escapes control characters, so no sanitization
-// is needed.
-func outputMicrosoft365EnumJSONL(w io.Writer, results []m365.Result) {
-	enc := json.NewEncoder(w)
-	for i := range results {
-		encodeMicrosoft365EnumResult(enc, results[i])
 	}
 }

--- a/cmd/brutus/cmd_enum_teams_users_test.go
+++ b/cmd/brutus/cmd_enum_teams_users_test.go
@@ -447,10 +447,10 @@ func TestTeamsEnumGenerate_LimitZeroReturnsAll(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Test 20: outputTeamsEnumHuman — ANSI sanitization strips ESC byte
+// Test 20: outputTeamsEnumResultLine — ANSI sanitization strips ESC byte
 // ---------------------------------------------------------------------------
 
-func TestOutputTeamsEnumHuman_Sanitization(t *testing.T) {
+func TestOutputTeamsEnumResultLine_Sanitization(t *testing.T) {
 	evilName := "\x1b[31mEVIL"
 	results := []teams.EnumResult{
 		{
@@ -471,7 +471,7 @@ func TestOutputTeamsEnumHuman_Sanitization(t *testing.T) {
 		flagVerbose = origVerbose
 	}()
 
-	outputTeamsEnumHuman(&buf, results, false /* useColor */)
+	outputTeamsEnumResultLine(&buf, &results[0], false /* useColor */)
 	out := buf.String()
 
 	// The raw ESC byte 0x1B must not appear in the output (sanitizeTerminal strips it).


### PR DESCRIPTION
## What

`outputMicrosoft365EnumJSONL` and `outputTeamsEnumHuman` have **no non-test callers** (verified via `deadcode` + grep). Production emits M365 JSONL per-result through `encodeMicrosoft365EnumResult` and renders Teams users via the streaming `outputTeamsEnumResultLine` + `outputTeamsEnumSummary`; the two removed functions are an unused batch-JSONL wrapper and an unused table renderer that were added but never wired.

## Preserving coverage

Instead of deleting the tests (which would drop the *only* ANSI-sanitization test for Teams human output and the JSONL-encoding coverage for M365), I **retargeted** them at the live equivalents — same assertions, now exercising production code:

- `TestOutputMicrosoft365EnumJSONL` → `TestEncodeMicrosoft365EnumResult` (drives `encodeMicrosoft365EnumResult` directly; output is byte-identical for a single result).
- `TestOutputTeamsEnumHuman_Sanitization` → `TestOutputTeamsEnumResultLine_Sanitization` (drives the live per-row renderer, which sanitizes `DisplayName` identically).

Also reworded `outputTeamsEnumResultLine`'s doc comment that referenced the removed function.

Build/vet/full `cmd/brutus` suite green; no references to the removed names remain.

Part of an audit series shipped as focused ~50-100-line PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)