### PR TITLE
fix(ci): scope external-contribution notify concurrency per PR/issue

### DIFF
--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -7,7 +7,11 @@ on:
     types: [opened, assigned, closed]
 
 concurrency:
-  group: external-contribution-${{ github.ref }}
+  # Key per PR/issue, not per base ref. On pull_request_target, github.ref
+  # resolves to the base branch (refs/heads/main) for every PR, so a single
+  # group would make each new PR/issue event cancel the previous one — e.g. a
+  # batch of Dependabot PRs would drop all but one notification.
+  group: external-contribution-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
   cancel-in-progress: true
 jobs:
   notify:


### PR DESCRIPTION
## Problem

The `notify / notify` check has been failing (red X) on essentially every open Dependabot PR (#267, #268, #269, #270, #272, #273). The failures are **not** errors in the notify logic — they are concurrency cancellations:

```
Canceling since a higher priority waiting request for external-contribution-refs/heads/main exists
A task was canceled.
```

## Root cause

`.github/workflows/external-contribution.yml` keyed its concurrency group on `github.ref`:

```yaml
concurrency:
  group: external-contribution-${{ github.ref }}
  cancel-in-progress: true
```

On `pull_request_target` events, `github.ref` resolves to the **base** branch (`refs/heads/main`) for *every* PR — not a PR-specific ref. So all PR/issue events collapse into one shared group `external-contribution-refs/heads/main`, and `cancel-in-progress: true` makes each new event cancel the previously-running one.

This is both cosmetic (red X on PRs) and a **functional bug**: when several PRs open at once (e.g. Dependabot's daily batch), only one notification survives — the rest are cancelled, so their Slack/Linear notifications are silently dropped.

## Fix

Key the concurrency group per PR/issue, falling back to `github.ref`:

```yaml
group: external-contribution-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
```

Distinct PRs no longer cancel each other; rapid duplicate events for the *same* PR still dedupe as before. No changes to secret handling or the pinned reusable-workflow SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)