### PR TITLE
feat(enum/github): surface session-establishment progress (no more silent hang)

### DIFF
--- a/cmd/brutus/cmd_enum_github.go
+++ b/cmd/brutus/cmd_enum_github.go
@@ -180,6 +180,30 @@ func runEnumGithub(cmd *cobra.Command, args []string) error {
 		progress.Update(processed, fmt.Sprintf("%d found", found))
 	}
 
+	// Surface live progress during the up-front CSRF-session gate. That gate runs
+	// before any email completes, so the progress bar correctly sits at 0/N;
+	// against a slow or IP-blocked proxy it can retry for tens of seconds with no
+	// feedback and look like a hang. Emitting a status line per attempt — with
+	// the failing reason (e.g. HTTP 403) on retries — makes the wait and its
+	// cause visible immediately. Interactive output only; quiet/JSON stay clean.
+	// Only the existence path has this gate (the map/reveal path uses the token
+	// flow), so wiring it here is sufficient.
+	if !flagQuiet && !flagJSON {
+		enumerator.OnSessionProgress = func(attempt, maxAttempts int, lastErr error) {
+			// Clear the in-place bar before printing so the bar's partial line
+			// doesn't corrupt the status line; the bar redraws on the next tick.
+			progress.Clear()
+			if lastErr == nil {
+				fmt.Fprintf(os.Stderr, "%s Establishing GitHub session (attempt %d/%d)…\n",
+					dim(useColor, SymbolInfo), attempt, maxAttempts)
+				return
+			}
+			fmt.Fprintf(os.Stderr, "%s Establishing GitHub session (attempt %d/%d; previous: %s)…\n",
+				dim(useColor, SymbolInfo), attempt, maxAttempts,
+				truncate(sanitizeTerminal(lastErr.Error()), 100))
+		}
+	}
+
 	results := enumerator.EnumerateWith(ctx, emails, flagThreads, flagRateLimit, flagJitter, onResult)
 	progress.Stop()
 

