### PR TITLE
ci(deps): ignore the leaderboard-backfill pin too (ENG-5687)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,29 @@ updates:
       # Auto-bumping it breaks OIDC AssumeRole (metrics silently stop) unless
       # the new SHA is added to the trust first via the ENG-4164 runbook, so it
       # must be rolled manually — not by dependabot. (See #229, which broke it.)
+      #
+      # leaderboard-backfill.yml is a SECOND reusable with the same coupling and
+      # its own separately-trusted pin (6c715ccf…, v2.17.0). It is added here
+      # BEFORE the ENG-5688 fan-out lands a backfill caller in this repo, so the
+      # rule is in place ahead of the dependency rather than after the first
+      # broken bump — which is how #229 was learned the expensive way. Until
+      # that caller exists the entry is simply a no-op.
+      #
+      # The EXACT NAMES are what do the work here, so ADDING A NEW LEADERBOARD
+      # REUSABLE MEANS ADDING ITS EXACT NAME to this list. The `leaderboard-*`
+      # wildcard below is OPPORTUNISTIC FORWARD COVERAGE and is NOT
+      # load-bearing: its match semantics against a reusable-workflow dependency
+      # name are unverified in this org, and — the part that matters — they
+      # CANNOT be verified by watching this rule work, because dependabot
+      # suppresses a bump if EITHER the wildcard or an exact name matches. A
+      # quiet dependabot run therefore only proves the exact names held and says
+      # nothing about the wildcard. Reading it as "a reusable added later needs
+      # no edit here" would rebuild the very failure mode this rule exists to
+      # stop — a control that looks present, does nothing, and tells no one.
       - dependency-name: "praetorian-inc/public-workflows/.github/workflows/leaderboard-metrics.yml"
+      - dependency-name: "praetorian-inc/public-workflows/.github/workflows/leaderboard-backfill.yml"
+      # Non-load-bearing; see above. Never a substitute for an exact entry.
+      - dependency-name: "praetorian-inc/public-workflows/.github/workflows/leaderboard-*"
 
   - package-ecosystem: "gomod"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,20 +21,30 @@ updates:
       # broken bump — which is how #229 was learned the expensive way. Until
       # that caller exists the entry is simply a no-op.
       #
-      # The EXACT NAMES are what do the work here, so ADDING A NEW LEADERBOARD
-      # REUSABLE MEANS ADDING ITS EXACT NAME to this list. The `leaderboard-*`
-      # wildcard below is OPPORTUNISTIC FORWARD COVERAGE and is NOT
-      # load-bearing: its match semantics against a reusable-workflow dependency
-      # name are unverified in this org, and — the part that matters — they
-      # CANNOT be verified by watching this rule work, because dependabot
-      # suppresses a bump if EITHER the wildcard or an exact name matches. A
-      # quiet dependabot run therefore only proves the exact names held and says
-      # nothing about the wildcard. Reading it as "a reusable added later needs
-      # no edit here" would rebuild the very failure mode this rule exists to
-      # stop — a control that looks present, does nothing, and tells no one.
+      # ADDING A NEW LEADERBOARD REUSABLE MEANS ADDING ITS EXACT NAME to this
+      # list. The two exact entries below are the load-bearing control. The
+      # `leaderboard-*` wildcard is forward coverage for the window between "a
+      # new coupled reusable lands" and "someone remembers to add its exact
+      # name" — which is exactly how this was learned the expensive way.
+      #
+      # The wildcard's behaviour is NOT observable from here, in either
+      # direction. An ignore list is match-ANY, so a quiet dependabot run proves
+      # only that SOMETHING matched and never which entry; watching this rule
+      # work can therefore never confirm the wildcard fires. Its match semantics
+      # against a reusable-workflow dependency name are unverified in this org.
+      #
+      # So do not read the wildcard EITHER way:
+      #   - NOT as "a reusable added later needs no edit here". If it does not
+      #     match, metrics go dark silently. Always add the exact name.
+      #   - NOT as inert. If it DOES match, it equally suppresses a future
+      #     leaderboard-*.yml that has NO IAM coupling and would be safe to
+      #     auto-bump — silently, with no error and nothing to alert on. If you
+      #     add such a reusable and its pin never updates, this line is why, and
+      #     the remedy is to narrow or remove the wildcard.
       - dependency-name: "praetorian-inc/public-workflows/.github/workflows/leaderboard-metrics.yml"
       - dependency-name: "praetorian-inc/public-workflows/.github/workflows/leaderboard-backfill.yml"
