### PR TITLE
fix(plugins/pop3): stop sending PASS after the server rejects USER

### DIFF
--- a/internal/plugins/pop3/pop3.go
+++ b/internal/plugins/pop3/pop3.go
@@ -81,9 +81,22 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	}
 
 	// Read response (should be +OK)
-	_, err = brutus.ReadLine(reader)
+	response, err := brutus.ReadLine(reader)
 	if err != nil {
 		result.Error = classifyAuthError(err)
+		return result
+	}
+
+	// Only proceed to PASS if the server accepted USER. Per RFC 1939 a -ERR
+	// here means the mailbox was rejected, so PASS cannot succeed and sending
+	// it would waste an attempt against lockout thresholds.
+	if !strings.HasPrefix(response, "+OK") {
+		if strings.HasPrefix(response, "-ERR") || strings.HasPrefix(response, "-err") {
+			// Mailbox rejected at the USER stage - auth failure, not an error.
+			result.Error = nil
+			return result
+		}
+		result.Error = fmt.Errorf("connection error: unexpected POP3 response to USER: %s", response)
 		return result
 	}
 
@@ -95,7 +108,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	}
 
 	// Read response (+OK = success, -ERR = failure)
-	response, err := brutus.ReadLine(reader)
+	response, err = brutus.ReadLine(reader)
 	if err != nil {
 		result.Error = classifyAuthError(err)
 		return result

--- a/internal/plugins/pop3/pop3_test.go
+++ b/internal/plugins/pop3/pop3_test.go
@@ -15,10 +15,17 @@
 package pop3
 
 import (
+	"bufio"
+	"context"
 	"errors"
+	"fmt"
+	"net"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/praetorian-inc/brutus/pkg/brutus"
 )
@@ -106,4 +113,142 @@ func TestClassifyAuthError(t *testing.T) {
 			}
 		})
 	}
