### PR TITLE
refactor(plugins): extract shared HTTPBasicAuthProbe (dedupe 3 Test methods)

### DIFF
--- a/internal/plugins/couchdb/couchdb.go
+++ b/internal/plugins/couchdb/couchdb.go
@@ -16,7 +16,6 @@ package couchdb
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -45,59 +44,10 @@ func (p *Plugin) Name() string {
 // - Success=false, Error!=nil: Connection/network error
 func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	timeout time.Duration, pluginCfg brutus.PluginConfig) *brutus.Result {
-	start := time.Now()
-
-	result := brutus.NewResult("couchdb", target, username, password)
-	defer func() { result.Duration = time.Since(start) }()
-
-	// Read TLS mode from context
-	tlsMode := pluginCfg.TLSMode
-
-	scheme := brutus.SchemeFromTLSMode(tlsMode)
-
-	// Build URL for CouchDB session endpoint
-	url := fmt.Sprintf("%s://%s/_session", scheme, target)
-
-	// Create HTTP client with TLS config
-	client, err := brutus.NewHTTPClientWithProxy(timeout, brutus.BuildTLSConfig(tlsMode), pluginCfg.ProxyURL)
-	if err != nil {
-		result.Error = brutus.WrapConnError(err)
-		return result
-	}
-	defer client.CloseIdleConnections()
-
-	// Create request
-	req, err := http.NewRequestWithContext(ctx, "GET", url, http.NoBody)
-	if err != nil {
-		result.Error = brutus.WrapConnError(err)
-		return result
-	}
-
-	// Set Basic Auth
-	req.SetBasicAuth(username, password)
-
-	// Execute request
-	resp, err := client.Do(req)
-	if err != nil {
-		result.Error = brutus.WrapConnError(err)
-		return result
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	// Classify response
-	if resp.StatusCode == http.StatusOK {
-		// Success - valid credentials
-		result.Success = true
-		return result
-	}
-
-	if resp.StatusCode == http.StatusUnauthorized {
-		// Auth failure - invalid credentials
-		// Return Success=false, Error=nil
-		return result
-	}
-
-	// All other status codes are connection/server errors
-	result.Error = fmt.Errorf("connection error: HTTP %d", resp.StatusCode)
-	return result
+	return brutus.HTTPBasicAuthProbe{
+		Service:      "couchdb",
+		Method:       http.MethodGet,
+		Path:         "/_session",
+		SuccessCodes: []int{http.StatusOK},
+	}.Run(ctx, target, username, password, timeout, pluginCfg)
 }

--- a/internal/plugins/elasticsearch/elasticsearch.go
+++ b/internal/plugins/elasticsearch/elasticsearch.go
@@ -46,64 +46,12 @@ func (p *Plugin) Name() string {
 // - Success=false, Error!=nil: Connection/network error
 func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	timeout time.Duration, pluginCfg brutus.PluginConfig) *brutus.Result {
-	start := time.Now()
-
-	result := brutus.NewResult("elasticsearch", target, username, password)
-	defer func() { result.Duration = time.Since(start) }()
-
-	// Read TLS mode from context
-	tlsMode := pluginCfg.TLSMode
-
-	scheme := brutus.SchemeFromTLSMode(tlsMode)
-
-	// Build URL for cluster info endpoint
-	url := fmt.Sprintf("%s://%s/", scheme, target)
-
-	// Create HTTP request
-	req, err := http.NewRequestWithContext(ctx, "GET", url, http.NoBody)
-	if err != nil {
-		result.Error = brutus.WrapConnError(err)
-		return result
-	}
-
-	// Set Basic Auth
-	req.SetBasicAuth(username, password)
-
-	// Create HTTP client with TLS config (proxy-aware)
-	client, err := brutus.NewHTTPClientWithProxy(timeout, brutus.BuildTLSConfig(tlsMode), pluginCfg.ProxyURL)
-	if err != nil {
-		result.Error = brutus.WrapConnError(err)
-		return result
-	}
-	defer client.CloseIdleConnections()
-
-	// Execute request
-	resp, err := client.Do(req)
-	if err != nil {
-		result.Error = brutus.WrapConnError(err)
-		return result
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	// Check status code
-	if resp.StatusCode == http.StatusUnauthorized {
-		// Authentication failed - this is expected for invalid credentials
-		result.Success = false
-		result.Error = nil // Auth failure returns nil error
-		return result
-	}
-
-	if resp.StatusCode == http.StatusOK {
-		// Success - valid credentials
-		result.Success = true
-		result.Error = nil
-		return result
-	}
-
-	// Any other status code is a connection/server error
-	result.Success = false
-	result.Error = fmt.Errorf("connection error: unexpected status code %d", resp.StatusCode)
-	return result
+	return brutus.HTTPBasicAuthProbe{
+		Service:      "elasticsearch",
+		Method:       http.MethodGet,
+		Path:         "/",
+		SuccessCodes: []int{http.StatusOK},
+	}.Run(ctx, target, username, password, timeout, pluginCfg)
 }
 
 // CheckUnauth probes for Elasticsearch without security enabled (X-Pack).

--- a/internal/plugins/influxdb/influxdb.go
+++ b/internal/plugins/influxdb/influxdb.go
@@ -16,7 +16,6 @@ package influxdb
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -45,63 +44,10 @@ func (p *Plugin) Name() string {
 // - Success=false, Error!=nil: Connection/network error
 func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	timeout time.Duration, pluginCfg brutus.PluginConfig) *brutus.Result {
-	start := time.Now()
-
-	result := brutus.NewResult("influxdb", target, username, password)
-	defer func() { result.Duration = time.Since(start) }()
-
-	// Read TLS mode from context
-	tlsMode := pluginCfg.TLSMode
-
-	scheme := brutus.SchemeFromTLSMode(tlsMode)
-
-	// Build InfluxDB signin endpoint URL
-	// POST /api/v2/signin accepts HTTP Basic Auth for username/password authentication
-	// Returns 204 No Content on success, 401 Unauthorized on failure
-	url := fmt.Sprintf("%s://%s/api/v2/signin", scheme, target)
-
-	// Create HTTP POST request with context
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, http.NoBody)
-	if err != nil {
-		result.Error = brutus.WrapConnError(err)
-		return result
-	}
-
-	// Set HTTP Basic Auth
-	req.SetBasicAuth(username, password)
-
-	// Create HTTP client with TLS config
-	client, err := brutus.NewHTTPClientWithProxy(timeout, brutus.BuildTLSConfig(tlsMode), pluginCfg.ProxyURL)
-	if err != nil {
-		result.Error = brutus.WrapConnError(err)
-		return result
-	}
-	defer client.CloseIdleConnections()
-
-	// Send HTTP request
-	resp, err := client.Do(req)
-	if err != nil {
-		result.Error = brutus.WrapConnError(err)
-		return result
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	// Classify response
-	if resp.StatusCode == http.StatusUnauthorized {
-		// 401 Unauthorized = authentication failure
-		result.Success = false
-		result.Error = nil
-		return result
-	}
-
-	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNoContent {
-		// 200 OK or 204 No Content = success
-		result.Success = true
-		result.Error = nil
-		return result
-	}
-
-	// Any other status code is a connection error
-	result.Error = fmt.Errorf("connection error: unexpected status code %d", resp.StatusCode)
-	return result
+	return brutus.HTTPBasicAuthProbe{
+		Service:      "influxdb",
+		Method:       http.MethodPost,
+		Path:         "/api/v2/signin",
+		SuccessCodes: []int{http.StatusOK, http.StatusNoContent},
+	}.Run(ctx, target, username, password, timeout, pluginCfg)
 }

--- a/pkg/brutus/http.go
+++ b/pkg/brutus/http.go
@@ -15,6 +15,7 @@
 package brutus
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -144,4 +145,62 @@ func DetectHTTPAuthType(target string, useHTTPS bool, timeout time.Duration, tls
 	}
 
 	return "form", banner
+}
+
+// HTTPBasicAuthProbe describes a single-request HTTP Basic Auth credential check
+// shared by the HTTP-based service plugins (elasticsearch, couchdb, influxdb).
+// It captures only what differs between them; the request/classify flow is
+// identical.
+type HTTPBasicAuthProbe struct {
+	Service      string // result protocol label, e.g. "elasticsearch"
+	Method       string // HTTP method, e.g. http.MethodGet
+	Path         string // request path, e.g. "/" or "/_session"
+	SuccessCodes []int  // status codes that indicate valid credentials
+}
+
+// Run performs the probe against target with the given credentials over a
+// proxy-aware, TLS-configured client. Classification: any of SuccessCodes ->
+// Success=true; 401 Unauthorized -> auth failure (Success=false, Error=nil);
+// any other status -> a "connection error" Error. Transport/setup failures are
+// wrapped via WrapConnError. Result.Duration is always set.
+func (probe HTTPBasicAuthProbe) Run(ctx context.Context, target, username, password string, timeout time.Duration, pluginCfg PluginConfig) *Result {
+	start := time.Now()
+	result := NewResult(probe.Service, target, username, password)
+	defer func() { result.Duration = time.Since(start) }()
+
+	scheme := SchemeFromTLSMode(pluginCfg.TLSMode)
+	url := fmt.Sprintf("%s://%s%s", scheme, target, probe.Path)
+
+	client, err := NewHTTPClientWithProxy(timeout, BuildTLSConfig(pluginCfg.TLSMode), pluginCfg.ProxyURL)
+	if err != nil {
+		result.Error = WrapConnError(err)
+		return result
+	}
+	defer client.CloseIdleConnections()
+
+	req, err := http.NewRequestWithContext(ctx, probe.Method, url, http.NoBody)
+	if err != nil {
+		result.Error = WrapConnError(err)
+		return result
+	}
+	req.SetBasicAuth(username, password)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		result.Error = WrapConnError(err)
+		return result
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	for _, code := range probe.SuccessCodes {
+		if resp.StatusCode == code {
+			result.Success = true
+			return result
+		}
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		return result // Success=false, Error=nil (invalid credentials)
+	}
+	result.Error = fmt.Errorf("connection error: unexpected status code %d", resp.StatusCode)
+	return result
 }

--- a/pkg/brutus/http_test.go
+++ b/pkg/brutus/http_test.go
@@ -15,13 +15,16 @@
 package brutus
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -96,4 +99,137 @@ func TestDetectHTTPAuthType_BasicAuth(t *testing.T) {
 			require.Equal(t, tt.expectedAuth, authType)
 		})
 	}