-      # Non-load-bearing; see above. Never a substitute for an exact entry.
+      # Forward coverage only. Never a substitute for an exact entry, and see
+      # the over-suppression note above before adding an uncoupled reusable.
       - dependency-name: "praetorian-inc/public-workflows/.github/workflows/leaderboard-*"
 
   - package-ecosystem: "gomod"


### PR DESCRIPTION
## What

Adds a second `ignore` entry to `.github/dependabot.yml` for
`praetorian-inc/public-workflows/.github/workflows/leaderboard-backfill.yml`,
and demotes the newly-added `leaderboard-*` wildcard to explicitly
non-load-bearing.

## Why this repo already has half of this rule

This repo learned the failure mode the expensive way. #229 was merged as a
routine dependabot bump of the `leaderboard-metrics.yml` pin, and it took this
repo's contribution metrics dark. The existing single `ignore` entry is the
fix that came out of it.

The chain, for anyone reading this cold: the leaderboard reusables are
SHA-pinned, and the pinned SHA is allow-listed by `job_workflow_ref` in the
`LeaderboardMetricsRole` IAM trust policy **in guard**. A pin bump presents a
`job_workflow_ref` that is not on the trust list, OIDC `AssumeRole` is denied,
and the run fails. Nothing alerts on it — `leaderboard-metrics.yml` has no
failure-notification step and nothing reconciles delivered metrics against
merged PRs — so metrics just stop, and the loss is only found by auditing run
conclusions afterwards.

## Why it needs extending now

ENG-5688 adds a **second** SHA-pinned reusable with the identical coupling:
`leaderboard-backfill.yml`, pinned at `6c715ccf` (v2.17.0), separately
allow-listed on the same trust policy. The existing rule names only
`leaderboard-metrics.yml`, so as written it would protect the old dependency
and leave the new one exposed to exactly the bump that caused #229.

The entry lands **before** the backfill caller does, so the control precedes
the dependency rather than following the first broken bump.

**Stated plainly so it is not mistaken for a tested control: the
`leaderboard-backfill.yml` entry is currently a no-op in this repo.** No
backfill caller exists here yet, so there is no dependency for it to suppress.
It becomes live when the ENG-5688 fan-out lands one.

## The wildcard is deliberately not load-bearing

The diff also adds `…/leaderboard-*`, and the comment is explicit that it
**cannot be relied on**:

A dependabot `ignore` list is **match-ANY**. Suppression happens if *either*
the wildcard or an exact name matches — so a quiet dependabot run proves only
that the exact names held, and says nothing whatsoever about the wildcard. The
wildcard's match semantics against a reusable-workflow dependency name are
unverified in this org, and in this configuration they are **unobservable**:
there is no outcome that distinguishes "wildcard works" from "wildcard is
inert."

That matters because the harm is not the untested wildcard — it is the
instruction someone would infer from it. "A reusable added later needs no edit
here" would rebuild the exact failure mode this rule exists to stop: a control
that looks present, does nothing, and tells no one. So the comment says the
opposite, in the imperative — **adding a new leaderboard reusable means adding
its exact name to this list** — and the exact names are listed first.

## What is verified

- Both `dependency-name` values match the real `uses:` reference byte-for-byte.
  A `dependency-name` for a reusable workflow keys off the **reusable's path**,
  not the caller's filename, and a non-matching entry is the one failure mode
  that would make this rule silently inert — no error, the bump opens anyway,
  and the config still looks correct.
- `yaml.safe_load` parses the file.
- The `gomod` entry is byte-identical to HEAD (hash-compared, not eyeballed).
- `ignore` has exactly 3 items in the intended order; `labels` unchanged on
  both ecosystem entries.
- Every added line at 6-space indent; em-dashes are U+2014; no tabs, CRs, or
  trailing whitespace.

## Scope

`.github/dependabot.yml` only, `+22/-0`. No workflow, no Go code. Rolling
either pin remains a manual, coordinated operation under the ENG-4164 runbook
(trust policy updated and deployed to prod *before* the pin moves) — which is
the half dependabot cannot do, and therefore why it must not do this half
either.

Refs ENG-5687, ENG-5688, ENG-5775.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
