### PR TITLE
fix(brutus): stop dropping panic results in the worker pool

### DIFF
--- a/pkg/brutus/workers.go
+++ b/pkg/brutus/workers.go
@@ -180,18 +180,19 @@ func executeWorkerPool(ctx context.Context, cfg *Config, plug Plugin, credential
 				if r := recover(); r != nil {
 					fmt.Fprintf(os.Stderr, "brutus: panic in worker for %s@%s: %v\n%s\n",
 						cred.username, cfg.Target, r, debug.Stack())
-					// Use TryLock to avoid deadlock if panic occurred while mu was held
-					if mu.TryLock() {
-						results = append(results, Result{
-							Protocol: cfg.Protocol,
-							Target:   cfg.Target,
-							Username: cred.username,
-							Password: cred.password,
-							Success:  false,
-							Error:    fmt.Errorf("plugin panic: %v", r),
-						})
-						mu.Unlock()
-					}
+					// Safe to block on mu: no evaluation that can panic happens
+					// while mu is held, so this lock is always acquirable and
+					// the panic result is never dropped.
+					mu.Lock()
+					results = append(results, Result{
+						Protocol: cfg.Protocol,
+						Target:   cfg.Target,
+						Username: cred.username,
+						Password: cred.password,
+						Success:  false,
+						Error:    fmt.Errorf("plugin panic: %v", r),
+					})
+					mu.Unlock()
 				}
 			}()
 
@@ -314,9 +315,12 @@ func executeWorkerPool(ctx context.Context, cfg *Config, plug Plugin, credential
 				result.LLMSuggestedCreds = llmSuggestions
 			}
 
-			// Collect result
+			// Collect result. Dereference before locking so no evaluation that
+			// can panic happens while mu is held, which would deadlock the
+			// recover path above (sync.Mutex is not reentrant).
+			collected := *result
 			mu.Lock()
-			results = append(results, *result)
+			results = append(results, collected)
 			mu.Unlock()
 
 			// Mark user as cracked to skip remaining passwords for this user