+}
+
+func TestHTTPBasicAuthProbe_Run(t *testing.T) {
+	t.Run("success (200)", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(server.Close)
+
+		target := strings.TrimPrefix(server.URL, "http://")
+		probe := HTTPBasicAuthProbe{
+			Service:      "testsvc",
+			Method:       http.MethodGet,
+			Path:         "/",
+			SuccessCodes: []int{http.StatusOK},
+		}
+
+		result := probe.Run(context.Background(), target, "user", "pass", 5*time.Second, PluginConfig{})
+
+		assert.True(t, result.Success)
+		assert.NoError(t, result.Error)
+		assert.Equal(t, "testsvc", result.Protocol)
+		assert.Equal(t, target, result.Target)
+		assert.Greater(t, result.Duration, time.Duration(0))
+	})
+
+	t.Run("auth failure (401)", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		t.Cleanup(server.Close)
+
+		target := strings.TrimPrefix(server.URL, "http://")
+		probe := HTTPBasicAuthProbe{
+			Service:      "testsvc",
+			Method:       http.MethodGet,
+			Path:         "/",
+			SuccessCodes: []int{http.StatusOK},
+		}
+
+		result := probe.Run(context.Background(), target, "user", "pass", 5*time.Second, PluginConfig{})
+
+		assert.False(t, result.Success)
+		assert.NoError(t, result.Error)
+	})
+
+	t.Run("unexpected status (500)", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		t.Cleanup(server.Close)
+
+		target := strings.TrimPrefix(server.URL, "http://")
+		probe := HTTPBasicAuthProbe{
+			Service:      "testsvc",
+			Method:       http.MethodGet,
+			Path:         "/",
+			SuccessCodes: []int{http.StatusOK},
+		}
+
+		result := probe.Run(context.Background(), target, "user", "pass", 5*time.Second, PluginConfig{})
+
+		assert.False(t, result.Success)
+		require.Error(t, result.Error)
+		assert.Contains(t, result.Error.Error(), "connection error")
+	})
+
+	t.Run("success via 204 (multiple success codes)", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		t.Cleanup(server.Close)
+
+		target := strings.TrimPrefix(server.URL, "http://")
+		probe := HTTPBasicAuthProbe{
+			Service:      "testsvc",
+			Method:       http.MethodPost,
+			Path:         "/",
+			SuccessCodes: []int{http.StatusOK, http.StatusNoContent},
+		}
+
+		result := probe.Run(context.Background(), target, "user", "pass", 5*time.Second, PluginConfig{})
+
+		assert.True(t, result.Success)
+		assert.NoError(t, result.Error)
+	})
+
+	t.Run("method and path propagation", func(t *testing.T) {
+		var gotMethod, gotPath string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotMethod = r.Method
+			gotPath = r.URL.Path
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(server.Close)
+
+		target := strings.TrimPrefix(server.URL, "http://")
+		probe := HTTPBasicAuthProbe{
+			Service:      "testsvc",
+			Method:       http.MethodPost,
+			Path:         "/api/v2/signin",
+			SuccessCodes: []int{http.StatusOK},
+		}
+
+		_ = probe.Run(context.Background(), target, "user", "pass", 5*time.Second, PluginConfig{})
+
+		assert.Equal(t, http.MethodPost, gotMethod)
+		assert.Equal(t, "/api/v2/signin", gotPath)
+	})
+
+	t.Run("basic auth credentials sent", func(t *testing.T) {
+		var gotUser, gotPass string
+		var gotOK bool
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotUser, gotPass, gotOK = r.BasicAuth()
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(server.Close)
+
+		target := strings.TrimPrefix(server.URL, "http://")
+		probe := HTTPBasicAuthProbe{
+			Service:      "testsvc",
+			Method:       http.MethodGet,
+			Path:         "/",
+			SuccessCodes: []int{http.StatusOK},
+		}
+
+		_ = probe.Run(context.Background(), target, "myuser", "mypass", 5*time.Second, PluginConfig{})
+
+		require.True(t, gotOK)
+		assert.Equal(t, "myuser", gotUser)
+		assert.Equal(t, "mypass", gotPass)
+	})
 }


