### PR TITLE
feat(enum): add Target and name fields on results (10T-535, 1/8)

### DIFF
--- a/pkg/enum/enum.go
+++ b/pkg/enum/enum.go
@@ -22,6 +22,24 @@ import (
 	"time"
 )
 
+// Target is an address to check, plus the name it was generated from.
+//
+// Address and name travel together deliberately. brutus generates most of the
+// addresses it checks, and at generation time it already knows the name behind
+// each one (see Candidate). Passing addresses alone would force consumers to
+// reverse-derive the name from the local part, which is lossy for
+// initial-based formats — "jsmith" could be John, James, or Jane. Keeping the
+// two in one value means a name can never desync from its address.
+//
+// First/Last are empty when the address was supplied by the operator (--emails
+// or --email-file) rather than generated: a supplied address says nothing about
+// whose it is, and the framework must not invent one.
+type Target struct {
+	Email string
+	First string // empty when the address was supplied rather than generated
+	Last  string
+}
+
 // Config defines the configuration for account enumeration.
 type Config struct {
 	Emails    []string      // emails to enumerate

--- a/pkg/enum/generate.go
+++ b/pkg/enum/generate.go
@@ -90,6 +90,17 @@ func (c Candidate) Email(domain string) string {
 	return c.Username + "@" + domain
 }
 
+// Target converts a generated Candidate into a Target for domain, carrying the
+// name the username was built from so the enumeration framework can stamp it
+// onto each Result.
+func (c Candidate) Target(domain string) Target {
+	return Target{
+		Email: c.Email(domain),
+		First: c.First,
+		Last:  c.Last,
+	}
+}
+
 // GenerateCandidates derives usernames in the requested format from the
 // frequency-ranked likely-names wordlist, each paired with the name it was built
 // from. Each source line is a "first.last" pair; the requested format is built

--- a/pkg/enum/generate_test.go
+++ b/pkg/enum/generate_test.go
@@ -679,3 +679,95 @@ func TestGenerateCandidates_AllFormatsPopulated(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// 10T-535: Candidate.Target
+//
+// Target carries a generated (or supplied) email together with the name it
+// was built from, all the way through the enumeration framework to Result,
+// so consumers never need to reverse-derive a name from an address (the
+// "jsmith" could be John/James/Jane problem). Candidate.Target(domain) is the
+// conversion point from generator output to framework input.
+// ---------------------------------------------------------------------------
+
+// TestCandidate_Target verifies that Candidate.Target(domain) produces an
+// Email identical to Candidate.Email(domain), and carries First/Last through
+// unchanged. Table-driven over several Candidate shapes, including a
+// Candidate with empty First/Last (representing an operator-supplied address
+// rather than a generated one) to verify nothing is invented.
+func TestCandidate_Target(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		candidate Candidate
+		domain    string
+	}{
+		{
+			name:      "simple",
+			candidate: Candidate{First: "john", Last: "smith", Username: "jsmith"},
+			domain:    "example.com",
+		},
+		{
+			name:      "dotted username and multi-label domain",
+			candidate: Candidate{First: "john", Last: "smith", Username: "john.smith"},
+			domain:    "corp.example.co.uk",
+		},
+		{
+			name:      "dotted last name preserved",
+			candidate: Candidate{First: "abdullah", Last: "al.mamun", Username: "abdullah.al.mamun"},
+			domain:    "fox.com",
+		},
+		{
+			name:      "empty First/Last stays empty (supplied, not generated)",
+			candidate: Candidate{First: "", Last: "", Username: "jsmith"},
+			domain:    "example.com",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			target := tc.candidate.Target(tc.domain)
+
+			assert.Equal(t, tc.candidate.Email(tc.domain), target.Email,
+				"Target.Email must equal Candidate.Email(domain)")
+			assert.Equal(t, tc.candidate.First, target.First,
+				"Target.First must carry Candidate.First unchanged")
+			assert.Equal(t, tc.candidate.Last, target.Last,
+				"Target.Last must carry Candidate.Last unchanged")
+		})
+	}
+}
+
+// TestGenerateCandidates_TargetRoundTrip verifies the GenerateCandidates ->
+// .Target(domain) round trip for a real format: every resulting Target has
+// non-empty First, Last, and Email, and Email matches the corresponding
+// GenerateEmails entry at the same index (order preserved).
+func TestGenerateCandidates_TargetRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	const domain = "example.com"
+
+	candidates, err := GenerateCandidates(FormatFirstDotLast)
+	require.NoError(t, err)
+	require.NotEmpty(t, candidates)
+
+	emails, err := GenerateEmails(FormatFirstDotLast, domain)
+	require.NoError(t, err)
+	require.Equal(t, len(candidates), len(emails),
+		"GenerateCandidates and GenerateEmails must produce the same count")
+
+	for i, c := range candidates {
+		target := c.Target(domain)
+
+		require.NotEmpty(t, target.Email, "candidate %d: Target.Email must not be empty", i)
+		require.NotEmpty(t, target.First, "candidate %d: Target.First must not be empty", i)
+		require.NotEmpty(t, target.Last, "candidate %d: Target.Last must not be empty", i)
+
+		assert.Equal(t, emails[i], target.Email,
+			"candidate %d: Target.Email must match GenerateEmails[%d] (order preserved)", i, i)
+	}
+}

