### PR TITLE
fix(ci): restore trusted pin for leaderboard-metrics (repair OIDC telemetry)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,13 @@ updates:
     labels:
       - "dependencies"
       - "ci"
+    ignore:
+      # The leaderboard-metrics reusable workflow is SHA-pinned to a commit
+      # whose job_workflow_ref is on the LeaderboardMetricsRole IAM trust list.
+      # Auto-bumping it breaks OIDC AssumeRole (metrics silently stop) unless
+      # the new SHA is added to the trust first via the ENG-4164 runbook, so it
+      # must be rolled manually — not by dependabot. (See #229, which broke it.)
+      - dependency-name: "praetorian-inc/public-workflows/.github/workflows/leaderboard-metrics.yml"
 
   - package-ecosystem: "gomod"
     directory: "/"

--- a/.github/workflows/leaderboard-metrics.yml
+++ b/.github/workflows/leaderboard-metrics.yml
@@ -11,6 +11,10 @@ permissions:
 
 jobs:
   metrics:
-    uses: praetorian-inc/public-workflows/.github/workflows/leaderboard-metrics.yml@dc359d4cf6ade393f811c13533b1a3abb780f5d1 # v2.16.7
+    # Pinned to the SHA whose job_workflow_ref is in the LeaderboardMetricsRole
+    # IAM trust list. Do NOT bump without the ENG-4164 runbook (add new SHA to
+    # the trust FIRST, then roll this pin) — dependabot's #229 bump to v2.16.7
+    # broke OIDC AssumeRole because that SHA was never added to the trust.
+    uses: praetorian-inc/public-workflows/.github/workflows/leaderboard-metrics.yml@c351826e6de27cadeb5b32ce81157355b283518b # v2.16.3
     with:
       capability_map: '[{"path": ".", "name": "brutus"}]'


### PR DESCRIPTION
## Problem — leaderboard telemetry is silently dropping

Since ~2026-07-15 13:17 UTC, the **Leaderboard Metrics** job (`metrics / submit-metrics`, runs on `pull_request_target: [closed]`) fails on every merged PR at the AWS step:

```
Could not assume role with OIDC:
Not authorized to perform sts:AssumeRoleWithWebIdentity
```

It's non-blocking (PRs still merge), so it went unnoticed — but **the PR metrics for every merge since then were never submitted.**

## Root cause — untrusted `job_workflow_ref`, not a code bug

Per the reusable workflow's own header docs, the `LeaderboardMetricsRole` IAM trust anchors on the OIDC **`job_workflow_ref`** claim and allow-lists **one value per trusted commit SHA**. A caller pinned to an **unlisted** SHA fails the trust match → AssumeRole denied.

- The AWS credential step is **byte-identical** between v2.16.3 and v2.16.7 — only the pinned SHA (and therefore the `job_workflow_ref` claim) changed.
- **Dependabot #229 bumped this caller `v2.16.3 → v2.16.7` (`dc359d4`)** without the coordinated **ENG-4164 runbook** (which requires adding the new SHA to the IAM trust *first*). So `dc359d4`'s `job_workflow_ref` isn't trusted.
- v2.16.7's *own* onboarding example still pins callers to **v2.16.3 (`c351826`)**, confirming that's the currently-trusted SHA. This repo ran cleanly on `c351826` (via #226) until #229.

## Fix — no AWS change required

1. **Repin** the caller to `c351826e6de27cadeb5b32ce81157355b283518b` (v2.16.3) — the SHA on the trust list and the last-known-good. This restores telemetry on the next merged PR.
2. **Dependabot ignore** for this reusable workflow, so it's rolled manually via the runbook instead of auto-bumped again.

> Note: the `v2.16.3` git tag has since been moved to a different commit, so this pins the **immutable trusted SHA** directly rather than the tag.

## Verification
- Both YAML files parse (`yaml.safe_load`).
- No AWS/IAM change needed; this returns the caller to the already-trusted `job_workflow_ref`.
- To fully confirm, watch the Leaderboard Metrics run on the next PR merged after this lands — the `Configure AWS credentials` step should succeed and `Send metrics to SQS` should run.

## Follow-up (not this PR)
If the team wants to actually move to **v2.16.7**, do it via ENG-4164: guard PR adds `dc359d4`'s `job_workflow_ref` to the trust → deploy/verify → roll caller pins → remove the old SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)