### PR TITLE
refactor(cmd): extract shared resolveAPIKey helper (dedupe 4 copies)

### DIFF
--- a/cmd/brutus/apikey_test.go
+++ b/cmd/brutus/apikey_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveAPIKey(t *testing.T) {
+	const testEnvVar = "BRUTUS_TEST_API_KEY"
+
+	t.Run("flag wins over env", func(t *testing.T) {
+		t.Setenv(testEnvVar, "env-value")
+
+		key, err := resolveAPIKey("flag-value", testEnvVar, "testprovider")
+
+		require.NoError(t, err)
+		assert.Equal(t, "flag-value", key)
+	})
+
+	t.Run("falls back to env when flag empty", func(t *testing.T) {
+		t.Setenv(testEnvVar, "env-value")
+
+		key, err := resolveAPIKey("", testEnvVar, "testprovider")
+
+		require.NoError(t, err)
+		assert.Equal(t, "env-value", key)
+	})
+
+	t.Run("errors when neither flag nor env set", func(t *testing.T) {
+		t.Setenv("HUNTER_API_KEY", "")
+
+		key, err := resolveAPIKey("", "HUNTER_API_KEY", "hunter.io")
+
+		require.Error(t, err)
+		assert.Equal(t, "hunter.io API key required: set HUNTER_API_KEY or pass --api-key", err.Error())
+		assert.Empty(t, key)
+	})
+}

--- a/cmd/brutus/cmd_enum_apollo.go
+++ b/cmd/brutus/cmd_enum_apollo.go
@@ -200,13 +200,7 @@ func runEnumApollo(cmd *cobra.Command, args []string) error {
 // resolveApolloAPIKey returns the flag value if set, else APOLLO_API_KEY env var.
 // The key is never logged (P0-1 security requirement).
 func resolveApolloAPIKey(flagValue string) (string, error) {
-	if flagValue != "" {
-		return flagValue, nil
-	}
-	if key := os.Getenv("APOLLO_API_KEY"); key != "" {
-		return key, nil
-	}
-	return "", fmt.Errorf("apollo API key required: set APOLLO_API_KEY or pass --api-key")
+	return resolveAPIKey(flagValue, "APOLLO_API_KEY", "apollo")
 }
 
 // classifyApolloError converts apollo sentinel errors into actionable, key-free

--- a/cmd/brutus/cmd_enum_dehashed.go
+++ b/cmd/brutus/cmd_enum_dehashed.go
@@ -173,13 +173,7 @@ func runEnumDehashed(cmd *cobra.Command, args []string) error {
 // resolveDehashedAPIKey returns the flag value if set, else DEHASHED_API_KEY env
 // var. The key is never logged (P0-1 security requirement).
 func resolveDehashedAPIKey(flagValue string) (string, error) {
-	if flagValue != "" {
-		return flagValue, nil
-	}
-	if key := os.Getenv("DEHASHED_API_KEY"); key != "" {
-		return key, nil
-	}
-	return "", fmt.Errorf("dehashed API key required: set DEHASHED_API_KEY or pass --api-key")
+	return resolveAPIKey(flagValue, "DEHASHED_API_KEY", "dehashed")
 }
 
 // classifyDehashedError converts dehashed sentinel errors into actionable,

--- a/cmd/brutus/cmd_enum_hunter.go
+++ b/cmd/brutus/cmd_enum_hunter.go
@@ -135,13 +135,7 @@ func runEnumHunter(cmd *cobra.Command, args []string) error {
 // resolveHunterAPIKey returns the flag value if set, else HUNTER_API_KEY env var.
 // The key is never logged (P0-1 security requirement).
 func resolveHunterAPIKey(flagValue string) (string, error) {
-	if flagValue != "" {
-		return flagValue, nil
-	}
-	if key := os.Getenv("HUNTER_API_KEY"); key != "" {
-		return key, nil
-	}
-	return "", fmt.Errorf("hunter.io API key required: set HUNTER_API_KEY or pass --api-key")
+	return resolveAPIKey(flagValue, "HUNTER_API_KEY", "hunter.io")
 }
 
 // classifyHunterError converts hunter sentinel errors into actionable, key-free messages.

--- a/cmd/brutus/cmd_enum_lusha.go
+++ b/cmd/brutus/cmd_enum_lusha.go
@@ -291,13 +291,7 @@ func validateLushaIdentity() error {
 // resolveLushaAPIKey returns the flag value if set, else LUSHA_API_KEY env var.
 // The key is never logged (P0-1 security requirement).
 func resolveLushaAPIKey(flagValue string) (string, error) {
-	if flagValue != "" {
-		return flagValue, nil
-	}
-	if key := os.Getenv("LUSHA_API_KEY"); key != "" {
-		return key, nil
-	}
-	return "", fmt.Errorf("lusha API key required: set LUSHA_API_KEY or pass --api-key")
+	return resolveAPIKey(flagValue, "LUSHA_API_KEY", "lusha")
 }
 
 // classifyLushaError converts lusha sentinel errors into actionable, key-free

--- a/cmd/brutus/flags.go
+++ b/cmd/brutus/flags.go
@@ -230,6 +230,19 @@ func resolveProxyURL() (string, error) {
 	return brutus.BuildProxyURL(flagProxy, flagProxyUser)
 }
 
+// resolveAPIKey returns flagValue if non-empty, otherwise the value of the
+// environment variable envVar. It errors when neither is set. provider is the
+// human-facing name used in the error message (e.g. "apollo", "hunter.io").
+func resolveAPIKey(flagValue, envVar, provider string) (string, error) {
+	if flagValue != "" {
+		return flagValue, nil
+	}
+	if key := os.Getenv(envVar); key != "" {
+		return key, nil
+	}
+	return "", fmt.Errorf("%s API key required: set %s or pass --api-key", provider, envVar)
+}
+
 // buildBaseConfig constructs a baseConfigOptions with only the shared fields.
 // Subcommand-specific loading (credentials, keys, AI config) is handled by
 // each subcommand's runXxx function.


### PR DESCRIPTION
## What

The `resolveApolloAPIKey` / `resolveLushaAPIKey` / `resolveHunterAPIKey` / `resolveDehashedAPIKey` functions were byte-identical except the env-var name and the provider noun. Extracted one `resolveAPIKey(flagValue, envVar, provider string) (string, error)` helper in `flags.go`; each vendor resolver is now a one-line delegation.

Kept the four per-vendor functions (names/signatures/doc comments intact) so **call sites and the existing per-vendor tests are unchanged**, and return values + error strings are byte-identical to before (including hunter's `"hunter.io"` noun).

## Test

`TestResolveAPIKey` covers flag-wins-over-env, env fallback, the exact error message, and no-key-leak on the error path. Build/vet/full `cmd/brutus` suite green; the existing per-vendor resolver tests pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)