### PR TITLE
fix(enum/github): send Accept header so signup page returns CSRF page, not 403

### DIFF
--- a/pkg/enum/github/existence.go
+++ b/pkg/enum/github/existence.go
@@ -177,6 +177,12 @@ func (e *Enumerator) tryEstablishSession(ctx context.Context) (*session, bool, e
 	if err != nil {
 		return nil, false, fmt.Errorf("github enum: creating join request: %w", err)
 	}
+	// GitHub's signup page returns 403 (a token-less stub) to requests that lack an
+	// Accept header — Go's net/http omits it by default. The browser User-Agent is
+	// already injected at the transport layer (enum.WithUserAgent in NewEnumerator);
+	// a browser-like Accept is the other half of that "look like a normal client"
+	// pattern, so the join page returns the real CSRF-bearing HTML.
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8")
 
 	resp, err := e.httpClient.Do(req)
 	if err != nil {
@@ -255,6 +261,7 @@ func (e *Enumerator) postValidity(ctx context.Context, sess *session, email stri
 			return false, fmt.Errorf("creating validity request: %w", err)
 		}
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("Accept", "*/*")
 		if sess.cookieHeader != "" {
 			req.Header.Set("Cookie", sess.cookieHeader)
 		}

--- a/pkg/enum/github/github_test.go
+++ b/pkg/enum/github/github_test.go
@@ -1176,3 +1176,78 @@ func TestExistence_SetsBrowserUserAgent(t *testing.T) {
 	assert.True(t, results[0].Exists,
 		"HTTP 422 from validity endpoint must map to Exists=true")
 }
+
+// TestExistence_SetsAcceptHeader is a regression test for the bug where the
+// existence client sent no Accept header on its requests, so Go's net/http
+// defaulted to omitting it entirely. GitHub's signup page (/join) returns HTTP
+// 403 to any request lacking an Accept header — proven empirically: the same
+// client, in the same second, got HTTP 200 WITH an Accept header and HTTP 403
+// WITHOUT one, across 25+ no-Accept samples that never succeeded.
+//
+// This test's /join and /email_validity_checks handlers record the Accept
+// header they actually received. Enumeration succeeding (no error) plus the
+// captured headers being non-empty proves both requests carry an Accept header
+// — not just that the fake server happened to tolerate a missing one.
+func TestExistence_SetsAcceptHeader(t *testing.T) {
+	t.Parallel()
+
+	const csrfToken = "csrf-accept-header-test-token"
+
+	signupHTML := fmt.Sprintf(`<!DOCTYPE html><html><body>
+<auto-check src="/email_validity_checks">
+  <input type="hidden" value="%s">
+</auto-check>
+</body></html>`, csrfToken)
+
+	var joinAccept, validityAccept string
+
+	mux := http.NewServeMux()
+
+	// /join records the Accept header it received before serving the
+	// CSRF-bearing page. In production, GitHub 403s this request when Accept
+	// is absent — this fake server always serves the page, so the assertion
+	// below is what actually catches a regression, not the handler.
+	mux.HandleFunc("/join", func(w http.ResponseWriter, r *http.Request) {
+		joinAccept = r.Header.Get("Accept")
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = fmt.Fprint(w, signupHTML)
+	})
+
+	// /email_validity_checks records the Accept header from the first request
+	// it sees (the establishSession sanity check fires before the target
+	// email's check, so this captures that first POST's header).
+	mux.HandleFunc("/email_validity_checks", func(w http.ResponseWriter, r *http.Request) {
+		if validityAccept == "" {
+			validityAccept = r.Header.Get("Accept")
+		}
+		if err := r.ParseForm(); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if r.FormValue("value") == "target@example.com" {
+			w.WriteHeader(http.StatusUnprocessableEntity) // 422 → exists
+		} else {
+			w.WriteHeader(http.StatusOK) // 200 → available
+		}
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	e := newTestEnumerator(t, srv, nil, "")
+
+	results := e.Enumerate(context.Background(), []string{"target@example.com"}, 1, 0, 0)
+
+	require.Len(t, results, 1)
+	require.NoError(t, results[0].Error)
+	assert.True(t, results[0].Exists,
+		"HTTP 422 from validity endpoint must map to Exists=true")
+
+	assert.NotEmpty(t, joinAccept,
+		"the join-page GET must carry a non-empty Accept header — GitHub 403s the join page when it is absent")
+	assert.Contains(t, joinAccept, "text/html",
+		"the join-page Accept header must include text/html so GitHub serves the real page, not a 403 stub")
+
+	assert.Equal(t, "*/*", validityAccept,
+		"the validity-check POST must carry Accept: */*")
+}


### PR DESCRIPTION
## Problem

`brutus enum active github` failed on every email with:

```
github enum: join page returned HTTP 403 ...
Errors: 200 / Total: 200   (0 found, 0 checks actually performed)
```

The existence flow fetches `github.com/join` once to grab the CSRF token before checking any email. That GET was returning **HTTP 403** (a token-less stub), so `establishSession` exhausted its retries and every email was recorded with the same error — no accounts were ever checked.

## Root cause

GitHub's signup page returns **403 to any request that lacks an `Accept` header**. Go's `net/http` omits `Accept` by default; browsers and curl always send one. brutus set a browser `User-Agent` (at the transport layer via `enum.WithUserAgent`) but never set `Accept` — so the request still looked non-browser and got the 403 stub.

### Evidence (same box, controlled)

| Request | Result |
|---|---|
| curl, `Accept: */*` present (curl default) | **200** |
| curl, `Accept` header removed — *same client, same second* | **403** |
| stock Go `net/http` + `Accept` | **200** (HTTP/1.1 **and** HTTP/2) |
| stock Go / curl, **no** `Accept` (25+ samples) | **403**, always |

This is **not** a TLS/JA3 fingerprint issue — stock Go's own TLS handshake returns 200 as soon as an `Accept` header is present.

## Fix

Set `Accept` on the two existence requests in `pkg/enum/github/existence.go`:

- join-page `GET` → `text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8`
- `email_validity_checks` `POST` → `*/*`

7-line change; no new dependencies. Adds regression test `TestExistence_SetsAcceptHeader` (asserts both requests carry `Accept`; RED-verified — removing the headers fails the test).

## Egress / IP-reputation note (not fixed here, by design)

The `Accept` header is **necessary everywhere but only sufficient from non-flagged (residential/ISP) egress**. GitHub blanket-blocks cloud/datacenter IP ranges at the reputation layer, independent of headers — measured during this investigation:

| Egress | `Accept` present | Pass rate |
|---|---|---|
| Direct / ISP | ✅ | ~100% (when the IP is cool) |
| Bright Data **datacenter** zone | ✅ | ~13% (n=30, all hosting ASNs) |
| **GCE** (Google Cloud) | ✅ | **0%** (8/8 blocked) |

Operationally: run GitHub existence enumeration from **residential/ISP egress** or a **residential / Web-Unlocker** proxy — not a cloud box or a datacenter proxy zone. The existing `--rotating-proxy` retry logic on the join page still helps for the residual intermittent case; rotating *residential* IPs pays off, rotating *datacenter* IPs largely does not.

## Follow-up (out of scope for this PR)

To make `--rotating-proxy` viable against datacenter zones end-to-end, two additional changes would be needed:
1. Retry the per-email `email_validity_checks` POST on **403** (currently only 429 is retried), so a rotated fresh IP gets another chance.
2. Disable HTTP keep-alives in rotating-proxy mode so each retry opens a new connection (and thus a new exit IP) instead of reusing the pinned one.

## Testing

- `go build ./...`, `go vet ./...` — clean
- `go test ./pkg/enum/... ./cmd/brutus/...` — all pass
- `golangci-lint run ./pkg/enum/... ./cmd/brutus/...` — 0 issues (incl. caps disabled)
- Live: direct request with the fix returns 200 and a valid CSRF page (once the test IP cooled from probing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
