### PR TITLE
fix(brutus): clamp non-positive Threads to default (negative = unbounded concurrency)

### DIFF
--- a/pkg/brutus/brutus.go
+++ b/pkg/brutus/brutus.go
@@ -311,7 +311,10 @@ func (c *Config) validate() error {
 	if c.Timeout == 0 {
 		c.Timeout = 10 * time.Second
 	}
-	if c.Threads == 0 {
+	// Non-positive thread counts fall back to the default. Negative values are
+	// especially dangerous: errgroup.SetLimit treats a negative limit as
+	// unlimited, which would spawn one goroutine per credential.
+	if c.Threads <= 0 {
 		c.Threads = 10
 	}
 

--- a/pkg/brutus/workers_test.go
+++ b/pkg/brutus/workers_test.go
@@ -16,6 +16,8 @@ package brutus
 
 import (
 	"context"
+	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -49,6 +51,103 @@ func TestCaptureBanner_EmptyUsernames(t *testing.T) {
 	assert.Equal(t, "http", banner.Protocol)
 	assert.Equal(t, "example.com:80", banner.Target)
 	// Banner may be empty, which is fine
+}
+
+// TestThreadsClampsConcurrency is a regression test for a bug where
+// Config.Threads was only defaulted when equal to 0 (`if c.Threads == 0`),
+// leaving negative values (e.g. Threads: -1) untouched. errgroup.SetLimit
+// treats a negative limit as unlimited, so a negative Threads value spawned
+// one goroutine per credential instead of being bounded.
+//
+// This test drives real credential attempts through Brute() with a mock
+// plugin that tracks the high-water mark of concurrently in-flight
+// Test() calls, and asserts the observed peak concurrency never exceeds
+// the expected effective limit. A field-equality check on cfg.Threads would
+// not catch this bug, since the bug is about how the (correctly defaulted
+// or not) value is enforced by the worker pool, not about the field value
+// itself.
+func TestThreadsClampsConcurrency(t *testing.T) {
+	// Enough credentials that unbounded concurrency (the bug) would clearly
+	// exceed any of the expected bounds below.
+	const numCredentials = 150
+
+	usernames := make([]string, numCredentials)
+	for i := range usernames {
+		usernames[i] = fmt.Sprintf("user%d", i)
+	}
+
+	tests := []struct {
+		name        string
+		threads     int
+		expectedMax int64
+	}{
+		{name: "negative threads clamps to default limit", threads: -1, expectedMax: 10},
+		{name: "zero threads defaults to default limit", threads: 0, expectedMax: 10},
+		{name: "positive threads respected as limit", threads: 3, expectedMax: 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := &concurrencyTrackingPlugin{}
+
+			cfg := &Config{
+				Target:    "test:22",
+				Protocol:  "mock-concurrency",
+				Usernames: usernames,
+				Passwords: []string{"password"},
+				Threads:   tt.threads,
+				Timeout:   1 * time.Second,
+				Plugin:    plugin,
+			}
+
+			_, err := Brute(cfg)
+			assert.NoError(t, err)
+
+			peak := atomic.LoadInt64(&plugin.peak)
+			assert.LessOrEqual(t, peak, tt.expectedMax,
+				"observed peak concurrency %d exceeds expected bound %d (Threads=%d)",
+				peak, tt.expectedMax, tt.threads)
+		})
+	}
+}
+
+// concurrencyTrackingPlugin is a mock Plugin that records the high-water
+// mark of concurrently in-flight Test() calls using atomic operations, so
+// tests can assert on real observed concurrency rather than config values.
+type concurrencyTrackingPlugin struct {
+	current int64
+	peak    int64
+}
+
+func (p *concurrencyTrackingPlugin) Name() string { return "mock-concurrency" }
+
+func (p *concurrencyTrackingPlugin) Test(ctx context.Context, target, username, password string, timeout time.Duration, pluginCfg PluginConfig) *Result {
+	n := atomic.AddInt64(&p.current, 1)
+
+	// CAS loop to record the high-water mark without losing updates from
+	// concurrent goroutines.
+	for {
+		old := atomic.LoadInt64(&p.peak)
+		if n <= old {
+			break
+		}
+		if atomic.CompareAndSwapInt64(&p.peak, old, n) {
+			break
+		}
+	}
+
+	// Hold the "attempt" open briefly so overlapping calls are observable.
+	time.Sleep(5 * time.Millisecond)
+
+	atomic.AddInt64(&p.current, -1)
+
+	return &Result{
+		Protocol: "mock-concurrency",
+		Target:   target,
+		Username: username,
+		Password: password,
+		Success:  false,
+	}
 }
 
 type mockHTTPPlugin struct{}


### PR DESCRIPTION
## Problem

`Config.validate()` defaulted `Threads` only when it was **exactly** `0`:

```go
if c.Threads == 0 {
    c.Threads = 10
}
```

A negative value passed straight through to `g.SetLimit(cfg.Threads)` in `executeWorkerPool` (`pkg/brutus/workers.go:148`). **`errgroup.SetLimit` treats a negative limit as unlimited**, so `Threads: -1` spawned one goroutine per credential with no bound at all.

Measured on the pre-fix code:

| `Threads` | Credentials | Peak concurrent in-flight |
|---|---|---|
| `-1` | 200 | **200** (fully unbounded) |
| `0` | 200 | 10 (correct) |

Reachable two ways:

- **CLI** — `--threads` flows through `flags.go` → `runner.go:293` with no validation.
- **Library** — `pkg/brutus` is public API, consumed by Guard's compute build.

Against a large credential set this is effectively a self-inflicted connection flood on the target: thousands of simultaneous sockets, and every rate-limit, jitter, and lockout guard in the worker pool becomes meaningless because nothing is throttling the pool itself.

## Fix

One-line condition change, with a comment recording *why* negative is the dangerous case:

```go
// Non-positive thread counts fall back to the default. Negative values are
// especially dangerous: errgroup.SetLimit treats a negative limit as
// unlimited, which would spawn one goroutine per credential.
if c.Threads <= 0 {
    c.Threads = 10
}
```

**Why clamp instead of returning an error:** it matches the zero-value default already living in `validate()`, mirrors the same clamping pattern in `pkg/enum/workers.go:86-93` (which guards this identical hazard — `pkg/brutus` just never got it), and it cannot break existing library consumers the way a new validation error could.

`validate()` is the single choke point — confirmed `applyDefaults()` never touches `Threads`, and `workers.go:148` is the only `SetLimit` caller.

## Test

`TestThreadsClampsConcurrency` is table-driven over `-1`, `0`, and `3`. It asserts the **observed peak concurrency** via an atomic high-water mark in a mock plugin — deliberately not `cfg.Threads == 10`, since a field assertion would pass even if the pool were still unbounded.

**Red-green verified:** against the pre-fix condition the negative case fails with `observed peak concurrency 150 exceeds expected bound 10`; the `0` and `3` cases stay green, correctly isolating the regression to negative input.

## Verification

- `go build ./...` — exit 0
- `go test ./...` — exit 0, 55 packages ok, 0 failures
- `go test -race -run TestThreadsClampsConcurrency ./pkg/brutus/` — race-clean
- `go vet ./...` — clean
- `golangci-lint run --max-same-issues=0 --max-issues-per-linter=0 ./...` — `0 issues.` (caps disabled; the defaults mask duplicate hits)

Independently re-confirmed with the original standalone reproducer, unmodified: peak went **200 → 10**.

## Scope

Found during a broader audit that turned up three other confirmed bugs, not addressed here:

1. **LLM mode silently tests zero credentials** — `runWorkersWithLLM` drops `cfg.Credentials` and `cfg.Keys`, so `--creds` + LLM against HTTP runs nothing and reports no error. Silent false negative.
2. **Panic recovery drops results** — `mu.TryLock()` in the recover path discarded 20 of 300 results under contention; the deadlock it guards against isn't reachable.
3. **POP3 ignores the `USER` response** — sends `PASS` even after `-ERR`, burning an attempt against lockout thresholds and discarding a username-enumeration oracle.

Happy to file those separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)