### PR TITLE
fix(enum/github): make --rotating-proxy actually rotate (403 retry + no keep-alive)

### DIFF
--- a/pkg/enum/github/existence.go
+++ b/pkg/enum/github/existence.go
@@ -242,7 +242,10 @@ func (e *Enumerator) checkEmail(ctx context.Context, sess *session, email string
 
 // postValidity POSTs email to {web}/email_validity_checks with the session's
 // CSRF token and cookies. It returns true when the address is in use (HTTP 422),
-// false when available (HTTP 200), retrying on HTTP 429 up to maxRateLimitRetries.
+// false when available (HTTP 200), retrying on HTTP 429 up to existenceMaxRetries.
+// HTTP 403 (GitHub blocking the exit IP) is also retried, but ONLY under
+// --rotating-proxy, where each retry egresses a fresh IP; in non-rotating mode a
+// 403 is a persistently blocked IP and fails fast.
 func (e *Enumerator) postValidity(ctx context.Context, sess *session, email string) (bool, error) {
 	form := url.Values{}
 	form.Set("authenticity_token", sess.csrfToken)
@@ -274,6 +277,23 @@ func (e *Enumerator) postValidity(ctx context.Context, sess *session, email stri
 		case http.StatusTooManyRequests: // 429 — rate limited
 			if attempt >= e.existenceMaxRetries {
 				return false, fmt.Errorf("rate limited (HTTP 429) after %d retries", attempt)
+			}
+			if err := e.sleep(ctx, e.existenceBackoff); err != nil {
+				return false, err
+			}
+			continue
+		case http.StatusForbidden: // 403 — GitHub blocked this exit IP
+			// GitHub blocks ~80-87% of datacenter/rotating-proxy exit IPs on the
+			// validity endpoint. Retrying only helps under --rotating-proxy, where
+			// each retry opens a fresh connection and thus a fresh exit IP (see
+			// DisableKeepAlives in NewEnumerator). In non-rotating mode a 403 is a
+			// persistently blocked IP, so retrying would just add ~10s/email of
+			// pointless latency — fail fast there. Retry accounting mirrors 429.
+			if !e.rotatingProxy {
+				return false, fmt.Errorf("unexpected status %d from validity endpoint", status)
+			}
+			if attempt >= e.existenceMaxRetries {
+				return false, fmt.Errorf("validity check blocked (HTTP 403) after %d retries", attempt)
 			}
 			if err := e.sleep(ctx, e.existenceBackoff); err != nil {
 				return false, err

--- a/pkg/enum/github/github.go
+++ b/pkg/enum/github/github.go
@@ -105,6 +105,14 @@ type Enumerator struct {
 	existenceBackoff    time.Duration
 	existenceMaxRetries int
 
+	// rotatingProxy records whether the existence path egresses through a
+	// rotating proxy (each new connection = a fresh exit IP). It gates the
+	// HTTP 403 retry in postValidity: GitHub blocks ~80-87% of datacenter exit
+	// IPs on the validity endpoint, so retrying a 403 only helps when the retry
+	// can land on a different IP. In non-rotating mode a 403 = a persistently
+	// blocked IP, so retrying would just add latency and is skipped.
+	rotatingProxy bool
+
 	// Base URLs default to the real GitHub hosts and are overridable by tests.
 	webBaseURL string
 	apiBaseURL string
@@ -144,6 +152,20 @@ func NewEnumerator(proxyURL string, timeout time.Duration, token string, rotatin
 		return nil, fmt.Errorf("github enum: configuring HTTP client: %w", err)
 	}
 
+	// With a rotating proxy, disable HTTP keep-alives so each request (and each
+	// retry) opens a fresh TCP connection and thus egresses from a fresh proxy
+	// exit IP. Without this, retries reuse the pooled connection = the SAME exit
+	// IP, and rotation never happens — defeating the whole point of retrying a
+	// 403/429 under --rotating-proxy. Set it on the underlying *http.Transport
+	// BEFORE the WithUserAgent wrap. NOTE: apiClient is a clone that shares this
+	// transport, so reveal also gets DisableKeepAlives in rotating mode; that is
+	// harmless (reveal is sequential and PAT-based, not IP-reputation-gated).
+	if rotatingProxy {
+		if tr, ok := httpClient.Transport.(*http.Transport); ok {
+			tr.DisableKeepAlives = true
+		}
+	}
+
 	// GitHub rejects Go's default "Go-http-client/…" User-Agent: github.com/join
 	// returns 403 with no CSRF token, and api.github.com requires a UA. Inject a
 	// browser UA at the transport layer so every existence and reveal request
@@ -179,6 +201,7 @@ func NewEnumerator(proxyURL string, timeout time.Duration, token string, rotatin
 		token:               token,
 		existenceBackoff:    existenceBackoff,
 		existenceMaxRetries: existenceMaxRetries,
+		rotatingProxy:       rotatingProxy,
 		webBaseURL:          webBaseURLDefault,
 		apiBaseURL:          apiBaseURLDefault,
 		settleDelay:         settleDelayDefault,

--- a/pkg/enum/github/github_test.go
+++ b/pkg/enum/github/github_test.go
@@ -214,6 +214,26 @@ func newTestEnumerator(t *testing.T, webSrv, apiSrv *httptest.Server, token stri
 	return e
 }
 
+// newRotatingTestEnumerator is like newTestEnumerator but constructs the
+// Enumerator with rotatingProxy=true, so the HTTP 403 retry-on-rotating-proxy
+// path in postValidity (and DisableKeepAlives wiring in NewEnumerator) is
+// exercised. existenceMaxRetries is overridden to the given small value so
+// retry-exhaustion tests stay fast and deterministic (real rotating-proxy
+// runs default to rotatingProxyMaxRetries, which is too large for a test).
+func newRotatingTestEnumerator(t *testing.T, webSrv *httptest.Server, existenceMaxRetries int) *Enumerator {
+	t.Helper()
+	e, err := NewEnumerator("", 5*time.Second, "", true)
+	require.NoError(t, err, "NewEnumerator must succeed")
+	if webSrv != nil {
+		e.webBaseURL = webSrv.URL
+	}
+	e.settleDelay = 0
+	e.sleep = noopSleep
+	e.newName = deterministicName
+	e.existenceMaxRetries = existenceMaxRetries
+	return e
+}
+
 // ---------------------------------------------------------------------------
 // Existence tests: 422 → Exists=true, 200 → Exists=false
 // ---------------------------------------------------------------------------
@@ -1175,4 +1195,222 @@ func TestExistence_SetsBrowserUserAgent(t *testing.T) {
 		"establishSession must succeed by sending a browser User-Agent so /join returns the CSRF token instead of a 403 stub")
 	assert.True(t, results[0].Exists,
 		"HTTP 422 from validity endpoint must map to Exists=true")
+}
+
+// ---------------------------------------------------------------------------
+// postValidity 403 handling: rotating-proxy retries, non-rotating fails fast
+// ---------------------------------------------------------------------------
+
+// validity403Mux builds an http.ServeMux for the postValidity 403-handling
+// tests. /join always serves a valid CSRF-bearing page. /email_validity_checks
+// always returns 200 for the sanity-check address (any @foobar.com email, per
+// establishSession) so session setup never itself hits the 403 path under
+// test; for every other email it increments targetCalls and returns 403 for
+// the first failCount calls, then 422 (exists) afterward. A failCount of -1
+// (or any count >= existenceMaxRetries+1) never recovers, modeling a
+// permanently blocked IP.
+func validity403Mux(t *testing.T, csrfToken string, targetCalls *atomic.Int32, failCount int) *http.ServeMux {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/join", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprintf(w, `<!DOCTYPE html><html><body>
+<auto-check src="/email_validity_checks">
+  <input type="hidden" value="%s">
+</auto-check>
+</body></html>`, csrfToken)
+	})
+	mux.HandleFunc("/email_validity_checks", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if strings.HasSuffix(r.FormValue("value"), "@foobar.com") {
+			w.WriteHeader(http.StatusOK) // sanity check always passes
+			return
+		}
+		n := targetCalls.Add(1)
+		if failCount < 0 || n <= int32(failCount) {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		w.WriteHeader(http.StatusUnprocessableEntity) // recovers to exists
+	})
+	return mux
+}
+
+// TestExistence_403RetriedToSuccess_RotatingProxy verifies that under
+// --rotating-proxy, an HTTP 403 from the validity endpoint is retried (each
+// retry modeling a fresh exit IP) rather than failing immediately, and that
+// once the block lifts the underlying 422/200 result is still returned
+// correctly.
+func TestExistence_403RetriedToSuccess_RotatingProxy(t *testing.T) {
+	t.Parallel()
+
+	const target = "blocked@example.com"
+	const failCount = 2
+	var targetCalls atomic.Int32
+
+	srv := httptest.NewServer(validity403Mux(t, "csrf-403-retry", &targetCalls, failCount))
+	t.Cleanup(srv.Close)
+
+	e := newRotatingTestEnumerator(t, srv, failCount+2) // retry budget covers failCount
+
+	results := e.Enumerate(context.Background(), []string{target}, 1, 0, 0)
+
+	require.Len(t, results, 1)
+	require.NoError(t, results[0].Error,
+		"403s must be retried to success under --rotating-proxy, not surfaced as an error")
+	assert.True(t, results[0].Exists, "422 after the retries succeed must map to Exists=true")
+	assert.Equal(t, int32(failCount+1), targetCalls.Load(),
+		"validity endpoint must be hit failCount+1 times: failCount 403s + 1 recovering 422")
+}
+
+// TestExistence_403FailsFast_NonRotatingProxy verifies that without
+// --rotating-proxy, an HTTP 403 from the validity endpoint is NOT retried: it
+// fails immediately with the generic "unexpected status" error (same as any
+// other unhandled status code), and the validity endpoint is hit exactly once.
+func TestExistence_403FailsFast_NonRotatingProxy(t *testing.T) {
+	t.Parallel()
+
+	const target = "blocked@example.com"
+	var targetCalls atomic.Int32
+
+	// failCount=-1: the handler would always return 403 for the target if ever
+	// called more than once, so a second call would also prove the (absent)
+	// retry happened; targetCalls asserts it was called exactly once regardless.
+	srv := httptest.NewServer(validity403Mux(t, "csrf-403-failfast", &targetCalls, -1))
+	t.Cleanup(srv.Close)
+
+	// newTestEnumerator always builds with rotatingProxy=false.
+	e := newTestEnumerator(t, srv, nil, "")
+
+	results := e.Enumerate(context.Background(), []string{target}, 1, 0, 0)
+
+	require.Len(t, results, 1)
+	require.Error(t, results[0].Error,
+		"a 403 from the validity endpoint in non-rotating mode must be surfaced as an error")
+	assert.Contains(t, results[0].Error.Error(), "unexpected status 403",
+		"non-rotating 403 must fail with the generic unexpected-status error, not a retry-exhaustion error")
+	assert.Equal(t, int32(1), targetCalls.Load(),
+		"validity endpoint must be hit exactly once — non-rotating mode must never retry a 403")
+}
+
+// TestExistence_403ExhaustsRetries_RotatingProxy verifies that under
+// --rotating-proxy, when the validity endpoint returns 403 on every attempt
+// (the block never lifts), postValidity retries up to existenceMaxRetries and
+// then returns the retry-exhaustion error, having hit the endpoint
+// existenceMaxRetries+1 times in total.
+func TestExistence_403ExhaustsRetries_RotatingProxy(t *testing.T) {
+	t.Parallel()
+
+	const target = "blocked@example.com"
+	const maxRetries = 2
+	var targetCalls atomic.Int32
+
+	// failCount=-1: 403 for every call to the target email, so retries never
+	// recover and existenceMaxRetries is exhausted.
+	srv := httptest.NewServer(validity403Mux(t, "csrf-403-exhaust", &targetCalls, -1))
+	t.Cleanup(srv.Close)
+
+	e := newRotatingTestEnumerator(t, srv, maxRetries)
+
+	results := e.Enumerate(context.Background(), []string{target}, 1, 0, 0)
+
+	require.Len(t, results, 1)
+	require.Error(t, results[0].Error,
+		"exhausting all retries on a persistent 403 under --rotating-proxy must produce an error")
+	assert.Contains(t, results[0].Error.Error(), "validity check blocked (HTTP 403) after",
+		"error must report retry exhaustion, not the generic unexpected-status error")
+	assert.Equal(t, int32(maxRetries+1), targetCalls.Load(),
+		"validity endpoint must be hit existenceMaxRetries+1 times: the initial attempt plus every retry")
+}
+
+// ---------------------------------------------------------------------------
+// NewEnumerator: rotatingProxy disables HTTP keep-alives (fresh exit IP)
+// ---------------------------------------------------------------------------
+
+// closeObservingWebServer starts a fake GitHub web server whose
+// /email_validity_checks handler records, in sawClose, whether the inbound
+// request for the (non-sanity-check) target email carried r.Close == true —
+// i.e. whether the client sent "Connection: close" — then returns 200
+// (available) so enumeration completes successfully regardless of the
+// keep-alive setting under test.
+func closeObservingWebServer(t *testing.T, sawClose *atomic.Bool) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/join", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, `<!DOCTYPE html><html><body>
+<auto-check src="/email_validity_checks">
+  <input type="hidden" value="csrf-keepalive-test">
+</auto-check>
+</body></html>`)
+	})
+	mux.HandleFunc("/email_validity_checks", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if !strings.HasSuffix(r.FormValue("value"), "@foobar.com") {
+			sawClose.Store(r.Close)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestNewEnumerator_RotatingProxyDisablesKeepAlives verifies the behavioral
+// effect of the DisableKeepAlives wiring in NewEnumerator: under
+// rotatingProxy=true every existence request must carry "Connection: close"
+// (observed server-side as http.Request.Close == true) so each retry opens a
+// fresh TCP connection — and thus a fresh proxy exit IP — instead of reusing a
+// pooled, already-blocked connection. Under rotatingProxy=false, connections
+// must be kept alive as normal (r.Close == false).
+//
+// This test goes through NewEnumerator directly (proxyURL="") so the real
+// *http.Transport built by brutus.NewHTTPClientWithProxy is exercised, rather
+// than asserting on the unexported field directly.
+func TestNewEnumerator_RotatingProxyDisablesKeepAlives(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rotatingProxy=true sends Connection: close", func(t *testing.T) {
+		t.Parallel()
+
+		var sawClose atomic.Bool
+		webSrv := closeObservingWebServer(t, &sawClose)
+
+		e, err := NewEnumerator("", 5*time.Second, "", true)
+		require.NoError(t, err)
+		e.webBaseURL = webSrv.URL
+		e.sleep = noopSleep
+		e.newName = deterministicName
+
+		results := e.Enumerate(context.Background(), []string{"alice@example.com"}, 1, 0, 0)
+
+		require.Len(t, results, 1)
+		require.NoError(t, results[0].Error, "enumeration against the fake server must succeed")
+		assert.True(t, sawClose.Load(),
+			"rotatingProxy=true must set DisableKeepAlives so requests carry Connection: close (r.Close == true)")
+	})
+
+	t.Run("rotatingProxy=false keeps connections alive", func(t *testing.T) {
+		t.Parallel()
+
+		var sawClose atomic.Bool
+		webSrv := closeObservingWebServer(t, &sawClose)
+
+		e, err := NewEnumerator("", 5*time.Second, "", false)
+		require.NoError(t, err)
+		e.webBaseURL = webSrv.URL
+		e.sleep = noopSleep
+		e.newName = deterministicName
+
+		results := e.Enumerate(context.Background(), []string{"alice@example.com"}, 1, 0, 0)
+
+		require.Len(t, results, 1)
+		require.NoError(t, results[0].Error, "enumeration against the fake server must succeed")
+		assert.False(t, sawClose.Load(),
+			"rotatingProxy=false must NOT set DisableKeepAlives — connections must be kept alive (r.Close == false)")
+	})
 }


### PR DESCRIPTION
## Why

Follow-up to #276. Even with the `Accept`-header fix, GitHub blocks **~80–87% of datacenter / rotating-proxy exit IPs** on the signup and validity endpoints (measured: Bright Data datacenter zone ~13% pass, n=30; GCE 0/8). A rotating proxy gives a fresh exit IP per connection, so retrying *should* land on a good IP within a few attempts — but two gaps stopped brutus from exploiting that:

1. **Per-email 403 wasn't retried.** `postValidity` only retried HTTP 429; a 403 fell through to `"unexpected status 403"` and hard-failed the email. So through a rotating proxy the join page would eventually succeed (it already retries 403) but ~80% of the per-email POSTs failed anyway.
2. **Keep-alives pinned the exit IP.** The existence client used the default `http.Transport` (keep-alives on), so retries reused the pooled TCP connection = the *same* exit IP. Rotation never actually happened.

## What

- **`postValidity` retries on 403 — gated to `--rotating-proxy`.** Retrying a 403 only helps if the retry egresses a fresh IP, so it fires only in rotating mode (retry accounting mirrors the existing 429 branch: bounded by `existenceMaxRetries`, ctx-aware backoff). **Non-rotating mode is unchanged** — a 403 still fails fast with the identical `"unexpected status 403 from validity endpoint"` error, avoiding ~10s/email of pointless latency against a persistently blocked IP.
- **`DisableKeepAlives` in rotating mode.** `NewEnumerator` sets `DisableKeepAlives=true` on the transport when `--rotating-proxy` is set, so each request/retry opens a fresh connection → fresh exit IP. (`apiClient` shares the transport, so reveal also gets it — harmless: reveal is sequential and PAT-per-request.)

No API or CLI-surface changes — the existing `--rotating-proxy` flag now behaves as its name implies.

## Expected effect

At an ~87% per-IP block rate, 15 rotating retries (`rotatingProxyMaxRetries`) → per-email success ≈ 1 − 0.87¹⁵ ≈ **88%** (≈97% at an 80% block rate), vs. ~13–20% before. A minority may still exhaust retries; that's a tuning tradeoff, not a failure.

## Testing

- New tests: 403 retry-to-success (rotating), fail-fast (non-rotating, 1 call, no retry), retry exhaustion, and keep-alive behavior (`r.Close` true under rotating / false otherwise). RED-verified.
- `go build ./...`, `go vet ./...`, `go test ./pkg/enum/github/`, `go test -race ./pkg/enum/github/`, `golangci-lint` (caps disabled) — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