+}
+
+// mockPOP3Server starts a TCP listener that speaks a scripted POP3 conversation.
+// handler receives the server-side conn and a reader for consuming client commands.
+func mockPOP3Server(t *testing.T, handler func(conn net.Conn, reader *bufio.Reader)) (addr string, cleanup func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		conn, acceptErr := ln.Accept()
+		if acceptErr != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		reader := bufio.NewReader(conn)
+		handler(conn, reader)
+	}()
+
+	cleanup = func() {
+		_ = ln.Close()
+		<-done
+	}
+	return ln.Addr().String(), cleanup
+}
+
+// pop3Send writes a POP3 response line to the connection.
+func pop3Send(conn net.Conn, msg string) {
+	_, _ = fmt.Fprint(conn, msg)
+}
+
+// pop3Recv reads one line from the connection (a client command), returning
+// ok=false if the connection was closed/errored before a line arrived. This
+// lets tests distinguish "no command sent" from "command sent".
+func pop3Recv(reader *bufio.Reader) (cmd string, ok bool) {
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return "", false
+	}
+	return strings.TrimRight(line, "\r\n"), true
+}
+
+func TestPlugin_USER_Rejected(t *testing.T) {
+	var commands []string
+	addr, cleanup := mockPOP3Server(t, func(conn net.Conn, reader *bufio.Reader) {
+		pop3Send(conn, "+OK POP3 server ready\r\n")
+		if cmd, ok := pop3Recv(reader); ok { // USER
+			commands = append(commands, cmd)
+		}
+		pop3Send(conn, "-ERR no such mailbox\r\n")
+		if cmd, ok := pop3Recv(reader); ok { // would be PASS, if sent
+			commands = append(commands, cmd)
+		}
+	})
+
+	p := &Plugin{}
+	result := p.Test(context.Background(), addr, "blocked", "hunter2", 5*time.Second, brutus.PluginConfig{})
+	cleanup() // synchronize with server goroutine before inspecting commands
+
+	assert.False(t, result.Success)
+	assert.Nil(t, result.Error)
+	require.Len(t, commands, 1, "PASS must not be sent after USER is rejected")
+	assert.Equal(t, "USER blocked", commands[0])
+}
+
+func TestPlugin_USER_UnexpectedResponse(t *testing.T) {
+	var commands []string
+	addr, cleanup := mockPOP3Server(t, func(conn net.Conn, reader *bufio.Reader) {
+		pop3Send(conn, "+OK POP3 server ready\r\n")
+		if cmd, ok := pop3Recv(reader); ok { // USER
+			commands = append(commands, cmd)
+		}
+		pop3Send(conn, "500 Syntax error\r\n")
+		if cmd, ok := pop3Recv(reader); ok { // would be PASS, if sent
+			commands = append(commands, cmd)
+		}
+	})
+
+	p := &Plugin{}
+	result := p.Test(context.Background(), addr, "admin", "hunter2", 5*time.Second, brutus.PluginConfig{})
+	cleanup()
+
+	assert.False(t, result.Success)
+	require.NotNil(t, result.Error)
+	require.Len(t, commands, 1, "PASS must not be sent after an unexpected USER response")
+	assert.Equal(t, "USER admin", commands[0])
+}
+
+func TestPlugin_ValidCredentials(t *testing.T) {
+	var commands []string
+	addr, cleanup := mockPOP3Server(t, func(conn net.Conn, reader *bufio.Reader) {
+		pop3Send(conn, "+OK POP3 server ready\r\n")
+		if cmd, ok := pop3Recv(reader); ok { // USER
+			commands = append(commands, cmd)
+		}
+		pop3Send(conn, "+OK\r\n")
+		if cmd, ok := pop3Recv(reader); ok { // PASS
+			commands = append(commands, cmd)
+		}
+		pop3Send(conn, "+OK Logged in\r\n")
+	})
+
+	p := &Plugin{}
+	result := p.Test(context.Background(), addr, "admin", "hunter2", 5*time.Second, brutus.PluginConfig{})
+	cleanup()
+
+	assert.True(t, result.Success)
+	assert.Nil(t, result.Error)
+	require.Len(t, commands, 2, "both USER and PASS must be sent for the happy path")
+	assert.Equal(t, "USER admin", commands[0])
+	assert.Equal(t, "PASS hunter2", commands[1])
+}
+
+func TestPlugin_InvalidPassword(t *testing.T) {
+	var commands []string
+	addr, cleanup := mockPOP3Server(t, func(conn net.Conn, reader *bufio.Reader) {
+		pop3Send(conn, "+OK POP3 server ready\r\n")
+		if cmd, ok := pop3Recv(reader); ok { // USER
+			commands = append(commands, cmd)
+		}
+		pop3Send(conn, "+OK\r\n")
+		if cmd, ok := pop3Recv(reader); ok { // PASS
+			commands = append(commands, cmd)
+		}
+		pop3Send(conn, "-ERR Invalid password\r\n")
+	})
+
+	p := &Plugin{}
+	result := p.Test(context.Background(), addr, "admin", "wrongpass", 5*time.Second, brutus.PluginConfig{})
+	cleanup()
+
+	assert.False(t, result.Success)
+	assert.Nil(t, result.Error)
+	require.Len(t, commands, 2, "USER and PASS are both sent on a normal auth failure")
+	assert.Equal(t, "USER admin", commands[0])
+	assert.Equal(t, "PASS wrongpass", commands[1])
 }


### PR DESCRIPTION
## Problem

`(*Plugin).Test` read the server's reply to `USER` and **discarded it**, then sent `PASS` unconditionally:

```go
// Read response (should be +OK)
_, err = brutus.ReadLine(reader)   // <- response thrown away
...
_, err = fmt.Fprintf(conn, "PASS %s\r\n", password)
```

Against a fake server answering `-ERR no such mailbox`, the recorded wire conversation was:

```
[USER nosuchuser  PASS hunter2]
```

Per RFC 1939 a `-ERR` to `USER` means the mailbox was rejected, so `PASS` cannot succeed. Sending it anyway:

