### PR TITLE
chore(lint): fix gocritic paramTypeCombine in rdp detect

### DIFF
--- a/internal/plugins/rdp/detect.go
+++ b/internal/plugins/rdp/detect.go
@@ -198,7 +198,7 @@ func mapUtilmanResult(utilmanResult *UtilmanResult, username string) *brutus.Res
 // RunStickyKeysCheck performs sticky keys detection on a separate connection.
 // The noVision flag disables Vision API confirmation. budget selects the settle
 // profile; fast enforces the never-clean invariant.
-func (p *Plugin) RunStickyKeysCheck(ctx context.Context, target string, proxyURL string, connectTimeout, timeout time.Duration, noVision bool, budget SettleBudget, fast bool) *StickyKeysResult {
+func (p *Plugin) RunStickyKeysCheck(ctx context.Context, target, proxyURL string, connectTimeout, timeout time.Duration, noVision bool, budget SettleBudget, fast bool) *StickyKeysResult {
 	host, port := brutus.ParseTarget(target, "3389")
 	addr := net.JoinHostPort(host, port)
 
@@ -229,7 +229,7 @@ func (p *Plugin) RunStickyKeysCheck(ctx context.Context, target string, proxyURL
 
 // RunUtilmanCheck performs utilman backdoor detection on a separate connection.
 // budget selects the settle profile; fast enforces the never-clean invariant.
-func (p *Plugin) RunUtilmanCheck(ctx context.Context, target string, proxyURL string, connectTimeout, timeout time.Duration, noVision bool, budget SettleBudget, fast bool) *UtilmanResult {
+func (p *Plugin) RunUtilmanCheck(ctx context.Context, target, proxyURL string, connectTimeout, timeout time.Duration, noVision bool, budget SettleBudget, fast bool) *UtilmanResult {
 	host, port := brutus.ParseTarget(target, "3389")
 	addr := net.JoinHostPort(host, port)
 


### PR DESCRIPTION
## What
Fixes the only two outstanding `golangci-lint` findings on `main` — both `gocritic: paramTypeCombine` (style) in `internal/plugins/rdp/detect.go`:

- `RunStickyKeysCheck` and `RunUtilmanCheck` declared `target string, proxyURL string`; combined to `target, proxyURL string`.

No behavior change — signatures are identical types, just the idiomatic combined form gocritic prefers.

## Verification
Run with the repo's `.golangci.yml`, per-issue caps disabled so nothing is masked (this repo's known `max-same-issues` gotcha):
```
golangci-lint run --max-same-issues=0 --max-issues-per-linter=0 ./...
→ 0 issues
```
`gofmt` clean; `go build` + `go test ./internal/plugins/rdp/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)