### PR TITLE
feat(enum): carry generated names through the framework onto Result (10T-535)

### DIFF
--- a/cmd/brutus/cmd_enum_custom.go
+++ b/cmd/brutus/cmd_enum_custom.go
@@ -88,11 +88,11 @@ func runEnumCustom(cmd *cobra.Command, args []string) error {
 	}
 	plugin := custom.New(spec)
 
-	subjects, err := buildCustomSubjects()
+	targets, err := buildCustomTargets()
 	if err != nil {
 		return err
 	}
-	if len(subjects) == 0 {
+	if len(targets) == 0 {
 		return fmt.Errorf("no subjects: provide -e/-E or --generate")
 	}
 
@@ -114,7 +114,7 @@ func runEnumCustom(cmd *cobra.Command, args []string) error {
 	}
 
 	cfg := &enum.Config{
-		Emails:    subjects,
+		Targets:   targets,
 		Threads:   flagThreads,
 		Timeout:   flagTimeout,
 		RateLimit: flagRateLimit,
@@ -175,15 +175,18 @@ func loadOracleSpec(path string) (*custom.Spec, error) {
 	return spec, nil
 }
 
-// buildCustomSubjects assembles the ordered subject list from CLI flags
-// (-e/-E/--generate), de-duplicated and preserving first-seen order.
-func buildCustomSubjects() ([]string, error) {
-	var subjects []string
+// buildCustomTargets assembles the ordered target list from CLI flags
+// (-e/-E/--generate), de-duplicated on the subject and preserving first-seen
+// order. Generated targets carry the name they were built from; subjects
+// supplied via -e/-E are nameless, because a supplied subject says nothing
+// about whose it is.
+func buildCustomTargets() ([]enum.Target, error) {
+	var targets []enum.Target
 
 	if flagCustomEmails != "" {
 		for _, e := range strings.Split(flagCustomEmails, ",") {
 			if e = strings.TrimSpace(e); e != "" {
-				subjects = append(subjects, e)
+				targets = append(targets, enum.Target{Email: e})
 			}
 		}
 	}
@@ -193,47 +196,55 @@ func buildCustomSubjects() ([]string, error) {
 		if err != nil {
 			return nil, fmt.Errorf("loading subject file: %w", err)
 		}
-		subjects = append(subjects, fileSubjects...)
+		for _, s := range fileSubjects {
+			targets = append(targets, enum.Target{Email: s})
+		}
 	}
 
 	if flagCustomGenerate {
-		generated, err := generateCustomSubjects()
+		generated, err := generateCustomTargets()
 		if err != nil {
 			return nil, err
 		}
-		subjects = append(subjects, generated...)
+		targets = append(targets, generated...)
 	}
 
-	return dedupe(subjects), nil
+	return dedupeTargets(targets), nil
 }
 
-// generateCustomSubjects generates usernames or emails depending on whether a
-// domain was provided.
-func generateCustomSubjects() ([]string, error) {
-	if flagEnumDomain == "" {
-		usernames, err := enum.GenerateUsernames(flagEnumFormat)
-		if err != nil {
-			return nil, fmt.Errorf("generating usernames: %w", err)
-		}
-		return usernames, nil
-	}
-	emails, err := enum.GenerateEmails(flagEnumFormat, flagEnumDomain)
+// generateCustomTargets generates subjects from the embedded name lists, each
+// carrying the name it was built from. The subject is a bare username when no
+// domain was provided and a full email when one was — the custom oracle
+// substitutes either into its {{username}} placeholder.
+func generateCustomTargets() ([]enum.Target, error) {
+	candidates, err := enum.GenerateCandidates(flagEnumFormat)
 	if err != nil {
-		return nil, fmt.Errorf("generating emails: %w", err)
+		return nil, fmt.Errorf("generating subjects: %w", err)
 	}
-	return emails, nil
-}
 
-// dedupe removes duplicate subjects while preserving first-seen order.
-func dedupe(in []string) []string {
-	seen := make(map[string]bool, len(in))
-	out := make([]string, 0, len(in))
-	for _, s := range in {
-		if seen[s] {
+	targets := make([]enum.Target, len(candidates))
+	for i, c := range candidates {
+		if flagEnumDomain == "" {
+			targets[i] = enum.Target{Email: c.Username, First: c.First, Last: c.Last}
 			continue
 		}
-		seen[s] = true
-		out = append(out, s)
+		targets[i] = c.Target(flagEnumDomain)
+	}
+	return targets, nil
+}
+
+// dedupeTargets removes targets with a duplicate subject while preserving
+// first-seen order, so the name attached to the surviving target is the one
+// that first produced that subject.
+func dedupeTargets(in []enum.Target) []enum.Target {
+	seen := make(map[string]bool, len(in))
+	out := make([]enum.Target, 0, len(in))
+	for _, t := range in {
+		if seen[t.Email] {
+			continue
+		}
+		seen[t.Email] = true
+		out = append(out, t)
 	}
 	return out
 }

--- a/cmd/brutus/cmd_enum_custom_test.go
+++ b/cmd/brutus/cmd_enum_custom_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/praetorian-inc/brutus/pkg/enum"
 	"github.com/praetorian-inc/brutus/pkg/enum/custom"
 )
 
@@ -192,50 +193,16 @@ func TestRunEnumCustom_OversizeFile(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// F1: Subject-building helpers (dedupe, buildCustomSubjects)
+// F1: Target-building helpers (buildCustomTargets)
+//
+// 10T-535: buildCustomSubjects()/dedupe() were address-only. buildCustomTargets
+// is now the single merger of file-supplied and generated addresses, and it
+// carries the generated name (First/Last) alongside each address so it can
+// never be reverse-derived downstream. These tests exercise buildCustomTargets
+// directly, asserting on []enum.Target rather than []string, so a bug that
+// stamped a name onto a supplied address (or dropped a name from a generated
+// one) fails here rather than just failing to compile.
 // ---------------------------------------------------------------------------
-
-// TestDedupe_RemovesDuplicatesPreservingOrder verifies that dedupe removes
-// repeated values while preserving the first-seen order.
-func TestDedupe_RemovesDuplicatesPreservingOrder(t *testing.T) {
-	tests := []struct {
-		name string
-		in   []string
-		want []string
-	}{
-		{
-			name: "no duplicates — unchanged",
-			in:   []string{"a", "b", "c"},
-			want: []string{"a", "b", "c"},
-		},
-		{
-			name: "all duplicates — single element",
-			in:   []string{"x", "x", "x"},
-			want: []string{"x"},
-		},
-		{
-			name: "duplicates across non-adjacent positions",
-			in:   []string{"a", "b", "a", "c", "b"},
-			want: []string{"a", "b", "c"},
-		},
-		{
-			name: "empty input",
-			in:   nil,
-			want: []string{},
-		},
-		{
-			name: "single element",
-			in:   []string{"only"},
-			want: []string{"only"},
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := dedupe(tc.in)
-			assert.Equal(t, tc.want, got)
-		})
-	}
-}
 
 // parseSpec is a test helper that parses and validates a spec from JSON.
 func parseSpec(t *testing.T, data string) *custom.Spec {
@@ -246,9 +213,20 @@ func parseSpec(t *testing.T, data string) *custom.Spec {
 	return spec
 }
 
-// TestBuildCustomSubjects_InlineEmails verifies the -e flag CSV path:
-// subjects are split on comma, trimmed of whitespace, and returned in order.
-func TestBuildCustomSubjects_InlineEmails(t *testing.T) {
+// targetEmails extracts the Email field from a []enum.Target slice, in order,
+// for compact order/content assertions.
+func targetEmails(targets []enum.Target) []string {
+	out := make([]string, len(targets))
+	for i, t := range targets {
+		out[i] = t.Email
+	}
+	return out
+}
+
+// TestBuildCustomTargets_InlineEmails verifies the -e flag CSV path: subjects
+// are split on comma, trimmed of whitespace, returned in order, and — because
+// a CLI-supplied subject says nothing about whose it is — carry no name.
+func TestBuildCustomTargets_InlineEmails(t *testing.T) {
 	origEmails := flagCustomEmails
 	origFile := flagCustomEmailFile
 	origGen := flagCustomGenerate
@@ -262,14 +240,19 @@ func TestBuildCustomSubjects_InlineEmails(t *testing.T) {
 	flagCustomEmailFile = ""
 	flagCustomGenerate = false
 
-	got, err := buildCustomSubjects()
+	got, err := buildCustomTargets()
 	require.NoError(t, err)
-	assert.Equal(t, []string{"alice", "bob", "charlie"}, got)
+	assert.Equal(t, []string{"alice", "bob", "charlie"}, targetEmails(got))
+	for i, target := range got {
+		assert.Empty(t, target.First, "target %d (%q): CLI-supplied address must have empty First", i, target.Email)
+		assert.Empty(t, target.Last, "target %d (%q): CLI-supplied address must have empty Last", i, target.Email)
+	}
 }
 
-// TestBuildCustomSubjects_EmailFile verifies the -E file path: subjects are
-// read one-per-line from the file.
-func TestBuildCustomSubjects_EmailFile(t *testing.T) {
+// TestBuildCustomTargets_EmailFile verifies the -E file path: subjects are
+// read one-per-line from the file and carry no name (file-supplied, not
+// generated).
+func TestBuildCustomTargets_EmailFile(t *testing.T) {
 	origEmails := flagCustomEmails
 	origFile := flagCustomEmailFile
 	origGen := flagCustomGenerate
@@ -290,14 +273,18 @@ func TestBuildCustomSubjects_EmailFile(t *testing.T) {
 	flagCustomEmailFile = tmp.Name()
 	flagCustomGenerate = false
 
-	got, err := buildCustomSubjects()
+	got, err := buildCustomTargets()
 	require.NoError(t, err)
-	assert.Equal(t, []string{"user1", "user2"}, got)
+	assert.Equal(t, []string{"user1", "user2"}, targetEmails(got))
+	for i, target := range got {
+		assert.Empty(t, target.First, "target %d (%q): file-supplied address must have empty First", i, target.Email)
+		assert.Empty(t, target.Last, "target %d (%q): file-supplied address must have empty Last", i, target.Email)
+	}
 }
 
-// TestBuildCustomSubjects_Dedupe verifies that buildCustomSubjects de-duplicates
-// subjects supplied via -e, preserving first-seen order.
-func TestBuildCustomSubjects_Dedupe(t *testing.T) {
+// TestBuildCustomTargets_Dedupe verifies that buildCustomTargets de-duplicates
+// on Email for subjects supplied via -e, preserving first-seen order.
+func TestBuildCustomTargets_Dedupe(t *testing.T) {
 	origEmails := flagCustomEmails
 	origFile := flagCustomEmailFile
 	origGen := flagCustomGenerate
@@ -312,19 +299,19 @@ func TestBuildCustomSubjects_Dedupe(t *testing.T) {
 	flagCustomEmailFile = ""
 	flagCustomGenerate = false
 
-	got, err := buildCustomSubjects()
+	got, err := buildCustomTargets()
 	require.NoError(t, err)
-	assert.Equal(t, []string{"alice", "bob", "charlie"}, got)
+	assert.Equal(t, []string{"alice", "bob", "charlie"}, targetEmails(got))
 }
 
-// TestBuildCustomSubjects_ConstraintRateLimitDefault verifies that the spec's
+// TestBuildCustomTargets_ConstraintRateLimitDefault verifies that the spec's
 // constraints.rate_limit_rps is applied to the enum config as a default only
 // when --rate-limit has not been set by the operator (isFlagChanged is false).
 //
-// buildCustomSubjects itself does not apply the rate-limit — that logic lives
+// buildCustomTargets itself does not apply the rate-limit — that logic lives
 // in runEnumCustom. This test verifies the constraint field is accessible via
 // the Spec type (it's the glue the command wires up).
-func TestBuildCustomSubjects_ConstraintRateLimitDefault(t *testing.T) {
+func TestBuildCustomTargets_ConstraintRateLimitDefault(t *testing.T) {
 	const constraintRPS = `{
 		"version": "1",
 		"oracle": {
@@ -347,7 +334,7 @@ func TestBuildCustomSubjects_ConstraintRateLimitDefault(t *testing.T) {
 	assert.Equal(t, 5.0, spec.Constraints.RateLimitRPS,
 		"Constraints.RateLimitRPS must equal the spec value (5.0)")
 
-	// Also verify buildCustomSubjects succeeds with a subject supplied via CLI.
+	// Also verify buildCustomTargets succeeds with a subject supplied via CLI.
 	origEmails := flagCustomEmails
 	origFile := flagCustomEmailFile
 	origGen := flagCustomGenerate
@@ -360,9 +347,181 @@ func TestBuildCustomSubjects_ConstraintRateLimitDefault(t *testing.T) {
 	flagCustomEmailFile = ""
 	flagCustomGenerate = false
 
-	got, err := buildCustomSubjects()
+	got, err := buildCustomTargets()
 	require.NoError(t, err)
-	assert.Equal(t, []string{"seed@example.com"}, got)
+	assert.Equal(t, []string{"seed@example.com"}, targetEmails(got))
+	require.Len(t, got, 1)
+	assert.Empty(t, got[0].First, "CLI-supplied address must have empty First")
+	assert.Empty(t, got[0].Last, "CLI-supplied address must have empty Last")
+}
+
+// TestBuildCustomTargets_GeneratedNoDomain is THE POINT OF 10T-535 for this
+// command: with --generate and no --domain, buildCustomTargets must build
+// Target{Email: c.Username, First: c.First, Last: c.Last} directly rather
+// than going through Candidate.Target(domain) — appending "@" to a bare
+// username would be wrong. This pins that no-domain branch: every generated
+// Target's Email is the bare username (no "@"), and First/Last are non-empty,
+// carrying the name the generator actually used.
+func TestBuildCustomTargets_GeneratedNoDomain(t *testing.T) {
+	origEmails := flagCustomEmails
+	origFile := flagCustomEmailFile
+	origGen := flagCustomGenerate
+	origFormat := flagEnumFormat
+	origDomain := flagEnumDomain
+	t.Cleanup(func() {
+		flagCustomEmails = origEmails
+		flagCustomEmailFile = origFile
+		flagCustomGenerate = origGen
+		flagEnumFormat = origFormat
+		flagEnumDomain = origDomain
+	})
+
+	flagCustomEmails = ""
+	flagCustomEmailFile = ""
+	flagCustomGenerate = true
+	flagEnumFormat = enum.FormatFirstDotLast
+	flagEnumDomain = ""
+
+	got, err := buildCustomTargets()
+	require.NoError(t, err)
+	require.NotEmpty(t, got)
+
+	// Compare against the real generator output (not a reimplementation) so
+	// this fails if generateCustomTargets ever diverges from GenerateCandidates.
+	candidates, genErr := enum.GenerateCandidates(enum.FormatFirstDotLast)
+	require.NoError(t, genErr)
+	require.Len(t, got, len(candidates),
+		"no-domain generation must produce exactly one target per candidate")
+
+	for i, c := range candidates {
+		assert.Equal(t, c.Username, got[i].Email,
+			"target %d: Email must be the bare username (no domain) when --domain is unset", i)
+		assert.NotContains(t, got[i].Email, "@",
+			"target %d: no-domain Email must not contain '@'", i)
+		assert.Equal(t, c.First, got[i].First, "target %d: First must match the generated candidate", i)
+		assert.Equal(t, c.Last, got[i].Last, "target %d: Last must match the generated candidate", i)
+		require.NotEmpty(t, got[i].First, "target %d: generated First must be non-empty", i)
+		require.NotEmpty(t, got[i].Last, "target %d: generated Last must be non-empty", i)
+	}
+}
+
+// TestBuildCustomTargets_GeneratedWithDomain verifies the --generate +
+// --domain branch: buildCustomTargets must build each Target via
+// Candidate.Target(domain), so Email is "username@domain" and First/Last are
+// still populated from the candidate.
+func TestBuildCustomTargets_GeneratedWithDomain(t *testing.T) {
+	origEmails := flagCustomEmails
+	origFile := flagCustomEmailFile
+	origGen := flagCustomGenerate
+	origFormat := flagEnumFormat
+	origDomain := flagEnumDomain
+	t.Cleanup(func() {
+		flagCustomEmails = origEmails
+		flagCustomEmailFile = origFile
+		flagCustomGenerate = origGen
+		flagEnumFormat = origFormat
+		flagEnumDomain = origDomain
+	})
+
+	const domain = "example.com"
+	flagCustomEmails = ""
+	flagCustomEmailFile = ""
+	flagCustomGenerate = true
+	flagEnumFormat = enum.FormatFirstDotLast
+	flagEnumDomain = domain
+
+	got, err := buildCustomTargets()
+	require.NoError(t, err)
+	require.NotEmpty(t, got)
+
+	candidates, genErr := enum.GenerateCandidates(enum.FormatFirstDotLast)
+	require.NoError(t, genErr)
+	require.Len(t, got, len(candidates),
+		"with-domain generation must produce exactly one target per candidate")
+
+	for i, c := range candidates {
+		assert.Equal(t, c.Target(domain), got[i],
+			"target %d: must equal Candidate.Target(domain) exactly", i)
+		assert.True(t, strings.HasSuffix(got[i].Email, "@"+domain),
+			"target %d: with-domain Email must end with @%s", i, domain)
+		require.NotEmpty(t, got[i].First, "target %d: generated First must be non-empty", i)
+		require.NotEmpty(t, got[i].Last, "target %d: generated Last must be non-empty", i)
+	}
+}
+
+// TestBuildCustomTargets_MergeDedupePrecedence covers the merge, the dedup,
+// the first-seen order, and the precedence between a file-supplied address
+// and a generated one, all in a single scenario: -E supplies the exact
+// address that --generate would also produce as its #1-ranked candidate
+// ("john.smith", from FormatFirstDotLast's top-ranked pair — pinned by
+// TestGenerateUsernames_FirstDotLast in pkg/enum/generate_test.go).
+//
+//   - Merge: the result contains both the -E entry and the --generate entries.
+//   - Order: -E is appended before --generate (source order), so the
+//     file-supplied "john.smith" occupies index 0.
+//   - Dedupe: the generated candidate that would also produce "john.smith" is
+//     dropped as a duplicate, not appended a second time.
+//   - Precedence: the surviving "john.smith" target is the file-supplied one
+//     (empty First/Last) — first-seen wins, so a generated duplicate can never
+//     retroactively attach a name to an address the operator supplied.
+func TestBuildCustomTargets_MergeDedupePrecedence(t *testing.T) {
+	origEmails := flagCustomEmails
+	origFile := flagCustomEmailFile
+	origGen := flagCustomGenerate
+	origFormat := flagEnumFormat
+	origDomain := flagEnumDomain
+	t.Cleanup(func() {
+		flagCustomEmails = origEmails
+		flagCustomEmailFile = origFile
+		flagCustomGenerate = origGen
+		flagEnumFormat = origFormat
+		flagEnumDomain = origDomain
+	})
+
+	// Write a one-line subject file containing the #1-ranked generated
+	// username, so it collides with the first generated candidate.
+	tmp, err := os.CreateTemp(t.TempDir(), "collide-*.txt")
+	require.NoError(t, err)
+	_, err = tmp.WriteString("john.smith\n")
+	require.NoError(t, err)
+	require.NoError(t, tmp.Close())
+
+	flagCustomEmails = ""
+	flagCustomEmailFile = tmp.Name()
+	flagCustomGenerate = true
+	flagEnumFormat = enum.FormatFirstDotLast
+	flagEnumDomain = ""
+
+	got, err := buildCustomTargets()
+	require.NoError(t, err)
+	require.NotEmpty(t, got)
+
+	candidates, genErr := enum.GenerateCandidates(enum.FormatFirstDotLast)
+	require.NoError(t, genErr)
+	require.Equal(t, "john.smith", candidates[0].Username,
+		"test assumption: FormatFirstDotLast's #1-ranked candidate must be john.smith")
+
+	// Merge + dedupe: exactly one target per unique candidate — the collision
+	// on "john.smith" means the file entry and the #1 candidate collapse to
+	// one target, so the total count equals len(candidates), not len+1.
+	assert.Len(t, got, len(candidates),
+		"merge+dedupe: file-supplied duplicate of the #1 candidate must not double-count")
+
+	// Order + precedence: index 0 is the file-supplied "john.smith", unnamed —
+	// not the generated candidate that would also produce it.
+	require.Equal(t, "john.smith", got[0].Email)
+	assert.Empty(t, got[0].First,
+		"precedence: file-supplied address must win over the colliding generated one — First must stay empty")
+	assert.Empty(t, got[0].Last,
+		"precedence: file-supplied address must win over the colliding generated one — Last must stay empty")
+
+	// Every remaining target came only from --generate (no other collisions
+	// are possible: GenerateCandidates guarantees unique usernames), so each
+	// must carry a name.
+	for i := 1; i < len(got); i++ {
+		assert.NotEmpty(t, got[i].First, "target %d (%q): generated target must have non-empty First", i, got[i].Email)
+		assert.NotEmpty(t, got[i].Last, "target %d (%q): generated target must have non-empty Last", i, got[i].Email)
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/brutus/cmd_enum_oracles.go
+++ b/cmd/brutus/cmd_enum_oracles.go
@@ -235,15 +235,16 @@ func runEnumOracles(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Phase 2: Build email list
-	var emails []string
+	// Phase 2: Build target list. Addresses supplied via -e/-E are nameless;
+	// generated ones carry the name they were built from.
+	var targets []enum.Target
 
 	// From --emails flag
 	if flagOraclesEmails != "" {
 		for _, e := range strings.Split(flagOraclesEmails, ",") {
 			e = strings.TrimSpace(e)
 			if e != "" {
-				emails = append(emails, e)
+				targets = append(targets, enum.Target{Email: e})
 			}
 		}
 	}
@@ -254,7 +255,9 @@ func runEnumOracles(cmd *cobra.Command, args []string) error {
 		if loadErr != nil {
 			return fmt.Errorf("loading email file: %w", loadErr)
 		}
-		emails = append(emails, fileEmails...)
+		for _, e := range fileEmails {
+			targets = append(targets, enum.Target{Email: e})
+		}
 	}
 
 	// From --generate flag
@@ -266,18 +269,20 @@ func runEnumOracles(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(os.Stderr, "%s Generating emails with format %q for %s...\n",
 				dim(useColor, SymbolInfo), flagEnumFormat, flagEnumDomain)
 		}
-		generated, genErr := enum.GenerateEmails(flagEnumFormat, flagEnumDomain)
+		candidates, genErr := enum.GenerateCandidates(flagEnumFormat)
 		if genErr != nil {
 			return fmt.Errorf("generating emails: %w", genErr)
 		}
-		logVerbose(flagVerbose, "Generated %d emails", len(generated))
-		emails = append(emails, generated...)
+		logVerbose(flagVerbose, "Generated %d emails", len(candidates))
+		for _, c := range candidates {
+			targets = append(targets, c.Target(flagEnumDomain))
+		}
 	}
 
 	// Determine the oracle-check label up front: the domain when provided,
 	// otherwise the explicit targets, so the Oracle Check block can announce
 	// what was checked even when there are no emails to enumerate.
-	checkLabel := oracleCheckLabel(emails)
+	checkLabel := oracleCheckLabel(targets)
 
 	// Phase 3: Determine oracles to check
 	var services []string
@@ -325,7 +330,7 @@ func runEnumOracles(cmd *cobra.Command, args []string) error {
 		}
 
 		validCfg := &enum.Config{
-			Emails:   []string{flagOraclesKnownValid},
+			Targets:  []enum.Target{{Email: flagOraclesKnownValid}},
 			Services: svcList,
 			Threads:  flagThreads,
 			Timeout:  flagTimeout,
@@ -362,7 +367,7 @@ func runEnumOracles(cmd *cobra.Command, args []string) error {
 
 			// If there are no emails to enumerate, the oracle check IS the
 			// output: emit the JSON results and return without enumerating.
-			if len(emails) == 0 {
+			if len(targets) == 0 {
 				if flagJSON {
 					if dnsResult != nil {
 						outputDNSReconJSONL(jsonWriter, dnsResult, teamsOracleAvailable(dnsResult))
@@ -386,7 +391,7 @@ func runEnumOracles(cmd *cobra.Command, args []string) error {
 
 	// If there were no oracles to check at all and no emails, there is nothing
 	// left to do beyond the DNS recon already surfaced above.
-	if len(emails) == 0 {
+	if len(targets) == 0 {
 		if dnsResult != nil && flagJSON {
 			outputDNSReconJSONL(jsonWriter, dnsResult, teamsOracleAvailable(dnsResult))
 		}
@@ -402,12 +407,12 @@ func runEnumOracles(cmd *cobra.Command, args []string) error {
 			svcNames = enum.ListPlugins()
 		}
 		fmt.Fprintf(os.Stderr, "%s Enumerating %d email(s) against %d working oracle(s): %s\n",
-			dim(useColor, SymbolInfo), len(emails), len(svcNames), strings.Join(svcNames, ", "))
+			dim(useColor, SymbolInfo), len(targets), len(svcNames), strings.Join(svcNames, ", "))
 	}
 
 	// Phase 4: Run enumeration against the working oracles
 	cfg := &enum.Config{
-		Emails:    emails,
+		Targets:   targets,
 		Services:  services,
 		Threads:   flagThreads,
 		Timeout:   flagTimeout,
@@ -513,7 +518,7 @@ func runEnumDiscover(cmd *cobra.Command, args []string) error {
 
 		// Phase 2: Test oracles
 		cfg := &enum.Config{
-			Emails:   []string{flagOraclesKnownValid},
+			Targets:  []enum.Target{{Email: flagOraclesKnownValid}},
 			Services: services,
 			Threads:  flagThreads,
 			Timeout:  flagTimeout,
@@ -684,12 +689,16 @@ func outputDiscoverTeamsJSONL(w io.Writer, statusLine string) {
 
 // oracleCheckLabel returns the label for the Oracle Check header: the --domain
 // when one was provided, otherwise a compact list of the explicit email targets.
-func oracleCheckLabel(emails []string) string {
+func oracleCheckLabel(targets []enum.Target) string {
 	if flagEnumDomain != "" {
 		return flagEnumDomain
 	}
-	if len(emails) > 0 {
-		return strings.Join(emails, ", ")
+	if len(targets) > 0 {
+		addrs := make([]string, len(targets))
+		for i, t := range targets {
+			addrs[i] = t.Email
+		}
+		return strings.Join(addrs, ", ")
 	}
 	return "(no targets)"
 }

--- a/pkg/enum/custom/plugin_test.go
+++ b/pkg/enum/custom/plugin_test.go
@@ -314,7 +314,7 @@ func TestE2E_ForgotPassword(t *testing.T) {
 	results, enumErr := enum.EnumerateWithPlugin(
 		context.Background(),
 		&enum.Config{
-			Emails:  []string{"jsmith", "nobody"},
+			Targets: []enum.Target{{Email: "jsmith"}, {Email: "nobody"}},
 			Threads: 2,
 			Timeout: 5 * time.Second,
 		},

--- a/pkg/enum/enum.go
+++ b/pkg/enum/enum.go
@@ -22,9 +22,27 @@ import (
 	"time"
 )
 
+// Target is an address to check, plus the name it was generated from.
+//
+// Address and name travel together deliberately. brutus generates most of the
+// addresses it checks, and at generation time it already knows the name behind
+// each one (see Candidate). Passing addresses alone would force consumers to
+// reverse-derive the name from the local part, which is lossy for
+// initial-based formats — "jsmith" could be John, James, or Jane. Keeping the
+// two in one value means a name can never desync from its address.
+//
+// First/Last are empty when the address was supplied by the operator (--emails
+// or --email-file) rather than generated: a supplied address says nothing about
+// whose it is, and the framework must not invent one.
+type Target struct {
+	Email string
+	First string // empty when the address was supplied rather than generated
+	Last  string
+}
+
 // Config defines the configuration for account enumeration.
 type Config struct {
-	Emails    []string      // emails to enumerate
+	Targets   []Target      // addresses to enumerate, with generated names when known
 	Services  []string      // service names to check (empty = all registered)
 	Threads   int           // concurrent workers (default: 10)
 	Timeout   time.Duration // per-check timeout (default: 10s)
@@ -70,7 +88,7 @@ func ProxyURLFromContext(ctx context.Context) string {
 
 // validate checks the configuration and applies defaults.
 func (c *Config) validate() error {
-	if len(c.Emails) == 0 {
+	if len(c.Targets) == 0 {
 		return errors.New("emails required")
 	}
 	if c.Threads < 0 {

--- a/pkg/enum/generate.go
+++ b/pkg/enum/generate.go
@@ -90,6 +90,17 @@ func (c Candidate) Email(domain string) string {
 	return c.Username + "@" + domain
 }
 
+// Target converts a generated Candidate into a Target for domain, carrying the
+// name the username was built from so the enumeration framework can stamp it
+// onto each Result.
+func (c Candidate) Target(domain string) Target {
+	return Target{
+		Email: c.Email(domain),
+		First: c.First,
+		Last:  c.Last,
+	}
+}
+
 // GenerateCandidates derives usernames in the requested format from the
 // frequency-ranked likely-names wordlist, each paired with the name it was built
 // from. Each source line is a "first.last" pair; the requested format is built

--- a/pkg/enum/generate_test.go
+++ b/pkg/enum/generate_test.go
@@ -679,3 +679,88 @@ func TestGenerateCandidates_AllFormatsPopulated(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// 10T-535: Candidate.Target
+//
+// Target carries a generated (or supplied) email together with the name it
+// was built from, all the way through the enumeration framework to Result,
+// so consumers never need to reverse-derive a name from an address (the
+// "jsmith" could be John/James/Jane problem). Candidate.Target(domain) is the
+// conversion point from generator output to framework input.
+// ---------------------------------------------------------------------------
+
+// TestCandidate_Target verifies that Candidate.Target(domain) produces an
+// Email identical to Candidate.Email(domain), and carries First/Last through
+// unchanged. Table-driven over several Candidate shapes.
+func TestCandidate_Target(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		candidate Candidate
+		domain    string
+	}{
+		{
+			name:      "simple",
+			candidate: Candidate{First: "john", Last: "smith", Username: "jsmith"},
+			domain:    "example.com",
+		},
+		{
+			name:      "dotted username and multi-label domain",
+			candidate: Candidate{First: "john", Last: "smith", Username: "john.smith"},
+			domain:    "corp.example.co.uk",
+		},
+		{
+			name:      "dotted last name preserved",
+			candidate: Candidate{First: "abdullah", Last: "al.mamun", Username: "abdullah.al.mamun"},
+			domain:    "fox.com",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			target := tc.candidate.Target(tc.domain)
+
+			assert.Equal(t, tc.candidate.Email(tc.domain), target.Email,
+				"Target.Email must equal Candidate.Email(domain)")
+			assert.Equal(t, tc.candidate.First, target.First,
+				"Target.First must carry Candidate.First unchanged")
+			assert.Equal(t, tc.candidate.Last, target.Last,
+				"Target.Last must carry Candidate.Last unchanged")
+		})
+	}
+}
+
+// TestGenerateCandidates_TargetRoundTrip verifies the GenerateCandidates ->
+// .Target(domain) round trip for a real format: every resulting Target has
+// non-empty First, Last, and Email, and Email matches the corresponding
+// GenerateEmails entry at the same index (order preserved).
+func TestGenerateCandidates_TargetRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	const domain = "example.com"
+
+	candidates, err := GenerateCandidates(FormatFirstDotLast)
+	require.NoError(t, err)
+	require.NotEmpty(t, candidates)
+
+	emails, err := GenerateEmails(FormatFirstDotLast, domain)
+	require.NoError(t, err)
+	require.Equal(t, len(candidates), len(emails),
+		"GenerateCandidates and GenerateEmails must produce the same count")
+
+	for i, c := range candidates {
+		target := c.Target(domain)
+
+		require.NotEmpty(t, target.Email, "candidate %d: Target.Email must not be empty", i)
+		require.NotEmpty(t, target.First, "candidate %d: Target.First must not be empty", i)
+		require.NotEmpty(t, target.Last, "candidate %d: Target.Last must not be empty", i)
+
+		assert.Equal(t, emails[i], target.Email,
+			"candidate %d: Target.Email must match GenerateEmails[%d] (order preserved)", i, i)
+	}
+}

--- a/pkg/enum/plugin.go
+++ b/pkg/enum/plugin.go
@@ -40,6 +40,8 @@ const (
 type Result struct {
 	Service    string        // service name (e.g., "microsoft365")
 	Email      string        // email tested
+	First      string        // generated given name; empty if the address was supplied
+	Last       string        // generated surname; empty if the address was supplied
 	Exists     bool          // account exists on this service?
 	Confidence Confidence    // high/medium/low
 	Error      error         // service/connection error (nil = clean check)

--- a/pkg/enum/runner.go
+++ b/pkg/enum/runner.go
@@ -20,9 +20,13 @@ import (
 	"errors"
 )
 
-// EnumerateWithPlugin runs cfg.Emails against a single provided Plugin instance,
-// bypassing the registry. It is used by runtime-constructed oracles (e.g. the
-// custom declarative oracle) that are not registered globally.
+// EnumerateWithPlugin runs cfg.Targets against a single provided Plugin
+// instance, bypassing the registry. It is used by runtime-constructed oracles
+// (e.g. the custom declarative oracle) that are not registered globally.
+//
+// Each Target's First/Last is stamped onto the Result it produced, on every
+// path including errors and panics. The Plugin itself only ever sees the
+// email — see runTasks.
 //
 // The same Plugin instance is shared across all goroutines, so the Plugin MUST
 // be stateless (enum.Plugin contract). cfg.Services is ignored.
@@ -37,10 +41,12 @@ func EnumerateWithPlugin(ctx context.Context, cfg *Config, p Plugin) ([]Result, 
 		return nil, err
 	}
 
-	tasks := make([]enumTask, 0, len(cfg.Emails))
-	for _, subject := range cfg.Emails {
+	tasks := make([]enumTask, 0, len(cfg.Targets))
+	for _, subject := range cfg.Targets {
 		tasks = append(tasks, enumTask{
-			email:   subject,
+			email:   subject.Email,
+			first:   subject.First,
+			last:    subject.Last,
 			service: p.Name(),
 			plugin:  p,
 		})

--- a/pkg/enum/runner_test.go
+++ b/pkg/enum/runner_test.go
@@ -16,6 +16,8 @@ package enum
 
 import (
 	"context"
+	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -53,7 +55,7 @@ func TestEnumerateWithPlugin_FanOut(t *testing.T) {
 	p := &stubPlugin{name: "stub-oracle", exists: true}
 
 	results, err := EnumerateWithPlugin(context.Background(), &Config{
-		Emails:  []string{"a", "b", "c"},
+		Targets: []Target{{Email: "a"}, {Email: "b"}, {Email: "c"}},
 		Threads: 2,
 		Timeout: 5 * time.Second,
 	}, p)
@@ -85,7 +87,7 @@ func TestEnumerateWithPlugin_EmptyEmails(t *testing.T) {
 	p := &stubPlugin{name: "stub", exists: true}
 
 	_, err := EnumerateWithPlugin(context.Background(), &Config{
-		Emails:  []string{},
+		Targets: []Target{},
 		Threads: 2,
 	}, p)
 
@@ -101,7 +103,7 @@ func TestEnumerateWithPlugin_AbsentResult(t *testing.T) {
 	p := &stubPlugin{name: "absent-oracle", exists: false}
 
 	results, err := EnumerateWithPlugin(context.Background(), &Config{
-		Emails:  []string{"user1", "user2"},
+		Targets: []Target{{Email: "user1"}, {Email: "user2"}},
 		Threads: 1,
 		Timeout: 5 * time.Second,
 	}, p)
@@ -122,7 +124,7 @@ func TestEnumerateWithPlugin_ServiceNameFromPlugin(t *testing.T) {
 	p := &stubPlugin{name: "my-custom-oracle", exists: true}
 
 	results, err := EnumerateWithPlugin(context.Background(), &Config{
-		Emails:  []string{"test@example.com"},
+		Targets: []Target{{Email: "test@example.com"}},
 		Threads: 1,
 		Timeout: 5 * time.Second,
 	}, p)
@@ -139,11 +141,224 @@ func TestEnumerateWithPlugin_SingleThread(t *testing.T) {
 	p := &stubPlugin{name: "single-thread-oracle", exists: true}
 
 	results, err := EnumerateWithPlugin(context.Background(), &Config{
-		Emails:  []string{"a", "b", "c", "d", "e"},
+		Targets: []Target{{Email: "a"}, {Email: "b"}, {Email: "c"}, {Email: "d"}, {Email: "e"}},
 		Threads: 1,
 		Timeout: 5 * time.Second,
 	}, p)
 
 	require.NoError(t, err)
 	require.Len(t, results, 5, "single-threaded must still produce all results")
+}
+
+// ---------------------------------------------------------------------------
+// 10T-535: EnumerateWithPlugin name propagation (framework half)
+//
+// The generator (Candidate.Target) already knows First/Last. This section
+// verifies the framework carries that name through to Result without
+// disturbing what the Plugin interface sees, and without ever inventing a
+// name for a Target that didn't have one.
+// ---------------------------------------------------------------------------
+
+// recordingPlugin is a stub Plugin that records every email it was asked to
+// Check, so tests can assert exactly what the framework passed into the
+// Plugin contract. Safe for concurrent use: checked is protected by mu.
+type recordingPlugin struct {
+	name   string
+	exists bool
+
+	mu      sync.Mutex
+	checked []string
+}
+
+func (r *recordingPlugin) Name() string { return r.name }
+
+func (r *recordingPlugin) Check(_ context.Context, email string, _ time.Duration) *Result {
+	r.mu.Lock()
+	r.checked = append(r.checked, email)
+	r.mu.Unlock()
+
+	return &Result{
+		Service:    r.name,
+		Email:      email,
+		Exists:     r.exists,
+		Confidence: ConfidenceHigh,
+	}
+}
+
+// erroringPlugin is a stub Plugin that always returns a service error from
+// Check, used to verify that name-stamping survives the error path.
+type erroringPlugin struct {
+	name string
+}
+
+func (e *erroringPlugin) Name() string { return e.name }
+
+func (e *erroringPlugin) Check(_ context.Context, email string, _ time.Duration) *Result {
+	return &Result{
+		Service: e.name,
+		Email:   email,
+		Error:   errors.New("service unavailable"),
+	}
+}
+
+// TestEnumerateWithPlugin_NameCorrelation is THE CORE TEST for the framework
+// half of 10T-535: EnumerateWithPlugin must stamp each Result with the
+// First/Last of the Target that actually produced it, not just "some" name
+// drawn from the batch. Using >=2 targets with DIFFERENT names is
+// deliberate — a bug that stamped every Result with (say) the first
+// target's name would still make a weaker "a name is present" assertion
+// pass, but fails this one because each result is correlated back to its
+// originating Target by Email.
+//
+// Correlating by Email rather than by result index is deliberate: neither
+// TestEnumerateWithPlugin_FanOut nor TestEnumerateWithPlugin_SingleThread
+// assert anything about result order (FanOut checks membership via a map;
+// SingleThread only checks length), because runTasks appends results from
+// concurrent goroutines under a mutex with no ordering guarantee relative to
+// submission order. This test follows that same established expectation.
+func TestEnumerateWithPlugin_NameCorrelation(t *testing.T) {
+	t.Parallel()
+	p := &stubPlugin{name: "name-oracle", exists: true}
+
+	targets := []Target{
+		{Email: "alice@example.com", First: "Alice", Last: "Anderson"},
+		{Email: "bob@example.com", First: "Bob", Last: "Baker"},
+	}
+
+	results, err := EnumerateWithPlugin(context.Background(), &Config{
+		Targets: targets,
+		Threads: 2,
+		Timeout: 5 * time.Second,
+	}, p)
+
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	byEmail := make(map[string]Result, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	aliceResult, ok := byEmail["alice@example.com"]
+	require.True(t, ok, "result for alice@example.com must be present")
+	assert.Equal(t, "Alice", aliceResult.First, "alice's result must carry Alice's First, not another target's")
+	assert.Equal(t, "Anderson", aliceResult.Last, "alice's result must carry Alice's Last, not another target's")
+
+	bobResult, ok := byEmail["bob@example.com"]
+	require.True(t, ok, "result for bob@example.com must be present")
+	assert.Equal(t, "Bob", bobResult.First, "bob's result must carry Bob's First, not another target's")
+	assert.Equal(t, "Baker", bobResult.Last, "bob's result must carry Bob's Last, not another target's")
+}
+
+// TestEnumerateWithPlugin_EmptyNameYieldsEmptyResult verifies that a Target
+// with no First/Last (the --email-file case: an address supplied directly
+// rather than generated) produces a Result with empty First/Last. The
+// framework must not invent or derive a name when the Target didn't carry
+// one.
+func TestEnumerateWithPlugin_EmptyNameYieldsEmptyResult(t *testing.T) {
+	t.Parallel()
+	p := &stubPlugin{name: "supplied-oracle", exists: true}
+
+	results, err := EnumerateWithPlugin(context.Background(), &Config{
+		Targets: []Target{{Email: "supplied@example.com"}},
+		Threads: 1,
+		Timeout: 5 * time.Second,
+	}, p)
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "supplied@example.com", results[0].Email)
+	assert.Empty(t, results[0].First, "First must be empty for a supplied (non-generated) address")
+	assert.Empty(t, results[0].Last, "Last must be empty for a supplied (non-generated) address")
+}
+
+// TestEnumerateWithPlugin_MixedNamedAndUnnamed verifies that in a batch
+// containing both generated (named) and supplied (unnamed) targets, each
+// Result carries exactly what its own Target had — no cross-contamination
+// in either direction.
+func TestEnumerateWithPlugin_MixedNamedAndUnnamed(t *testing.T) {
+	t.Parallel()
+	p := &stubPlugin{name: "mixed-oracle", exists: true}
+
+	targets := []Target{
+		{Email: "named@example.com", First: "Carol", Last: "Chen"},
+		{Email: "unnamed@example.com"},
+	}
+
+	results, err := EnumerateWithPlugin(context.Background(), &Config{
+		Targets: targets,
+		Threads: 2,
+		Timeout: 5 * time.Second,
+	}, p)
+
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	byEmail := make(map[string]Result, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	named, ok := byEmail["named@example.com"]
+	require.True(t, ok, "result for named@example.com must be present")
+	assert.Equal(t, "Carol", named.First, "named target's result must carry its First")
+	assert.Equal(t, "Chen", named.Last, "named target's result must carry its Last")
+
+	unnamed, ok := byEmail["unnamed@example.com"]
+	require.True(t, ok, "result for unnamed@example.com must be present")
+	assert.Empty(t, unnamed.First, "unnamed target's result must not have an invented First")
+	assert.Empty(t, unnamed.Last, "unnamed target's result must not have an invented Last")
+}
+
+// TestEnumerateWithPlugin_PluginReceivesOnlyEmail verifies that the Plugin
+// interface is unaffected by name propagation: the fake plugin in this
+// harness observes only the email string passed to Check, proving the
+// framework attaches First/Last to the Result AFTER Check returns rather
+// than threading names into the Plugin contract. No per-service checker
+// needs to know about names.
+func TestEnumerateWithPlugin_PluginReceivesOnlyEmail(t *testing.T) {
+	t.Parallel()
+	p := &recordingPlugin{name: "recording-oracle", exists: true}
+
+	targets := []Target{
+		{Email: "dana@example.com", First: "Dana", Last: "Diaz"},
+		{Email: "erin@example.com"},
+	}
+
+	results, err := EnumerateWithPlugin(context.Background(), &Config{
+		Targets: targets,
+		Threads: 2,
+		Timeout: 5 * time.Second,
+	}, p)
+
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	p.mu.Lock()
+	checked := append([]string(nil), p.checked...)
+	p.mu.Unlock()
+
+	assert.ElementsMatch(t, []string{"dana@example.com", "erin@example.com"}, checked,
+		"plugin must observe exactly the target emails and nothing else — the name path is additive")
+}
+
+// TestEnumerateWithPlugin_ErrorPathPreservesName verifies that name-stamping
+// survives the error path: a Target whose Check returns a service error
+// still gets First/Last on its Result. The name is a property of the
+// address being checked, not of the check outcome.
+func TestEnumerateWithPlugin_ErrorPathPreservesName(t *testing.T) {
+	t.Parallel()
+	p := &erroringPlugin{name: "erroring-oracle"}
+
+	results, err := EnumerateWithPlugin(context.Background(), &Config{
+		Targets: []Target{{Email: "failing@example.com", First: "Frank", Last: "Foster"}},
+		Threads: 1,
+		Timeout: 5 * time.Second,
+	}, p)
+
+	require.NoError(t, err, "EnumerateWithPlugin itself must not error for a per-check service error")
+	require.Len(t, results, 1)
+	assert.Error(t, results[0].Error, "result must carry the service error")
+	assert.Equal(t, "Frank", results[0].First, "name must be stamped even when the check errored")
+	assert.Equal(t, "Foster", results[0].Last, "name must be stamped even when the check errored")
 }

--- a/pkg/enum/workers.go
+++ b/pkg/enum/workers.go
@@ -29,8 +29,14 @@ import (
 )
 
 // enumTask represents a single enumeration check to perform.
+//
+// first/last carry the name the email was generated from (empty for supplied
+// addresses) so runTasks can stamp it onto the resulting Result. They are
+// never passed to the Plugin.
 type enumTask struct {
 	email   string
+	first   string
+	last    string
 	service string
 	plugin  Plugin
 }
@@ -44,16 +50,18 @@ func runWorkers(ctx context.Context, cfg *Config) ([]Result, error) {
 		services = ListPlugins()
 	}
 
-	// Build task list: emails x services
+	// Build task list: targets x services
 	var tasks []enumTask
-	for _, email := range cfg.Emails {
+	for _, target := range cfg.Targets {
 		for _, svcName := range services {
 			plug, err := GetPlugin(svcName)
 			if err != nil {
 				return nil, fmt.Errorf("resolving service %q: %w", svcName, err)
 			}
 			tasks = append(tasks, enumTask{
-				email:   email,
+				email:   target.Email,
+				first:   target.First,
+				last:    target.Last,
 				service: svcName,
 				plugin:  plug,
 			})
@@ -114,6 +122,8 @@ func runTasks(ctx context.Context, cfg *Config, tasks []enumTask) ([]Result, err
 					results = append(results, Result{
 						Service: task.service,
 						Email:   task.email,
+						First:   task.first,
+						Last:    task.last,
 						Error:   fmt.Errorf("plugin panicked: %v", r),
 					})
 					mu.Unlock()
@@ -141,7 +151,9 @@ func runTasks(ctx context.Context, cfg *Config, tasks []enumTask) ([]Result, err
 				}
 			}
 
-			// Execute check
+			// Execute check. The Plugin receives only the email — names are
+			// stamped on afterwards, which is what keeps the Plugin interface
+			// (and every per-service checker) unaware of them.
 			result := task.plugin.Check(ctx, task.email, cfg.Timeout)
 			if result == nil {
 				result = &Result{
@@ -150,6 +162,13 @@ func runTasks(ctx context.Context, cfg *Config, tasks []enumTask) ([]Result, err
 					Error:   fmt.Errorf("plugin returned nil result"),
 				}
 			}
+
+			// Stamp the generated name onto the result. A name is a property of
+			// the address, not of the check outcome, so this applies on every
+			// path: clean checks, plugin errors, and the nil-result substitute
+			// above (the panic path stamps it in the deferred recover).
+			result.First = task.first
+			result.Last = task.last
 
 			if cfg.Verbose && result.Error != nil {
 				fmt.Fprintf(os.Stderr, "enum: error checking %s on %s: %v\n",


### PR DESCRIPTION
Second of two for 10T-535. **Stacked on #299** — review that one first; this branch contains its commit.

## What this buys

The generator knows the name behind every address it produces (#299). This carries that name to the `Result`, so a name brutus generated is **never reverse-derived** downstream.

Proven end to end against the real wordlist with the lossy `flast` format:

```
jsmith@example.com     First="john"     Last="smith"
dsmith@example.com     First="david"    Last="smith"
msmith@example.com     First="michael"  Last="smith"
supplied@example.com   First=""         Last=""
```

Three different first names collapse to the same initial pattern — `jsmith → john` is knowable only by carrying it, never by parsing it back out.

## Design: the Plugin interface does not change

```go
Check(ctx context.Context, email string, timeout time.Duration) *Result   // byte-identical
```

Plugins still receive only an email. The **framework** stamps the name onto the `Result` after `Check` returns, because it knows which `Target` produced that email. That's what lets all six per-service checkers stay untouched while every one of them gets names for free — `git status` on `pkg/enum/{github,google,microsoft365,teams,gravatar,kerberos}` is empty.

Stamping happens on **every** path — clean checks, plugin errors, the nil-result substitute, and the deferred panic recovery — because a name is a property of the address, not of the check outcome.

## The breaking change, and why it's the right one

```go
type Target struct {
    Email string
    First string   // empty when the address was supplied rather than generated
    Last  string
}

func (c Candidate) Target(domain string) Target

// Config.Emails []string  ->  Config.Targets []Target
```

The alternative was keeping `Emails` and adding a `map[email]name` beside it. That map can drift out of step with the address list, and preventing exactly that desync is the point of the ticket. One representation makes it impossible.

## Which inputs carry names — stated precisely

| Source | Named? | Why |
|---|---|---|
| `--generate` | **yes** | generation knows the pair behind each address |
| `--emails` / `-e` | no | a supplied address says nothing about whose it is |
| `--email-file` / `-E` | no | same |
| `--known-valid` | no | operator-supplied validation address |

The framework **never invents** a name — pinned by `TestEnumerateWithPlugin_EmptyNameYieldsEmptyResult` and `_MixedNamedAndUnnamed`.

This is also why `DeriveName` can't simply be deleted on the Guard side: supplied addresses genuinely have no name to propagate. What this removes is the need to derive for anything brutus generated, which is the actual defect.

The custom oracle carries names in **both** of its branches — a bare `Candidate.Username` when no `--domain` is set, and `Candidate.Target(domain)` when one is — so the no-domain path neither loses names nor gains a stray `@`.

## Result ordering is unchanged, deliberately

`runTasks` appends under a mutex from an `errgroup`, so completion order doesn't track submission order. No existing test asserted otherwise, and I didn't add a guarantee — the new tests correlate results to targets **by email**. Worth noting because index-based correlation would have been flaky *and* would have let a bug that stamps every result with the first target's name pass.

## Cleanup included

`buildCustomTargets` is now the single merger for the custom oracle (dedup on address, first-seen order preserved, so a surviving duplicate keeps the name that first produced it and a supplied address beats a generated one). The address-only `buildCustomSubjects` and its `dedupe` helper are **deleted** rather than left as a second merge implementation that could disagree with the first — which is the same desync failure mode this ticket exists to prevent.

Their tests weren't dropped: the custom-oracle merge cases were retargeted onto `buildCustomTargets`, and strengthened to assert that generated entries carry names while supplied entries do not. Three new cases cover the no-domain branch, the with-domain branch, and merge/dedup/precedence.

## Verification

```
go build ./...                       exit 0
go vet ./pkg/enum/... ./cmd/...      exit 0
go test ./... -count=1               whole repo green, no pre-existing failures
gofmt -l (all 11 changed files)      clean
```

Constraints held: `Plugin` interface unchanged, no per-service checker touched, no `First`/`Last` added to per-service `Result` structs or JSONL output.

## Follow-up, deliberately not here

Surfacing `First`/`Last` on the per-service `Result` structs and in the JSONL output (github/google/microsoft365/teams/gravatar) is a third change. It touches output that Guard parses, so the contract deserves agreement rather than being bundled in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
