### PR TITLE
chore(lint): fix misspell/gocritic/errcheck failures blocking CI on main

### DIFF
--- a/cmd/brutus/cmd_enum_dehashed_test.go
+++ b/cmd/brutus/cmd_enum_dehashed_test.go
@@ -31,6 +31,16 @@ import (
 // sentinel key used to verify no leakage through error messages.
 const dehashedTestSentinelKey = "SECRETKEY-DO-NOT-LEAK-abc123"
 
+// firstElem asserts that v is a non-empty []interface{} and returns its first
+// element. Used to keep repeated single-value type assertions in comma-ok form.
+func firstElem(t *testing.T, v interface{}) interface{} {
+	t.Helper()
+	s, ok := v.([]interface{})
+	require.True(t, ok)
+	require.NotEmpty(t, s)
+	return s[0]
+}
+
 // ---------------------------------------------------------------------------
 // Task 7: resolveDehashedAPIKey
 // ---------------------------------------------------------------------------
@@ -497,13 +507,14 @@ func TestOutputDehashedDetailedJSON(t *testing.T) {
 		arr, ok := obj["entries"].([]interface{})
 		require.True(t, ok)
 		require.Len(t, arr, 1)
-		entry := arr[0].(map[string]interface{})
+		entry, ok := arr[0].(map[string]interface{})
+		require.True(t, ok)
 		assert.Equal(t, "alice@example.com", entry["email"])
-		assert.Equal(t, "1.2.3.4", entry["ip_addresses"].([]interface{})[0])
-		assert.Equal(t, "123 Main St", entry["addresses"].([]interface{})[0])
-		assert.Equal(t, "1990-01-01", entry["dobs"].([]interface{})[0])
-		assert.Equal(t, "2021-01", entry["obtained_dates"].([]interface{})[0])
-		assert.Equal(t, "breach-db", entry["databases"].([]interface{})[0])
+		assert.Equal(t, "1.2.3.4", firstElem(t, entry["ip_addresses"]))
+		assert.Equal(t, "123 Main St", firstElem(t, entry["addresses"]))
+		assert.Equal(t, "1990-01-01", firstElem(t, entry["dobs"]))
+		assert.Equal(t, "2021-01", firstElem(t, entry["obtained_dates"]))
+		assert.Equal(t, "breach-db", firstElem(t, entry["databases"]))
 		assert.Equal(t, float64(3), entry["count"])
 		_, hasPw := entry["passwords"]
 		assert.False(t, hasPw, "passwords key must be ABSENT when showCredentials=false")
@@ -519,7 +530,11 @@ func TestOutputDehashedDetailedJSON(t *testing.T) {
 		require.NoError(t, err)
 		var obj map[string]interface{}
 		require.NoError(t, json.Unmarshal(buf.Bytes(), &obj))
-		entry := obj["entries"].([]interface{})[0].(map[string]interface{})
+		entriesArr, ok := obj["entries"].([]interface{})
+		require.True(t, ok)
+		require.NotEmpty(t, entriesArr)
+		entry, ok := entriesArr[0].(map[string]interface{})
+		require.True(t, ok)
 		pw, ok := entry["passwords"].([]interface{})
 		require.True(t, ok, "passwords key must be PRESENT when showCredentials=true")
 		assert.Equal(t, "secret123", pw[0])

--- a/internal/plugins/ldap/ldap.go
+++ b/internal/plugins/ldap/ldap.go
@@ -66,9 +66,9 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	result := brutus.NewResult("ldap", target, username, password)
 	defer func() { result.Duration = time.Since(start) }()
 
-	// Honor a cancelled/expired context before touching the network. The
+	// Honor a canceled/expired context before touching the network. The
 	// go-ldap DialURL path is not context-aware, so without this guard a
-	// cancelled context would still dial and bind (unlike the proxy path and
+	// canceled context would still dial and bind (unlike the proxy path and
 	// the other plugins, which thread ctx through the dialer).
 	if err := ctx.Err(); err != nil {
 		result.Error = brutus.WrapConnError(err)

--- a/pkg/enum/dehashed/dehashed.go
+++ b/pkg/enum/dehashed/dehashed.go
@@ -411,9 +411,9 @@ func filterBySource(records []Record, sources []string) []Record {
 		return records
 	}
 	out := make([]Record, 0, len(records))
-	for _, r := range records {
-		if _, ok := allowed[strings.ToLower(strings.TrimSpace(r.Database))]; ok {
-			out = append(out, r)
+	for i := range records {
+		if _, ok := allowed[strings.ToLower(strings.TrimSpace(records[i].Database))]; ok {
+			out = append(out, records[i])
 		}
 	}
 	return out


### PR DESCRIPTION
## Why

`ci / Lint` is currently **red on `main`**. golangci-lint runs `only-new-issues: false` (whole-tree), so this failing check blocks the required lint gate on **every open PR** — nothing can merge until `main` lints clean.

## Issues fixed (6 total → `golangci-lint run ./...` now reports `0 issues`)

| File | Linter | Fix |
|---|---|---|
| `internal/plugins/ldap/ldap.go` (×2) | `misspell` (US) | `cancelled` → `canceled` (comment regression from #262) |
| `pkg/enum/dehashed/dehashed.go` | `gocritic` `rangeValCopy` | index the filter loop instead of copying each `Record` (240 B/iter) |
| `cmd/brutus/cmd_enum_dehashed_test.go` (×7) | `errcheck` (`check-type-assertions`) | unchecked type assertions → comma-ok with `require.True`; repeated `[]interface{}` access factored into a helper |

## Verification

- `golangci-lint run ./...` → **0 issues**
- `go build ./...` → OK
- `go test ./cmd/brutus/ ./pkg/enum/dehashed/ ./internal/plugins/ldap/` → all pass

No behavior changes — spelling, loop mechanics, and test-assertion mechanics only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)