--- a/pkg/brutus/workers_test.go
+++ b/pkg/brutus/workers_test.go
@@ -16,11 +16,67 @@ package brutus
 
 import (
 	"context"
+	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// TestExecuteWorkerPool_PanicResultsNotDropped is a regression test for a bug
+// where the panic-recovery path used mu.TryLock() instead of mu.Lock(). Under
+// mutex contention (many workers panicking concurrently), TryLock would fail
+// and the panic Result was silently discarded instead of recorded. This test
+// drives enough concurrent panicking attempts to create genuine contention and
+// asserts the conservation property: every credential attempt that panics
+// still produces exactly one recorded Result carrying the panic error.
+func TestExecuteWorkerPool_PanicResultsNotDropped(t *testing.T) {
+	mock := &panickingPlugin{}
+
+	const numPasswords = 300
+	passwords := make([]string, numPasswords)
+	for i := range passwords {
+		passwords[i] = fmt.Sprintf("pass%d", i)
+	}
+
+	cfg := &Config{
+		Target:    "test:22",
+		Protocol:  "panic-mock",
+		Usernames: []string{"user"},
+		Passwords: passwords,
+		Threads:   32,
+		Timeout:   1 * time.Second,
+		Plugin:    mock,
+	}
+
+	results, err := Brute(cfg)
+	assert.NoError(t, err)
+
+	invocations := int(atomic.LoadInt64(&mock.invocations))
+	dropped := invocations - len(results)
+	assert.Equal(t, invocations, len(results),
+		"dropped %d of %d panic results (invocations=%d, results=%d)",
+		dropped, invocations, invocations, len(results))
+
+	for _, r := range results {
+		assert.Error(t, r.Error, "panic result should carry a non-nil Error")
+	}
+}
+
+// panickingPlugin counts every Test invocation and then panics, simulating a
+// plugin bug. The worker pool must recover from the panic and still record a
+// Result for every invocation.
+type panickingPlugin struct {
+	invocations int64
+}
+
+func (p *panickingPlugin) Name() string { return "panic-mock" }
+
+func (p *panickingPlugin) Test(ctx context.Context, target, username, password string, timeout time.Duration, pluginCfg PluginConfig) *Result {
+	atomic.AddInt64(&p.invocations, 1)
+	panic("simulated plugin panic for regression test")
+}
 
 func TestCaptureBanner_EmptyUsernames(t *testing.T) {
 	// Setup: Config with only Credentials (no Usernames), HTTP protocol, LLM enabled


### PR DESCRIPTION
## Problem

`executeWorkerPool`'s per-goroutine panic recovery appended its `Result` under `mu.TryLock()`:

```go
// Use TryLock to avoid deadlock if panic occurred while mu was held
if mu.TryLock() {
    results = append(results, Result{ /* ... plugin panic ... */ })
    mu.Unlock()
}
```

Whenever another worker happened to hold `mu`, the `TryLock` failed and **the result was discarded with no trace** — no log line, no error, nothing. Measured across five runs at 300 panicking attempts / 32 threads:

| Run | Expected | Recorded | Dropped |
|---|---|---|---|
| 1 | 300 | 289 | 11 |
| 2 | 300 | 288 | 12 |
| 3 | 300 | 282 | 18 |
| 4 | 300 | 280 | 20 |
| 5 | 300 | 279 | 21 |

The loss scales with contention, so it is worst exactly when thread count is highest. A misbehaving plugin could panic on a credential and have that attempt vanish from the report entirely — the run looks clean rather than degraded.

## Why the `TryLock` wasn't simply redundant

Worth spelling out, because a naive `TryLock` → `Lock` swap would leave a latent deadlock:

Result collection did `mu.Lock()`, then `results = append(results, *result)`. **The `*result` dereference is evaluated *after* the lock is taken.** So a nil `result` there would panic *while holding `mu`*, and a plain `Lock()` in the recover path would deadlock — `sync.Mutex` is not reentrant.

That case is unreachable today, but only because line 292 (`if result.Error == nil`) already dereferences `result` outside the lock, so a nil plugin return panics there first. That is incidental safety depending on unrelated code staying put.

## Fix

Make the safety structural, then the plain lock is provably correct:

1. **Hoist the dereference above the lock**, leaving only a slice append under `mu`:

```go
// Collect result. Dereference before locking so no evaluation that
// can panic happens while mu is held, which would deadlock the
// recover path above (sync.Mutex is not reentrant).
collected := *result
mu.Lock()
results = append(results, collected)
mu.Unlock()
```

2. **Plain `mu.Lock()` in the recover path.** Nothing evaluated under `mu` can panic, so the lock is always acquirable and results are never dropped. This matches the recover pattern already used in `pkg/enum/workers.go:109-121`.

## Test

`TestExecuteWorkerPool_PanicResultsNotDropped` asserts **exact conservation** — every panicking attempt yields exactly one recorded `Result` — deliberately not a tolerance like "at least 90%", which would defeat the purpose. It also asserts the recorded `Error` values are non-nil, so it verifies the panic path specifically rather than just a count.

Deterministic in the passing direction: with the fix, `mu.Lock()` always succeeds, so the count is exact every run.

**Red-green verified:** against the `TryLock` form it fails **5 out of 5** runs (the table above *is* that failing output). Restored to the fixed form, it passes.

Note: the test intentionally drives plugin panics, so `go test` prints recovered panic stack traces to stderr. That is expected output from the recovery path, not a failure.

## Verification

- `go build ./...` — exit 0
- `go test ./...` — exit 0, 55 packages ok, 0 failures
- `go test -race -run TestExecuteWorkerPool_PanicResultsNotDropped ./pkg/brutus/` — race-clean
- `go vet ./...` — clean
- `golangci-lint run --max-same-issues=0 --max-issues-per-linter=0 ./...` — `0 issues.` (caps disabled; the defaults mask duplicate hits)

Independently re-confirmed with the original standalone reproducer, unmodified: **280/300 → 300/300**, stable across 5 consecutive runs.

## Scope

Deliberately **not** included: a nil-result guard on the plugin return (`pkg/enum/workers.go:146-152` has one; `pkg/brutus` does not). This fix is intentionally independent of that — the deadlock safety no longer depends on line 292 surviving — so the guard can land separately on its own merits.

Independent of #295 (negative `Threads`); both branch from `main` and touch different concerns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)