### PR TITLE
test(plugins): env-gate DB integration tests (couchdb/elasticsearch/influxdb/mysql/redis)

### DIFF
--- a/internal/plugins/couchdb/couchdb_test.go
+++ b/internal/plugins/couchdb/couchdb_test.go
@@ -16,6 +16,7 @@ package couchdb
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -24,45 +25,52 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/brutus"
 )
 
+var (
+	couchdbTestHost = os.Getenv("COUCHDB_TEST_HOST")
+	couchdbTestUser = os.Getenv("COUCHDB_TEST_USER")
+	couchdbTestPass = os.Getenv("COUCHDB_TEST_PASS")
+)
+
 func TestPlugin_Name(t *testing.T) {
 	p := &Plugin{}
 	assert.Equal(t, "couchdb", p.Name())
 }
 
 func TestPlugin_Test_ValidCredentials(t *testing.T) {
-	// Skip if no CouchDB server available
-	// In real tests, use Docker container with known credentials
-	t.Skip("Integration test - requires CouchDB server")
+	if couchdbTestHost == "" {
+		t.Skip("Integration test - requires CouchDB server (set COUCHDB_TEST_HOST)")
+	}
 
 	p := &Plugin{}
 	ctx := context.Background()
 
-	result := p.Test(ctx, "localhost:5984", "admin", "password", 5*time.Second, brutus.PluginConfig{})
+	result := p.Test(ctx, couchdbTestHost, couchdbTestUser, couchdbTestPass, 5*time.Second, brutus.PluginConfig{})
 
 	assert.NotNil(t, result)
 	assert.Equal(t, "couchdb", result.Protocol)
-	assert.Equal(t, "localhost:5984", result.Target)
-	assert.Equal(t, "admin", result.Username)
-	assert.Equal(t, "password", result.Password)
+	assert.Equal(t, couchdbTestHost, result.Target)
+	assert.Equal(t, couchdbTestUser, result.Username)
+	assert.Equal(t, couchdbTestPass, result.Password)
 	assert.True(t, result.Success)
 	assert.Nil(t, result.Error)
 	assert.Greater(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_InvalidCredentials(t *testing.T) {
-	// Skip if no CouchDB server available
-	t.Skip("Integration test - requires CouchDB server")
+	if couchdbTestHost == "" {
+		t.Skip("Integration test - requires CouchDB server (set COUCHDB_TEST_HOST)")
+	}
 
 	p := &Plugin{}
 	ctx := context.Background()
 
-	result := p.Test(ctx, "localhost:5984", "admin", "wrongpassword", 5*time.Second, brutus.PluginConfig{})
+	result := p.Test(ctx, couchdbTestHost, couchdbTestUser, "definitely-wrong-password", 5*time.Second, brutus.PluginConfig{})
 
 	assert.NotNil(t, result)
 	assert.Equal(t, "couchdb", result.Protocol)
-	assert.Equal(t, "localhost:5984", result.Target)
-	assert.Equal(t, "admin", result.Username)
-	assert.Equal(t, "wrongpassword", result.Password)
+	assert.Equal(t, couchdbTestHost, result.Target)
+	assert.Equal(t, couchdbTestUser, result.Username)
+	assert.Equal(t, "definitely-wrong-password", result.Password)
 	assert.False(t, result.Success)
 	assert.Nil(t, result.Error) // Auth failure returns nil error
 	assert.Greater(t, result.Duration, time.Duration(0))
@@ -84,7 +92,9 @@ func TestPlugin_Test_ConnectionError(t *testing.T) {
 }
 
 func TestPlugin_Test_ContextCancellation(t *testing.T) {
-	t.Skip("Integration test - requires CouchDB server")
+	if couchdbTestHost == "" {
+		t.Skip("Integration test - requires CouchDB server (set COUCHDB_TEST_HOST)")
+	}
 
 	p := &Plugin{}
 	ctx, cancel := context.WithCancel(context.Background())
@@ -92,7 +102,7 @@ func TestPlugin_Test_ContextCancellation(t *testing.T) {
 	// Cancel immediately
 	cancel()
 
-	result := p.Test(ctx, "localhost:5984", "admin", "password", 5*time.Second, brutus.PluginConfig{})
+	result := p.Test(ctx, couchdbTestHost, couchdbTestUser, couchdbTestPass, 5*time.Second, brutus.PluginConfig{})
 
 	assert.NotNil(t, result)
 	assert.False(t, result.Success)

--- a/internal/plugins/elasticsearch/elasticsearch_test.go
+++ b/internal/plugins/elasticsearch/elasticsearch_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -27,45 +28,52 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/brutus"
 )
 
+var (
+	elasticsearchTestHost = os.Getenv("ELASTICSEARCH_TEST_HOST")
+	elasticsearchTestUser = os.Getenv("ELASTICSEARCH_TEST_USER")
+	elasticsearchTestPass = os.Getenv("ELASTICSEARCH_TEST_PASS")
+)
+
 func TestPlugin_Name(t *testing.T) {
 	p := &Plugin{}
 	assert.Equal(t, "elasticsearch", p.Name())
 }
 
 func TestPlugin_Test_ValidCredentials(t *testing.T) {
-	// Skip if no Elasticsearch server available
-	// In real tests, use Docker container with known credentials
-	t.Skip("Integration test - requires Elasticsearch server")
+	if elasticsearchTestHost == "" {
+		t.Skip("Integration test - requires Elasticsearch server (set ELASTICSEARCH_TEST_HOST)")
+	}
 
 	p := &Plugin{}
 	ctx := context.Background()
 
-	result := p.Test(ctx, "localhost:9200", "elastic", "password", 5*time.Second, brutus.PluginConfig{})
+	result := p.Test(ctx, elasticsearchTestHost, elasticsearchTestUser, elasticsearchTestPass, 5*time.Second, brutus.PluginConfig{})
 
 	assert.NotNil(t, result)
 	assert.Equal(t, "elasticsearch", result.Protocol)
-	assert.Equal(t, "localhost:9200", result.Target)
-	assert.Equal(t, "elastic", result.Username)
-	assert.Equal(t, "password", result.Password)
+	assert.Equal(t, elasticsearchTestHost, result.Target)
+	assert.Equal(t, elasticsearchTestUser, result.Username)
+	assert.Equal(t, elasticsearchTestPass, result.Password)
 	assert.True(t, result.Success)
 	assert.Nil(t, result.Error)
 	assert.Greater(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_InvalidCredentials(t *testing.T) {
-	// Skip if no Elasticsearch server available
-	t.Skip("Integration test - requires Elasticsearch server")
+	if elasticsearchTestHost == "" {
+		t.Skip("Integration test - requires Elasticsearch server (set ELASTICSEARCH_TEST_HOST)")
+	}
 
 	p := &Plugin{}
 	ctx := context.Background()
 
-	result := p.Test(ctx, "localhost:9200", "elastic", "wrongpassword", 5*time.Second, brutus.PluginConfig{})
+	result := p.Test(ctx, elasticsearchTestHost, elasticsearchTestUser, "definitely-wrong-password", 5*time.Second, brutus.PluginConfig{})
 
 	assert.NotNil(t, result)
 	assert.Equal(t, "elasticsearch", result.Protocol)
-	assert.Equal(t, "localhost:9200", result.Target)
-	assert.Equal(t, "elastic", result.Username)
-	assert.Equal(t, "wrongpassword", result.Password)
+	assert.Equal(t, elasticsearchTestHost, result.Target)
+	assert.Equal(t, elasticsearchTestUser, result.Username)
+	assert.Equal(t, "definitely-wrong-password", result.Password)
 	assert.False(t, result.Success)
 	assert.Nil(t, result.Error) // Auth failure (401) returns nil error
 	assert.Greater(t, result.Duration, time.Duration(0))
@@ -87,7 +95,9 @@ func TestPlugin_Test_ConnectionError(t *testing.T) {
 }
 
 func TestPlugin_Test_ContextCancellation(t *testing.T) {
-	t.Skip("Integration test - requires Elasticsearch server")
+	if elasticsearchTestHost == "" {
+		t.Skip("Integration test - requires Elasticsearch server (set ELASTICSEARCH_TEST_HOST)")
+	}
 
 	p := &Plugin{}
 	ctx, cancel := context.WithCancel(context.Background())
@@ -95,7 +105,7 @@ func TestPlugin_Test_ContextCancellation(t *testing.T) {
 	// Cancel immediately
 	cancel()
 
-	result := p.Test(ctx, "localhost:9200", "elastic", "password", 5*time.Second, brutus.PluginConfig{})
+	result := p.Test(ctx, elasticsearchTestHost, elasticsearchTestUser, elasticsearchTestPass, 5*time.Second, brutus.PluginConfig{})
 
 	assert.NotNil(t, result)
 	assert.False(t, result.Success)

--- a/internal/plugins/influxdb/influxdb_test.go
+++ b/internal/plugins/influxdb/influxdb_test.go
@@ -16,6 +16,7 @@ package influxdb
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -24,45 +25,52 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/brutus"
 )
 
+var (
+	influxdbTestHost = os.Getenv("INFLUXDB_TEST_HOST")
+	influxdbTestUser = os.Getenv("INFLUXDB_TEST_USER")
+	influxdbTestPass = os.Getenv("INFLUXDB_TEST_PASS")
+)
+
 func TestPlugin_Name(t *testing.T) {
 	p := &Plugin{}
 	assert.Equal(t, "influxdb", p.Name())
 }
 
 func TestPlugin_Test_ValidCredentials(t *testing.T) {
-	// Skip if no InfluxDB server available
-	// In real tests, use Docker container with known credentials
-	t.Skip("Integration test - requires InfluxDB server")
+	if influxdbTestHost == "" {
+		t.Skip("Integration test - requires InfluxDB server (set INFLUXDB_TEST_HOST)")
+	}
 
 	p := &Plugin{}
 	ctx := context.Background()
 
-	result := p.Test(ctx, "localhost:8086", "admin", "password", 5*time.Second, brutus.PluginConfig{})
+	result := p.Test(ctx, influxdbTestHost, influxdbTestUser, influxdbTestPass, 5*time.Second, brutus.PluginConfig{})
 
 	assert.NotNil(t, result)
 	assert.Equal(t, "influxdb", result.Protocol)
-	assert.Equal(t, "localhost:8086", result.Target)
-	assert.Equal(t, "admin", result.Username)
-	assert.Equal(t, "password", result.Password)
+	assert.Equal(t, influxdbTestHost, result.Target)
+	assert.Equal(t, influxdbTestUser, result.Username)
+	assert.Equal(t, influxdbTestPass, result.Password)
 	assert.True(t, result.Success)
 	assert.Nil(t, result.Error)
 	assert.Greater(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_InvalidCredentials(t *testing.T) {
-	// Skip if no InfluxDB server available
-	t.Skip("Integration test - requires InfluxDB server")
+	if influxdbTestHost == "" {
+		t.Skip("Integration test - requires InfluxDB server (set INFLUXDB_TEST_HOST)")
+	}
 
 	p := &Plugin{}
 	ctx := context.Background()
 
-	result := p.Test(ctx, "localhost:8086", "admin", "wrongpassword", 5*time.Second, brutus.PluginConfig{})
+	result := p.Test(ctx, influxdbTestHost, influxdbTestUser, "definitely-wrong-password", 5*time.Second, brutus.PluginConfig{})
 
 	assert.NotNil(t, result)
 	assert.Equal(t, "influxdb", result.Protocol)
-	assert.Equal(t, "localhost:8086", result.Target)
-	assert.Equal(t, "admin", result.Username)
-	assert.Equal(t, "wrongpassword", result.Password)
+	assert.Equal(t, influxdbTestHost, result.Target)
+	assert.Equal(t, influxdbTestUser, result.Username)
+	assert.Equal(t, "definitely-wrong-password", result.Password)
 	assert.False(t, result.Success)
 	assert.Nil(t, result.Error) // Auth failure returns nil error
 	assert.Greater(t, result.Duration, time.Duration(0))
@@ -84,7 +92,9 @@ func TestPlugin_Test_ConnectionError(t *testing.T) {
 }
 
 func TestPlugin_Test_ContextCancellation(t *testing.T) {
-	t.Skip("Integration test - requires InfluxDB server")
+	if influxdbTestHost == "" {
+		t.Skip("Integration test - requires InfluxDB server (set INFLUXDB_TEST_HOST)")
+	}
 
 	p := &Plugin{}
 	ctx, cancel := context.WithCancel(context.Background())
@@ -92,7 +102,7 @@ func TestPlugin_Test_ContextCancellation(t *testing.T) {
 	// Cancel immediately
 	cancel()
 
-	result := p.Test(ctx, "localhost:8086", "admin", "password", 5*time.Second, brutus.PluginConfig{})
+	result := p.Test(ctx, influxdbTestHost, influxdbTestUser, influxdbTestPass, 5*time.Second, brutus.PluginConfig{})
 
 	assert.NotNil(t, result)
 	assert.False(t, result.Success)

--- a/internal/plugins/mysql/mysql_test.go
+++ b/internal/plugins/mysql/mysql_test.go
@@ -16,6 +16,7 @@ package mysql
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -24,45 +25,52 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/brutus"
 )
 
+var (
+	mysqlTestHost = os.Getenv("MYSQL_TEST_HOST")
+	mysqlTestUser = os.Getenv("MYSQL_TEST_USER")
+	mysqlTestPass = os.Getenv("MYSQL_TEST_PASS")
+)
+
 func TestPlugin_Name(t *testing.T) {
 	p := &Plugin{}
 	assert.Equal(t, "mysql", p.Name())
 }
 
 func TestPlugin_Test_ValidCredentials(t *testing.T) {
-	// Skip if no MySQL server available
-	// In real tests, use Docker container with known credentials
-	t.Skip("Integration test - requires MySQL server")
+	if mysqlTestHost == "" {
+		t.Skip("Integration test - requires MySQL server (set MYSQL_TEST_HOST)")
+	}
 
 	p := &Plugin{}
 	ctx := context.Background()
 
-	result := p.Test(ctx, "localhost:3306", "root", "password", 5*time.Second, brutus.PluginConfig{})
+	result := p.Test(ctx, mysqlTestHost, mysqlTestUser, mysqlTestPass, 5*time.Second, brutus.PluginConfig{})
 
 	assert.NotNil(t, result)
 	assert.Equal(t, "mysql", result.Protocol)
-	assert.Equal(t, "localhost:3306", result.Target)
-	assert.Equal(t, "root", result.Username)
-	assert.Equal(t, "password", result.Password)
+	assert.Equal(t, mysqlTestHost, result.Target)
+	assert.Equal(t, mysqlTestUser, result.Username)
+	assert.Equal(t, mysqlTestPass, result.Password)
 	assert.True(t, result.Success)
 	assert.Nil(t, result.Error)
 	assert.Greater(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_InvalidCredentials(t *testing.T) {
-	// Skip if no MySQL server available
-	t.Skip("Integration test - requires MySQL server")
+	if mysqlTestHost == "" {
+		t.Skip("Integration test - requires MySQL server (set MYSQL_TEST_HOST)")
+	}
 
 	p := &Plugin{}
 	ctx := context.Background()
 
-	result := p.Test(ctx, "localhost:3306", "root", "wrongpassword", 5*time.Second, brutus.PluginConfig{})
+	result := p.Test(ctx, mysqlTestHost, mysqlTestUser, "definitely-wrong-password", 5*time.Second, brutus.PluginConfig{})
 
 	assert.NotNil(t, result)
 	assert.Equal(t, "mysql", result.Protocol)
-	assert.Equal(t, "localhost:3306", result.Target)
-	assert.Equal(t, "root", result.Username)
-	assert.Equal(t, "wrongpassword", result.Password)
+	assert.Equal(t, mysqlTestHost, result.Target)
+	assert.Equal(t, mysqlTestUser, result.Username)
+	assert.Equal(t, "definitely-wrong-password", result.Password)
 	assert.False(t, result.Success)
 	assert.Nil(t, result.Error) // Auth failure returns nil error
 	assert.Greater(t, result.Duration, time.Duration(0))
@@ -84,7 +92,9 @@ func TestPlugin_Test_ConnectionError(t *testing.T) {
 }
 
 func TestPlugin_Test_ContextCancellation(t *testing.T) {
-	t.Skip("Integration test - requires MySQL server")
+	if mysqlTestHost == "" {
+		t.Skip("Integration test - requires MySQL server (set MYSQL_TEST_HOST)")
+	}
 
 	p := &Plugin{}
 	ctx, cancel := context.WithCancel(context.Background())
@@ -92,7 +102,7 @@ func TestPlugin_Test_ContextCancellation(t *testing.T) {
 	// Cancel immediately
 	cancel()
 
-	result := p.Test(ctx, "localhost:3306", "root", "password", 5*time.Second, brutus.PluginConfig{})
+	result := p.Test(ctx, mysqlTestHost, mysqlTestUser, mysqlTestPass, 5*time.Second, brutus.PluginConfig{})
 
 	assert.NotNil(t, result)
 	assert.False(t, result.Success)

--- a/internal/plugins/redis/redis_test.go
+++ b/internal/plugins/redis/redis_test.go
@@ -112,7 +112,9 @@ func TestPlugin_Test_ErrorClassification(t *testing.T) {
 }
 
 func TestPlugin_Test_ValidCredentials(t *testing.T) {
-	t.Skip("Integration test - requires Redis server")
+	if os.Getenv("REDIS_TEST_HOST") == "" {
+		t.Skip("Integration test - requires Redis server (set REDIS_TEST_HOST)")
+	}
 
 	host, pass := getTestConfig()
 
@@ -133,7 +135,9 @@ func TestPlugin_Test_ValidCredentials(t *testing.T) {
 }
 
 func TestPlugin_Test_InvalidCredentials(t *testing.T) {
-	t.Skip("Integration test - requires Redis server")
+	if os.Getenv("REDIS_TEST_HOST") == "" {
+		t.Skip("Integration test - requires Redis server (set REDIS_TEST_HOST)")
+	}
 
 	host, _ := getTestConfig()
 
@@ -154,18 +158,22 @@ func TestPlugin_Test_InvalidCredentials(t *testing.T) {
 }
 
 func TestPlugin_Test_NoAuthRequired(t *testing.T) {
-	t.Skip("Integration test - requires Redis server without auth")
+	if os.Getenv("REDIS_TEST_HOST") == "" {
+		t.Skip("Integration test - requires Redis server without auth (set REDIS_TEST_HOST)")
+	}
+
+	host, _ := getTestConfig()
 
 	p := &Plugin{}
 	ctx := context.Background()
 	timeout := 5 * time.Second
 
 	// Try empty password on Redis with no auth required
-	result := p.Test(ctx, "localhost:6379", "", "", timeout, brutus.PluginConfig{})
+	result := p.Test(ctx, host, "", "", timeout, brutus.PluginConfig{})
 
 	assert.NotNil(t, result)
 	assert.Equal(t, "redis", result.Protocol)
-	assert.Equal(t, "localhost:6379", result.Target)
+	assert.Equal(t, host, result.Target)
 	assert.Equal(t, "", result.Username)
 	assert.Equal(t, "", result.Password)
 	// If Redis has no auth, this should succeed
@@ -223,7 +231,11 @@ func TestPlugin_Test_Timeout(t *testing.T) {
 }
 
 func TestPlugin_Test_ContextCancellation(t *testing.T) {
-	t.Skip("Integration test - requires Redis server")
+	if os.Getenv("REDIS_TEST_HOST") == "" {
+		t.Skip("Integration test - requires Redis server (set REDIS_TEST_HOST)")
+	}
+
+	host, pass := getTestConfig()
 
 	p := &Plugin{}
 	ctx, cancel := context.WithCancel(context.Background())
@@ -233,7 +245,7 @@ func TestPlugin_Test_ContextCancellation(t *testing.T) {
 
 	timeout := 5 * time.Second
 
-	result := p.Test(ctx, "localhost:6379", "", "password", timeout, brutus.PluginConfig{})
+	result := p.Test(ctx, host, "", pass, timeout, brutus.PluginConfig{})
 
 	assert.NotNil(t, result)
 	assert.False(t, result.Success, "Expected context cancellation failure")


### PR DESCRIPTION
## Problem

These plugins' `TestPlugin_Test_ValidCredentials` / `_InvalidCredentials` / `_ContextCancellation` tests called `t.Skip("Integration test - requires X server")` **unconditionally**, so their credential-verification path never ran even with a server present — giving false coverage signal. The `mssql`/`oracle` plugins already use the right convention (gate on an env var, run when configured).

## Fix

Convert them to that convention: package-level `host`/`user`/`pass` from `<PLUGIN>_TEST_*` env vars, gate each test on the host var, use the env values as target/creds, and update the assertions that compared against the old hardcoded literals.

Only the unconditionally-skipped tests were converted; already-running tests (`ConnectionError`, `Timeout`, `Name`, elasticsearch `CheckUnauth`, redis error-classification) are untouched. **CI behavior is unchanged** — with the env vars unset, all converted tests still `SKIP` (verified; nothing `FAIL`s).

Plugins in this PR: couchdb, elasticsearch, influxdb, mysql, redis. (Companion PR handles ldap/neo4j/postgresql/smtp/vnc/smb.)

## Caveat

I could not run these against live servers, so the live-run assertions are **best-effort**, faithful to the established mssql/oracle template. One flag for maintainers: redis `NoAuthRequired` now shares `REDIS_TEST_HOST`; it asserts only structural fields (won't hard-fail), but a distinct no-auth host would make it more meaningful.

Part of an audit series shipped as focused PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)