### PR TITLE
test(plugins): env-gate integration tests (ldap/neo4j/postgresql/smtp/vnc/smb)

### DIFF
--- a/internal/plugins/ldap/ldap_test.go
+++ b/internal/plugins/ldap/ldap_test.go
@@ -16,6 +16,7 @@ package ldap
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -24,45 +25,52 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/brutus"
 )
 
+var (
+	ldapTestHost = os.Getenv("LDAP_TEST_HOST")
+	ldapTestUser = os.Getenv("LDAP_TEST_USER")
+	ldapTestPass = os.Getenv("LDAP_TEST_PASS")
+)
+
 func TestPlugin_Name(t *testing.T) {
 	p := &Plugin{}
 	assert.Equal(t, "ldap", p.Name())
 }
 
 func TestPlugin_Test_ValidCredentials(t *testing.T) {
-	// Skip if no LDAP server available
-	// In real tests, use Docker container with known credentials
-	t.Skip("Integration test - requires LDAP server")
+	if ldapTestHost == "" {
+		t.Skip("Integration test - requires LDAP server (set LDAP_TEST_HOST)")
+	}
 
 	p := &Plugin{}
 	ctx := context.Background()
 
-	result := p.Test(ctx, "localhost:389", "admin", "password", 5*time.Second, brutus.PluginConfig{})
+	result := p.Test(ctx, ldapTestHost, ldapTestUser, ldapTestPass, 5*time.Second, brutus.PluginConfig{})
 
 	assert.NotNil(t, result)
 	assert.Equal(t, "ldap", result.Protocol)
-	assert.Equal(t, "localhost:389", result.Target)
-	assert.Equal(t, "admin", result.Username)
-	assert.Equal(t, "password", result.Password)
+	assert.Equal(t, ldapTestHost, result.Target)
+	assert.Equal(t, ldapTestUser, result.Username)
+	assert.Equal(t, ldapTestPass, result.Password)
 	assert.True(t, result.Success)
 	assert.Nil(t, result.Error)
 	assert.Greater(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_InvalidCredentials(t *testing.T) {
-	// Skip if no LDAP server available
-	t.Skip("Integration test - requires LDAP server")
+	if ldapTestHost == "" {
+		t.Skip("Integration test - requires LDAP server (set LDAP_TEST_HOST)")
+	}
 
 	p := &Plugin{}
 	ctx := context.Background()
 
-	result := p.Test(ctx, "localhost:389", "admin", "wrongpassword", 5*time.Second, brutus.PluginConfig{})
+	result := p.Test(ctx, ldapTestHost, ldapTestUser, "definitely-wrong-password", 5*time.Second, brutus.PluginConfig{})
 
 	assert.NotNil(t, result)
 	assert.Equal(t, "ldap", result.Protocol)
-	assert.Equal(t, "localhost:389", result.Target)
-	assert.Equal(t, "admin", result.Username)
-	assert.Equal(t, "wrongpassword", result.Password)
+	assert.Equal(t, ldapTestHost, result.Target)
+	assert.Equal(t, ldapTestUser, result.Username)
+	assert.Equal(t, "definitely-wrong-password", result.Password)
 	assert.False(t, result.Success)
 	assert.Nil(t, result.Error) // Auth failure returns nil error
 	assert.Greater(t, result.Duration, time.Duration(0))
@@ -84,7 +92,9 @@ func TestPlugin_Test_ConnectionError(t *testing.T) {
 }
 
 func TestPlugin_Test_ContextCancellation(t *testing.T) {
-	t.Skip("Integration test - requires LDAP server")
+	if ldapTestHost == "" {
+		t.Skip("Integration test - requires LDAP server (set LDAP_TEST_HOST)")
+	}
 
 	p := &Plugin{}
 	ctx, cancel := context.WithCancel(context.Background())
@@ -92,7 +102,7 @@ func TestPlugin_Test_ContextCancellation(t *testing.T) {
 	// Cancel immediately
 	cancel()
 
-	result := p.Test(ctx, "localhost:389", "admin", "password", 5*time.Second, brutus.PluginConfig{})
+	result := p.Test(ctx, ldapTestHost, ldapTestUser, ldapTestPass, 5*time.Second, brutus.PluginConfig{})
 
 	assert.NotNil(t, result)
 	assert.False(t, result.Success)

--- a/internal/plugins/neo4j/neo4j_test.go
+++ b/internal/plugins/neo4j/neo4j_test.go
@@ -16,6 +16,7 @@ package neo4j
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -24,45 +25,52 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/brutus"
 )
 
+var (
+	neo4jTestHost = os.Getenv("NEO4J_TEST_HOST")
+	neo4jTestUser = os.Getenv("NEO4J_TEST_USER")
+	neo4jTestPass = os.Getenv("NEO4J_TEST_PASS")
+)
+
 func TestPlugin_Name(t *testing.T) {
 	p := &Plugin{}
 	assert.Equal(t, "neo4j", p.Name())
 }
 
 func TestPlugin_Test_ValidCredentials(t *testing.T) {
-	// Skip if no Neo4j server available
-	// In real tests, use Docker container with known credentials
-	t.Skip("Integration test - requires Neo4j server")
+	if neo4jTestHost == "" {
+		t.Skip("Integration test - requires Neo4j server (set NEO4J_TEST_HOST)")
+	}
 
 	p := &Plugin{}
 	ctx := context.Background()
 
-	result := p.Test(ctx, "localhost:7687", "neo4j", "password", 5*time.Second, brutus.PluginConfig{})
+	result := p.Test(ctx, neo4jTestHost, neo4jTestUser, neo4jTestPass, 5*time.Second, brutus.PluginConfig{})
 
 	assert.NotNil(t, result)
 	assert.Equal(t, "neo4j", result.Protocol)
-	assert.Equal(t, "localhost:7687", result.Target)
-	assert.Equal(t, "neo4j", result.Username)
-	assert.Equal(t, "password", result.Password)
+	assert.Equal(t, neo4jTestHost, result.Target)
+	assert.Equal(t, neo4jTestUser, result.Username)
+	assert.Equal(t, neo4jTestPass, result.Password)
 	assert.True(t, result.Success)
 	assert.Nil(t, result.Error)
 	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_InvalidCredentials(t *testing.T) {
-	// Skip if no Neo4j server available
-	t.Skip("Integration test - requires Neo4j server")
+	if neo4jTestHost == "" {
+		t.Skip("Integration test - requires Neo4j server (set NEO4J_TEST_HOST)")
+	}
 
 	p := &Plugin{}
 	ctx := context.Background()
 
-	result := p.Test(ctx, "localhost:7687", "neo4j", "wrongpassword", 5*time.Second, brutus.PluginConfig{})
+	result := p.Test(ctx, neo4jTestHost, neo4jTestUser, "definitely-wrong-password", 5*time.Second, brutus.PluginConfig{})
 
 	assert.NotNil(t, result)
 	assert.Equal(t, "neo4j", result.Protocol)
-	assert.Equal(t, "localhost:7687", result.Target)
-	assert.Equal(t, "neo4j", result.Username)
-	assert.Equal(t, "wrongpassword", result.Password)
+	assert.Equal(t, neo4jTestHost, result.Target)
+	assert.Equal(t, neo4jTestUser, result.Username)
+	assert.Equal(t, "definitely-wrong-password", result.Password)
 	assert.False(t, result.Success)
 	assert.Nil(t, result.Error) // Auth failure returns nil error
 	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
@@ -84,7 +92,9 @@ func TestPlugin_Test_ConnectionError(t *testing.T) {
 }
 
 func TestPlugin_Test_ContextCancellation(t *testing.T) {
-	t.Skip("Integration test - requires Neo4j server")
+	if neo4jTestHost == "" {
+		t.Skip("Integration test - requires Neo4j server (set NEO4J_TEST_HOST)")
+	}
 
 	p := &Plugin{}
 	ctx, cancel := context.WithCancel(context.Background())
@@ -92,7 +102,7 @@ func TestPlugin_Test_ContextCancellation(t *testing.T) {
 	// Cancel immediately
 	cancel()
 
-	result := p.Test(ctx, "localhost:7687", "neo4j", "password", 5*time.Second, brutus.PluginConfig{})
+	result := p.Test(ctx, neo4jTestHost, neo4jTestUser, neo4jTestPass, 5*time.Second, brutus.PluginConfig{})
 
 	assert.NotNil(t, result)
 	assert.False(t, result.Success)

--- a/internal/plugins/postgresql/postgresql_test.go
+++ b/internal/plugins/postgresql/postgresql_test.go
@@ -101,9 +101,10 @@ func TestPlugin_Test_ErrorClassification(t *testing.T) {
 }
 
 func TestPlugin_Test_ValidCredentials(t *testing.T) {
-	t.Skip("Integration test - requires PostgreSQL server")
-
 	host, user, pass := getTestConfig()
+	if os.Getenv("POSTGRES_TEST_HOST") == "" {
+		t.Skip("Integration test - requires PostgreSQL server (set POSTGRES_TEST_HOST)")
+	}
 
 	p := &Plugin{}
 	ctx := context.Background()
@@ -122,21 +123,22 @@ func TestPlugin_Test_ValidCredentials(t *testing.T) {
 }
 
 func TestPlugin_Test_InvalidCredentials(t *testing.T) {
-	t.Skip("Integration test - requires PostgreSQL server")
-
 	host, user, _ := getTestConfig()
+	if os.Getenv("POSTGRES_TEST_HOST") == "" {
+		t.Skip("Integration test - requires PostgreSQL server (set POSTGRES_TEST_HOST)")
+	}
 
 	p := &Plugin{}
 	ctx := context.Background()
 	timeout := 5 * time.Second
 
-	result := p.Test(ctx, host, user, "wrongpassword", timeout, brutus.PluginConfig{})
+	result := p.Test(ctx, host, user, "definitely-wrong-password", timeout, brutus.PluginConfig{})
 
 	assert.NotNil(t, result)
 	assert.Equal(t, "postgresql", result.Protocol)
 	assert.Equal(t, host, result.Target)
 	assert.Equal(t, user, result.Username)
-	assert.Equal(t, "wrongpassword", result.Password)
+	assert.Equal(t, "definitely-wrong-password", result.Password)
 	assert.False(t, result.Success, "Expected failed authentication")
 	assert.Nil(t, result.Error, "Authentication failure should have nil error")
 	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
@@ -192,7 +194,10 @@ func TestPlugin_Test_Timeout(t *testing.T) {
 }
 
 func TestPlugin_Test_ContextCancellation(t *testing.T) {
-	t.Skip("Integration test - requires PostgreSQL server")
+	host, user, pass := getTestConfig()
+	if os.Getenv("POSTGRES_TEST_HOST") == "" {
+		t.Skip("Integration test - requires PostgreSQL server (set POSTGRES_TEST_HOST)")
+	}
 
 	p := &Plugin{}
 	ctx, cancel := context.WithCancel(context.Background())
@@ -202,7 +207,7 @@ func TestPlugin_Test_ContextCancellation(t *testing.T) {
 
 	timeout := 5 * time.Second
 
-	result := p.Test(ctx, "localhost:5432", "postgres", "postgres", timeout, brutus.PluginConfig{})
+	result := p.Test(ctx, host, user, pass, timeout, brutus.PluginConfig{})
 
 	assert.NotNil(t, result)
 	assert.False(t, result.Success, "Expected context cancellation failure")

--- a/internal/plugins/smb/smb_test.go
+++ b/internal/plugins/smb/smb_test.go
@@ -31,39 +31,45 @@ func TestPlugin_Name(t *testing.T) {
 }
 
 func TestPlugin_Test_ValidCredentials(t *testing.T) {
-	// Skip if no SMB server available
-	// In real tests, use Docker container with known credentials
-	t.Skip("Integration test - requires SMB server")
+	host := os.Getenv("SMB_TEST_HOST")
+	if host == "" {
+		t.Skip("Integration test - requires SMB server (set SMB_TEST_HOST)")
+	}
+	user := os.Getenv("SMB_TEST_USER")
+	pass := os.Getenv("SMB_TEST_PASS")
 
 	p := &Plugin{}
 	ctx := context.Background()
 
-	result := p.Test(ctx, "localhost:445", "Administrator", "password", 5*time.Second, brutus.PluginConfig{})
+	result := p.Test(ctx, host, user, pass, 5*time.Second, brutus.PluginConfig{})
 
 	assert.NotNil(t, result)
 	assert.Equal(t, "smb", result.Protocol)
-	assert.Equal(t, "localhost:445", result.Target)
-	assert.Equal(t, "Administrator", result.Username)
-	assert.Equal(t, "password", result.Password)
+	assert.Equal(t, host, result.Target)
+	assert.Equal(t, user, result.Username)
+	assert.Equal(t, pass, result.Password)
 	assert.True(t, result.Success)
 	assert.Nil(t, result.Error)
 	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_InvalidCredentials(t *testing.T) {
-	// Skip if no SMB server available
-	t.Skip("Integration test - requires SMB server")
+	host := os.Getenv("SMB_TEST_HOST")
+	if host == "" {
+		t.Skip("Integration test - requires SMB server (set SMB_TEST_HOST)")
+	}
+	user := os.Getenv("SMB_TEST_USER")
 
 	p := &Plugin{}
 	ctx := context.Background()
 
-	result := p.Test(ctx, "localhost:445", "Administrator", "wrongpassword", 5*time.Second, brutus.PluginConfig{})
+	result := p.Test(ctx, host, user, "definitely-wrong-password", 5*time.Second, brutus.PluginConfig{})
 
 	assert.NotNil(t, result)
 	assert.Equal(t, "smb", result.Protocol)
-	assert.Equal(t, "localhost:445", result.Target)
-	assert.Equal(t, "Administrator", result.Username)
-	assert.Equal(t, "wrongpassword", result.Password)
+	assert.Equal(t, host, result.Target)
+	assert.Equal(t, user, result.Username)
+	assert.Equal(t, "definitely-wrong-password", result.Password)
 	assert.False(t, result.Success)
 	assert.Nil(t, result.Error) // Auth failure returns nil error
 	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
@@ -85,7 +91,12 @@ func TestPlugin_Test_ConnectionError(t *testing.T) {
 }
 
 func TestPlugin_Test_ContextCancellation(t *testing.T) {
-	t.Skip("Integration test - requires SMB server")
+	host := os.Getenv("SMB_TEST_HOST")
+	if host == "" {
+		t.Skip("Integration test - requires SMB server (set SMB_TEST_HOST)")
+	}
+	user := os.Getenv("SMB_TEST_USER")
+	pass := os.Getenv("SMB_TEST_PASS")
 
 	p := &Plugin{}
 	ctx, cancel := context.WithCancel(context.Background())
@@ -93,7 +104,7 @@ func TestPlugin_Test_ContextCancellation(t *testing.T) {
 	// Cancel immediately
 	cancel()
 
-	result := p.Test(ctx, "localhost:445", "Administrator", "password", 5*time.Second, brutus.PluginConfig{})
+	result := p.Test(ctx, host, user, pass, 5*time.Second, brutus.PluginConfig{})
 
 	assert.NotNil(t, result)
 	assert.False(t, result.Success)
@@ -114,18 +125,23 @@ func TestPlugin_Test_Timeout(t *testing.T) {
 }
 
 func TestPlugin_Test_DomainUsername(t *testing.T) {
-	// Skip if no SMB server available
-	t.Skip("Integration test - requires SMB server with domain")
+	host := os.Getenv("SMB_TEST_HOST")
+	if host == "" {
+		t.Skip("Integration test - requires SMB server with domain (set SMB_TEST_HOST)")
+	}
 
 	p := &Plugin{}
 	ctx := context.Background()
 
 	// Test with DOMAIN\username format
-	result := p.Test(ctx, "localhost:445", "DOMAIN\\Administrator", "password", 5*time.Second, brutus.PluginConfig{})
+	// NOTE: "DOMAIN\Administrator"/"password" are hardcoded since there is no
+	// SMB_TEST_DOMAIN env var - this assumes the SMB_TEST_HOST server is
+	// configured with this exact domain account. Uncertain against real servers.
+	result := p.Test(ctx, host, "DOMAIN\\Administrator", "password", 5*time.Second, brutus.PluginConfig{})
 
 	assert.NotNil(t, result)
 	assert.Equal(t, "smb", result.Protocol)
-	assert.Equal(t, "localhost:445", result.Target)
+	assert.Equal(t, host, result.Target)
 	assert.Equal(t, "DOMAIN\\Administrator", result.Username)
 	assert.True(t, result.Success)
 	assert.Nil(t, result.Error)

--- a/internal/plugins/smtp/smtp_test.go
+++ b/internal/plugins/smtp/smtp_test.go
@@ -16,6 +16,7 @@ package smtp
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -24,45 +25,52 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/brutus"
 )
 
+var (
+	smtpTestHost = os.Getenv("SMTP_TEST_HOST")
+	smtpTestUser = os.Getenv("SMTP_TEST_USER")
+	smtpTestPass = os.Getenv("SMTP_TEST_PASS")
+)
+
 func TestPlugin_Name(t *testing.T) {
 	p := &Plugin{}
 	assert.Equal(t, "smtp", p.Name())
 }
 
 func TestPlugin_Test_ValidCredentials(t *testing.T) {
-	// Skip if no SMTP server available
-	// In real tests, use Docker container with known credentials
-	t.Skip("Integration test - requires SMTP server")
+	if smtpTestHost == "" {
+		t.Skip("Integration test - requires SMTP server (set SMTP_TEST_HOST)")
+	}
 
 	p := &Plugin{}
 	ctx := context.Background()
 
-	result := p.Test(ctx, "localhost:587", "user@example.com", "password", 5*time.Second, brutus.PluginConfig{})
+	result := p.Test(ctx, smtpTestHost, smtpTestUser, smtpTestPass, 5*time.Second, brutus.PluginConfig{})
 
 	assert.NotNil(t, result)
 	assert.Equal(t, "smtp", result.Protocol)
-	assert.Equal(t, "localhost:587", result.Target)
-	assert.Equal(t, "user@example.com", result.Username)
-	assert.Equal(t, "password", result.Password)
+	assert.Equal(t, smtpTestHost, result.Target)
+	assert.Equal(t, smtpTestUser, result.Username)
+	assert.Equal(t, smtpTestPass, result.Password)
 	assert.True(t, result.Success)
 	assert.Nil(t, result.Error)
 	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_InvalidCredentials(t *testing.T) {
-	// Skip if no SMTP server available
-	t.Skip("Integration test - requires SMTP server")
+	if smtpTestHost == "" {
+		t.Skip("Integration test - requires SMTP server (set SMTP_TEST_HOST)")
+	}
 
 	p := &Plugin{}
 	ctx := context.Background()
 
-	result := p.Test(ctx, "localhost:587", "user@example.com", "wrongpassword", 5*time.Second, brutus.PluginConfig{})
+	result := p.Test(ctx, smtpTestHost, smtpTestUser, "definitely-wrong-password", 5*time.Second, brutus.PluginConfig{})
 
 	assert.NotNil(t, result)
 	assert.Equal(t, "smtp", result.Protocol)
-	assert.Equal(t, "localhost:587", result.Target)
-	assert.Equal(t, "user@example.com", result.Username)
-	assert.Equal(t, "wrongpassword", result.Password)
+	assert.Equal(t, smtpTestHost, result.Target)
+	assert.Equal(t, smtpTestUser, result.Username)
+	assert.Equal(t, "definitely-wrong-password", result.Password)
 	assert.False(t, result.Success)
 	assert.Nil(t, result.Error) // Auth failure returns nil error
 	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
@@ -84,7 +92,9 @@ func TestPlugin_Test_ConnectionError(t *testing.T) {
 }
 
 func TestPlugin_Test_ContextCancellation(t *testing.T) {
-	t.Skip("Integration test - requires SMTP server")
+	if smtpTestHost == "" {
+		t.Skip("Integration test - requires SMTP server (set SMTP_TEST_HOST)")
+	}
 
 	p := &Plugin{}
 	ctx, cancel := context.WithCancel(context.Background())
@@ -92,7 +102,7 @@ func TestPlugin_Test_ContextCancellation(t *testing.T) {
 	// Cancel immediately
 	cancel()
 
-	result := p.Test(ctx, "localhost:587", "user@example.com", "password", 5*time.Second, brutus.PluginConfig{})
+	result := p.Test(ctx, smtpTestHost, smtpTestUser, smtpTestPass, 5*time.Second, brutus.PluginConfig{})
 
 	assert.NotNil(t, result)
 	assert.False(t, result.Success)

--- a/internal/plugins/vnc/vnc_test.go
+++ b/internal/plugins/vnc/vnc_test.go
@@ -17,12 +17,18 @@ package vnc
 import (
 	"context"
 	"net"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/praetorian-inc/brutus/pkg/brutus"
+)
+
+var (
+	vncTestHost = os.Getenv("VNC_TEST_HOST")
+	vncTestPass = os.Getenv("VNC_TEST_PASS")
 )
 
 // startStallingServer starts a TCP listener that accepts connections but
@@ -74,40 +80,41 @@ func TestPlugin_Name(t *testing.T) {
 }
 
 func TestPlugin_Test_ValidCredentials(t *testing.T) {
-	// Skip if no VNC server available
-	// In real tests, use Docker container with known credentials
-	t.Skip("Integration test - requires VNC server")
+	if vncTestHost == "" {
+		t.Skip("Integration test - requires VNC server (set VNC_TEST_HOST)")
+	}
 
 	p := &Plugin{}
 	ctx := context.Background()
 
 	// VNC uses password-only authentication (no username)
-	result := p.Test(ctx, "localhost:5900", "", "password", 5*time.Second, brutus.PluginConfig{})
+	result := p.Test(ctx, vncTestHost, "", vncTestPass, 5*time.Second, brutus.PluginConfig{})
 
 	assert.NotNil(t, result)
 	assert.Equal(t, "vnc", result.Protocol)
-	assert.Equal(t, "localhost:5900", result.Target)
+	assert.Equal(t, vncTestHost, result.Target)
 	assert.Equal(t, "", result.Username) // VNC doesn't use username
-	assert.Equal(t, "password", result.Password)
+	assert.Equal(t, vncTestPass, result.Password)
 	assert.True(t, result.Success)
 	assert.Nil(t, result.Error)
 	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
 func TestPlugin_Test_InvalidCredentials(t *testing.T) {
-	// Skip if no VNC server available
-	t.Skip("Integration test - requires VNC server")
+	if vncTestHost == "" {
+		t.Skip("Integration test - requires VNC server (set VNC_TEST_HOST)")
+	}
 
 	p := &Plugin{}
 	ctx := context.Background()
 
-	result := p.Test(ctx, "localhost:5900", "", "wrongpassword", 5*time.Second, brutus.PluginConfig{})
+	result := p.Test(ctx, vncTestHost, "", "definitely-wrong-password", 5*time.Second, brutus.PluginConfig{})
 
 	assert.NotNil(t, result)
 	assert.Equal(t, "vnc", result.Protocol)
-	assert.Equal(t, "localhost:5900", result.Target)
+	assert.Equal(t, vncTestHost, result.Target)
 	assert.Equal(t, "", result.Username)
-	assert.Equal(t, "wrongpassword", result.Password)
+	assert.Equal(t, "definitely-wrong-password", result.Password)
 	assert.False(t, result.Success)
 	assert.Nil(t, result.Error) // Auth failure returns nil error
 	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
@@ -129,7 +136,9 @@ func TestPlugin_Test_ConnectionError(t *testing.T) {
 }
 
 func TestPlugin_Test_ContextCancellation(t *testing.T) {
-	t.Skip("Integration test - requires VNC server")
+	if vncTestHost == "" {
+		t.Skip("Integration test - requires VNC server (set VNC_TEST_HOST)")
+	}
 
 	p := &Plugin{}
 	ctx, cancel := context.WithCancel(context.Background())
@@ -137,7 +146,7 @@ func TestPlugin_Test_ContextCancellation(t *testing.T) {
 	// Cancel immediately
 	cancel()
 
-	result := p.Test(ctx, "localhost:5900", "", "password", 5*time.Second, brutus.PluginConfig{})
+	result := p.Test(ctx, vncTestHost, "", vncTestPass, 5*time.Second, brutus.PluginConfig{})
 
 	assert.NotNil(t, result)
 	assert.False(t, result.Success)


### PR DESCRIPTION
Companion to #258 (couchdb/elasticsearch/influxdb/mysql/redis). Same fix for the remaining plugins whose `ValidCredentials`/`InvalidCredentials`/`ContextCancellation` (and smb's `DomainUsername`) integration tests called `t.Skip()` **unconditionally** and so never ran even with a server present.

Convert to the `mssql`/`oracle` convention: `host`/`user`/`pass` from `<PLUGIN>_TEST_*` env vars, gate each test on the host var, use the env values as target/creds. Adaptations: VNC is password-only (no user var); smb and postgresql reuse their existing env accessors instead of a duplicate block. `TestInit` (postgresql), the recent VNC stalling-handshake tests, and already-running `ConnectionError`/`Timeout`/`Name` tests are untouched.

**CI behavior unchanged** — env vars unset ⇒ all converted tests `SKIP` (verified; nothing `FAIL`s).

## Caveats
- Not verified against live servers (best-effort, faithful to the existing convention).
- `smb` `DomainUsername` still asserts `Success==true` against a hardcoded `DOMAIN\Administrator` account (there's no `SMB_TEST_DOMAIN` var); gated on `SMB_TEST_HOST` with an inline comment, but it may fail against a server that lacks that exact domain account — flagged for maintainers.

> Touches `postgresql_test.go`, as does #257 (which fixed its `TestInit`); different functions, so a trivial rebase at most if #257 merges first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)