### PR TITLE
feat(enum): carry generated names to Result and into JSONL output (10T-535)

### DIFF
--- a/cmd/brutus/cmd_enum.go
+++ b/cmd/brutus/cmd_enum.go
@@ -169,12 +169,48 @@ func runEnumGenerate(cmd *cobra.Command, args []string) error {
 }
 
 // capResults returns the first limit elements of results (the most likely,
-// since results are frequency-ranked). A limit <= 0 means no cap.
-func capResults(results []string, limit int) []string {
+// since results are frequency-ranked). A limit <= 0 means no cap. It is generic
+// so the same cap applies whether a command carries bare addresses or the
+// enum.Candidate/enum.Target values that keep each address's generated name.
+func capResults[T any](results []T, limit int) []T {
 	if limit <= 0 || limit >= len(results) {
 		return results
 	}
 	return results[:limit]
+}
+
+// enumTargetEmails returns just the addresses of targets, in order, for the
+// per-service checkers (which take a []string of addresses).
+func enumTargetEmails(targets []enum.Target) []string {
+	emails := make([]string, len(targets))
+	for i, t := range targets {
+		emails[i] = t.Email
+	}
+	return emails
+}
+
+// enumNamesByEmail indexes the GENERATED targets by address, so a per-service
+// Result can be stamped with the name behind its address once the check
+// returns. Addresses the operator supplied (--emails/--email-file) carry no
+// name and are deliberately omitted: a supplied address says nothing about
+// whose it is, so a lookup for one must yield nothing rather than a guess.
+func enumNamesByEmail(targets []enum.Target) map[string]enum.Target {
+	names := make(map[string]enum.Target, len(targets))
+	for _, t := range targets {
+		if t.First == "" && t.Last == "" {
+			continue
+		}
+		names[t.Email] = t
+	}
+	return names
+}
+
+// enumNameFor returns the generated name behind email, or empty strings when
+// the address was not generated. Nothing invents a name here: an address that
+// is absent from names simply has none.
+func enumNameFor(names map[string]enum.Target, email string) (first, last string) {
+	t := names[email]
+	return t.First, t.Last
 }
 
 // pageSizeForLimit derives an API page size from a --limit total cap: min(limit,100),

--- a/cmd/brutus/cmd_enum_custom.go
+++ b/cmd/brutus/cmd_enum_custom.go
@@ -88,11 +88,11 @@ func runEnumCustom(cmd *cobra.Command, args []string) error {
 	}
 	plugin := custom.New(spec)
 
-	subjects, err := buildCustomSubjects()
+	targets, err := buildCustomTargets()
 	if err != nil {
 		return err
 	}
-	if len(subjects) == 0 {
+	if len(targets) == 0 {
 		return fmt.Errorf("no subjects: provide -e/-E or --generate")
 	}
 
@@ -114,7 +114,7 @@ func runEnumCustom(cmd *cobra.Command, args []string) error {
 	}
 
 	cfg := &enum.Config{
-		Emails:    subjects,
+		Targets:   targets,
 		Threads:   flagThreads,
 		Timeout:   flagTimeout,
 		RateLimit: flagRateLimit,
@@ -175,15 +175,18 @@ func loadOracleSpec(path string) (*custom.Spec, error) {
 	return spec, nil
 }
 
-// buildCustomSubjects assembles the ordered subject list from CLI flags
-// (-e/-E/--generate), de-duplicated and preserving first-seen order.
-func buildCustomSubjects() ([]string, error) {
-	var subjects []string
+// buildCustomTargets assembles the ordered target list from CLI flags
+// (-e/-E/--generate), de-duplicated on the subject and preserving first-seen
+// order. Generated targets carry the name they were built from; subjects
+// supplied via -e/-E are nameless, because a supplied subject says nothing
+// about whose it is.
+func buildCustomTargets() ([]enum.Target, error) {
+	var targets []enum.Target
 
 	if flagCustomEmails != "" {
 		for _, e := range strings.Split(flagCustomEmails, ",") {
 			if e = strings.TrimSpace(e); e != "" {
-				subjects = append(subjects, e)
+				targets = append(targets, enum.Target{Email: e})
 			}
 		}
 	}
@@ -193,47 +196,55 @@ func buildCustomSubjects() ([]string, error) {
 		if err != nil {
 			return nil, fmt.Errorf("loading subject file: %w", err)
 		}
-		subjects = append(subjects, fileSubjects...)
+		for _, s := range fileSubjects {
+			targets = append(targets, enum.Target{Email: s})
+		}
 	}
 
 	if flagCustomGenerate {
-		generated, err := generateCustomSubjects()
+		generated, err := generateCustomTargets()
 		if err != nil {
 			return nil, err
 		}
-		subjects = append(subjects, generated...)
+		targets = append(targets, generated...)
 	}
 
-	return dedupe(subjects), nil
+	return dedupeTargets(targets), nil
 }
 
-// generateCustomSubjects generates usernames or emails depending on whether a
-// domain was provided.
-func generateCustomSubjects() ([]string, error) {
-	if flagEnumDomain == "" {
-		usernames, err := enum.GenerateUsernames(flagEnumFormat)
-		if err != nil {
-			return nil, fmt.Errorf("generating usernames: %w", err)
-		}
-		return usernames, nil
-	}
-	emails, err := enum.GenerateEmails(flagEnumFormat, flagEnumDomain)
+// generateCustomTargets generates subjects from the embedded name lists, each
+// carrying the name it was built from. The subject is a bare username when no
+// domain was provided and a full email when one was — the custom oracle
+// substitutes either into its {{username}} placeholder.
+func generateCustomTargets() ([]enum.Target, error) {
+	candidates, err := enum.GenerateCandidates(flagEnumFormat)
 	if err != nil {
-		return nil, fmt.Errorf("generating emails: %w", err)
+		return nil, fmt.Errorf("generating subjects: %w", err)
 	}
-	return emails, nil
-}
 
-// dedupe removes duplicate subjects while preserving first-seen order.
-func dedupe(in []string) []string {
-	seen := make(map[string]bool, len(in))
-	out := make([]string, 0, len(in))
-	for _, s := range in {
-		if seen[s] {
+	targets := make([]enum.Target, len(candidates))
+	for i, c := range candidates {
+		if flagEnumDomain == "" {
+			targets[i] = enum.Target{Email: c.Username, First: c.First, Last: c.Last}
 			continue
 		}
-		seen[s] = true
-		out = append(out, s)
+		targets[i] = c.Target(flagEnumDomain)
+	}
+	return targets, nil
+}
+
+// dedupeTargets removes targets with a duplicate subject while preserving
+// first-seen order, so the name attached to the surviving target is the one
+// that first produced that subject.
+func dedupeTargets(in []enum.Target) []enum.Target {
+	seen := make(map[string]bool, len(in))
+	out := make([]enum.Target, 0, len(in))
+	for _, t := range in {
+		if seen[t.Email] {
+			continue
+		}
+		seen[t.Email] = true
+		out = append(out, t)
 	}
 	return out
 }

--- a/cmd/brutus/cmd_enum_custom_test.go
+++ b/cmd/brutus/cmd_enum_custom_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/praetorian-inc/brutus/pkg/enum"
 	"github.com/praetorian-inc/brutus/pkg/enum/custom"
 )
 
@@ -192,50 +193,16 @@ func TestRunEnumCustom_OversizeFile(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// F1: Subject-building helpers (dedupe, buildCustomSubjects)
+// F1: Target-building helpers (buildCustomTargets)
+//
+// 10T-535: buildCustomSubjects()/dedupe() were address-only. buildCustomTargets
+// is now the single merger of file-supplied and generated addresses, and it
+// carries the generated name (First/Last) alongside each address so it can
+// never be reverse-derived downstream. These tests exercise buildCustomTargets
+// directly, asserting on []enum.Target rather than []string, so a bug that
+// stamped a name onto a supplied address (or dropped a name from a generated
+// one) fails here rather than just failing to compile.
 // ---------------------------------------------------------------------------
-
-// TestDedupe_RemovesDuplicatesPreservingOrder verifies that dedupe removes
-// repeated values while preserving the first-seen order.
-func TestDedupe_RemovesDuplicatesPreservingOrder(t *testing.T) {
-	tests := []struct {
-		name string
-		in   []string
-		want []string
-	}{
-		{
-			name: "no duplicates — unchanged",
-			in:   []string{"a", "b", "c"},
-			want: []string{"a", "b", "c"},
-		},
-		{
-			name: "all duplicates — single element",
-			in:   []string{"x", "x", "x"},
-			want: []string{"x"},
-		},
-		{
-			name: "duplicates across non-adjacent positions",
-			in:   []string{"a", "b", "a", "c", "b"},
-			want: []string{"a", "b", "c"},
-		},
-		{
-			name: "empty input",
-			in:   nil,
-			want: []string{},
-		},
-		{
-			name: "single element",
-			in:   []string{"only"},
-			want: []string{"only"},
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := dedupe(tc.in)
-			assert.Equal(t, tc.want, got)
-		})
-	}
-}
 
 // parseSpec is a test helper that parses and validates a spec from JSON.
 func parseSpec(t *testing.T, data string) *custom.Spec {
@@ -246,9 +213,20 @@ func parseSpec(t *testing.T, data string) *custom.Spec {
 	return spec
 }
 
-// TestBuildCustomSubjects_InlineEmails verifies the -e flag CSV path:
-// subjects are split on comma, trimmed of whitespace, and returned in order.
-func TestBuildCustomSubjects_InlineEmails(t *testing.T) {
+// targetEmails extracts the Email field from a []enum.Target slice, in order,
+// for compact order/content assertions.
+func targetEmails(targets []enum.Target) []string {
+	out := make([]string, len(targets))
+	for i, t := range targets {
+		out[i] = t.Email
+	}
+	return out
+}
+
+// TestBuildCustomTargets_InlineEmails verifies the -e flag CSV path: subjects
+// are split on comma, trimmed of whitespace, returned in order, and — because
+// a CLI-supplied subject says nothing about whose it is — carry no name.
+func TestBuildCustomTargets_InlineEmails(t *testing.T) {
 	origEmails := flagCustomEmails
 	origFile := flagCustomEmailFile
 	origGen := flagCustomGenerate
@@ -262,14 +240,19 @@ func TestBuildCustomSubjects_InlineEmails(t *testing.T) {
 	flagCustomEmailFile = ""
 	flagCustomGenerate = false
 
-	got, err := buildCustomSubjects()
+	got, err := buildCustomTargets()
 	require.NoError(t, err)
-	assert.Equal(t, []string{"alice", "bob", "charlie"}, got)
+	assert.Equal(t, []string{"alice", "bob", "charlie"}, targetEmails(got))
+	for i, target := range got {
+		assert.Empty(t, target.First, "target %d (%q): CLI-supplied address must have empty First", i, target.Email)
+		assert.Empty(t, target.Last, "target %d (%q): CLI-supplied address must have empty Last", i, target.Email)
+	}
 }
 
-// TestBuildCustomSubjects_EmailFile verifies the -E file path: subjects are
-// read one-per-line from the file.
-func TestBuildCustomSubjects_EmailFile(t *testing.T) {
+// TestBuildCustomTargets_EmailFile verifies the -E file path: subjects are
+// read one-per-line from the file and carry no name (file-supplied, not
+// generated).
+func TestBuildCustomTargets_EmailFile(t *testing.T) {
 	origEmails := flagCustomEmails
 	origFile := flagCustomEmailFile
 	origGen := flagCustomGenerate
@@ -290,14 +273,18 @@ func TestBuildCustomSubjects_EmailFile(t *testing.T) {
 	flagCustomEmailFile = tmp.Name()
 	flagCustomGenerate = false
 
-	got, err := buildCustomSubjects()
+	got, err := buildCustomTargets()
 	require.NoError(t, err)
-	assert.Equal(t, []string{"user1", "user2"}, got)
+	assert.Equal(t, []string{"user1", "user2"}, targetEmails(got))
+	for i, target := range got {
+		assert.Empty(t, target.First, "target %d (%q): file-supplied address must have empty First", i, target.Email)
+		assert.Empty(t, target.Last, "target %d (%q): file-supplied address must have empty Last", i, target.Email)
+	}
 }
 
-// TestBuildCustomSubjects_Dedupe verifies that buildCustomSubjects de-duplicates
-// subjects supplied via -e, preserving first-seen order.
-func TestBuildCustomSubjects_Dedupe(t *testing.T) {
+// TestBuildCustomTargets_Dedupe verifies that buildCustomTargets de-duplicates
+// on Email for subjects supplied via -e, preserving first-seen order.
+func TestBuildCustomTargets_Dedupe(t *testing.T) {
 	origEmails := flagCustomEmails
 	origFile := flagCustomEmailFile
 	origGen := flagCustomGenerate
@@ -312,19 +299,19 @@ func TestBuildCustomSubjects_Dedupe(t *testing.T) {
 	flagCustomEmailFile = ""
 	flagCustomGenerate = false
 
-	got, err := buildCustomSubjects()
+	got, err := buildCustomTargets()
 	require.NoError(t, err)
-	assert.Equal(t, []string{"alice", "bob", "charlie"}, got)
+	assert.Equal(t, []string{"alice", "bob", "charlie"}, targetEmails(got))
 }
 
-// TestBuildCustomSubjects_ConstraintRateLimitDefault verifies that the spec's
+// TestBuildCustomTargets_ConstraintRateLimitDefault verifies that the spec's
 // constraints.rate_limit_rps is applied to the enum config as a default only
 // when --rate-limit has not been set by the operator (isFlagChanged is false).
 //
-// buildCustomSubjects itself does not apply the rate-limit — that logic lives
+// buildCustomTargets itself does not apply the rate-limit — that logic lives
 // in runEnumCustom. This test verifies the constraint field is accessible via
 // the Spec type (it's the glue the command wires up).
-func TestBuildCustomSubjects_ConstraintRateLimitDefault(t *testing.T) {
+func TestBuildCustomTargets_ConstraintRateLimitDefault(t *testing.T) {
 	const constraintRPS = `{
 		"version": "1",
 		"oracle": {
@@ -347,7 +334,7 @@ func TestBuildCustomSubjects_ConstraintRateLimitDefault(t *testing.T) {
 	assert.Equal(t, 5.0, spec.Constraints.RateLimitRPS,
 		"Constraints.RateLimitRPS must equal the spec value (5.0)")
 
-	// Also verify buildCustomSubjects succeeds with a subject supplied via CLI.
+	// Also verify buildCustomTargets succeeds with a subject supplied via CLI.
 	origEmails := flagCustomEmails
 	origFile := flagCustomEmailFile
 	origGen := flagCustomGenerate
@@ -360,9 +347,181 @@ func TestBuildCustomSubjects_ConstraintRateLimitDefault(t *testing.T) {
 	flagCustomEmailFile = ""
 	flagCustomGenerate = false
 
-	got, err := buildCustomSubjects()
+	got, err := buildCustomTargets()
 	require.NoError(t, err)
-	assert.Equal(t, []string{"seed@example.com"}, got)
+	assert.Equal(t, []string{"seed@example.com"}, targetEmails(got))
+	require.Len(t, got, 1)
+	assert.Empty(t, got[0].First, "CLI-supplied address must have empty First")
+	assert.Empty(t, got[0].Last, "CLI-supplied address must have empty Last")
+}
+
+// TestBuildCustomTargets_GeneratedNoDomain is THE POINT OF 10T-535 for this
+// command: with --generate and no --domain, buildCustomTargets must build
+// Target{Email: c.Username, First: c.First, Last: c.Last} directly rather
+// than going through Candidate.Target(domain) — appending "@" to a bare
+// username would be wrong. This pins that no-domain branch: every generated
+// Target's Email is the bare username (no "@"), and First/Last are non-empty,
+// carrying the name the generator actually used.
+func TestBuildCustomTargets_GeneratedNoDomain(t *testing.T) {
+	origEmails := flagCustomEmails
+	origFile := flagCustomEmailFile
+	origGen := flagCustomGenerate
+	origFormat := flagEnumFormat
+	origDomain := flagEnumDomain
+	t.Cleanup(func() {
+		flagCustomEmails = origEmails
+		flagCustomEmailFile = origFile
+		flagCustomGenerate = origGen
+		flagEnumFormat = origFormat
+		flagEnumDomain = origDomain
+	})
+
+	flagCustomEmails = ""
+	flagCustomEmailFile = ""
+	flagCustomGenerate = true
+	flagEnumFormat = enum.FormatFirstDotLast
+	flagEnumDomain = ""
+
+	got, err := buildCustomTargets()
+	require.NoError(t, err)
+	require.NotEmpty(t, got)
+
+	// Compare against the real generator output (not a reimplementation) so
+	// this fails if generateCustomTargets ever diverges from GenerateCandidates.
+	candidates, genErr := enum.GenerateCandidates(enum.FormatFirstDotLast)
+	require.NoError(t, genErr)
+	require.Len(t, got, len(candidates),
+		"no-domain generation must produce exactly one target per candidate")
+
+	for i, c := range candidates {
+		assert.Equal(t, c.Username, got[i].Email,
+			"target %d: Email must be the bare username (no domain) when --domain is unset", i)
+		assert.NotContains(t, got[i].Email, "@",
+			"target %d: no-domain Email must not contain '@'", i)
+		assert.Equal(t, c.First, got[i].First, "target %d: First must match the generated candidate", i)
+		assert.Equal(t, c.Last, got[i].Last, "target %d: Last must match the generated candidate", i)
+		require.NotEmpty(t, got[i].First, "target %d: generated First must be non-empty", i)
+		require.NotEmpty(t, got[i].Last, "target %d: generated Last must be non-empty", i)
+	}
+}
+
+// TestBuildCustomTargets_GeneratedWithDomain verifies the --generate +
+// --domain branch: buildCustomTargets must build each Target via
+// Candidate.Target(domain), so Email is "username@domain" and First/Last are
+// still populated from the candidate.
+func TestBuildCustomTargets_GeneratedWithDomain(t *testing.T) {
+	origEmails := flagCustomEmails
+	origFile := flagCustomEmailFile
+	origGen := flagCustomGenerate
+	origFormat := flagEnumFormat
+	origDomain := flagEnumDomain
+	t.Cleanup(func() {
+		flagCustomEmails = origEmails
+		flagCustomEmailFile = origFile
+		flagCustomGenerate = origGen
+		flagEnumFormat = origFormat
+		flagEnumDomain = origDomain
+	})
+
+	const domain = "example.com"
+	flagCustomEmails = ""
+	flagCustomEmailFile = ""
+	flagCustomGenerate = true
+	flagEnumFormat = enum.FormatFirstDotLast
+	flagEnumDomain = domain
+
+	got, err := buildCustomTargets()
+	require.NoError(t, err)
+	require.NotEmpty(t, got)
+
+	candidates, genErr := enum.GenerateCandidates(enum.FormatFirstDotLast)
+	require.NoError(t, genErr)
+	require.Len(t, got, len(candidates),
+		"with-domain generation must produce exactly one target per candidate")
+
+	for i, c := range candidates {
+		assert.Equal(t, c.Target(domain), got[i],
+			"target %d: must equal Candidate.Target(domain) exactly", i)
+		assert.True(t, strings.HasSuffix(got[i].Email, "@"+domain),
+			"target %d: with-domain Email must end with @%s", i, domain)
+		require.NotEmpty(t, got[i].First, "target %d: generated First must be non-empty", i)
+		require.NotEmpty(t, got[i].Last, "target %d: generated Last must be non-empty", i)
+	}
+}
+
+// TestBuildCustomTargets_MergeDedupePrecedence covers the merge, the dedup,
+// the first-seen order, and the precedence between a file-supplied address
+// and a generated one, all in a single scenario: -E supplies the exact
+// address that --generate would also produce as its #1-ranked candidate
+// ("john.smith", from FormatFirstDotLast's top-ranked pair — pinned by
+// TestGenerateUsernames_FirstDotLast in pkg/enum/generate_test.go).
+//
+//   - Merge: the result contains both the -E entry and the --generate entries.
+//   - Order: -E is appended before --generate (source order), so the
+//     file-supplied "john.smith" occupies index 0.
+//   - Dedupe: the generated candidate that would also produce "john.smith" is
+//     dropped as a duplicate, not appended a second time.
+//   - Precedence: the surviving "john.smith" target is the file-supplied one
+//     (empty First/Last) — first-seen wins, so a generated duplicate can never
+//     retroactively attach a name to an address the operator supplied.
+func TestBuildCustomTargets_MergeDedupePrecedence(t *testing.T) {
+	origEmails := flagCustomEmails
+	origFile := flagCustomEmailFile
+	origGen := flagCustomGenerate
+	origFormat := flagEnumFormat
+	origDomain := flagEnumDomain
+	t.Cleanup(func() {
+		flagCustomEmails = origEmails
+		flagCustomEmailFile = origFile
+		flagCustomGenerate = origGen
+		flagEnumFormat = origFormat
+		flagEnumDomain = origDomain
+	})
+
+	// Write a one-line subject file containing the #1-ranked generated
+	// username, so it collides with the first generated candidate.
+	tmp, err := os.CreateTemp(t.TempDir(), "collide-*.txt")
+	require.NoError(t, err)
+	_, err = tmp.WriteString("john.smith\n")
+	require.NoError(t, err)
+	require.NoError(t, tmp.Close())
+
+	flagCustomEmails = ""
+	flagCustomEmailFile = tmp.Name()
+	flagCustomGenerate = true
+	flagEnumFormat = enum.FormatFirstDotLast
+	flagEnumDomain = ""
+
+	got, err := buildCustomTargets()
+	require.NoError(t, err)
+	require.NotEmpty(t, got)
+
+	candidates, genErr := enum.GenerateCandidates(enum.FormatFirstDotLast)
+	require.NoError(t, genErr)
+	require.Equal(t, "john.smith", candidates[0].Username,
+		"test assumption: FormatFirstDotLast's #1-ranked candidate must be john.smith")
+
+	// Merge + dedupe: exactly one target per unique candidate — the collision
+	// on "john.smith" means the file entry and the #1 candidate collapse to
+	// one target, so the total count equals len(candidates), not len+1.
+	assert.Len(t, got, len(candidates),
+		"merge+dedupe: file-supplied duplicate of the #1 candidate must not double-count")
+
+	// Order + precedence: index 0 is the file-supplied "john.smith", unnamed —
+	// not the generated candidate that would also produce it.
+	require.Equal(t, "john.smith", got[0].Email)
+	assert.Empty(t, got[0].First,
+		"precedence: file-supplied address must win over the colliding generated one — First must stay empty")
+	assert.Empty(t, got[0].Last,
+		"precedence: file-supplied address must win over the colliding generated one — Last must stay empty")
+
+	// Every remaining target came only from --generate (no other collisions
+	// are possible: GenerateCandidates guarantees unique usernames), so each
+	// must carry a name.
+	for i := 1; i < len(got); i++ {
+		assert.NotEmpty(t, got[i].First, "target %d (%q): generated target must have non-empty First", i, got[i].Email)
+		assert.NotEmpty(t, got[i].Last, "target %d (%q): generated target must have non-empty Last", i, got[i].Email)
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/brutus/cmd_enum_github.go
+++ b/cmd/brutus/cmd_enum_github.go
@@ -120,10 +120,12 @@ func runEnumGithub(cmd *cobra.Command, args []string) error {
 		flagJSON = true
 	}
 
-	emails, err := githubEnumTargets()
+	targets, err := githubEnumTargetList()
 	if err != nil {
 		return err
 	}
+	emails := enumTargetEmails(targets)
+	names := enumNamesByEmail(targets)
 
 	token := resolveGithubToken(flagGithubEnumToken, useColor)
 
@@ -159,6 +161,12 @@ func runEnumGithub(cmd *cobra.Command, args []string) error {
 	progress.Start()
 	var processed, found int
 	onResult := func(res githubenum.Result) {
+		// Stamp the generated name onto the result the enumerator just returned.
+		// The enumerator only ever sees the address, so the name is attached
+		// here; an address that came from --emails/--email-file is absent from
+		// names and stays nameless.
+		res.First, res.Last = enumNameFor(names, res.Email)
+
 		processed++
 		if res.Exists {
 			found++
@@ -207,6 +215,12 @@ func runEnumGithub(cmd *cobra.Command, args []string) error {
 	results := enumerator.EnumerateWith(ctx, emails, flagThreads, flagRateLimit, flagJitter, onResult)
 	progress.Stop()
 
+	// onResult received copies, so the returned slice is still unnamed. Stamp it
+	// too: the post-reveal re-emit below encodes its rows from this slice.
+	for i := range results {
+		results[i].First, results[i].Last = enumNameFor(names, results[i].Email)
+	}
+
 	// Username reveal: only when not disabled, a token is set, and at least one
 	// account exists.
 	existing := existingEmails(results)
@@ -250,11 +264,12 @@ func runEnumGithub(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// githubEnumTargets parses, trims, and dedups the email targets from --emails
-// and --email-file, plus any --domain-generated candidates. It errors when no
-// targets are supplied.
-func githubEnumTargets() ([]string, error) {
-	var generated []string
+// githubEnumTargetList resolves the email targets from --emails and
+// --email-file, plus any --domain-generated candidates, each generated target
+// carrying the name its username was built from. It errors when no targets are
+// supplied.
+func githubEnumTargetList() ([]enum.Target, error) {
+	var generated []enum.Target
 	if flagGithubEnumDomain != "" {
 		g, err := githubEnumGenerate()
 		if err != nil {
@@ -263,65 +278,93 @@ func githubEnumTargets() ([]string, error) {
 		generated = g
 	}
 
-	return collectGithubEmails(flagGithubEnumEmails, flagGithubEnumEmailFile, generated,
+	return collectGithubTargets(flagGithubEnumEmails, flagGithubEnumEmailFile, generated,
 		fmt.Errorf("provide --emails/-e, --email-file/-E, or --domain"))
 }
 
-// collectGithubEmails parses, trims, and dedups email targets from an --emails
-// CSV and an --email-file (preserving first-seen order), then appends any
-// pre-generated candidates. noSourceErr is returned verbatim when no targets
-// resolve, letting each subcommand phrase its own guidance (the parent allows
-// --domain; the map subcommand does not).
+// collectGithubEmails returns just the addresses resolved by
+// collectGithubTargets. The map subcommand uses it: it never generates, so none
+// of its addresses have a name to carry.
 func collectGithubEmails(emailsCSV, emailFile string, generated []string, noSourceErr error) ([]string, error) {
-	var raw []string
+	targets := make([]enum.Target, len(generated))
+	for i, e := range generated {
+		targets[i] = enum.Target{Email: e}
+	}
+	resolved, err := collectGithubTargets(emailsCSV, emailFile, targets, noSourceErr)
+	if err != nil {
+		return nil, err
+	}
+	return enumTargetEmails(resolved), nil
+}
+
+// collectGithubTargets parses, trims, and dedups email targets from an --emails
+// CSV and an --email-file (preserving first-seen order), then appends any
+// pre-generated candidates. Supplied addresses carry no name, because an address
+// the operator provided says nothing about whose it is; dedup keeps the
+// first-seen entry, so a supplied address that a generated candidate duplicates
+// stays nameless. noSourceErr is returned verbatim when no targets resolve,
+// letting each subcommand phrase its own guidance (the parent allows --domain;
+// the map subcommand does not).
+func collectGithubTargets(emailsCSV, emailFile string, generated []enum.Target, noSourceErr error) ([]enum.Target, error) {
+	var raw []enum.Target
 	if emailsCSV != "" {
-		raw = append(raw, strings.Split(emailsCSV, ",")...)
+		for _, e := range strings.Split(emailsCSV, ",") {
+			raw = append(raw, enum.Target{Email: e})
+		}
 	}
 	if emailFile != "" {
 		lines, err := loadLinesFromFile(emailFile)
 		if err != nil {
 			return nil, fmt.Errorf("reading --email-file: %w", err)
 		}
-		raw = append(raw, lines...)
+		for _, e := range lines {
+			raw = append(raw, enum.Target{Email: e})
+		}
 	}
 	raw = append(raw, generated...)
 
 	seen := make(map[string]struct{})
-	var emails []string
-	for _, e := range raw {
-		e = strings.TrimSpace(e)
-		if e == "" {
+	var targets []enum.Target
+	for _, t := range raw {
+		t.Email = strings.TrimSpace(t.Email)
+		if t.Email == "" {
 			continue
 		}
-		if _, ok := seen[e]; ok {
+		if _, ok := seen[t.Email]; ok {
 			continue
 		}
-		seen[e] = struct{}{}
-		emails = append(emails, e)
+		seen[t.Email] = struct{}{}
+		targets = append(targets, t)
 	}
 
-	if len(emails) == 0 {
+	if len(targets) == 0 {
 		return nil, noSourceErr
 	}
-	return emails, nil
+	return targets, nil
 }
 
 // githubEnumGenerate produces the candidate email wordlist for --domain by
-// reusing the shared, frequency-ranked generator (enum.GenerateEmails) and the
-// shared capResults helper — no duplicated generation logic. The format is
-// validated against enum.ListFormats() first. A status line goes to stderr
-// (never stdout) unless quiet or JSON.
-func githubEnumGenerate() ([]string, error) {
+// reusing the shared, frequency-ranked generator (enum.GenerateCandidates) and
+// the shared capResults helper — no duplicated generation logic. Candidates, not
+// bare addresses, are generated so each target keeps the name its username was
+// built from, which is knowable for free here and lossy to recover later. The
+// format is validated against enum.ListFormats() first. A status line goes to
+// stderr (never stdout) unless quiet or JSON.
+func githubEnumGenerate() ([]enum.Target, error) {
 	if !slices.Contains(enum.ListFormats(), flagGithubEnumFormat) {
 		return nil, fmt.Errorf("invalid --format %q; valid formats: %s",
 			flagGithubEnumFormat, strings.Join(enum.ListFormats(), ", "))
 	}
 
-	generated, err := enum.GenerateEmails(flagGithubEnumFormat, flagGithubEnumDomain)
+	candidates, err := enum.GenerateCandidates(flagGithubEnumFormat)
 	if err != nil {
 		return nil, fmt.Errorf("generating candidate emails: %w", err)
 	}
-	generated = capResults(generated, flagGithubEnumLimit)
+	candidates = capResults(candidates, flagGithubEnumLimit)
+	generated := make([]enum.Target, len(candidates))
+	for i, c := range candidates {
+		generated[i] = c.Target(flagGithubEnumDomain)
+	}
 
 	if !flagQuiet && !flagJSON {
 		useColor := isColorEnabled(flagNoColor)

--- a/cmd/brutus/cmd_enum_github_output.go
+++ b/cmd/brutus/cmd_enum_github_output.go
@@ -135,6 +135,8 @@ func outputGithubEnumJSONL(w io.Writer, results []githubenum.Result) {
 	type githubEnumJSON struct {
 		Type     string `json:"type"`
 		Email    string `json:"email"`
+		First    string `json:"first,omitempty"`
+		Last     string `json:"last,omitempty"`
 		Exists   bool   `json:"exists"`
 		Username string `json:"username,omitempty"`
 		Error    string `json:"error,omitempty"`
@@ -146,6 +148,8 @@ func outputGithubEnumJSONL(w io.Writer, results []githubenum.Result) {
 		jr := githubEnumJSON{
 			Type:     "github_account",
 			Email:    r.Email,
+			First:    r.First,
+			Last:     r.Last,
 			Exists:   r.Exists,
 			Username: r.Username,
 		}

--- a/cmd/brutus/cmd_enum_github_test.go
+++ b/cmd/brutus/cmd_enum_github_test.go
@@ -146,12 +146,21 @@ func TestEnumGithubCmd_NoRevealFlag(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// githubEnumTargets
+// githubEnumTargetList
+//
+// 10T-535: githubEnumTargets() ([]string, error) was a dead []string adapter
+// kept alive only by these tests (the real logic — and the only production
+// caller, runEnumGithub — lives in githubEnumTargetList() ([]enum.Target,
+// error)). Retargeted onto githubEnumTargetList and strengthened to assert
+// that supplied (--emails/--email-file) targets carry no name, using the
+// targetEmails helper from cmd_enum_custom_test.go for compact address
+// assertions.
 // ---------------------------------------------------------------------------
 
-// TestGithubEnumTargets_InlineEmails verifies that --emails CSV is parsed,
-// trimmed, and deduplicated.
-func TestGithubEnumTargets_InlineEmails(t *testing.T) {
+// TestGithubEnumTargetList_InlineEmails verifies that --emails CSV is parsed,
+// trimmed, and deduplicated, and that every CLI-supplied target carries no
+// name (a supplied address says nothing about whose it is).
+func TestGithubEnumTargetList_InlineEmails(t *testing.T) {
 	origEmails := flagGithubEnumEmails
 	origEmailFile := flagGithubEnumEmailFile
 	origDomain := flagGithubEnumDomain
@@ -165,18 +174,24 @@ func TestGithubEnumTargets_InlineEmails(t *testing.T) {
 	flagGithubEnumEmailFile = ""
 	flagGithubEnumDomain = ""
 
-	emails, err := githubEnumTargets()
+	got, err := githubEnumTargetList()
 	require.NoError(t, err)
 
+	emails := targetEmails(got)
 	// Dedup: alice appears twice but must appear once.
 	assert.Len(t, emails, 2, "deduplication must collapse duplicate emails")
 	assert.Contains(t, emails, "alice@example.com")
 	assert.Contains(t, emails, "bob@example.com")
+
+	for i, target := range got {
+		assert.Empty(t, target.First, "target %d (%q): CLI-supplied address must have empty First", i, target.Email)
+		assert.Empty(t, target.Last, "target %d (%q): CLI-supplied address must have empty Last", i, target.Email)
+	}
 }
 
-// TestGithubEnumTargets_NoSource verifies that an error is returned (and
+// TestGithubEnumTargetList_NoSource verifies that an error is returned (and
 // mentions "provide") when no --emails, --email-file, or --domain is given.
-func TestGithubEnumTargets_NoSource(t *testing.T) {
+func TestGithubEnumTargetList_NoSource(t *testing.T) {
 	origEmails := flagGithubEnumEmails
 	origEmailFile := flagGithubEnumEmailFile
 	origDomain := flagGithubEnumDomain
@@ -190,8 +205,8 @@ func TestGithubEnumTargets_NoSource(t *testing.T) {
 	flagGithubEnumEmailFile = ""
 	flagGithubEnumDomain = ""
 
-	_, err := githubEnumTargets()
-	require.Error(t, err, "githubEnumTargets must fail when no source is supplied")
+	_, err := githubEnumTargetList()
+	require.Error(t, err, "githubEnumTargetList must fail when no source is supplied")
 	assert.Contains(t, err.Error(), "provide",
 		"error must guide the user to supply a target source")
 }
@@ -355,6 +370,92 @@ func TestOutputGithubEnumJSONL(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ---------------------------------------------------------------------------
+// outputGithubEnumJSONL — First/Last name propagation (10T-535)
+// ---------------------------------------------------------------------------
+
+// TestOutputGithubEnumJSONL_NameFields pins the never-invent-a-name rule: a
+// Result carrying First/Last (from --generate) must emit "first"/"last" in
+// the JSONL row, while a Result with empty First/Last (supplied via --emails
+// or --email-file) must OMIT both keys entirely rather than emit them as "".
+// Pre-existing fields (type/email/exists/username) must be unaffected.
+func TestOutputGithubEnumJSONL_NameFields(t *testing.T) {
+	named := githubenum.Result{
+		Email:    "john.smith@example.com",
+		Exists:   true,
+		Username: "jsmith-gh",
+		First:    "john",
+		Last:     "smith",
+	}
+	unnamed := githubenum.Result{
+		Email:    "supplied@example.com",
+		Exists:   true,
+		Username: "supplied-gh",
+	}
+
+	t.Run("named result emits first and last", func(t *testing.T) {
+		var buf bytes.Buffer
+		outputGithubEnumJSONL(&buf, []githubenum.Result{named})
+
+		line := strings.TrimSpace(buf.String())
+		require.NotEmpty(t, line, "outputGithubEnumJSONL must produce a JSONL line")
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(line), &obj),
+			"JSONL output must be valid JSON: %q", line)
+
+		assert.Equal(t, "john", obj["first"], `first field must be "john"`)
+		assert.Equal(t, "smith", obj["last"], `last field must be "smith"`)
+
+		// Pre-existing fields must remain unaffected by the new ones.
+		assert.Equal(t, "github_account", obj["type"])
+		assert.Equal(t, named.Email, obj["email"])
+		assert.Equal(t, true, obj["exists"])
+		assert.Equal(t, "jsmith-gh", obj["username"])
+	})
+
+	t.Run("unnamed result omits first and last keys", func(t *testing.T) {
+		var buf bytes.Buffer
+		outputGithubEnumJSONL(&buf, []githubenum.Result{unnamed})
+
+		line := strings.TrimSpace(buf.String())
+		require.NotEmpty(t, line, "outputGithubEnumJSONL must produce a JSONL line")
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(line), &obj),
+			"JSONL output must be valid JSON: %q", line)
+
+		assert.NotContains(t, obj, "first",
+			`first key must be absent (omitempty), not emitted as ""`)
+		assert.NotContains(t, obj, "last",
+			`last key must be absent (omitempty), not emitted as ""`)
+
+		// Pre-existing fields must remain unaffected.
+		assert.Equal(t, "github_account", obj["type"])
+		assert.Equal(t, unnamed.Email, obj["email"])
+		assert.Equal(t, true, obj["exists"])
+		assert.Equal(t, "supplied-gh", obj["username"])
+	})
+
+	t.Run("mixed batch: one named, one unnamed", func(t *testing.T) {
+		var buf bytes.Buffer
+		outputGithubEnumJSONL(&buf, []githubenum.Result{named, unnamed})
+
+		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+		require.Len(t, lines, 2, "must emit exactly one JSONL line per result")
+
+		var first map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[0]), &first))
+		assert.Equal(t, "john", first["first"])
+		assert.Equal(t, "smith", first["last"])
+
+		var second map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[1]), &second))
+		assert.NotContains(t, second, "first")
+		assert.NotContains(t, second, "last")
+	})
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/brutus/cmd_enum_google.go
+++ b/cmd/brutus/cmd_enum_google.go
@@ -101,10 +101,12 @@ func runEnumGoogle(cmd *cobra.Command, args []string) error {
 		flagJSON = true
 	}
 
-	emails, err := googleEnumTargets()
+	targets, err := googleEnumTargetList()
 	if err != nil {
 		return err
 	}
+	emails := enumTargetEmails(targets)
+	names := enumNamesByEmail(targets)
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
@@ -136,6 +138,12 @@ func runEnumGoogle(cmd *cobra.Command, args []string) error {
 	progress.Start()
 	var processed, found int
 	onResult := func(res google.Result) {
+		// Stamp the generated name onto the result the checker just returned.
+		// The checker only ever sees the address, so the name is attached here;
+		// an address that came from --emails/--email-file is absent from names
+		// and stays nameless.
+		res.First, res.Last = enumNameFor(names, res.Email)
+
 		processed++
 		if res.Exists {
 			found++
@@ -162,20 +170,28 @@ func runEnumGoogle(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// googleEnumTargets parses, trims, and dedups the email targets from --emails
-// and --email-file, plus any --domain-generated candidates. It errors when no
+// googleEnumTargetList parses, trims, and dedups the email targets from
+// --emails and --email-file, plus any --domain-generated candidates. Each
+// generated target carries the name its username was built from; supplied
+// addresses carry none, because an address the operator provided says nothing
+// about whose it is. Dedup keeps the first-seen entry, so a supplied address
+// that a generated candidate duplicates stays nameless. It errors when no
 // targets are supplied.
-func googleEnumTargets() ([]string, error) {
-	var raw []string
+func googleEnumTargetList() ([]enum.Target, error) {
+	var raw []enum.Target
 	if flagGoogleEnumEmails != "" {
-		raw = append(raw, strings.Split(flagGoogleEnumEmails, ",")...)
+		for _, e := range strings.Split(flagGoogleEnumEmails, ",") {
+			raw = append(raw, enum.Target{Email: e})
+		}
 	}
 	if flagGoogleEnumEmailFile != "" {
 		lines, err := loadLinesFromFile(flagGoogleEnumEmailFile)
 		if err != nil {
 			return nil, fmt.Errorf("reading --email-file: %w", err)
 		}
-		raw = append(raw, lines...)
+		for _, e := range lines {
+			raw = append(raw, enum.Target{Email: e})
+		}
 	}
 
 	// --domain generates the candidate wordlist internally (reusing the same
@@ -191,42 +207,49 @@ func googleEnumTargets() ([]string, error) {
 	}
 
 	seen := make(map[string]struct{})
-	var emails []string
-	for _, e := range raw {
-		e = strings.TrimSpace(e)
-		if e == "" {
+	var targets []enum.Target
+	for _, t := range raw {
+		t.Email = strings.TrimSpace(t.Email)
+		if t.Email == "" {
 			continue
 		}
-		if _, ok := seen[e]; ok {
+		if _, ok := seen[t.Email]; ok {
 			continue
 		}
-		seen[e] = struct{}{}
-		emails = append(emails, e)
+		seen[t.Email] = struct{}{}
+		targets = append(targets, t)
 	}
 
-	if len(emails) == 0 {
+	if len(targets) == 0 {
 		return nil, fmt.Errorf("provide --emails/-e, --email-file/-E, or --domain")
 	}
-	return emails, nil
+	return targets, nil
 }
 
 // googleEnumGenerate produces the candidate email wordlist for --domain by
-// reusing the shared, frequency-ranked generator (enum.GenerateEmails) and the
-// shared capResults helper — no duplicated generation logic. The requested
-// format is validated against enum.ListFormats() first, because GenerateEmails
-// silently yields an empty list for an unknown format. A status line goes to
-// stderr (never stdout, so --json/-o output stays clean) unless quiet or JSON.
-func googleEnumGenerate() ([]string, error) {
+// reusing the shared, frequency-ranked generator (enum.GenerateCandidates) and
+// the shared capResults helper — no duplicated generation logic. Candidates,
+// not bare addresses, are generated so each target keeps the name its username
+// was built from, which is knowable for free here and lossy to recover later.
+// The requested format is validated against enum.ListFormats() first, because
+// the generator silently yields an empty list for an unknown format. A status
+// line goes to stderr (never stdout, so --json/-o output stays clean) unless
+// quiet or JSON.
+func googleEnumGenerate() ([]enum.Target, error) {
 	if !slices.Contains(enum.ListFormats(), flagGoogleEnumFormat) {
 		return nil, fmt.Errorf("invalid --format %q; valid formats: %s",
 			flagGoogleEnumFormat, strings.Join(enum.ListFormats(), ", "))
 	}
 
-	generated, err := enum.GenerateEmails(flagGoogleEnumFormat, flagGoogleEnumDomain)
+	candidates, err := enum.GenerateCandidates(flagGoogleEnumFormat)
 	if err != nil {
 		return nil, fmt.Errorf("generating candidate emails: %w", err)
 	}
-	generated = capResults(generated, flagGoogleEnumLimit)
+	candidates = capResults(candidates, flagGoogleEnumLimit)
+	generated := make([]enum.Target, len(candidates))
+	for i, c := range candidates {
+		generated[i] = c.Target(flagGoogleEnumDomain)
+	}
 
 	if !flagQuiet && !flagJSON {
 		useColor := isColorEnabled(flagNoColor)

--- a/cmd/brutus/cmd_enum_google_test.go
+++ b/cmd/brutus/cmd_enum_google_test.go
@@ -193,6 +193,93 @@ func TestOutputGoogleEnumJSONL(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// TestOutputGoogleEnumJSONL_NameFields
+// Pins the never-invent-a-name rule for the Google output path: a Result
+// carrying First/Last emits "first"/"last", while a Result with empty
+// First/Last (a supplied address) omits both keys entirely rather than
+// emitting them as "". Pre-existing fields (type/email/exists/method/idp)
+// must be unaffected.
+// ---------------------------------------------------------------------------
+
+func TestOutputGoogleEnumJSONL_NameFields(t *testing.T) {
+	named := google.Result{
+		Email:  "john.smith@example.com",
+		Exists: true,
+		Method: google.MethodWorkspaceSSO,
+		IdP:    "login.okta.com",
+		First:  "john",
+		Last:   "smith",
+	}
+	unnamed := google.Result{
+		Email:  "supplied@example.com",
+		Exists: true,
+		Method: google.MethodGmail,
+	}
+
+	t.Run("named result emits first and last", func(t *testing.T) {
+		var buf bytes.Buffer
+		outputGoogleEnumJSONL(&buf, []google.Result{named})
+
+		line := strings.TrimSpace(buf.String())
+		require.NotEmpty(t, line, "outputGoogleEnumJSONL must produce a JSONL line")
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(line), &obj),
+			"JSONL output must be valid JSON: %q", line)
+
+		assert.Equal(t, "john", obj["first"], `first field must be "john"`)
+		assert.Equal(t, "smith", obj["last"], `last field must be "smith"`)
+
+		// Pre-existing fields must remain unaffected.
+		assert.Equal(t, "google_account", obj["type"])
+		assert.Equal(t, named.Email, obj["email"])
+		assert.Equal(t, true, obj["exists"])
+		assert.Equal(t, "workspace-sso", obj["method"])
+		assert.Equal(t, "login.okta.com", obj["idp"])
+	})
+
+	t.Run("unnamed result omits first and last keys", func(t *testing.T) {
+		var buf bytes.Buffer
+		outputGoogleEnumJSONL(&buf, []google.Result{unnamed})
+
+		line := strings.TrimSpace(buf.String())
+		require.NotEmpty(t, line, "outputGoogleEnumJSONL must produce a JSONL line")
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(line), &obj),
+			"JSONL output must be valid JSON: %q", line)
+
+		assert.NotContains(t, obj, "first",
+			`first key must be absent (omitempty), not emitted as ""`)
+		assert.NotContains(t, obj, "last",
+			`last key must be absent (omitempty), not emitted as ""`)
+
+		// Pre-existing fields must remain unaffected.
+		assert.Equal(t, "google_account", obj["type"])
+		assert.Equal(t, unnamed.Email, obj["email"])
+		assert.Equal(t, "gmail", obj["method"])
+	})
+
+	t.Run("mixed batch: one named, one unnamed", func(t *testing.T) {
+		var buf bytes.Buffer
+		outputGoogleEnumJSONL(&buf, []google.Result{named, unnamed})
+
+		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+		require.Len(t, lines, 2, "must emit exactly one JSONL line per result")
+
+		var first map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[0]), &first))
+		assert.Equal(t, "john", first["first"])
+		assert.Equal(t, "smith", first["last"])
+
+		var second map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[1]), &second))
+		assert.NotContains(t, second, "first")
+		assert.NotContains(t, second, "last")
+	})
+}
+
+// ---------------------------------------------------------------------------
 // TestOutputGoogleEnumResultLine
 // Verifies human-readable line output for EXISTS, gmail, and ANSI safety.
 // ---------------------------------------------------------------------------
@@ -271,12 +358,19 @@ func TestOutputGoogleEnumResultLine(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// TestGoogleEnumTargets
-// Exercises googleEnumTargets() using the file-local flag variables directly,
-// saving and restoring them with defer.
+// TestGoogleEnumTargetList
+//
+// 10T-535: googleEnumTargets() ([]string, error) was a dead []string adapter
+// kept alive only by these tests (the real logic — and the only production
+// caller, runEnumGoogle — lives in googleEnumTargetList() ([]enum.Target,
+// error)). Retargeted onto googleEnumTargetList and strengthened to assert
+// that supplied (--emails/--email-file) targets carry no name, using the
+// targetEmails helper from cmd_enum_custom_test.go for compact address
+// assertions. Exercises googleEnumTargetList() using the file-local flag
+// variables directly, saving and restoring them with defer.
 // ---------------------------------------------------------------------------
 
-func TestGoogleEnumTargets_InlineEmails(t *testing.T) {
+func TestGoogleEnumTargetList_InlineEmails(t *testing.T) {
 	// Save and restore flag globals.
 	origEmails := flagGoogleEnumEmails
 	origEmailFile := flagGoogleEnumEmailFile
@@ -291,16 +385,22 @@ func TestGoogleEnumTargets_InlineEmails(t *testing.T) {
 	flagGoogleEnumEmailFile = ""
 	flagGoogleEnumDomain = ""
 
-	emails, err := googleEnumTargets()
+	got, err := googleEnumTargetList()
 	require.NoError(t, err)
 
+	emails := targetEmails(got)
 	// Deduplication: alice@example.com appears twice but must appear once.
 	assert.Len(t, emails, 2, "deduplication must collapse duplicate emails")
 	assert.Contains(t, emails, "alice@example.com")
 	assert.Contains(t, emails, "bob@example.com")
+
+	for i, target := range got {
+		assert.Empty(t, target.First, "target %d (%q): CLI-supplied address must have empty First", i, target.Email)
+		assert.Empty(t, target.Last, "target %d (%q): CLI-supplied address must have empty Last", i, target.Email)
+	}
 }
 
-func TestGoogleEnumTargets_NoSource(t *testing.T) {
+func TestGoogleEnumTargetList_NoSource(t *testing.T) {
 	origEmails := flagGoogleEnumEmails
 	origEmailFile := flagGoogleEnumEmailFile
 	origDomain := flagGoogleEnumDomain
@@ -314,8 +414,8 @@ func TestGoogleEnumTargets_NoSource(t *testing.T) {
 	flagGoogleEnumEmailFile = ""
 	flagGoogleEnumDomain = ""
 
-	_, err := googleEnumTargets()
-	require.Error(t, err, "googleEnumTargets must fail when no source is supplied")
+	_, err := googleEnumTargetList()
+	require.Error(t, err, "googleEnumTargetList must fail when no source is supplied")
 	assert.Contains(t, err.Error(), "provide",
 		"error message must guide the user to supply a target source")
 }

--- a/cmd/brutus/cmd_enum_gravatar.go
+++ b/cmd/brutus/cmd_enum_gravatar.go
@@ -101,10 +101,12 @@ func runEnumGravatar(cmd *cobra.Command, args []string) error {
 		flagJSON = true
 	}
 
-	emails, err := gravatarEnumTargets()
+	targets, err := gravatarEnumTargetList()
 	if err != nil {
 		return err
 	}
+	emails := enumTargetEmails(targets)
+	names := enumNamesByEmail(targets)
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
@@ -136,6 +138,12 @@ func runEnumGravatar(cmd *cobra.Command, args []string) error {
 	progress.Start()
 	var processed, found int
 	onResult := func(res gravatar.Result) {
+		// Stamp the generated name onto the result the checker just returned.
+		// The checker only ever sees the address, so the name is attached here;
+		// an address that came from --emails/--email-file is absent from names
+		// and stays nameless.
+		res.First, res.Last = enumNameFor(names, res.Email)
+
 		processed++
 		if res.Exists {
 			found++
@@ -162,20 +170,28 @@ func runEnumGravatar(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// gravatarEnumTargets parses, trims, lower-cases, and dedups the email targets
-// from --emails and --email-file, plus any --domain-generated candidates. It
+// gravatarEnumTargetList parses, trims, lower-cases, and dedups the email
+// targets from --emails and --email-file, plus any --domain-generated
+// candidates. Each generated target carries the name its username was built
+// from; supplied addresses carry none, because an address the operator provided
+// says nothing about whose it is. Dedup keeps the first-seen entry, so a
+// supplied address that a generated candidate duplicates stays nameless. It
 // errors when no targets are supplied.
-func gravatarEnumTargets() ([]string, error) {
-	var raw []string
+func gravatarEnumTargetList() ([]enum.Target, error) {
+	var raw []enum.Target
 	if flagGravatarEnumEmails != "" {
-		raw = append(raw, strings.Split(flagGravatarEnumEmails, ",")...)
+		for _, e := range strings.Split(flagGravatarEnumEmails, ",") {
+			raw = append(raw, enum.Target{Email: e})
+		}
 	}
 	if flagGravatarEnumEmailFile != "" {
 		lines, err := loadLinesFromFile(flagGravatarEnumEmailFile)
 		if err != nil {
 			return nil, fmt.Errorf("reading --email-file: %w", err)
 		}
-		raw = append(raw, lines...)
+		for _, e := range lines {
+			raw = append(raw, enum.Target{Email: e})
+		}
 	}
 
 	// --domain generates the candidate wordlist internally (reusing the same
@@ -183,7 +199,7 @@ func gravatarEnumTargets() ([]string, error) {
 	// Generated candidates are appended to any -e/-E targets and flow through
 	// the same dedup + enumeration path.
 	if flagGravatarEnumDomain != "" {
-		generated, err := gravatarEnumGenerate()
+		generated, err := gravatarEnumGenerateTargets()
 		if err != nil {
 			return nil, err
 		}
@@ -191,42 +207,51 @@ func gravatarEnumTargets() ([]string, error) {
 	}
 
 	seen := make(map[string]struct{})
-	var emails []string
-	for _, e := range raw {
-		e = strings.ToLower(strings.TrimSpace(e))
-		if e == "" {
+	var targets []enum.Target
+	for _, t := range raw {
+		// Lower-case here too, so the address on the target is exactly the one
+		// handed to the checker and echoed back on its Result.
+		t.Email = strings.ToLower(strings.TrimSpace(t.Email))
+		if t.Email == "" {
 			continue
 		}
-		if _, ok := seen[e]; ok {
+		if _, ok := seen[t.Email]; ok {
 			continue
 		}
-		seen[e] = struct{}{}
-		emails = append(emails, e)
+		seen[t.Email] = struct{}{}
+		targets = append(targets, t)
 	}
 
-	if len(emails) == 0 {
+	if len(targets) == 0 {
 		return nil, fmt.Errorf("provide --emails/-e, --email-file/-E, or --domain")
 	}
-	return emails, nil
+	return targets, nil
 }
 
-// gravatarEnumGenerate produces the candidate email wordlist for --domain by
-// reusing the shared, frequency-ranked generator (enum.GenerateEmails) and the
-// shared capResults helper — no duplicated generation logic. The requested
-// format is validated against enum.ListFormats() first, because GenerateEmails
-// silently yields an empty list for an unknown format. A status line goes to
-// stderr (never stdout, so --json/-o output stays clean) unless quiet or JSON.
-func gravatarEnumGenerate() ([]string, error) {
+// gravatarEnumGenerateTargets produces the candidate email wordlist for --domain
+// by reusing the shared, frequency-ranked generator (enum.GenerateCandidates)
+// and the shared capResults helper — no duplicated generation logic.
+// Candidates, not bare addresses, are generated so each target keeps the name
+// its username was built from, which is knowable for free here and lossy to
+// recover later. The requested format is validated against enum.ListFormats()
+// first, because the generator silently yields an empty list for an unknown
+// format. A status line goes to stderr (never stdout, so --json/-o output stays
+// clean) unless quiet or JSON.
+func gravatarEnumGenerateTargets() ([]enum.Target, error) {
 	if !slices.Contains(enum.ListFormats(), flagGravatarEnumFormat) {
 		return nil, fmt.Errorf("invalid --format %q; valid formats: %s",
 			flagGravatarEnumFormat, strings.Join(enum.ListFormats(), ", "))
 	}
 
-	generated, err := enum.GenerateEmails(flagGravatarEnumFormat, flagGravatarEnumDomain)
+	candidates, err := enum.GenerateCandidates(flagGravatarEnumFormat)
 	if err != nil {
 		return nil, fmt.Errorf("generating candidate emails: %w", err)
 	}
-	generated = capResults(generated, flagGravatarEnumLimit)
+	candidates = capResults(candidates, flagGravatarEnumLimit)
+	generated := make([]enum.Target, len(candidates))
+	for i, c := range candidates {
+		generated[i] = c.Target(flagGravatarEnumDomain)
+	}
 
 	if !flagQuiet && !flagJSON {
 		useColor := isColorEnabled(flagNoColor)

--- a/cmd/brutus/cmd_enum_gravatar_output.go
+++ b/cmd/brutus/cmd_enum_gravatar_output.go
@@ -78,6 +78,8 @@ func outputGravatarEnumSummary(w io.Writer, results []gravatar.Result, useColor 
 // avatar URL is derived from the hash for convenience.
 type gravatarEnumJSON struct {
 	Email     string `json:"email"`
+	First     string `json:"first,omitempty"`
+	Last      string `json:"last,omitempty"`
 	Hash      string `json:"hash"`
 	Exists    bool   `json:"exists"`
 	AvatarURL string `json:"avatar_url"`
@@ -88,6 +90,8 @@ type gravatarEnumJSON struct {
 func encodeGravatarEnumResult(r gravatar.Result) gravatarEnumJSON {
 	jr := gravatarEnumJSON{
 		Email:     r.Email,
+		First:     r.First,
+		Last:      r.Last,
 		Hash:      r.Hash,
 		Exists:    r.Exists,
 		AvatarURL: fmt.Sprintf("https://www.gravatar.com/avatar/%s", r.Hash),

--- a/cmd/brutus/cmd_enum_gravatar_output_test.go
+++ b/cmd/brutus/cmd_enum_gravatar_output_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/brutus/pkg/enum/gravatar"
+)
+
+// ---------------------------------------------------------------------------
+// outputGravatarEnumJSONL — First/Last name propagation (10T-535)
+// ---------------------------------------------------------------------------
+
+// TestOutputGravatarEnumJSONL_NameFields pins the never-invent-a-name rule: a
+// Result carrying First/Last (from --generate) must emit "first"/"last" in
+// the JSONL row, while a Result with empty First/Last (supplied via
+// --emails or --email-file) must OMIT both keys entirely rather than emit
+// them as "". Pre-existing fields (email/hash/exists/avatar_url) must be
+// unaffected.
+func TestOutputGravatarEnumJSONL_NameFields(t *testing.T) {
+	named := gravatar.Result{
+		Email:  "john.smith@example.com",
+		Hash:   gravatar.HashEmail("john.smith@example.com"),
+		Exists: true,
+		First:  "john",
+		Last:   "smith",
+	}
+	unnamed := gravatar.Result{
+		Email:  "supplied@example.com",
+		Hash:   gravatar.HashEmail("supplied@example.com"),
+		Exists: true,
+	}
+
+	t.Run("named result emits first and last", func(t *testing.T) {
+		var buf bytes.Buffer
+		outputGravatarEnumJSONL(&buf, []gravatar.Result{named})
+
+		line := strings.TrimSpace(buf.String())
+		require.NotEmpty(t, line, "outputGravatarEnumJSONL must produce a JSONL line")
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(line), &obj),
+			"JSONL output must be valid JSON: %q", line)
+
+		assert.Equal(t, "john", obj["first"], `first field must be "john"`)
+		assert.Equal(t, "smith", obj["last"], `last field must be "smith"`)
+
+		// Pre-existing fields must remain unaffected.
+		assert.Equal(t, named.Email, obj["email"])
+		assert.Equal(t, named.Hash, obj["hash"])
+		assert.Equal(t, true, obj["exists"])
+		assert.Contains(t, obj["avatar_url"], named.Hash)
+	})
+
+	t.Run("unnamed result omits first and last keys", func(t *testing.T) {
+		var buf bytes.Buffer
+		outputGravatarEnumJSONL(&buf, []gravatar.Result{unnamed})
+
+		line := strings.TrimSpace(buf.String())
+		require.NotEmpty(t, line, "outputGravatarEnumJSONL must produce a JSONL line")
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(line), &obj),
+			"JSONL output must be valid JSON: %q", line)
+
+		assert.NotContains(t, obj, "first",
+			`first key must be absent (omitempty), not emitted as ""`)
+		assert.NotContains(t, obj, "last",
+			`last key must be absent (omitempty), not emitted as ""`)
+
+		// Pre-existing fields must remain unaffected.
+		assert.Equal(t, unnamed.Email, obj["email"])
+		assert.Equal(t, unnamed.Hash, obj["hash"])
+		assert.Equal(t, true, obj["exists"])
+	})
+
+	t.Run("mixed batch: one named, one unnamed", func(t *testing.T) {
+		var buf bytes.Buffer
+		outputGravatarEnumJSONL(&buf, []gravatar.Result{named, unnamed})
+
+		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+		require.Len(t, lines, 2, "must emit exactly one JSONL line per result")
+
+		var first map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[0]), &first))
+		assert.Equal(t, "john", first["first"])
+		assert.Equal(t, "smith", first["last"])
+
+		var second map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[1]), &second))
+		assert.NotContains(t, second, "first")
+		assert.NotContains(t, second, "last")
+	})
+}

--- a/cmd/brutus/cmd_enum_gravatar_test.go
+++ b/cmd/brutus/cmd_enum_gravatar_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,10 +25,19 @@ import (
 )
 
 // ---------------------------------------------------------------------------
-// TestGravatarEnumTargets
-// Exercises gravatarEnumTargets() using the file-local flag variables
-// directly, saving and restoring them with defer (mirrors
-// TestGoogleEnumTargets_InlineEmails).
+// TestGravatarEnumTargetList
+//
+// 10T-535: gravatarEnumTargets() ([]string, error) and gravatarEnumGenerate()
+// ([]string, error) were dead []string adapters kept alive only by these
+// tests (the real logic — and the only production callers, runEnumGravatar
+// — lives in gravatarEnumTargetList() and gravatarEnumGenerateTargets(),
+// both returning ([]enum.Target, error)). Retargeted onto those and
+// strengthened to assert that supplied (--emails/--email-file) targets carry
+// no name while generated ones do, using the targetEmails helper from
+// cmd_enum_custom_test.go for compact address assertions. Exercises
+// gravatarEnumTargetList()/gravatarEnumGenerateTargets() using the
+// file-local flag variables directly, saving and restoring them with defer
+// (mirrors TestGoogleEnumTargetList_InlineEmails).
 // ---------------------------------------------------------------------------
 
 func resetGravatarEnumFlags() (restore func()) {
@@ -45,86 +55,140 @@ func resetGravatarEnumFlags() (restore func()) {
 	}
 }
 
-func TestGravatarEnumTargets_InlineEmails(t *testing.T) {
+func TestGravatarEnumTargetList_InlineEmails(t *testing.T) {
 	defer resetGravatarEnumFlags()()
 
 	flagGravatarEnumEmails = "Alice@Example.com, Bob@Example.com ,alice@example.com"
 	flagGravatarEnumEmailFile = ""
 	flagGravatarEnumDomain = ""
 
-	emails, err := gravatarEnumTargets()
+	got, err := gravatarEnumTargetList()
 	require.NoError(t, err)
 
+	emails := targetEmails(got)
 	// Deduplication (case-insensitive) and lower-casing/trimming: Alice and
 	// alice must collapse to one lower-cased, trimmed entry.
 	assert.Len(t, emails, 2, "deduplication must collapse case-insensitive duplicate emails")
 	assert.Contains(t, emails, "alice@example.com")
 	assert.Contains(t, emails, "bob@example.com")
+
+	for i, target := range got {
+		assert.Empty(t, target.First, "target %d (%q): CLI-supplied address must have empty First", i, target.Email)
+		assert.Empty(t, target.Last, "target %d (%q): CLI-supplied address must have empty Last", i, target.Email)
+	}
 }
 
-func TestGravatarEnumTargets_NoSource(t *testing.T) {
+func TestGravatarEnumTargetList_NoSource(t *testing.T) {
 	defer resetGravatarEnumFlags()()
 
 	flagGravatarEnumEmails = ""
 	flagGravatarEnumEmailFile = ""
 	flagGravatarEnumDomain = ""
 
-	_, err := gravatarEnumTargets()
-	require.Error(t, err, "gravatarEnumTargets must fail when no source is supplied")
+	_, err := gravatarEnumTargetList()
+	require.Error(t, err, "gravatarEnumTargetList must fail when no source is supplied")
 	assert.Contains(t, err.Error(), "provide",
 		"error message must guide the user to supply a target source")
 }
 
 // ---------------------------------------------------------------------------
-// TestGravatarEnumGenerate
+// TestGravatarEnumGenerateTargets
 // ---------------------------------------------------------------------------
 
-func TestGravatarEnumGenerate_ProducesCandidatesForDomain(t *testing.T) {
+func TestGravatarEnumGenerateTargets_ProducesCandidatesForDomain(t *testing.T) {
 	defer resetGravatarEnumFlags()()
 
 	flagGravatarEnumDomain = "target.com"
 	flagGravatarEnumFormat = "first.last"
 	flagGravatarEnumLimit = 0
 
-	generated, err := gravatarEnumGenerate()
+	got, err := gravatarEnumGenerateTargets()
 	require.NoError(t, err)
 
-	want, err := enum.GenerateEmails("first.last", "target.com")
+	wantEmails, err := enum.GenerateEmails("first.last", "target.com")
 	require.NoError(t, err)
 
-	assert.Equal(t, want, generated,
-		"gravatarEnumGenerate must reuse enum.GenerateEmails and return the same candidates")
-	for _, e := range generated {
-		assert.Contains(t, e, "@target.com", "every generated candidate must be for the requested domain")
+	generated := targetEmails(got)
+	assert.Equal(t, wantEmails, generated,
+		"gravatarEnumGenerateTargets must reuse enum.GenerateEmails/GenerateCandidates and return the same candidate addresses")
+	for i, target := range got {
+		assert.Contains(t, target.Email, "@target.com", "every generated candidate must be for the requested domain")
+		require.NotEmpty(t, target.First, "target %d (%q): generated candidate must have non-empty First", i, target.Email)
+		require.NotEmpty(t, target.Last, "target %d (%q): generated candidate must have non-empty Last", i, target.Email)
 	}
 }
 
-func TestGravatarEnumGenerate_RespectsLimit(t *testing.T) {
+func TestGravatarEnumGenerateTargets_RespectsLimit(t *testing.T) {
 	defer resetGravatarEnumFlags()()
 
 	flagGravatarEnumDomain = "target.com"
 	flagGravatarEnumFormat = "first.last"
 	flagGravatarEnumLimit = 3
 
-	generated, err := gravatarEnumGenerate()
+	got, err := gravatarEnumGenerateTargets()
 	require.NoError(t, err)
 
-	assert.Len(t, generated, 3, "--limit must cap the number of generated candidates")
+	assert.Len(t, got, 3, "--limit must cap the number of generated candidates")
 
-	want, err := enum.GenerateEmails("first.last", "target.com")
+	wantEmails, err := enum.GenerateEmails("first.last", "target.com")
 	require.NoError(t, err)
-	require.GreaterOrEqual(t, len(want), 3, "full generated list must have at least 3 candidates for this assertion to be meaningful")
-	assert.Equal(t, want[:3], generated, "--limit must keep the first (most-likely) N candidates")
+	require.GreaterOrEqual(t, len(wantEmails), 3, "full generated list must have at least 3 candidates for this assertion to be meaningful")
+	assert.Equal(t, wantEmails[:3], targetEmails(got), "--limit must keep the first (most-likely) N candidates")
 }
 
-func TestGravatarEnumGenerate_InvalidFormatRejected(t *testing.T) {
+func TestGravatarEnumGenerateTargets_InvalidFormatRejected(t *testing.T) {
 	defer resetGravatarEnumFlags()()
 
 	flagGravatarEnumDomain = "target.com"
 	flagGravatarEnumFormat = "not-a-real-format"
 	flagGravatarEnumLimit = 0
 
-	_, err := gravatarEnumGenerate()
+	_, err := gravatarEnumGenerateTargets()
 	require.Error(t, err, "an invalid --format must be rejected")
 	assert.Contains(t, err.Error(), "invalid --format")
+}
+
+// TestGravatarEnumTargetList_NamesSurviveLowerCasing pins a normalization
+// behavior the developer found a real bug in: gravatar lower-cases every
+// address (see gravatarEnumTargetList — unlike microsoft365, this is the
+// FULL address, not just the dedup key), because Gravatar hashing and the
+// avatar-existence check are both case-insensitive. The name-lookup helpers
+// (enumNamesByEmail/enumNameFor) key on the exact target Email, so this test
+// proves the index key gravatarEnumTargetList produces is exactly the
+// lower-cased address that enumTargetEmails hands to the checker — a
+// mismatch here would silently drop every generated name.
+func TestGravatarEnumTargetList_NamesSurviveLowerCasing(t *testing.T) {
+	defer resetGravatarEnumFlags()()
+
+	flagGravatarEnumEmails = ""
+	flagGravatarEnumEmailFile = ""
+	flagGravatarEnumDomain = "Target.com" // mixed case, as an operator might type it
+	flagGravatarEnumFormat = "first.last"
+	flagGravatarEnumLimit = 5
+
+	got, err := gravatarEnumTargetList()
+	require.NoError(t, err)
+	require.NotEmpty(t, got)
+
+	for i, target := range got {
+		// Gravatar lower-cases the FULL address, domain included — not just the
+		// dedup key — so the mixed-case --domain must not survive on Email.
+		assert.Equal(t, strings.ToLower(target.Email), target.Email,
+			"target %d: gravatar target Email must be fully lower-cased, got %q", i, target.Email)
+		require.NotEmpty(t, target.First, "target %d (%q): generated target must have non-empty First", i, target.Email)
+		require.NotEmpty(t, target.Last, "target %d (%q): generated target must have non-empty Last", i, target.Email)
+	}
+
+	// The real production round trip: the emails handed to the checker
+	// (enumTargetEmails) must be exactly the lower-cased addresses stored on
+	// each target, and enumNamesByEmail/enumNameFor must resolve each one back
+	// to its name by that same lower-cased key.
+	emails := enumTargetEmails(got)
+	names := enumNamesByEmail(got)
+	for i, target := range got {
+		assert.Equal(t, target.Email, emails[i], "target %d: enumTargetEmails must hand the checker the exact stored (lower-cased) Email", i)
+		first, last := enumNameFor(names, emails[i])
+		assert.Equal(t, target.First, first, "target %d (%q): name lookup by the lower-cased address handed to the checker must find First", i, target.Email)
+		assert.Equal(t, target.Last, last, "target %d (%q): name lookup by the lower-cased address handed to the checker must find Last", i, target.Email)
+	}
 }

--- a/cmd/brutus/cmd_enum_microsoft365.go
+++ b/cmd/brutus/cmd_enum_microsoft365.go
@@ -103,10 +103,12 @@ func runEnumMicrosoft365(cmd *cobra.Command, args []string) error {
 		flagJSON = true
 	}
 
-	emails, err := microsoft365EnumTargets()
+	targets, err := microsoft365EnumTargetList()
 	if err != nil {
 		return err
 	}
+	emails := enumTargetEmails(targets)
+	names := enumNamesByEmail(targets)
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
@@ -143,6 +145,12 @@ func runEnumMicrosoft365(cmd *cobra.Command, args []string) error {
 	progress.Start()
 	var processed, found int
 	onResult := func(res m365.Result) {
+		// Stamp the generated name onto the result the checker just returned.
+		// The checker only ever sees the address, so the name is attached here;
+		// an address that came from --emails/--email-file is absent from names
+		// and stays nameless.
+		res.First, res.Last = enumNameFor(names, res.Email)
+
 		processed++
 		if res.Exists {
 			found++
@@ -169,20 +177,28 @@ func runEnumMicrosoft365(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// microsoft365EnumTargets parses, trims, and dedups the email targets from
-// --emails and --email-file, plus any --domain-generated candidates. It errors
-// when no targets are supplied.
-func microsoft365EnumTargets() ([]string, error) {
-	var raw []string
+// microsoft365EnumTargetList parses, trims, and dedups the email targets from
+// --emails and --email-file, plus any --domain-generated candidates. Each
+// generated target carries the name its username was built from; supplied
+// addresses carry none, because an address the operator provided says nothing
+// about whose it is. Dedup keeps the first-seen entry, so a supplied address
+// that a generated candidate duplicates stays nameless. It errors when no
+// targets are supplied.
+func microsoft365EnumTargetList() ([]enum.Target, error) {
+	var raw []enum.Target
 	if flagM365EnumEmails != "" {
-		raw = append(raw, strings.Split(flagM365EnumEmails, ",")...)
+		for _, e := range strings.Split(flagM365EnumEmails, ",") {
+			raw = append(raw, enum.Target{Email: e})
+		}
 	}
 	if flagM365EnumEmailFile != "" {
 		lines, err := loadLinesFromFile(flagM365EnumEmailFile)
 		if err != nil {
 			return nil, fmt.Errorf("reading --email-file: %w", err)
 		}
-		raw = append(raw, lines...)
+		for _, e := range lines {
+			raw = append(raw, enum.Target{Email: e})
+		}
 	}
 
 	// --domain generates the candidate wordlist internally (reusing the same
@@ -198,45 +214,53 @@ func microsoft365EnumTargets() ([]string, error) {
 	}
 
 	seen := make(map[string]struct{})
-	var emails []string
-	for _, e := range raw {
-		e = strings.TrimSpace(e)
-		if e == "" {
+	var targets []enum.Target
+	for _, t := range raw {
+		t.Email = strings.TrimSpace(t.Email)
+		if t.Email == "" {
 			continue
 		}
 		// Key on the lowercased address (the API is case-insensitive) while
-		// appending the original-cased email to the results.
-		key := strings.ToLower(e)
+		// keeping the original-cased email on the target, which is also the
+		// address the checker echoes back on its Result.
+		key := strings.ToLower(t.Email)
 		if _, ok := seen[key]; ok {
 			continue
 		}
 		seen[key] = struct{}{}
-		emails = append(emails, e)
+		targets = append(targets, t)
 	}
 
-	if len(emails) == 0 {
+	if len(targets) == 0 {
 		return nil, fmt.Errorf("provide --emails/-e, --email-file/-E, or --domain")
 	}
-	return emails, nil
+	return targets, nil
 }
 
 // microsoft365EnumGenerate produces the candidate email wordlist for --domain by
-// reusing the shared, frequency-ranked generator (enum.GenerateEmails) and the
-// shared capResults helper — no duplicated generation logic. The requested
-// format is validated against enum.ListFormats() first, because GenerateEmails
-// silently yields an empty list for an unknown format. A status line goes to
-// stderr (never stdout, so --json/-o output stays clean) unless quiet or JSON.
-func microsoft365EnumGenerate() ([]string, error) {
+// reusing the shared, frequency-ranked generator (enum.GenerateCandidates) and
+// the shared capResults helper — no duplicated generation logic. Candidates,
+// not bare addresses, are generated so each target keeps the name its username
+// was built from, which is knowable for free here and lossy to recover later.
+// The requested format is validated against enum.ListFormats() first, because
+// the generator silently yields an empty list for an unknown format. A status
+// line goes to stderr (never stdout, so --json/-o output stays clean) unless
+// quiet or JSON.
+func microsoft365EnumGenerate() ([]enum.Target, error) {
 	if !slices.Contains(enum.ListFormats(), flagM365EnumFormat) {
 		return nil, fmt.Errorf("invalid --format %q; valid formats: %s",
 			flagM365EnumFormat, strings.Join(enum.ListFormats(), ", "))
 	}
 
-	generated, err := enum.GenerateEmails(flagM365EnumFormat, flagM365EnumDomain)
+	candidates, err := enum.GenerateCandidates(flagM365EnumFormat)
 	if err != nil {
 		return nil, fmt.Errorf("generating candidate emails: %w", err)
 	}
-	generated = capResults(generated, flagM365EnumLimit)
+	candidates = capResults(candidates, flagM365EnumLimit)
+	generated := make([]enum.Target, len(candidates))
+	for i, c := range candidates {
+		generated[i] = c.Target(flagM365EnumDomain)
+	}
 
 	if !flagQuiet && !flagJSON {
 		useColor := isColorEnabled(flagNoColor)

--- a/cmd/brutus/cmd_enum_microsoft365_test.go
+++ b/cmd/brutus/cmd_enum_microsoft365_test.go
@@ -240,6 +240,97 @@ func TestEncodeMicrosoft365EnumResult(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// TestEncodeMicrosoft365EnumResult_NameFields
+// Pins the never-invent-a-name rule: a Result carrying First/Last emits
+// "first"/"last" in the JSONL row, while a Result with empty First/Last (a
+// supplied address) omits both keys entirely rather than emitting them as "".
+// Pre-existing fields (type/email/exists/if_exists_result/federated) must be
+// unaffected.
+// ---------------------------------------------------------------------------
+
+func TestEncodeMicrosoft365EnumResult_NameFields(t *testing.T) {
+	named := m365.Result{
+		Email:          "john.smith@example.com",
+		Exists:         true,
+		IfExistsResult: m365.IfExistsResultExists,
+		First:          "john",
+		Last:           "smith",
+	}
+	unnamed := m365.Result{
+		Email:          "supplied@example.com",
+		Exists:         true,
+		IfExistsResult: m365.IfExistsResultExists,
+	}
+
+	t.Run("named result emits first and last", func(t *testing.T) {
+		var buf bytes.Buffer
+		enc := json.NewEncoder(&buf)
+		encodeMicrosoft365EnumResult(enc, named)
+
+		line := strings.TrimSpace(buf.String())
+		require.NotEmpty(t, line, "encodeMicrosoft365EnumResult must produce a JSONL line")
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(line), &obj),
+			"JSONL output must be valid JSON: %q", line)
+
+		assert.Equal(t, "john", obj["first"], `first field must be "john"`)
+		assert.Equal(t, "smith", obj["last"], `last field must be "smith"`)
+
+		// Pre-existing fields must remain unaffected.
+		assert.Equal(t, "microsoft365_account", obj["type"])
+		assert.Equal(t, named.Email, obj["email"])
+		assert.Equal(t, true, obj["exists"])
+		gotIfExists, ok := obj["if_exists_result"].(float64)
+		require.True(t, ok, "if_exists_result must be numeric")
+		assert.Equal(t, 0, int(gotIfExists))
+	})
+
+	t.Run("unnamed result omits first and last keys", func(t *testing.T) {
+		var buf bytes.Buffer
+		enc := json.NewEncoder(&buf)
+		encodeMicrosoft365EnumResult(enc, unnamed)
+
+		line := strings.TrimSpace(buf.String())
+		require.NotEmpty(t, line, "encodeMicrosoft365EnumResult must produce a JSONL line")
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(line), &obj),
+			"JSONL output must be valid JSON: %q", line)
+
+		assert.NotContains(t, obj, "first",
+			`first key must be absent (omitempty), not emitted as ""`)
+		assert.NotContains(t, obj, "last",
+			`last key must be absent (omitempty), not emitted as ""`)
+
+		// Pre-existing fields must remain unaffected.
+		assert.Equal(t, "microsoft365_account", obj["type"])
+		assert.Equal(t, unnamed.Email, obj["email"])
+		assert.Equal(t, true, obj["exists"])
+	})
+
+	t.Run("mixed batch: one named, one unnamed", func(t *testing.T) {
+		var buf bytes.Buffer
+		enc := json.NewEncoder(&buf)
+		encodeMicrosoft365EnumResult(enc, named)
+		encodeMicrosoft365EnumResult(enc, unnamed)
+
+		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+		require.Len(t, lines, 2, "must emit exactly one JSONL line per result")
+
+		var first map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[0]), &first))
+		assert.Equal(t, "john", first["first"])
+		assert.Equal(t, "smith", first["last"])
+
+		var second map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[1]), &second))
+		assert.NotContains(t, second, "first")
+		assert.NotContains(t, second, "last")
+	})
+}
+
+// ---------------------------------------------------------------------------
 // TestOutputMicrosoft365EnumResultLine
 // Verifies human-readable line output for EXISTS, federation, and ANSI safety.
 // ---------------------------------------------------------------------------
@@ -359,12 +450,20 @@ func TestOutputMicrosoft365EnumResultLine(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// TestMicrosoft365EnumTargets
-// Exercises microsoft365EnumTargets() using the file-local flag variables
+// TestMicrosoft365EnumTargetList
+//
+// 10T-535: microsoft365EnumTargets() ([]string, error) was a dead []string
+// adapter kept alive only by these tests (the real logic — and the only
+// production caller, runEnumMicrosoft365 — lives in
+// microsoft365EnumTargetList() ([]enum.Target, error)). Retargeted onto
+// microsoft365EnumTargetList and strengthened to assert that supplied
+// (--emails/--email-file) targets carry no name, using the targetEmails
+// helper from cmd_enum_custom_test.go for compact address assertions.
+// Exercises microsoft365EnumTargetList() using the file-local flag variables
 // directly, saving and restoring them with defer.
 // ---------------------------------------------------------------------------
 
-func TestMicrosoft365EnumTargets_InlineEmails(t *testing.T) {
+func TestMicrosoft365EnumTargetList_InlineEmails(t *testing.T) {
 	// Save and restore flag globals.
 	origEmails := flagM365EnumEmails
 	origEmailFile := flagM365EnumEmailFile
@@ -379,16 +478,22 @@ func TestMicrosoft365EnumTargets_InlineEmails(t *testing.T) {
 	flagM365EnumEmailFile = ""
 	flagM365EnumDomain = ""
 
-	emails, err := microsoft365EnumTargets()
+	got, err := microsoft365EnumTargetList()
 	require.NoError(t, err)
 
+	emails := targetEmails(got)
 	// Deduplication: alice@example.com appears twice but must appear once.
 	assert.Len(t, emails, 2, "deduplication must collapse duplicate emails")
 	assert.Contains(t, emails, "alice@example.com")
 	assert.Contains(t, emails, "bob@example.com")
+
+	for i, target := range got {
+		assert.Empty(t, target.First, "target %d (%q): CLI-supplied address must have empty First", i, target.Email)
+		assert.Empty(t, target.Last, "target %d (%q): CLI-supplied address must have empty Last", i, target.Email)
+	}
 }
 
-func TestMicrosoft365EnumTargets_NoSource(t *testing.T) {
+func TestMicrosoft365EnumTargetList_NoSource(t *testing.T) {
 	origEmails := flagM365EnumEmails
 	origEmailFile := flagM365EnumEmailFile
 	origDomain := flagM365EnumDomain
@@ -402,16 +507,17 @@ func TestMicrosoft365EnumTargets_NoSource(t *testing.T) {
 	flagM365EnumEmailFile = ""
 	flagM365EnumDomain = ""
 
-	_, err := microsoft365EnumTargets()
-	require.Error(t, err, "microsoft365EnumTargets must fail when no source is supplied")
+	_, err := microsoft365EnumTargetList()
+	require.Error(t, err, "microsoft365EnumTargetList must fail when no source is supplied")
 	assert.Contains(t, err.Error(), "provide",
 		"error message must guide the user to supply a target source")
 }
 
-// TestMicrosoft365EnumTargets_CaseInsensitiveDedup verifies that dedup keys on
-// the lowercased email (the GetCredentialType API is case-insensitive) while
-// preserving the first-seen casing in the returned results.
-func TestMicrosoft365EnumTargets_CaseInsensitiveDedup(t *testing.T) {
+// TestMicrosoft365EnumTargetList_CaseInsensitiveDedup verifies that dedup keys
+// on the lowercased email (the GetCredentialType API is case-insensitive)
+// while preserving the first-seen casing in the returned targets. None of
+// these targets are generated, so all must carry no name.
+func TestMicrosoft365EnumTargetList_CaseInsensitiveDedup(t *testing.T) {
 	origEmails := flagM365EnumEmails
 	origEmailFile := flagM365EnumEmailFile
 	origDomain := flagM365EnumDomain
@@ -425,9 +531,10 @@ func TestMicrosoft365EnumTargets_CaseInsensitiveDedup(t *testing.T) {
 	flagM365EnumEmailFile = ""
 	flagM365EnumDomain = ""
 
-	emails, err := microsoft365EnumTargets()
+	got, err := microsoft365EnumTargetList()
 	require.NoError(t, err)
 
+	emails := targetEmails(got)
 	// Case-variant duplicates collapse: "Alice@Example.com" and
 	// "alice@example.com" are the same target.
 	assert.Len(t, emails, 2, "case-variant duplicates must collapse")
@@ -438,4 +545,73 @@ func TestMicrosoft365EnumTargets_CaseInsensitiveDedup(t *testing.T) {
 	assert.NotContains(t, emails, "alice@example.com",
 		"the later-seen lowercase duplicate must not also appear")
 	assert.Contains(t, emails, "BOB@example.com")
+
+	for i, target := range got {
+		assert.Empty(t, target.First, "target %d (%q): CLI-supplied address must have empty First", i, target.Email)
+		assert.Empty(t, target.Last, "target %d (%q): CLI-supplied address must have empty Last", i, target.Email)
+	}
+}
+
+// TestMicrosoft365EnumTargetList_NamesSurviveMixedCaseDomain pins a
+// normalization behavior the developer found a real bug in: microsoft365
+// dedups on the LOWERCASED email (the GetCredentialType API is
+// case-insensitive) but keeps each target's ORIGINAL casing on Email, and
+// m365.Result.Email echoes that original casing back verbatim (see
+// microsoft365.Checker.CheckAccount). A --domain value typed in mixed case
+// (e.g. "Example.com") therefore produces generated targets whose Email is
+// NOT all-lowercase. The name-lookup helpers (enumNamesByEmail/enumNameFor)
+// key on the exact target Email, so this test proves that round trip holds:
+// the name attached to a mixed-case generated target is still found when
+// looked up by that target's own (mixed-case) Email — the name is not lost
+// or mismatched because of the casing.
+func TestMicrosoft365EnumTargetList_NamesSurviveMixedCaseDomain(t *testing.T) {
+	origEmails := flagM365EnumEmails
+	origEmailFile := flagM365EnumEmailFile
+	origDomain := flagM365EnumDomain
+	origFormat := flagM365EnumFormat
+	origLimit := flagM365EnumLimit
+	origQuiet := flagQuiet
+	origJSON := flagJSON
+	defer func() {
+		flagM365EnumEmails = origEmails
+		flagM365EnumEmailFile = origEmailFile
+		flagM365EnumDomain = origDomain
+		flagM365EnumFormat = origFormat
+		flagM365EnumLimit = origLimit
+		flagQuiet = origQuiet
+		flagJSON = origJSON
+	}()
+
+	flagM365EnumEmails = ""
+	flagM365EnumEmailFile = ""
+	flagM365EnumDomain = "Example.com" // mixed case, as an operator might type it
+	flagM365EnumFormat = "first.last"
+	flagM365EnumLimit = 5
+	flagQuiet = true
+	flagJSON = false
+
+	got, err := microsoft365EnumTargetList()
+	require.NoError(t, err)
+	require.NotEmpty(t, got)
+
+	for i, target := range got {
+		// The domain casing the operator typed must survive verbatim on Email —
+		// dedup only lowercases the map KEY, never the stored Email.
+		assert.True(t, strings.HasSuffix(target.Email, "@Example.com"),
+			"target %d: generated Email must preserve the mixed-case --domain verbatim, got %q", i, target.Email)
+		require.NotEmpty(t, target.First, "target %d (%q): generated target must have non-empty First", i, target.Email)
+		require.NotEmpty(t, target.Last, "target %d (%q): generated target must have non-empty Last", i, target.Email)
+	}
+
+	// The real production round trip: enumNamesByEmail indexes by each target's
+	// exact Email, and enumNameFor looks up by that same string (the one the
+	// checker would echo back on Result.Email). If the index key ever diverged
+	// from the target's stored (mixed-case) Email, every one of these lookups
+	// would silently miss and return empty names.
+	names := enumNamesByEmail(got)
+	for i, target := range got {
+		first, last := enumNameFor(names, target.Email)
+		assert.Equal(t, target.First, first, "target %d (%q): name lookup by the target's own mixed-case Email must find First", i, target.Email)
+		assert.Equal(t, target.Last, last, "target %d (%q): name lookup by the target's own mixed-case Email must find Last", i, target.Email)
+	}
 }

--- a/cmd/brutus/cmd_enum_oracles.go
+++ b/cmd/brutus/cmd_enum_oracles.go
@@ -235,15 +235,16 @@ func runEnumOracles(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Phase 2: Build email list
-	var emails []string
+	// Phase 2: Build target list. Addresses supplied via -e/-E are nameless;
+	// generated ones carry the name they were built from.
+	var targets []enum.Target
 
 	// From --emails flag
 	if flagOraclesEmails != "" {
 		for _, e := range strings.Split(flagOraclesEmails, ",") {
 			e = strings.TrimSpace(e)
 			if e != "" {
-				emails = append(emails, e)
+				targets = append(targets, enum.Target{Email: e})
 			}
 		}
 	}
@@ -254,7 +255,9 @@ func runEnumOracles(cmd *cobra.Command, args []string) error {
 		if loadErr != nil {
 			return fmt.Errorf("loading email file: %w", loadErr)
 		}
-		emails = append(emails, fileEmails...)
+		for _, e := range fileEmails {
+			targets = append(targets, enum.Target{Email: e})
+		}
 	}
 
 	// From --generate flag
@@ -266,18 +269,20 @@ func runEnumOracles(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(os.Stderr, "%s Generating emails with format %q for %s...\n",
 				dim(useColor, SymbolInfo), flagEnumFormat, flagEnumDomain)
 		}
-		generated, genErr := enum.GenerateEmails(flagEnumFormat, flagEnumDomain)
+		candidates, genErr := enum.GenerateCandidates(flagEnumFormat)
 		if genErr != nil {
 			return fmt.Errorf("generating emails: %w", genErr)
 		}
-		logVerbose(flagVerbose, "Generated %d emails", len(generated))
-		emails = append(emails, generated...)
+		logVerbose(flagVerbose, "Generated %d emails", len(candidates))
+		for _, c := range candidates {
+			targets = append(targets, c.Target(flagEnumDomain))
+		}
 	}
 
 	// Determine the oracle-check label up front: the domain when provided,
 	// otherwise the explicit targets, so the Oracle Check block can announce
 	// what was checked even when there are no emails to enumerate.
-	checkLabel := oracleCheckLabel(emails)
+	checkLabel := oracleCheckLabel(targets)
 
 	// Phase 3: Determine oracles to check
 	var services []string
@@ -325,7 +330,7 @@ func runEnumOracles(cmd *cobra.Command, args []string) error {
 		}
 
 		validCfg := &enum.Config{
-			Emails:   []string{flagOraclesKnownValid},
+			Targets:  []enum.Target{{Email: flagOraclesKnownValid}},
 			Services: svcList,
 			Threads:  flagThreads,
 			Timeout:  flagTimeout,
@@ -362,7 +367,7 @@ func runEnumOracles(cmd *cobra.Command, args []string) error {
 
 			// If there are no emails to enumerate, the oracle check IS the
 			// output: emit the JSON results and return without enumerating.
-			if len(emails) == 0 {
+			if len(targets) == 0 {
 				if flagJSON {
 					if dnsResult != nil {
 						outputDNSReconJSONL(jsonWriter, dnsResult, teamsOracleAvailable(dnsResult))
@@ -386,7 +391,7 @@ func runEnumOracles(cmd *cobra.Command, args []string) error {
 
 	// If there were no oracles to check at all and no emails, there is nothing
 	// left to do beyond the DNS recon already surfaced above.
-	if len(emails) == 0 {
+	if len(targets) == 0 {
 		if dnsResult != nil && flagJSON {
 			outputDNSReconJSONL(jsonWriter, dnsResult, teamsOracleAvailable(dnsResult))
 		}
@@ -402,12 +407,12 @@ func runEnumOracles(cmd *cobra.Command, args []string) error {
 			svcNames = enum.ListPlugins()
 		}
 		fmt.Fprintf(os.Stderr, "%s Enumerating %d email(s) against %d working oracle(s): %s\n",
-			dim(useColor, SymbolInfo), len(emails), len(svcNames), strings.Join(svcNames, ", "))
+			dim(useColor, SymbolInfo), len(targets), len(svcNames), strings.Join(svcNames, ", "))
 	}
 
 	// Phase 4: Run enumeration against the working oracles
 	cfg := &enum.Config{
-		Emails:    emails,
+		Targets:   targets,
 		Services:  services,
 		Threads:   flagThreads,
 		Timeout:   flagTimeout,
@@ -513,7 +518,7 @@ func runEnumDiscover(cmd *cobra.Command, args []string) error {
 
 		// Phase 2: Test oracles
 		cfg := &enum.Config{
-			Emails:   []string{flagOraclesKnownValid},
+			Targets:  []enum.Target{{Email: flagOraclesKnownValid}},
 			Services: services,
 			Threads:  flagThreads,
 			Timeout:  flagTimeout,
@@ -684,12 +689,16 @@ func outputDiscoverTeamsJSONL(w io.Writer, statusLine string) {
 
 // oracleCheckLabel returns the label for the Oracle Check header: the --domain
 // when one was provided, otherwise a compact list of the explicit email targets.
-func oracleCheckLabel(emails []string) string {
+func oracleCheckLabel(targets []enum.Target) string {
 	if flagEnumDomain != "" {
 		return flagEnumDomain
 	}
-	if len(emails) > 0 {
-		return strings.Join(emails, ", ")
+	if len(targets) > 0 {
+		addrs := make([]string, len(targets))
+		for i, t := range targets {
+			addrs[i] = t.Email
+		}
+		return strings.Join(addrs, ", ")
 	}
 	return "(no targets)"
 }

--- a/cmd/brutus/cmd_enum_output.go
+++ b/cmd/brutus/cmd_enum_output.go
@@ -268,6 +268,8 @@ func outputEnumJSONL(w io.Writer, results []enum.Result) {
 		Type       string `json:"type"`
 		Service    string `json:"service"`
 		Email      string `json:"email"`
+		First      string `json:"first,omitempty"`
+		Last       string `json:"last,omitempty"`
 		Exists     bool   `json:"exists"`
 		Confidence string `json:"confidence,omitempty"`
 		Error      string `json:"error,omitempty"`
@@ -281,6 +283,8 @@ func outputEnumJSONL(w io.Writer, results []enum.Result) {
 			Type:       "enum",
 			Service:    r.Service,
 			Email:      r.Email,
+			First:      r.First,
+			Last:       r.Last,
 			Exists:     r.Exists,
 			Confidence: string(r.Confidence),
 			Duration:   r.Duration.String(),
@@ -620,6 +624,8 @@ func outputTeamsEnumJSONL(w io.Writer, results []teams.EnumResult) {
 	type teamsEnumJSON struct {
 		Type              string `json:"type"`
 		Email             string `json:"email"`
+		First             string `json:"first,omitempty"`
+		Last              string `json:"last,omitempty"`
 		Exists            string `json:"exists"`
 		DetailsRestricted bool   `json:"details_restricted,omitempty"`
 		DisplayName       string `json:"display_name,omitempty"`
@@ -641,9 +647,14 @@ func outputTeamsEnumJSONL(w io.Writer, results []teams.EnumResult) {
 	enc := json.NewEncoder(w)
 	for i := range results {
 		r := &results[i]
+		// First/Last are set here, outside the existence switch: the generated
+		// name is a property of the address, not of the check outcome, so a
+		// blocked (403) hit carries it exactly like a resolved one.
 		jr := teamsEnumJSON{
 			Type:  "teams_enum",
 			Email: r.Email,
+			First: r.First,
+			Last:  r.Last,
 		}
 		// Map internal existence to the output shape. A 403/blocked result is a
 		// confirmed hit whose details the tenant withholds, so it is presented as
@@ -974,6 +985,8 @@ func outputGoogleEnumJSONL(w io.Writer, results []google.Result) {
 	type googleEnumJSON struct {
 		Type   string `json:"type"`
 		Email  string `json:"email"`
+		First  string `json:"first,omitempty"`
+		Last   string `json:"last,omitempty"`
 		Exists bool   `json:"exists"`
 		Method string `json:"method,omitempty"`
 		IdP    string `json:"idp,omitempty"`
@@ -986,6 +999,8 @@ func outputGoogleEnumJSONL(w io.Writer, results []google.Result) {
 		jr := googleEnumJSON{
 			Type:   "google_account",
 			Email:  r.Email,
+			First:  r.First,
+			Last:   r.Last,
 			Exists: r.Exists,
 			Method: string(r.Method),
 			IdP:    r.IdP,
@@ -1116,6 +1131,8 @@ func outputMicrosoft365EnumSummary(w io.Writer, results []m365.Result, useColor 
 type microsoft365EnumJSON struct {
 	Type           string `json:"type"`
 	Email          string `json:"email"`
+	First          string `json:"first,omitempty"`
+	Last           string `json:"last,omitempty"`
 	Exists         bool   `json:"exists"`
 	IfExistsResult *int   `json:"if_exists_result,omitempty"`
 	Federated      bool   `json:"federated,omitempty"`
@@ -1132,6 +1149,8 @@ func encodeMicrosoft365EnumResult(enc *json.Encoder, r m365.Result) { //nolint:g
 	jr := microsoft365EnumJSON{
 		Type:          "microsoft365_account",
 		Email:         r.Email,
+		First:         r.First,
+		Last:          r.Last,
 		Exists:        r.Exists,
 		Federated:     r.Federated,
 		FederationURL: r.FederationURL,

--- a/cmd/brutus/cmd_enum_output_teams_test.go
+++ b/cmd/brutus/cmd_enum_output_teams_test.go
@@ -252,6 +252,91 @@ func TestOutputTeamsEnumJSONL_AccountType(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Test: outputTeamsEnumJSONL — First/Last name propagation (10T-535)
+// ---------------------------------------------------------------------------
+
+// TestOutputTeamsEnumJSONL_NameFields pins the never-invent-a-name rule: a
+// Result carrying First/Last emits "first"/"last" in the JSONL row, while a
+// Result with empty First/Last (a supplied address) omits both keys entirely
+// rather than emitting them as "". Pre-existing fields (type/email/exists/
+// account_type) must be unaffected.
+func TestOutputTeamsEnumJSONL_NameFields(t *testing.T) {
+	named := teams.EnumResult{
+		Email:  "john.smith@contoso.com",
+		Exists: teams.ExistenceYes,
+		MRI:    "8:orgid:some-guid",
+		First:  "john",
+		Last:   "smith",
+	}
+	unnamed := teams.EnumResult{
+		Email:  "supplied@contoso.com",
+		Exists: teams.ExistenceYes,
+		MRI:    "8:orgid:other-guid",
+	}
+
+	t.Run("named result emits first and last", func(t *testing.T) {
+		var buf bytes.Buffer
+		outputTeamsEnumJSONL(&buf, []teams.EnumResult{named})
+
+		line := strings.TrimSpace(buf.String())
+		require.NotEmpty(t, line, "outputTeamsEnumJSONL must produce a JSONL line")
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(line), &obj),
+			"JSONL output must be valid JSON: %q", line)
+
+		assert.Equal(t, "john", obj["first"], `first field must be "john"`)
+		assert.Equal(t, "smith", obj["last"], `last field must be "smith"`)
+
+		// Pre-existing fields must remain unaffected.
+		assert.Equal(t, "teams_enum", obj["type"])
+		assert.Equal(t, named.Email, obj["email"])
+		assert.Equal(t, string(teams.ExistenceYes), obj["exists"])
+		assert.Equal(t, "corporate", obj["account_type"])
+	})
+
+	t.Run("unnamed result omits first and last keys", func(t *testing.T) {
+		var buf bytes.Buffer
+		outputTeamsEnumJSONL(&buf, []teams.EnumResult{unnamed})
+
+		line := strings.TrimSpace(buf.String())
+		require.NotEmpty(t, line, "outputTeamsEnumJSONL must produce a JSONL line")
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(line), &obj),
+			"JSONL output must be valid JSON: %q", line)
+
+		assert.NotContains(t, obj, "first",
+			`first key must be absent (omitempty), not emitted as ""`)
+		assert.NotContains(t, obj, "last",
+			`last key must be absent (omitempty), not emitted as ""`)
+
+		// Pre-existing fields must remain unaffected.
+		assert.Equal(t, "teams_enum", obj["type"])
+		assert.Equal(t, unnamed.Email, obj["email"])
+		assert.Equal(t, string(teams.ExistenceYes), obj["exists"])
+	})
+
+	t.Run("mixed batch: one named, one unnamed", func(t *testing.T) {
+		var buf bytes.Buffer
+		outputTeamsEnumJSONL(&buf, []teams.EnumResult{named, unnamed})
+
+		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+		require.Len(t, lines, 2, "must emit exactly one JSONL line per result")
+
+		var first map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[0]), &first))
+		assert.Equal(t, "john", first["first"])
+		assert.Equal(t, "smith", first["last"])
+
+		var second map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[1]), &second))
+		assert.NotContains(t, second, "first")
+		assert.NotContains(t, second, "last")
+	})
+}
+
+// ---------------------------------------------------------------------------
 // Test: outputTeamsEnumJSONL — ExistenceBlocked shape and existence value coverage
 // ---------------------------------------------------------------------------
 

--- a/cmd/brutus/cmd_enum_output_test.go
+++ b/cmd/brutus/cmd_enum_output_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/brutus/pkg/enum"
+)
+
+// ---------------------------------------------------------------------------
+// outputEnumJSONL — First/Last name propagation (10T-535)
+// ---------------------------------------------------------------------------
+
+// TestOutputEnumJSONL_NameFields pins the never-invent-a-name rule for the
+// generic enum output path: a Result carrying First/Last (from --generate)
+// must emit "first"/"last" in the JSONL row, while a Result with empty
+// First/Last (supplied via --emails or --email-file) must OMIT both keys
+// entirely rather than emit them as "". Pre-existing fields
+// (type/service/email/exists/confidence) must be unaffected.
+func TestOutputEnumJSONL_NameFields(t *testing.T) {
+	named := enum.Result{
+		Service:    "github",
+		Email:      "john.smith@example.com",
+		First:      "john",
+		Last:       "smith",
+		Exists:     true,
+		Confidence: enum.ConfidenceHigh,
+	}
+	unnamed := enum.Result{
+		Service:    "github",
+		Email:      "supplied@example.com",
+		Exists:     false,
+		Confidence: enum.ConfidenceLow,
+	}
+
+	t.Run("named result emits first and last", func(t *testing.T) {
+		var buf bytes.Buffer
+		outputEnumJSONL(&buf, []enum.Result{named})
+
+		line := strings.TrimSpace(buf.String())
+		require.NotEmpty(t, line, "outputEnumJSONL must produce a JSONL line")
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(line), &obj),
+			"JSONL output must be valid JSON: %q", line)
+
+		assert.Equal(t, "john", obj["first"], `first field must be "john"`)
+		assert.Equal(t, "smith", obj["last"], `last field must be "smith"`)
+
+		// Pre-existing fields must remain unaffected.
+		assert.Equal(t, "enum", obj["type"])
+		assert.Equal(t, "github", obj["service"])
+		assert.Equal(t, named.Email, obj["email"])
+		assert.Equal(t, true, obj["exists"])
+		assert.Equal(t, string(enum.ConfidenceHigh), obj["confidence"])
+	})
+
+	t.Run("unnamed result omits first and last keys", func(t *testing.T) {
+		var buf bytes.Buffer
+		outputEnumJSONL(&buf, []enum.Result{unnamed})
+
+		line := strings.TrimSpace(buf.String())
+		require.NotEmpty(t, line, "outputEnumJSONL must produce a JSONL line")
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(line), &obj),
+			"JSONL output must be valid JSON: %q", line)
+
+		assert.NotContains(t, obj, "first",
+			`first key must be absent (omitempty), not emitted as ""`)
+		assert.NotContains(t, obj, "last",
+			`last key must be absent (omitempty), not emitted as ""`)
+
+		// Pre-existing fields must remain unaffected.
+		assert.Equal(t, "enum", obj["type"])
+		assert.Equal(t, "github", obj["service"])
+		assert.Equal(t, unnamed.Email, obj["email"])
+		assert.Equal(t, false, obj["exists"])
+		assert.Equal(t, string(enum.ConfidenceLow), obj["confidence"])
+	})
+
+	t.Run("mixed batch: one named, one unnamed", func(t *testing.T) {
+		var buf bytes.Buffer
+		outputEnumJSONL(&buf, []enum.Result{named, unnamed})
+
+		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+		require.Len(t, lines, 2, "must emit exactly one JSONL line per result")
+
+		var first map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[0]), &first))
+		assert.Equal(t, "john", first["first"])
+		assert.Equal(t, "smith", first["last"])
+
+		var second map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[1]), &second))
+		assert.NotContains(t, second, "first")
+		assert.NotContains(t, second, "last")
+	})
+}

--- a/cmd/brutus/cmd_enum_teams.go
+++ b/cmd/brutus/cmd_enum_teams.go
@@ -360,10 +360,12 @@ func runEnumTeamsUsers(cmd *cobra.Command, args []string) error {
 		flagJSON = true
 	}
 
-	emails, err := teamsEnumTargets()
+	targets, err := teamsEnumTargetList()
 	if err != nil {
 		return err
 	}
+	emails := enumTargetEmails(targets)
+	names := enumNamesByEmail(targets)
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
@@ -425,6 +427,12 @@ func runEnumTeamsUsers(cmd *cobra.Command, args []string) error {
 	progress.Start()
 	var processed, found, blocked int
 	onResult := func(res teams.EnumResult) {
+		// Stamp the generated name onto the result the enumerator just returned.
+		// The enumerator only ever sees the address, so the name is attached
+		// here; an address that came from --emails/--email-file is absent from
+		// names and stays nameless.
+		res.First, res.Last = enumNameFor(names, res.Email)
+
 		processed++
 		switch res.Exists {
 		case teams.ExistenceYes:
@@ -576,19 +584,27 @@ func teamsEnumDomain(emails []string) string {
 	return domain
 }
 
-// teamsEnumTargets parses, trims, and dedups the email targets from --emails
-// and --email-file. It errors when no targets are supplied.
-func teamsEnumTargets() ([]string, error) {
-	var raw []string
+// teamsEnumTargetList parses, trims, and dedups the email targets from --emails
+// and --email-file, plus any --domain-generated candidates. Each generated
+// target carries the name its username was built from; supplied addresses carry
+// none, because an address the operator provided says nothing about whose it is.
+// Dedup keeps the first-seen entry, so a supplied address that a generated
+// candidate duplicates stays nameless. It errors when no targets are supplied.
+func teamsEnumTargetList() ([]enum.Target, error) {
+	var raw []enum.Target
 	if flagTeamsEnumEmails != "" {
-		raw = append(raw, strings.Split(flagTeamsEnumEmails, ",")...)
+		for _, e := range strings.Split(flagTeamsEnumEmails, ",") {
+			raw = append(raw, enum.Target{Email: e})
+		}
 	}
 	if flagTeamsEnumEmailFile != "" {
 		lines, err := loadLinesFromFile(flagTeamsEnumEmailFile)
 		if err != nil {
 			return nil, fmt.Errorf("reading --email-file: %w", err)
 		}
-		raw = append(raw, lines...)
+		for _, e := range lines {
+			raw = append(raw, enum.Target{Email: e})
+		}
 	}
 
 	// --domain generates the candidate wordlist internally (reusing the same
@@ -596,7 +612,7 @@ func teamsEnumTargets() ([]string, error) {
 	// Generated candidates are appended to any -e/-E targets and flow through
 	// the same dedup + enumeration path.
 	if flagTeamsEnumDomain != "" {
-		generated, err := teamsEnumGenerate()
+		generated, err := teamsEnumGenerateTargets()
 		if err != nil {
 			return nil, err
 		}
@@ -604,42 +620,49 @@ func teamsEnumTargets() ([]string, error) {
 	}
 
 	seen := make(map[string]struct{})
-	var emails []string
-	for _, e := range raw {
-		e = strings.TrimSpace(e)
-		if e == "" {
+	var targets []enum.Target
+	for _, t := range raw {
+		t.Email = strings.TrimSpace(t.Email)
+		if t.Email == "" {
 			continue
 		}
-		if _, ok := seen[e]; ok {
+		if _, ok := seen[t.Email]; ok {
 			continue
 		}
-		seen[e] = struct{}{}
-		emails = append(emails, e)
+		seen[t.Email] = struct{}{}
+		targets = append(targets, t)
 	}
 
-	if len(emails) == 0 {
+	if len(targets) == 0 {
 		return nil, fmt.Errorf("provide --emails/-e, --email-file/-E, or --domain")
 	}
-	return emails, nil
+	return targets, nil
 }
 
-// teamsEnumGenerate produces the candidate email wordlist for --domain by
-// reusing the shared, frequency-ranked generator (enum.GenerateEmails) and the
-// shared capResults helper — no duplicated generation logic. The requested
-// format is validated against enum.ListFormats() first, because GenerateEmails
-// silently yields an empty list for an unknown format. A status line goes to
-// stderr (never stdout, so --json/-o output stays clean) unless quiet or JSON.
-func teamsEnumGenerate() ([]string, error) {
+// teamsEnumGenerateTargets produces the candidate email wordlist for --domain by
+// reusing the shared, frequency-ranked generator (enum.GenerateCandidates) and
+// the shared capResults helper — no duplicated generation logic. Candidates, not
+// bare addresses, are generated so each target keeps the name its username was
+// built from, which is knowable for free here and lossy to recover later. The
+// requested format is validated against enum.ListFormats() first, because the
+// generator silently yields an empty list for an unknown format. A status line
+// goes to stderr (never stdout, so --json/-o output stays clean) unless quiet or
+// JSON.
+func teamsEnumGenerateTargets() ([]enum.Target, error) {
 	if !slices.Contains(enum.ListFormats(), flagTeamsEnumFormat) {
 		return nil, fmt.Errorf("invalid --format %q; valid formats: %s",
 			flagTeamsEnumFormat, strings.Join(enum.ListFormats(), ", "))
 	}
 
-	generated, err := enum.GenerateEmails(flagTeamsEnumFormat, flagTeamsEnumDomain)
+	candidates, err := enum.GenerateCandidates(flagTeamsEnumFormat)
 	if err != nil {
 		return nil, fmt.Errorf("generating candidate emails: %w", err)
 	}
-	generated = capResults(generated, flagTeamsEnumLimit)
+	candidates = capResults(candidates, flagTeamsEnumLimit)
+	generated := make([]enum.Target, len(candidates))
+	for i, c := range candidates {
+		generated[i] = c.Target(flagTeamsEnumDomain)
+	}
 
 	if !flagQuiet && !flagJSON {
 		useColor := isColorEnabled(flagNoColor)

--- a/cmd/brutus/cmd_enum_teams_users_test.go
+++ b/cmd/brutus/cmd_enum_teams_users_test.go
@@ -238,13 +238,25 @@ func TestEnumTeamsUsersCmd_GenerationFlags(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Test 22: teamsEnumGenerate — basic generation, limit, domain suffix
+// Test 22: teamsEnumGenerateTargets — basic generation, limit, domain suffix
+//
+// 10T-535: teamsEnumGenerate() ([]string, error) and teamsEnumTargets()
+// ([]string, error) were dead []string adapters kept alive only by these
+// tests (the real logic — and the only production callers, runEnumTeamsUsers
+// (via teamsEnumTargetList) — live in teamsEnumTargetList() and
+// teamsEnumGenerateTargets(), both returning ([]enum.Target, error)).
+// Retargeted onto those and strengthened to assert that supplied
+// (--emails/--email-file) targets carry no name while generated ones do,
+// using the targetEmails helper from cmd_enum_custom_test.go for compact
+// address assertions.
 // ---------------------------------------------------------------------------
 
-// TestTeamsEnumGenerate_Basic verifies that teamsEnumGenerate produces the
-// expected number of emails ending with the target domain and that the
-// statistically most-likely first name / last name pair leads the list.
-func TestTeamsEnumGenerate_Basic(t *testing.T) {
+// TestTeamsEnumGenerateTargets_Basic verifies that teamsEnumGenerateTargets
+// produces the expected number of targets ending with the target domain,
+// that the statistically most-likely first name / last name pair leads the
+// list, and that every generated target carries the name its username was
+// built from.
+func TestTeamsEnumGenerateTargets_Basic(t *testing.T) {
 	// Save and restore all package-level flag vars mutated below.
 	origDomain := flagTeamsEnumDomain
 	origFormat := flagTeamsEnumFormat
@@ -266,10 +278,11 @@ func TestTeamsEnumGenerate_Basic(t *testing.T) {
 	flagQuiet = true
 	flagJSON = false
 
-	emails, err := teamsEnumGenerate()
-	require.NoError(t, err, "teamsEnumGenerate must not return an error for a valid format")
-	require.Len(t, emails, 5, "teamsEnumGenerate must return exactly --limit emails")
+	got, err := teamsEnumGenerateTargets()
+	require.NoError(t, err, "teamsEnumGenerateTargets must not return an error for a valid format")
+	require.Len(t, got, 5, "teamsEnumGenerateTargets must return exactly --limit targets")
 
+	emails := targetEmails(got)
 	for _, e := range emails {
 		assert.True(t, strings.HasSuffix(e, "@example.com"),
 			"every generated email must end with @example.com, got: %q", e)
@@ -279,17 +292,23 @@ func TestTeamsEnumGenerate_Basic(t *testing.T) {
 	// must be john.smith@example.com.
 	assert.Equal(t, "john.smith@example.com", emails[0],
 		"first generated email must be john.smith@example.com (highest-ranked pair)")
+
+	for i, target := range got {
+		require.NotEmpty(t, target.First, "target %d (%q): generated target must have non-empty First", i, target.Email)
+		require.NotEmpty(t, target.Last, "target %d (%q): generated target must have non-empty Last", i, target.Email)
+	}
 }
 
 // ---------------------------------------------------------------------------
-// Test 23: teamsEnumGenerate — invalid format returns error
+// Test 23: teamsEnumGenerateTargets — invalid format returns error
 // ---------------------------------------------------------------------------
 
-// TestTeamsEnumGenerate_InvalidFormat verifies that teamsEnumGenerate returns
-// a non-nil error containing valid format names when an unknown format is
-// provided, exercising the ListFormats validation gate added to protect
-// against GenerateEmails silently returning an empty list.
-func TestTeamsEnumGenerate_InvalidFormat(t *testing.T) {
+// TestTeamsEnumGenerateTargets_InvalidFormat verifies that
+// teamsEnumGenerateTargets returns a non-nil error containing valid format
+// names when an unknown format is provided, exercising the ListFormats
+// validation gate added to protect against GenerateEmails silently
+// returning an empty list.
+func TestTeamsEnumGenerateTargets_InvalidFormat(t *testing.T) {
 	origDomain := flagTeamsEnumDomain
 	origFormat := flagTeamsEnumFormat
 	origLimit := flagTeamsEnumLimit
@@ -309,22 +328,23 @@ func TestTeamsEnumGenerate_InvalidFormat(t *testing.T) {
 	flagQuiet = true
 	flagJSON = false
 
-	emails, err := teamsEnumGenerate()
-	require.Error(t, err, "teamsEnumGenerate must return an error for an invalid format")
-	assert.Nil(t, emails, "no emails must be returned on error")
+	got, err := teamsEnumGenerateTargets()
+	require.Error(t, err, "teamsEnumGenerateTargets must return an error for an invalid format")
+	assert.Nil(t, got, "no targets must be returned on error")
 	// The error message must mention at least one valid format to be actionable.
 	assert.Contains(t, err.Error(), "first.last",
 		"error message must list valid formats so the user knows what to fix")
 }
 
 // ---------------------------------------------------------------------------
-// Test 24: teamsEnumTargets — --domain appended to -e emails, deduped
+// Test 24: teamsEnumTargetList — --domain appended to -e emails, deduped
 // ---------------------------------------------------------------------------
 
-// TestTeamsEnumTargets_DomainCombinesWithEmails verifies that when both
-// --emails and --domain are provided, teamsEnumTargets returns the -e address
-// alongside the generated @example.com emails, with no duplicates.
-func TestTeamsEnumTargets_DomainCombinesWithEmails(t *testing.T) {
+// TestTeamsEnumTargetList_DomainCombinesWithEmails verifies that when both
+// --emails and --domain are provided, teamsEnumTargetList returns the -e
+// address alongside the generated @example.com targets, with no duplicates,
+// and that the -e address carries no name while every generated target does.
+func TestTeamsEnumTargetList_DomainCombinesWithEmails(t *testing.T) {
 	origEmails := flagTeamsEnumEmails
 	origEmailFile := flagTeamsEnumEmailFile
 	origDomain := flagTeamsEnumDomain
@@ -350,8 +370,10 @@ func TestTeamsEnumTargets_DomainCombinesWithEmails(t *testing.T) {
 	flagQuiet = true
 	flagJSON = false
 
-	result, err := teamsEnumTargets()
-	require.NoError(t, err, "teamsEnumTargets must not error when both -e and --domain are set")
+	got, err := teamsEnumTargetList()
+	require.NoError(t, err, "teamsEnumTargetList must not error when both -e and --domain are set")
+
+	result := targetEmails(got)
 
 	// Must contain the explicit -e address.
 	assert.Contains(t, result, "alice@x.com",
@@ -380,16 +402,29 @@ func TestTeamsEnumTargets_DomainCombinesWithEmails(t *testing.T) {
 		assert.Equal(t, 1, count,
 			"address %q appears %d times; dedup must ensure each address appears exactly once", addr, count)
 	}
+
+	// Strengthen: the -e address must carry no name; every @example.com
+	// (generated) target must carry one.
+	for i, target := range got {
+		if target.Email == "alice@x.com" {
+			assert.Empty(t, target.First, "target %d (%q): CLI-supplied address must have empty First", i, target.Email)
+			assert.Empty(t, target.Last, "target %d (%q): CLI-supplied address must have empty Last", i, target.Email)
+			continue
+		}
+		require.NotEmpty(t, target.First, "target %d (%q): generated target must have non-empty First", i, target.Email)
+		require.NotEmpty(t, target.Last, "target %d (%q): generated target must have non-empty Last", i, target.Email)
+	}
 }
 
 // ---------------------------------------------------------------------------
-// Test 25: teamsEnumTargets — no sources → error mentioning --domain
+// Test 25: teamsEnumTargetList — no sources → error mentioning --domain
 // ---------------------------------------------------------------------------
 
-// TestTeamsEnumTargets_NoSourcesErrors verifies that teamsEnumTargets returns
-// an error when all of --emails, --email-file, and --domain are empty. The
-// error message must mention --domain so the user knows generation is an option.
-func TestTeamsEnumTargets_NoSourcesErrors(t *testing.T) {
+// TestTeamsEnumTargetList_NoSourcesErrors verifies that teamsEnumTargetList
+// returns an error when all of --emails, --email-file, and --domain are
+// empty. The error message must mention --domain so the user knows
+// generation is an option.
+func TestTeamsEnumTargetList_NoSourcesErrors(t *testing.T) {
 	origEmails := flagTeamsEnumEmails
 	origEmailFile := flagTeamsEnumEmailFile
 	origDomain := flagTeamsEnumDomain
@@ -403,22 +438,23 @@ func TestTeamsEnumTargets_NoSourcesErrors(t *testing.T) {
 	flagTeamsEnumEmailFile = ""
 	flagTeamsEnumDomain = ""
 
-	result, err := teamsEnumTargets()
-	require.Error(t, err, "teamsEnumTargets must return an error when no email sources are set")
+	result, err := teamsEnumTargetList()
+	require.Error(t, err, "teamsEnumTargetList must return an error when no email sources are set")
 	assert.Nil(t, result, "no results must be returned when there is an error")
 	assert.Contains(t, err.Error(), "--domain",
 		"error message must mention --domain as a valid source of targets")
 }
 
 // ---------------------------------------------------------------------------
-// Test 26 (optional): teamsEnumGenerate — limit=0 returns the full list
+// Test 26 (optional): teamsEnumGenerateTargets — limit=0 returns the full list
 // ---------------------------------------------------------------------------
 
-// TestTeamsEnumGenerate_LimitZeroReturnsAll verifies that limit=0 causes
-// teamsEnumGenerate to return the entire embedded wordlist (~248k entries).
-// It does not pin the exact count to avoid brittleness if the wordlist is
-// updated; it checks the list is large (>1000) and bounded (<250k+margin).
-func TestTeamsEnumGenerate_LimitZeroReturnsAll(t *testing.T) {
+// TestTeamsEnumGenerateTargets_LimitZeroReturnsAll verifies that limit=0
+// causes teamsEnumGenerateTargets to return the entire embedded wordlist
+// (~248k entries). It does not pin the exact count to avoid brittleness if
+// the wordlist is updated; it checks the list is large (>1000) and bounded
+// (<250k+margin).
+func TestTeamsEnumGenerateTargets_LimitZeroReturnsAll(t *testing.T) {
 	origDomain := flagTeamsEnumDomain
 	origFormat := flagTeamsEnumFormat
 	origLimit := flagTeamsEnumLimit
@@ -438,11 +474,11 @@ func TestTeamsEnumGenerate_LimitZeroReturnsAll(t *testing.T) {
 	flagQuiet = true
 	flagJSON = false
 
-	emails, err := teamsEnumGenerate()
-	require.NoError(t, err, "teamsEnumGenerate with limit=0 must not error")
-	assert.Greater(t, len(emails), 1000,
+	got, err := teamsEnumGenerateTargets()
+	require.NoError(t, err, "teamsEnumGenerateTargets with limit=0 must not error")
+	assert.Greater(t, len(got), 1000,
 		"limit=0 must return a large list (>1000 entries)")
-	assert.Less(t, len(emails), 300_000,
+	assert.Less(t, len(got), 300_000,
 		"limit=0 list must be bounded (<300,000 entries; embedded wordlist sanity check)")
 }
 

--- a/pkg/enum/custom/plugin_test.go
+++ b/pkg/enum/custom/plugin_test.go
@@ -314,7 +314,7 @@ func TestE2E_ForgotPassword(t *testing.T) {
 	results, enumErr := enum.EnumerateWithPlugin(
 		context.Background(),
 		&enum.Config{
-			Emails:  []string{"jsmith", "nobody"},
+			Targets: []enum.Target{{Email: "jsmith"}, {Email: "nobody"}},
 			Threads: 2,
 			Timeout: 5 * time.Second,
 		},

--- a/pkg/enum/enum.go
+++ b/pkg/enum/enum.go
@@ -22,9 +22,27 @@ import (
 	"time"
 )
 
+// Target is an address to check, plus the name it was generated from.
+//
+// Address and name travel together deliberately. brutus generates most of the
+// addresses it checks, and at generation time it already knows the name behind
+// each one (see Candidate). Passing addresses alone would force consumers to
+// reverse-derive the name from the local part, which is lossy for
+// initial-based formats — "jsmith" could be John, James, or Jane. Keeping the
+// two in one value means a name can never desync from its address.
+//
+// First/Last are empty when the address was supplied by the operator (--emails
+// or --email-file) rather than generated: a supplied address says nothing about
+// whose it is, and the framework must not invent one.
+type Target struct {
+	Email string
+	First string // empty when the address was supplied rather than generated
+	Last  string
+}
+
 // Config defines the configuration for account enumeration.
 type Config struct {
-	Emails    []string      // emails to enumerate
+	Targets   []Target      // addresses to enumerate, with generated names when known
 	Services  []string      // service names to check (empty = all registered)
 	Threads   int           // concurrent workers (default: 10)
 	Timeout   time.Duration // per-check timeout (default: 10s)
@@ -70,7 +88,7 @@ func ProxyURLFromContext(ctx context.Context) string {
 
 // validate checks the configuration and applies defaults.
 func (c *Config) validate() error {
-	if len(c.Emails) == 0 {
+	if len(c.Targets) == 0 {
 		return errors.New("emails required")
 	}
 	if c.Threads < 0 {

--- a/pkg/enum/generate.go
+++ b/pkg/enum/generate.go
@@ -90,6 +90,17 @@ func (c Candidate) Email(domain string) string {
 	return c.Username + "@" + domain
 }
 
+// Target converts a generated Candidate into a Target for domain, carrying the
+// name the username was built from so the enumeration framework can stamp it
+// onto each Result.
+func (c Candidate) Target(domain string) Target {
+	return Target{
+		Email: c.Email(domain),
+		First: c.First,
+		Last:  c.Last,
+	}
+}
+
 // GenerateCandidates derives usernames in the requested format from the
 // frequency-ranked likely-names wordlist, each paired with the name it was built
 // from. Each source line is a "first.last" pair; the requested format is built

--- a/pkg/enum/generate_test.go
+++ b/pkg/enum/generate_test.go
@@ -679,3 +679,88 @@ func TestGenerateCandidates_AllFormatsPopulated(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// 10T-535: Candidate.Target
+//
+// Target carries a generated (or supplied) email together with the name it
+// was built from, all the way through the enumeration framework to Result,
+// so consumers never need to reverse-derive a name from an address (the
+// "jsmith" could be John/James/Jane problem). Candidate.Target(domain) is the
+// conversion point from generator output to framework input.
+// ---------------------------------------------------------------------------
+
+// TestCandidate_Target verifies that Candidate.Target(domain) produces an
+// Email identical to Candidate.Email(domain), and carries First/Last through
+// unchanged. Table-driven over several Candidate shapes.
+func TestCandidate_Target(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		candidate Candidate
+		domain    string
+	}{
+		{
+			name:      "simple",
+			candidate: Candidate{First: "john", Last: "smith", Username: "jsmith"},
+			domain:    "example.com",
+		},
+		{
+			name:      "dotted username and multi-label domain",
+			candidate: Candidate{First: "john", Last: "smith", Username: "john.smith"},
+			domain:    "corp.example.co.uk",
+		},
+		{
+			name:      "dotted last name preserved",
+			candidate: Candidate{First: "abdullah", Last: "al.mamun", Username: "abdullah.al.mamun"},
+			domain:    "fox.com",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			target := tc.candidate.Target(tc.domain)
+
+			assert.Equal(t, tc.candidate.Email(tc.domain), target.Email,
+				"Target.Email must equal Candidate.Email(domain)")
+			assert.Equal(t, tc.candidate.First, target.First,
+				"Target.First must carry Candidate.First unchanged")
+			assert.Equal(t, tc.candidate.Last, target.Last,
+				"Target.Last must carry Candidate.Last unchanged")
+		})
+	}
+}
+
+// TestGenerateCandidates_TargetRoundTrip verifies the GenerateCandidates ->
+// .Target(domain) round trip for a real format: every resulting Target has
+// non-empty First, Last, and Email, and Email matches the corresponding
+// GenerateEmails entry at the same index (order preserved).
+func TestGenerateCandidates_TargetRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	const domain = "example.com"
+
+	candidates, err := GenerateCandidates(FormatFirstDotLast)
+	require.NoError(t, err)
+	require.NotEmpty(t, candidates)
+
+	emails, err := GenerateEmails(FormatFirstDotLast, domain)
+	require.NoError(t, err)
+	require.Equal(t, len(candidates), len(emails),
+		"GenerateCandidates and GenerateEmails must produce the same count")
+
+	for i, c := range candidates {
+		target := c.Target(domain)
+
+		require.NotEmpty(t, target.Email, "candidate %d: Target.Email must not be empty", i)
+		require.NotEmpty(t, target.First, "candidate %d: Target.First must not be empty", i)
+		require.NotEmpty(t, target.Last, "candidate %d: Target.Last must not be empty", i)
+
+		assert.Equal(t, emails[i], target.Email,
+			"candidate %d: Target.Email must match GenerateEmails[%d] (order preserved)", i, i)
+	}
+}

--- a/pkg/enum/github/github.go
+++ b/pkg/enum/github/github.go
@@ -59,6 +59,8 @@ import (
 // and are NOT sanitized here; sanitization happens at the output layer.
 type Result struct {
 	Email    string
+	First    string // generated given name; empty if the address was supplied
+	Last     string // generated surname; empty if the address was supplied
 	Exists   bool
 	Username string
 	Error    error

--- a/pkg/enum/google/google.go
+++ b/pkg/enum/google/google.go
@@ -61,6 +61,8 @@ const (
 // transport error.
 type Result struct {
 	Email  string
+	First  string // generated given name; empty if the address was supplied
+	Last   string // generated surname; empty if the address was supplied
 	Exists bool
 	Method Method
 	IdP    string

--- a/pkg/enum/gravatar/gravatar.go
+++ b/pkg/enum/gravatar/gravatar.go
@@ -52,6 +52,8 @@ func HashEmail(email string) string {
 // endpoint.
 type Result struct {
 	Email    string
+	First    string // generated given name; empty if the address was supplied
+	Last     string // generated surname; empty if the address was supplied
 	Hash     string
 	Exists   bool
 	Error    error

--- a/pkg/enum/microsoft365/microsoft365.go
+++ b/pkg/enum/microsoft365/microsoft365.go
@@ -60,6 +60,8 @@ type credTypeResponse struct {
 // GetCredentialType API.
 type Result struct {
 	Email          string
+	First          string // generated given name; empty if the address was supplied
+	Last           string // generated surname; empty if the address was supplied
 	Exists         bool
 	IfExistsResult int
 	Federated      bool

--- a/pkg/enum/plugin.go
+++ b/pkg/enum/plugin.go
@@ -40,6 +40,8 @@ const (
 type Result struct {
 	Service    string        // service name (e.g., "microsoft365")
 	Email      string        // email tested
+	First      string        // generated given name; empty if the address was supplied
+	Last       string        // generated surname; empty if the address was supplied
 	Exists     bool          // account exists on this service?
 	Confidence Confidence    // high/medium/low
 	Error      error         // service/connection error (nil = clean check)

--- a/pkg/enum/runner.go
+++ b/pkg/enum/runner.go
@@ -20,9 +20,13 @@ import (
 	"errors"
 )
 
-// EnumerateWithPlugin runs cfg.Emails against a single provided Plugin instance,
-// bypassing the registry. It is used by runtime-constructed oracles (e.g. the
-// custom declarative oracle) that are not registered globally.
+// EnumerateWithPlugin runs cfg.Targets against a single provided Plugin
+// instance, bypassing the registry. It is used by runtime-constructed oracles
+// (e.g. the custom declarative oracle) that are not registered globally.
+//
+// Each Target's First/Last is stamped onto the Result it produced, on every
+// path including errors and panics. The Plugin itself only ever sees the
+// email — see runTasks.
 //
 // The same Plugin instance is shared across all goroutines, so the Plugin MUST
 // be stateless (enum.Plugin contract). cfg.Services is ignored.
@@ -37,10 +41,12 @@ func EnumerateWithPlugin(ctx context.Context, cfg *Config, p Plugin) ([]Result, 
 		return nil, err
 	}
 
-	tasks := make([]enumTask, 0, len(cfg.Emails))
-	for _, subject := range cfg.Emails {
+	tasks := make([]enumTask, 0, len(cfg.Targets))
+	for _, subject := range cfg.Targets {
 		tasks = append(tasks, enumTask{
-			email:   subject,
+			email:   subject.Email,
+			first:   subject.First,
+			last:    subject.Last,
 			service: p.Name(),
 			plugin:  p,
 		})

--- a/pkg/enum/runner_test.go
+++ b/pkg/enum/runner_test.go
@@ -16,6 +16,8 @@ package enum
 
 import (
 	"context"
+	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -53,7 +55,7 @@ func TestEnumerateWithPlugin_FanOut(t *testing.T) {
 	p := &stubPlugin{name: "stub-oracle", exists: true}
 
 	results, err := EnumerateWithPlugin(context.Background(), &Config{
-		Emails:  []string{"a", "b", "c"},
+		Targets: []Target{{Email: "a"}, {Email: "b"}, {Email: "c"}},
 		Threads: 2,
 		Timeout: 5 * time.Second,
 	}, p)
@@ -85,7 +87,7 @@ func TestEnumerateWithPlugin_EmptyEmails(t *testing.T) {
 	p := &stubPlugin{name: "stub", exists: true}
 
 	_, err := EnumerateWithPlugin(context.Background(), &Config{
-		Emails:  []string{},
+		Targets: []Target{},
 		Threads: 2,
 	}, p)
 
@@ -101,7 +103,7 @@ func TestEnumerateWithPlugin_AbsentResult(t *testing.T) {
 	p := &stubPlugin{name: "absent-oracle", exists: false}
 
 	results, err := EnumerateWithPlugin(context.Background(), &Config{
-		Emails:  []string{"user1", "user2"},
+		Targets: []Target{{Email: "user1"}, {Email: "user2"}},
 		Threads: 1,
 		Timeout: 5 * time.Second,
 	}, p)
@@ -122,7 +124,7 @@ func TestEnumerateWithPlugin_ServiceNameFromPlugin(t *testing.T) {
 	p := &stubPlugin{name: "my-custom-oracle", exists: true}
 
 	results, err := EnumerateWithPlugin(context.Background(), &Config{
-		Emails:  []string{"test@example.com"},
+		Targets: []Target{{Email: "test@example.com"}},
 		Threads: 1,
 		Timeout: 5 * time.Second,
 	}, p)
@@ -139,11 +141,224 @@ func TestEnumerateWithPlugin_SingleThread(t *testing.T) {
 	p := &stubPlugin{name: "single-thread-oracle", exists: true}
 
 	results, err := EnumerateWithPlugin(context.Background(), &Config{
-		Emails:  []string{"a", "b", "c", "d", "e"},
+		Targets: []Target{{Email: "a"}, {Email: "b"}, {Email: "c"}, {Email: "d"}, {Email: "e"}},
 		Threads: 1,
 		Timeout: 5 * time.Second,
 	}, p)
 
 	require.NoError(t, err)
 	require.Len(t, results, 5, "single-threaded must still produce all results")
+}
+
+// ---------------------------------------------------------------------------
+// 10T-535: EnumerateWithPlugin name propagation (framework half)
+//
+// The generator (Candidate.Target) already knows First/Last. This section
+// verifies the framework carries that name through to Result without
+// disturbing what the Plugin interface sees, and without ever inventing a
+// name for a Target that didn't have one.
+// ---------------------------------------------------------------------------
+
+// recordingPlugin is a stub Plugin that records every email it was asked to
+// Check, so tests can assert exactly what the framework passed into the
+// Plugin contract. Safe for concurrent use: checked is protected by mu.
+type recordingPlugin struct {
+	name   string
+	exists bool
+
+	mu      sync.Mutex
+	checked []string
+}
+
+func (r *recordingPlugin) Name() string { return r.name }
+
+func (r *recordingPlugin) Check(_ context.Context, email string, _ time.Duration) *Result {
+	r.mu.Lock()
+	r.checked = append(r.checked, email)
+	r.mu.Unlock()
+
+	return &Result{
+		Service:    r.name,
+		Email:      email,
+		Exists:     r.exists,
+		Confidence: ConfidenceHigh,
+	}
+}
+
+// erroringPlugin is a stub Plugin that always returns a service error from
+// Check, used to verify that name-stamping survives the error path.
+type erroringPlugin struct {
+	name string
+}
+
+func (e *erroringPlugin) Name() string { return e.name }
+
+func (e *erroringPlugin) Check(_ context.Context, email string, _ time.Duration) *Result {
+	return &Result{
+		Service: e.name,
+		Email:   email,
+		Error:   errors.New("service unavailable"),
+	}
+}
+
+// TestEnumerateWithPlugin_NameCorrelation is THE CORE TEST for the framework
+// half of 10T-535: EnumerateWithPlugin must stamp each Result with the
+// First/Last of the Target that actually produced it, not just "some" name
+// drawn from the batch. Using >=2 targets with DIFFERENT names is
+// deliberate — a bug that stamped every Result with (say) the first
+// target's name would still make a weaker "a name is present" assertion
+// pass, but fails this one because each result is correlated back to its
+// originating Target by Email.
+//
+// Correlating by Email rather than by result index is deliberate: neither
+// TestEnumerateWithPlugin_FanOut nor TestEnumerateWithPlugin_SingleThread
+// assert anything about result order (FanOut checks membership via a map;
+// SingleThread only checks length), because runTasks appends results from
+// concurrent goroutines under a mutex with no ordering guarantee relative to
+// submission order. This test follows that same established expectation.
+func TestEnumerateWithPlugin_NameCorrelation(t *testing.T) {
+	t.Parallel()
+	p := &stubPlugin{name: "name-oracle", exists: true}
+
+	targets := []Target{
+		{Email: "alice@example.com", First: "Alice", Last: "Anderson"},
+		{Email: "bob@example.com", First: "Bob", Last: "Baker"},
+	}
+
+	results, err := EnumerateWithPlugin(context.Background(), &Config{
+		Targets: targets,
+		Threads: 2,
+		Timeout: 5 * time.Second,
+	}, p)
+
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	byEmail := make(map[string]Result, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	aliceResult, ok := byEmail["alice@example.com"]
+	require.True(t, ok, "result for alice@example.com must be present")
+	assert.Equal(t, "Alice", aliceResult.First, "alice's result must carry Alice's First, not another target's")
+	assert.Equal(t, "Anderson", aliceResult.Last, "alice's result must carry Alice's Last, not another target's")
+
+	bobResult, ok := byEmail["bob@example.com"]
+	require.True(t, ok, "result for bob@example.com must be present")
+	assert.Equal(t, "Bob", bobResult.First, "bob's result must carry Bob's First, not another target's")
+	assert.Equal(t, "Baker", bobResult.Last, "bob's result must carry Bob's Last, not another target's")
+}
+
+// TestEnumerateWithPlugin_EmptyNameYieldsEmptyResult verifies that a Target
+// with no First/Last (the --email-file case: an address supplied directly
+// rather than generated) produces a Result with empty First/Last. The
+// framework must not invent or derive a name when the Target didn't carry
+// one.
+func TestEnumerateWithPlugin_EmptyNameYieldsEmptyResult(t *testing.T) {
+	t.Parallel()
+	p := &stubPlugin{name: "supplied-oracle", exists: true}
+
+	results, err := EnumerateWithPlugin(context.Background(), &Config{
+		Targets: []Target{{Email: "supplied@example.com"}},
+		Threads: 1,
+		Timeout: 5 * time.Second,
+	}, p)
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "supplied@example.com", results[0].Email)
+	assert.Empty(t, results[0].First, "First must be empty for a supplied (non-generated) address")
+	assert.Empty(t, results[0].Last, "Last must be empty for a supplied (non-generated) address")
+}
+
+// TestEnumerateWithPlugin_MixedNamedAndUnnamed verifies that in a batch
+// containing both generated (named) and supplied (unnamed) targets, each
+// Result carries exactly what its own Target had — no cross-contamination
+// in either direction.
+func TestEnumerateWithPlugin_MixedNamedAndUnnamed(t *testing.T) {
+	t.Parallel()
+	p := &stubPlugin{name: "mixed-oracle", exists: true}
+
+	targets := []Target{
+		{Email: "named@example.com", First: "Carol", Last: "Chen"},
+		{Email: "unnamed@example.com"},
+	}
+
+	results, err := EnumerateWithPlugin(context.Background(), &Config{
+		Targets: targets,
+		Threads: 2,
+		Timeout: 5 * time.Second,
+	}, p)
+
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	byEmail := make(map[string]Result, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	named, ok := byEmail["named@example.com"]
+	require.True(t, ok, "result for named@example.com must be present")
+	assert.Equal(t, "Carol", named.First, "named target's result must carry its First")
+	assert.Equal(t, "Chen", named.Last, "named target's result must carry its Last")
+
+	unnamed, ok := byEmail["unnamed@example.com"]
+	require.True(t, ok, "result for unnamed@example.com must be present")
+	assert.Empty(t, unnamed.First, "unnamed target's result must not have an invented First")
+	assert.Empty(t, unnamed.Last, "unnamed target's result must not have an invented Last")
+}
+
+// TestEnumerateWithPlugin_PluginReceivesOnlyEmail verifies that the Plugin
+// interface is unaffected by name propagation: the fake plugin in this
+// harness observes only the email string passed to Check, proving the
+// framework attaches First/Last to the Result AFTER Check returns rather
+// than threading names into the Plugin contract. No per-service checker
+// needs to know about names.
+func TestEnumerateWithPlugin_PluginReceivesOnlyEmail(t *testing.T) {
+	t.Parallel()
+	p := &recordingPlugin{name: "recording-oracle", exists: true}
+
+	targets := []Target{
+		{Email: "dana@example.com", First: "Dana", Last: "Diaz"},
+		{Email: "erin@example.com"},
+	}
+
+	results, err := EnumerateWithPlugin(context.Background(), &Config{
+		Targets: targets,
+		Threads: 2,
+		Timeout: 5 * time.Second,
+	}, p)
+
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	p.mu.Lock()
+	checked := append([]string(nil), p.checked...)
+	p.mu.Unlock()
+
+	assert.ElementsMatch(t, []string{"dana@example.com", "erin@example.com"}, checked,
+		"plugin must observe exactly the target emails and nothing else — the name path is additive")
+}
+
+// TestEnumerateWithPlugin_ErrorPathPreservesName verifies that name-stamping
+// survives the error path: a Target whose Check returns a service error
+// still gets First/Last on its Result. The name is a property of the
+// address being checked, not of the check outcome.
+func TestEnumerateWithPlugin_ErrorPathPreservesName(t *testing.T) {
+	t.Parallel()
+	p := &erroringPlugin{name: "erroring-oracle"}
+
+	results, err := EnumerateWithPlugin(context.Background(), &Config{
+		Targets: []Target{{Email: "failing@example.com", First: "Frank", Last: "Foster"}},
+		Threads: 1,
+		Timeout: 5 * time.Second,
+	}, p)
+
+	require.NoError(t, err, "EnumerateWithPlugin itself must not error for a per-check service error")
+	require.Len(t, results, 1)
+	assert.Error(t, results[0].Error, "result must carry the service error")
+	assert.Equal(t, "Frank", results[0].First, "name must be stamped even when the check errored")
+	assert.Equal(t, "Foster", results[0].Last, "name must be stamped even when the check errored")
 }

--- a/pkg/enum/teams/enum.go
+++ b/pkg/enum/teams/enum.go
@@ -57,6 +57,8 @@ const (
 // struct, in logs, or in Error.
 type EnumResult struct {
 	Email        string
+	First        string // generated given name; empty if the address was supplied
+	Last         string // generated surname; empty if the address was supplied
 	Exists       Existence
 	DisplayName  string
 	MRI          string

--- a/pkg/enum/workers.go
+++ b/pkg/enum/workers.go
@@ -29,8 +29,14 @@ import (
 )
 
 // enumTask represents a single enumeration check to perform.
+//
+// first/last carry the name the email was generated from (empty for supplied
+// addresses) so runTasks can stamp it onto the resulting Result. They are
+// never passed to the Plugin.
 type enumTask struct {
 	email   string
+	first   string
+	last    string
 	service string
 	plugin  Plugin
 }
@@ -44,16 +50,18 @@ func runWorkers(ctx context.Context, cfg *Config) ([]Result, error) {
 		services = ListPlugins()
 	}
 
-	// Build task list: emails x services
+	// Build task list: targets x services
 	var tasks []enumTask
-	for _, email := range cfg.Emails {
+	for _, target := range cfg.Targets {
 		for _, svcName := range services {
 			plug, err := GetPlugin(svcName)
 			if err != nil {
 				return nil, fmt.Errorf("resolving service %q: %w", svcName, err)
 			}
 			tasks = append(tasks, enumTask{
-				email:   email,
+				email:   target.Email,
+				first:   target.First,
+				last:    target.Last,
 				service: svcName,
 				plugin:  plug,
 			})
@@ -114,6 +122,8 @@ func runTasks(ctx context.Context, cfg *Config, tasks []enumTask) ([]Result, err
 					results = append(results, Result{
 						Service: task.service,
 						Email:   task.email,
+						First:   task.first,
+						Last:    task.last,
 						Error:   fmt.Errorf("plugin panicked: %v", r),
 					})
 					mu.Unlock()
@@ -141,7 +151,9 @@ func runTasks(ctx context.Context, cfg *Config, tasks []enumTask) ([]Result, err
 				}
 			}
 
-			// Execute check
+			// Execute check. The Plugin receives only the email — names are
+			// stamped on afterwards, which is what keeps the Plugin interface
+			// (and every per-service checker) unaware of them.
 			result := task.plugin.Check(ctx, task.email, cfg.Timeout)
 			if result == nil {
 				result = &Result{
@@ -150,6 +162,13 @@ func runTasks(ctx context.Context, cfg *Config, tasks []enumTask) ([]Result, err
 					Error:   fmt.Errorf("plugin returned nil result"),
 				}
 			}
+
+			// Stamp the generated name onto the result. A name is a property of
+			// the address, not of the check outcome, so this applies on every
+			// path: clean checks, plugin errors, and the nil-result substitute
+			// above (the panic path stamps it in the deferred recover).
+			result.First = task.first
+			result.Last = task.last
 
 			if cfg.Verbose && result.Error != nil {
 				fmt.Fprintf(os.Stderr, "enum: error checking %s on %s: %v\n",


### PR DESCRIPTION
Re-lands #300 and #301 **on `main`**. Supersedes both.

## Why this exists

#299, #300 and #301 were a stacked chain — each opened against its predecessor's branch. Merging them merged each into its *base branch*, not into `main`:

| PR | merged into | reached `main`? |
|---|---|---|
| #299 | `main` | ✅ |
| #300 | the #299 branch | ❌ |
| #301 | the #300 branch | ❌ |

So `main` currently has only #299 (the generator returning `Candidate{First, Last, Username}`), and the framework and output halves are sitting on two orphaned feature branches.

#299 was also **squash-merged**, so its original commit is not an ancestor of `main`. That means the old stack can't simply be retargeted — `git merge-tree` reports conflicts, because git can't tell that `bc9fb7c`'s content is already present under a different commit.

This branch was therefore built fresh from `main` with the combined tree applied on top. Content is **identical** to #300 + #301; only the base differs. Confirmed no duplication: `pkg/enum/generate.go` picks up only #300's new `Candidate.Target` method, and `main` already has `GenerateCandidates` from #299.

## What's in it

**Framework half (was #300)** — `Target{Email, First, Last}` and `Candidate.Target(domain)`; `Config.Emails` → `Config.Targets`; `First`/`Last` on `enum.Result`. `EnumerateWithPlugin` stamps the name from the `Target` that produced each `Result`, on every path including plugin errors and the deferred panic recovery.

The `Plugin` interface is **unchanged** — plugins still receive only an email, and the framework attaches the name after `Check` returns. That's what keeps all six per-service checkers untouched.

**Output half (was #301)** — `First`/`Last` on the github, google, gravatar, microsoft365 and teams result types, emitted from six JSONL encoders. Both keys `omitempty`, so a supplied address omits them rather than emitting `"first":""` — *"we don't know"* stays structurally distinct from *"empty"*, and tests assert key absence so removing `omitempty` fails loudly.

```jsonc
{"type":"google_account","email":"jsmith@acme.com","exists":true,"first":"john","last":"smith"}
{"type":"google_account","email":"someone@acme.com","exists":true}   // supplied — no name exists
```

## The rule

Names come **only** from generation. Addresses supplied via `--emails`, `--email-file` or `--known-valid` stay nameless and nothing invents one.

## Two bugs worth a reviewer's eye

Both silent-failure modes, found by running the real paths rather than reading them, both now pinned by tests:

* **gravatar lowercases every address** before checking — an index keyed on the pre-normalized candidate misses every lookup and drops **every** name, with no error at all.
* **microsoft365 dedups on a lowercased key** but keeps first-seen casing, which is what `Result.Email` echoes.

Also: github's `EnumerateWith` hands the callback a copy and stores another in the returned slice, and github alone re-encodes from that slice for its post-reveal record — so it needs a second stamp.

## Verification, on top of `main`

```
go build ./...                    exit 0
go vet ./pkg/enum/... ./cmd/...   exit 0
go test ./... -count=1            all packages ok, 0 FAIL, no pre-existing failures
gofmt -l (all changed files)      clean
```

## Housekeeping

#300 and #301 should be closed as superseded, and the three old branches deleted once this lands:

* `adamcrosser/10t-535-propagate-generated-names-through-brutus-existence-oracles`
* `adamcrosser/10t-535-propagate-names-through-enum-framework`
* `adamcrosser/10t-535-surface-names-in-cli-output`

## Scope note

JSONL only. The interactive `output*EnumResultLine` renderers are unchanged; surfacing names there needs a decision rather than a copy of this work, since teams already prints a tenant-provided `DisplayName` and a generated name is a different kind of claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
