### PR TITLE
ci(codex-review): bump reviewer model → gpt-5.6-sol (LAB-5088)

### DIFF
--- a/.github/workflows/codex-code.yml
+++ b/.github/workflows/codex-code.yml
@@ -23,6 +23,6 @@ jobs:
       contents: read
       pull-requests: write
     with:
-      model: "gpt-5.5"
+      model: "gpt-5.6-sol"
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
Part of the fleet-wide reviewer-model rollout (LAB-5088): bumps the `codex-review` job's model to `gpt-5.6-sol`. Validated by palatine#324 (ran gpt-5.6-sol on the identical codex runtime 0.135.0) and public-workflows#145 (default bumped). This is a one-line change; no reusable-workflow SHA bump is needed since all reusable versions pin the same codex-version. Merge is a human decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)