### PR TITLE
test: drop a dead skip test, fix two vacuous TestInit tests, cover ReadResponseBody

### DIFF
--- a/internal/plugins/imap/imap_test.go
+++ b/internal/plugins/imap/imap_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/praetorian-inc/brutus/pkg/brutus"
 )
@@ -186,13 +187,9 @@ func TestPlugin_Test_MissingPort(t *testing.T) {
 }
 
 func TestInit(t *testing.T) {
-	// Verify that the plugin registers itself
-	// This test ensures init() was called
-	// We can't directly test init(), but we can verify the plugin is registered
-	// by checking that plugin.Register was called (indirectly)
-
-	// Just verify the plugin can be instantiated
-	p := &Plugin{}
-	assert.NotNil(t, p)
+	// Verify that init() registered this plugin with the global registry
+	// under the name "imap", so brutus.GetPlugin("imap") resolves it.
+	p, err := brutus.GetPlugin("imap")
+	require.NoError(t, err, "imap plugin must be registered via init()")
 	assert.Equal(t, "imap", p.Name())
 }

--- a/internal/plugins/integration_test.go
+++ b/internal/plugins/integration_test.go
@@ -328,12 +328,3 @@ func runProtocolTest(t *testing.T, tc testCase) {
 	})
 }
 
-// TestHTTPBasicAuth tests HTTP Basic Authentication
-// Uses httptest server since HTTP is often tested inline
-func TestHTTPBasicAuth(t *testing.T) {
-	t.Parallel()
-
-	// HTTP tests use in-process httptest server
-	// See cmd/brutus/integration_test.go for full HTTP pipeline tests
-	t.Skip("HTTP tests use in-process httptest server in cmd/brutus/integration_test.go")
-}

--- a/internal/plugins/postgresql/postgresql_test.go
+++ b/internal/plugins/postgresql/postgresql_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/praetorian-inc/brutus/pkg/brutus"
 )
@@ -227,9 +228,10 @@ func TestPlugin_Test_MissingPort(t *testing.T) {
 }
 
 func TestInit(t *testing.T) {
-	// Just verify the plugin can be instantiated
-	p := &Plugin{}
-	assert.NotNil(t, p)
+	// Verify that init() registered this plugin with the global registry
+	// under the name "postgresql", so brutus.GetPlugin("postgresql") resolves it.
+	p, err := brutus.GetPlugin("postgresql")
+	require.NoError(t, err, "postgresql plugin must be registered via init()")
 	assert.Equal(t, "postgresql", p.Name())
 }
 

--- a/pkg/enum/httpclient_test.go
+++ b/pkg/enum/httpclient_test.go
@@ -15,6 +15,7 @@
 package enum
 
 import (
+	"bytes"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -88,4 +89,36 @@ func TestNewEnumHTTPClientWithProxy_EndToEnd(t *testing.T) {
 		"default User-Agent must contain Chrome/120 (injected by uaTransport)")
 	assert.Contains(t, gotUserAgent, "Mozilla/5.0",
 		"default User-Agent must contain Mozilla/5.0 (injected by uaTransport)")
+}
+
+func TestReadResponseBody(t *testing.T) {
+	t.Run("positive limit truncates", func(t *testing.T) {
+		data := bytes.Repeat([]byte("a"), 100)
+		resp := &http.Response{Body: io.NopCloser(bytes.NewReader(data))}
+
+		got, err := ReadResponseBody(resp, 10)
+
+		require.NoError(t, err)
+		assert.Len(t, got, 10)
+	})
+
+	t.Run("limit<=0 uses default cap, small body read fully", func(t *testing.T) {
+		data := bytes.Repeat([]byte("a"), 50)
+		resp := &http.Response{Body: io.NopCloser(bytes.NewReader(data))}
+
+		got, err := ReadResponseBody(resp, 0)
+
+		require.NoError(t, err)
+		assert.Len(t, got, 50)
+	})
+
+	t.Run("limit<=0 caps at 1 MB", func(t *testing.T) {
+		data := bytes.Repeat([]byte("a"), 1<<20+1024)
+		resp := &http.Response{Body: io.NopCloser(bytes.NewReader(data))}
+
+		got, err := ReadResponseBody(resp, 0)
+
+		require.NoError(t, err)
+		assert.Len(t, got, 1<<20)
+	})
 }


### PR DESCRIPTION
Test-quality cleanup found during a codebase audit. Test-only — no production code touched.

- **Delete `TestHTTPBasicAuth`** (`internal/plugins/integration_test.go`): its body was `t.Parallel()` + an unconditional `t.Skip`, so it could never run and only produced a false coverage signal. Its own skip message notes HTTP is covered in `cmd/brutus/integration_test.go`. (Verified no dangling refs under `-tags=integration`.)
- **Fix two vacuous `TestInit` tests** (imap, postgresql): both asserted `NotNil` on a struct literal (can never fail) and *claimed* to verify `init()` registration without checking it. They now assert `brutus.GetPlugin("<name>")` succeeds and returns the right `Name()`, actually exercising registration.
- **Add `TestReadResponseBody`** (`pkg/enum`): the exported helper's OOM-guard size cap was untested. Covers positive-limit truncation, the `limit<=0` default path, and the 1 MB default cap on an oversized body.

Build/vet (default + `integration` tag) and the affected suites are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)