### PR DESCRIPTION
## What

The `elasticsearch`, `couchdb`, and `influxdb` plugin `Test` methods were the same HTTP-Basic-Auth credential probe — scheme from TLS mode → proxy+TLS client (with `defer client.CloseIdleConnections()`) → one request with Basic Auth → classify (`401` ⇒ auth failure, success codes ⇒ `Success`, else ⇒ connection error). They differed only in service label, HTTP method, URL path, and success status codes.

Extracted `brutus.HTTPBasicAuthProbe{Service, Method, Path, SuccessCodes}.Run(...)` (in `pkg/brutus/http.go`) and collapsed each plugin's `Test` to a short delegation (~7 lines). Removed the now-unused `fmt` import from couchdb/influxdb.

Behavior is preserved, including the idle-connection close from #246. One cosmetic unification: couchdb's unexpected-status error text changes from `"connection error: HTTP %d"` to `"connection error: unexpected status code %d"` (matching the other two) — a status path no running test exercises.

## Test

`TestHTTPBasicAuthProbe_Run` gives the shared probe direct coverage: 200 success, 401 auth-failure (nil error), 500 connection error, multi-success-code 204, method+path propagation, and Basic-Auth credential wiring. The existing per-plugin `ConnectionError`/`Timeout` tests (which actually run) stay green. Build/vet/affected suites green.

This is a single cohesive extraction (net removes ~120 lines of duplication), so the diff is a bit larger than the other PRs in this series but stays one concern.

Part of an audit series (DRY / dead code / test quality).

🤖 Generated with [Claude Code](https://claude.com/claude-code)