--- a/pkg/enum/github/existence.go
+++ b/pkg/enum/github/existence.go
@@ -152,7 +152,11 @@ func (e *Enumerator) EnumerateWith(ctx context.Context, emails []string, threads
 // that signals a genuine endpoint change, so it fails fast.
 func (e *Enumerator) establishSession(ctx context.Context) (*session, error) {
 	var lastErr error
+	maxAttempts := e.existenceMaxRetries + 1
 	for attempt := 0; ; attempt++ {
+		if e.OnSessionProgress != nil {
+			e.OnSessionProgress(attempt+1, maxAttempts, lastErr)
+		}
 		sess, retryable, err := e.tryEstablishSession(ctx)
 		if err == nil {
 			return sess, nil

--- a/pkg/enum/github/github.go
+++ b/pkg/enum/github/github.go
@@ -121,6 +121,16 @@ type Enumerator struct {
 	// them, giving GitHub time to resolve author logins. Overridable by tests.
 	settleDelay time.Duration
 
+	// OnSessionProgress, if non-nil, is invoked at the start of each
+	// session-establishment attempt with the 1-based attempt number, the total
+	// attempt budget (existenceMaxRetries+1), and the previous attempt's error
+	// (nil on the first attempt). It lets the operator CLI surface live feedback
+	// during the up-front CSRF-session gate — which otherwise runs silently and,
+	// under a slow or IP-blocked proxy, looks like a hang. The library leaves it
+	// nil (no output, no behavior change) so pkg/enum stays print-free for its
+	// SaaS/Guard importers.
+	OnSessionProgress func(attempt, maxAttempts int, lastErr error)
+
 	// sleep waits for d or until ctx is canceled; overridable by tests to avoid
 	// real delays. newName generates a random hex name for repos and files;
 	// overridable by tests for determinism.

--- a/pkg/enum/github/session_progress_test.go
+++ b/pkg/enum/github/session_progress_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sessionProgressCall records the arguments of one OnSessionProgress
+// invocation, in call order.
+type sessionProgressCall struct {
+	attempt     int
+	maxAttempts int
+	lastErr     error
+}
+
+// TestOnSessionProgress_InvokedPerAttempt verifies that establishSession
+// invokes Enumerator.OnSessionProgress once at the start of every attempt —
+// including the first — with a 1-based attempt number, a constant
+// maxAttempts (existenceMaxRetries+1), and the previous attempt's error (nil
+// on the first call). The /join handler returns HTTP 403 for the first two
+// attempts (mirroring GitHub's bot/rate detection stub) and then serves the
+// CSRF-bearing page on the third, so the callback must fire exactly 3 times:
+// twice with a non-nil lastErr describing the prior 403, and once (the first
+// call) with lastErr == nil.
+func TestOnSessionProgress_InvokedPerAttempt(t *testing.T) {
+	t.Parallel()
+
+	const csrfToken = "csrf-session-progress-token"
+	var joinCalls atomic.Int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/join", func(w http.ResponseWriter, _ *http.Request) {
+		n := joinCalls.Add(1)
+		if n <= 2 {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = fmt.Fprint(w, `<!DOCTYPE html><html><body>blocked</body></html>`)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = fmt.Fprintf(w, `<!DOCTYPE html><html><body>
+<auto-check src="/email_validity_checks">
+  <input type="hidden" value="%s">
+</auto-check>
+</body></html>`, csrfToken)
+	})
+	mux.HandleFunc("/email_validity_checks", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if r.FormValue("value") == "target@example.com" {
+			w.WriteHeader(http.StatusUnprocessableEntity) // 422 → exists
+		} else {
+			w.WriteHeader(http.StatusOK) // 200 → available (sanity-check passes)
+		}
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	e := newTestEnumerator(t, srv, nil, "")
+	e.existenceMaxRetries = 4 // survive the 2 forced 403s with room to spare
+
+	var calls []sessionProgressCall
+	e.OnSessionProgress = func(attempt, maxAttempts int, lastErr error) {
+		calls = append(calls, sessionProgressCall{attempt: attempt, maxAttempts: maxAttempts, lastErr: lastErr})
+	}
+
+	results := e.Enumerate(context.Background(), []string{"target@example.com"}, 1, 0, 0)
+
+	require.Len(t, results, 1)
+	require.NoError(t, results[0].Error, "establishSession must succeed after retrying past the 403 stubs")
+	assert.True(t, results[0].Exists, "HTTP 422 from validity endpoint must map to Exists=true")
+
+	require.Len(t, calls, 3, "OnSessionProgress must fire once per attempt: 2 failed + 1 success")
+	for i, c := range calls {
+		assert.Equal(t, i+1, c.attempt, "call[%d] must report 1-based attempt %d", i, i+1)
+		assert.Equal(t, e.existenceMaxRetries+1, c.maxAttempts,
+			"call[%d] must report the constant maxAttempts == existenceMaxRetries+1", i)
+	}
+
+	assert.NoError(t, calls[0].lastErr, "the first attempt must report lastErr == nil")
+	for i := 1; i < len(calls); i++ {
+		require.Error(t, calls[i].lastErr, "call[%d] must report the previous attempt's error", i)
+		assert.Contains(t, calls[i].lastErr.Error(), "join page returned HTTP 403",
+			"call[%d] lastErr must describe the prior attempt's HTTP 403", i)
+	}
+}
+
+// TestOnSessionProgress_NilCallbackNoPanic guards the library default: when
+// OnSessionProgress is left unset (as NewEnumerator does), establishSession
+// must not panic on the nil callback, and a normal existence check must still
+// succeed.
+func TestOnSessionProgress_NilCallbackNoPanic(t *testing.T) {
+	t.Parallel()
+
+	webSrv := newWebServer(t, "csrf-nil-progress", map[string]int{
+		"alice@example.com": http.StatusUnprocessableEntity,
+	})
+	e := newTestEnumerator(t, webSrv, nil, "")
+	require.Nil(t, e.OnSessionProgress, "NewEnumerator must leave OnSessionProgress nil by default")
+
+	results := e.Enumerate(context.Background(), []string{"alice@example.com"}, 1, 0, 0)
+
+	require.Len(t, results, 1)
+	require.NoError(t, results[0].Error)
+	assert.True(t, results[0].Exists)
+}


### PR DESCRIPTION
## Problem

`brutus enum active github` establishes a CSRF session **once, up front, as a hard gate** (`establishSession`) before any email is processed. Against a slow or IP-blocked proxy this gate retries for tens of seconds while the progress bar correctly sits at `0/N` — indistinguishable from a hang. The observed failure mode in the field:

- User sees `[>] 0% · 0/N` for a long time with no feedback and assumes it's frozen.
- User hits Ctrl-C. The signal cancels the context, `establishSession`'s retry-backoff sleep returns a bare `ctx.Err()`, and that `context canceled` gets stamped onto **every** result — completely hiding the real cause.
- The real cause here was GitHub's **DataDome** anti-bot returning HTTP 403 on `/signup` for datacenter proxy exit IPs (confirmed via curl: header-independent, IP/fingerprint-driven).

## Change

Add an optional `Enumerator.OnSessionProgress(attempt, maxAttempts int, lastErr error)` callback, invoked at the start of each `establishSession` attempt. The existence CLI wires it to a per-attempt status line that includes the failing reason on retries:

```
[*] Establishing GitHub session (attempt 1/6)…
[*] Establishing GitHub session (attempt 2/6; previous: github enum: join page returned HTTP 403 …)…
```

So the wait — and its cause — are visible immediately instead of surfacing only after all retries (or being masked by a Ctrl-C).

## Notes / constraints

- **UX only.** Does not change enumeration behavior and does **not** defeat the DataDome block — that requires residential egress. This just makes the block visible.
- **Additive, library stays print-free.** The callback is left `nil` by `NewEnumerator`; no exported signatures changed. `pkg/enum/github` adds no new prints (Guard/SaaS import it). The only new output is in `cmd/brutus`.
- Only the existence path has this gate; the `map`/reveal (token) path is untouched.

## Testing

- New `pkg/enum/github/session_progress_test.go`: `TestOnSessionProgress_InvokedPerAttempt` (per-attempt invocation, 1-based `attempt`, constant `maxAttempts == existenceMaxRetries+1`, `lastErr` nil on first call and carrying the prior 403 thereafter) and `TestOnSessionProgress_NilCallbackNoPanic` (library default).
- `go build ./...`, `go test ./pkg/enum/github/... ./cmd/brutus/...`, `go vet` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)