- **Burns a second authentication attempt per credential** against server lockout and rate-limit thresholds — doubling lockout pressure for no possible gain. That directly undercuts the pool's own anti-lockout machinery (`--max-attempts`, spray ordering), which counts one attempt per credential.
- **Discards the username-enumeration signal** the `-ERR` represents.

## Fix

Gate the `PASS` command on the USER response, mirroring the FTP plugin, which already handles this correctly (`internal/plugins/ftp/ftp.go` only proceeds to PASS on `331` and treats `530` as auth failure):

```go
// Only proceed to PASS if the server accepted USER. Per RFC 1939 a -ERR
// here means the mailbox was rejected, so PASS cannot succeed and sending
// it would waste an attempt against lockout thresholds.
if !strings.HasPrefix(response, "+OK") {
    if strings.HasPrefix(response, "-ERR") || strings.HasPrefix(response, "-err") {
        // Mailbox rejected at the USER stage - auth failure, not an error.
        result.Error = nil
        return result
    }
    result.Error = fmt.Errorf("connection error: unexpected POP3 response to USER: %s", response)
    return result
}
```

Design notes:

- `Success=false, Error=nil` for `-ERR` matches this function's own documented contract for invalid credentials, so the verdict is unchanged — the scan reaches the same conclusion with half the traffic.
- POP3 has no analogue of FTP's `230`-after-USER (no password-less login in the USER/PASS flow), so there is deliberately **no** success-at-USER branch — `+OK` only means "proceed".
- The `-ERR`/`-err` two-case check mirrors the existing PASS-response switch in this same file. No broader case-insensitivity, which would be an unrelated behavior change.
- The second hunk (`response, err :=` → `response, err =` on the PASS read) is a mechanical consequence of `response` now being in scope. `ftp.go:120` has the identical shape for the same reason.

**Out of scope:** the POP3 greeting is still not validated. The FTP reference doesn't validate its banner either, so this keeps parity; greeting handling is a separate concern.

## Test — this package was the coverage hole that let the bug survive

`internal/plugins/pop3` was **the least-tested protocol plugin at 7.3%, with `Test()` itself at 0%**. The existing test file only covered `Name()` and error classification. Sibling plugins already had the analogous cases — `ftp` has `TestPlugin_USER_Rejected_530` and `TestPlugin_USER_UnexpectedResponse` — which is exactly why FTP was correct here and POP3 wasn't.

Four new tests, using a fake POP3 server that **records the commands actually sent**, so they assert on the wire conversation rather than only the returned `Result`:

| Test | Scenario | Asserts |
|---|---|---|
| `TestPlugin_USER_Rejected` | `-ERR` to USER | `Success=false`, `Error=nil`, **no PASS on the wire** |
| `TestPlugin_USER_UnexpectedResponse` | garbage to USER | `Error != nil`, no PASS sent |
| `TestPlugin_ValidCredentials` | `+OK` / `+OK` | `Success=true`, both commands sent |
| `TestPlugin_InvalidPassword` | `+OK` / `-ERR` | `Success=false`, `Error=nil`, both sent |

The last two guard against the fix collapsing normal auth failures into the USER branch.

**Coverage: 7.3% → 70.2%.**

**Red-green verified:** against the pre-fix code, `TestPlugin_USER_Rejected` fails showing `[USER blocked  PASS hunter2]` — 2 commands where 1 is expected — while the valid-credential and invalid-password cases stay green, correctly isolating the regression.

## Verification

- `go build ./...` — exit 0
- `go test ./...` — exit 0, 55 packages ok, 0 failures
- `go test -race ./internal/plugins/pop3/` — race-clean
- `go vet ./...` — clean
- `golangci-lint run --max-same-issues=0 --max-issues-per-linter=0 ./...` — `0 issues.` (caps disabled; defaults mask duplicates)

Independently re-confirmed with the original standalone reproducer, unmodified: the wire trace went from `[USER nosuchuser  PASS hunter2]` to `[USER nosuchuser]`, with the happy path still sending both.

Independent of #295 and #296; all three branch from `main` and touch separate concerns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)