### PR TITLE
style(lint): fix gocritic paramTypeCombine in rdp detect

### DIFF
--- a/internal/plugins/rdp/detect.go
+++ b/internal/plugins/rdp/detect.go
@@ -198,7 +198,7 @@ func mapUtilmanResult(utilmanResult *UtilmanResult, username string) *brutus.Res
 // RunStickyKeysCheck performs sticky keys detection on a separate connection.
 // The noVision flag disables Vision API confirmation. budget selects the settle
 // profile; fast enforces the never-clean invariant.
-func (p *Plugin) RunStickyKeysCheck(ctx context.Context, target string, proxyURL string, connectTimeout, timeout time.Duration, noVision bool, budget SettleBudget, fast bool) *StickyKeysResult {
+func (p *Plugin) RunStickyKeysCheck(ctx context.Context, target, proxyURL string, connectTimeout, timeout time.Duration, noVision bool, budget SettleBudget, fast bool) *StickyKeysResult {
 	host, port := brutus.ParseTarget(target, "3389")
 	addr := net.JoinHostPort(host, port)
 
@@ -229,7 +229,7 @@ func (p *Plugin) RunStickyKeysCheck(ctx context.Context, target string, proxyURL
 
 // RunUtilmanCheck performs utilman backdoor detection on a separate connection.
 // budget selects the settle profile; fast enforces the never-clean invariant.
-func (p *Plugin) RunUtilmanCheck(ctx context.Context, target string, proxyURL string, connectTimeout, timeout time.Duration, noVision bool, budget SettleBudget, fast bool) *UtilmanResult {
+func (p *Plugin) RunUtilmanCheck(ctx context.Context, target, proxyURL string, connectTimeout, timeout time.Duration, noVision bool, budget SettleBudget, fast bool) *UtilmanResult {
 	host, port := brutus.ParseTarget(target, "3389")
 	addr := net.JoinHostPort(host, port)
 


### PR DESCRIPTION
## What

`golangci-lint run ./...` is currently failing on `main` with 2 `gocritic` `paramTypeCombine` issues in `internal/plugins/rdp/detect.go`:

- `RunStickyKeysCheck` (line 201)
- `RunUtilmanCheck` (line 232)

Both declared `target string, proxyURL string` where adjacent params share a type. This collapses them to `target, proxyURL string`.

## Why

Unblocks CI lint — these were the only issues golangci-lint reported repo-wide.

## Verification

- `golangci-lint run ./...` → **0 issues** (was 2)
- `go build ./internal/plugins/rdp/` → OK
- `go vet ./internal/plugins/rdp/` → OK

Signature-only change; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)