--- a/pkg/enum/github/github.go
+++ b/pkg/enum/github/github.go
@@ -59,6 +59,8 @@ import (
 // and are NOT sanitized here; sanitization happens at the output layer.
 type Result struct {
 	Email    string
+	First    string // generated given name; empty if the address was supplied
+	Last     string // generated surname; empty if the address was supplied
 	Exists   bool
 	Username string
 	Error    error

--- a/pkg/enum/google/google.go
+++ b/pkg/enum/google/google.go
@@ -61,6 +61,8 @@ const (
 // transport error.
 type Result struct {
 	Email  string
+	First  string // generated given name; empty if the address was supplied
+	Last   string // generated surname; empty if the address was supplied
 	Exists bool
 	Method Method
 	IdP    string

--- a/pkg/enum/gravatar/gravatar.go
+++ b/pkg/enum/gravatar/gravatar.go
@@ -52,6 +52,8 @@ func HashEmail(email string) string {
 // endpoint.
 type Result struct {
 	Email    string
+	First    string // generated given name; empty if the address was supplied
+	Last     string // generated surname; empty if the address was supplied
 	Hash     string
 	Exists   bool
 	Error    error

--- a/pkg/enum/microsoft365/microsoft365.go
+++ b/pkg/enum/microsoft365/microsoft365.go
@@ -60,6 +60,8 @@ type credTypeResponse struct {
 // GetCredentialType API.
 type Result struct {
 	Email          string
+	First          string // generated given name; empty if the address was supplied
+	Last           string // generated surname; empty if the address was supplied
 	Exists         bool
 	IfExistsResult int
 	Federated      bool

--- a/pkg/enum/plugin.go
+++ b/pkg/enum/plugin.go
@@ -40,6 +40,8 @@ const (
 type Result struct {
 	Service    string        // service name (e.g., "microsoft365")
 	Email      string        // email tested
+	First      string        // generated given name; empty if the address was supplied
+	Last       string        // generated surname; empty if the address was supplied
 	Exists     bool          // account exists on this service?
 	Confidence Confidence    // high/medium/low
 	Error      error         // service/connection error (nil = clean check)

--- a/pkg/enum/teams/enum.go
+++ b/pkg/enum/teams/enum.go
@@ -57,6 +57,8 @@ const (
 // struct, in logs, or in Error.
 type EnumResult struct {
 	Email        string
+	First        string // generated given name; empty if the address was supplied
+	Last         string // generated surname; empty if the address was supplied
 	Exists       Existence
 	DisplayName  string
 	MRI          string


### PR DESCRIPTION
**1 of 8** for 10T-535. Types only — **133 insertions, 0 deletions.**

Supersedes the oversized #302, which is being split into eight reviewable pieces. All eight are based on `main` (not stacked), to be merged in order.

## What's here

```go
type Target struct {
    Email string
    First string   // empty when the address was supplied rather than generated
    Last  string
}

func (c Candidate) Target(domain string) Target
```

Plus `First`/`Last` fields on `enum.Result` and on the github, google, gravatar, microsoft365 and teams result types.

## Nothing populates them yet — deliberately

A reviewer will see `Target` with no construction site and name fields that are dead until the stamping change lands. That's intentional: it keeps this PR a pure addition so the interesting changes later are small.

## Why address and name travel together

The name is free at generation time. Reverse-deriving it from an initial-based local part is lossy — `jsmith` could be John, James or Jane, and no amount of parsing recovers which. Carrying the pair keeps the generator's own knowledge instead of guessing it back later.

## Scope, mechanically proven

`133 insertions, 0 deletions` — so no existing field was reordered or renamed and no checker logic changed. Also verified empty: `git status -- cmd/`, and `pkg/enum/runner.go` / `workers.go`. `Config` is byte-identical (no `Targets` field yet).

## Verification

```
go build ./...              exit 0
go vet ./pkg/enum/...       exit 0
go test ./... -count=1      56 packages ok, 0 FAIL
gofmt -l (9 files)          clean
```

Tests cover the only behavior present: `Candidate.Target` round-trips `Email` and carries First/Last through, including the empty case where nothing is invented.

## The remaining seven

2) framework accepts `Targets` additively + stamping + generic JSONL · 3-7) one per service: github, google, gravatar, microsoft365, teams · 8) delete the `Config.Emails` shim.

Nothing breaking until (8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
