### PR TITLE
fix(plugins): fix failing smb/vnc/ldap integration tests (auth classification + ctx)

### DIFF
--- a/internal/plugins/ldap/ldap.go
+++ b/internal/plugins/ldap/ldap.go
@@ -66,6 +66,15 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	result := brutus.NewResult("ldap", target, username, password)
 	defer func() { result.Duration = time.Since(start) }()
 
+	// Honor a cancelled/expired context before touching the network. The
+	// go-ldap DialURL path is not context-aware, so without this guard a
+	// cancelled context would still dial and bind (unlike the proxy path and
+	// the other plugins, which thread ctx through the dialer).
+	if err := ctx.Err(); err != nil {
+		result.Error = brutus.WrapConnError(err)
+		return result
+	}
+
 	// Parse target to extract host and port
 	host, port := brutus.ParseTarget(target, "389")
 

--- a/internal/plugins/smb/smb.go
+++ b/internal/plugins/smb/smb.go
@@ -28,6 +28,10 @@ import (
 var smbAuthIndicators = []string{
 	"STATUS_LOGON_FAILURE",
 	"authentication failed",
+	// go-smb2 surfaces STATUS_LOGON_FAILURE as this descriptive text rather
+	// than the symbolic code, so match it explicitly.
+	"the attempted logon is invalid",
+	"bad username or authentication information",
 }
 
 func init() {

--- a/internal/plugins/vnc/vnc.go
+++ b/internal/plugins/vnc/vnc.go
@@ -26,6 +26,7 @@ import (
 // vncAuthIndicators defines authentication failure strings returned by VNC servers
 var vncAuthIndicators = []string{
 	"authentication failed",
+	"authentication failure",
 	"invalid password",
 	"auth failed",
 }


### PR DESCRIPTION
## What

Three integration tests have been failing on `main` since #259:

| Package | Test | Root cause |
|---|---|---|
| `internal/plugins/smb` | `TestPlugin_Test_InvalidCredentials` | wrong-password error misclassified as a connection error |
| `internal/plugins/vnc` | `TestPlugin_Test_InvalidCredentials` | same — auth-failure string not recognized |
| `internal/plugins/ldap` | `TestPlugin_Test_ContextCancellation` | cancelled context ignored; dial+bind still succeeded |

#259 flipped these tests from unconditional `t.Skip()` to env-gated tests that actually exercise the CI docker services. They had never been validated against live servers, so the assertions were correct but the **plugins** had gaps.

## Fixes (production code only — no test changes)

- **smb**: `go-smb2` reports a bad password as *"The attempted logon is invalid. This is either due to a bad username or authentication information."*, which `smbAuthIndicators` didn't match, so `ClassifyAuthError` wrapped it as a connection error instead of returning `nil`. Added the descriptive `STATUS_LOGON_FAILURE` text.
- **vnc**: server returns *"Authentication failure"*; list only had `authentication failed`/`auth failed`. Added `authentication failure`.
- **ldap**: the `go-ldap` `DialURL` path is not context-aware, so a cancelled context still dialed and bound (`Success=true`, nil `Error`). Added a `ctx.Err()` guard before dialing — matching the proxy path and the sibling plugins (smb/vnc) whose `ContextCancellation` tests already pass.

## Verification

- `go build` + `go vet` clean on all three packages.
- Ran `brutus.ClassifyAuthError` against the **exact** live-server error strings from the CI logs:
  - SMB invalid-cred → `nil` ✅
  - VNC invalid-cred → `nil` ✅
  - genuine connection error → still `connection error: …` (no over-matching) ✅
  - cancelled `ctx.Err()` → `context canceled` (→ non-nil `Error`) ✅

Cannot run the env-gated integration tests locally (no docker services), but the fixes target the precise misclassification/ctx-handling that produced the CI failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)