### PR TITLE
feat(enum): carry a Target name onto every Result (10T-535, 2/8)

### DIFF
--- a/cmd/brutus/cmd_enum_output.go
+++ b/cmd/brutus/cmd_enum_output.go
@@ -265,9 +265,13 @@ func outputOracleValidationHuman(results []enum.Result, useColor bool) {
 // outputEnumJSONL writes enumeration results as JSONL.
 func outputEnumJSONL(w io.Writer, results []enum.Result) {
 	type enumResultJSON struct {
-		Type       string `json:"type"`
-		Service    string `json:"service"`
-		Email      string `json:"email"`
+		Type    string `json:"type"`
+		Service string `json:"service"`
+		Email   string `json:"email"`
+		// omitempty is deliberate: a supplied address has no name, and an
+		// absent key says that more honestly than an empty string.
+		First      string `json:"first,omitempty"`
+		Last       string `json:"last,omitempty"`
 		Exists     bool   `json:"exists"`
 		Confidence string `json:"confidence,omitempty"`
 		Error      string `json:"error,omitempty"`
@@ -281,6 +285,8 @@ func outputEnumJSONL(w io.Writer, results []enum.Result) {
 			Type:       "enum",
 			Service:    r.Service,
 			Email:      r.Email,
+			First:      r.First,
+			Last:       r.Last,
 			Exists:     r.Exists,
 			Confidence: string(r.Confidence),
 			Duration:   r.Duration.String(),

--- a/cmd/brutus/cmd_enum_output_test.go
+++ b/cmd/brutus/cmd_enum_output_test.go
@@ -1,0 +1,120 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/brutus/pkg/enum"
+)
+
+// ---------------------------------------------------------------------------
+// outputEnumJSONL — First/Last name propagation (10T-535 PR2)
+// ---------------------------------------------------------------------------
+
+// TestOutputEnumJSONL_NameFields pins the never-invent-a-name rule for the
+// generic enum output path: a Result carrying First/Last (from --generate)
+// must emit "first"/"last" in the JSONL row, while a Result with empty
+// First/Last (supplied via --emails or --email-file) must OMIT both keys
+// entirely rather than emit them as "". Pre-existing fields
+// (type/service/email/exists/confidence/duration) must be unaffected.
+func TestOutputEnumJSONL_NameFields(t *testing.T) {
+	named := enum.Result{
+		Service:    "github",
+		Email:      "john.smith@example.com",
+		First:      "john",
+		Last:       "smith",
+		Exists:     true,
+		Confidence: enum.ConfidenceHigh,
+	}
+	unnamed := enum.Result{
+		Service:    "github",
+		Email:      "supplied@example.com",
+		Exists:     false,
+		Confidence: enum.ConfidenceLow,
+	}
+
+	t.Run("named result emits first and last", func(t *testing.T) {
+		var buf bytes.Buffer
+		outputEnumJSONL(&buf, []enum.Result{named})
+
+		line := strings.TrimSpace(buf.String())
+		require.NotEmpty(t, line, "outputEnumJSONL must produce a JSONL line")
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(line), &obj),
+			"JSONL output must be valid JSON: %q", line)
+
+		assert.Equal(t, "john", obj["first"], `first field must be "john"`)
+		assert.Equal(t, "smith", obj["last"], `last field must be "smith"`)
+
+		// Pre-existing fields must remain unaffected.
+		assert.Equal(t, "enum", obj["type"])
+		assert.Equal(t, "github", obj["service"])
+		assert.Equal(t, named.Email, obj["email"])
+		assert.Equal(t, true, obj["exists"])
+		assert.Equal(t, string(enum.ConfidenceHigh), obj["confidence"])
+		assert.Contains(t, obj, "duration", "duration key must still be present")
+	})
+
+	t.Run("unnamed result omits first and last keys", func(t *testing.T) {
+		var buf bytes.Buffer
+		outputEnumJSONL(&buf, []enum.Result{unnamed})
+
+		line := strings.TrimSpace(buf.String())
+		require.NotEmpty(t, line, "outputEnumJSONL must produce a JSONL line")
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(line), &obj),
+			"JSONL output must be valid JSON: %q", line)
+
+		assert.NotContains(t, obj, "first",
+			`first key must be absent (omitempty), not emitted as ""`)
+		assert.NotContains(t, obj, "last",
+			`last key must be absent (omitempty), not emitted as ""`)
+
+		// Pre-existing fields must remain unaffected.
+		assert.Equal(t, "enum", obj["type"])
+		assert.Equal(t, "github", obj["service"])
+		assert.Equal(t, unnamed.Email, obj["email"])
+		assert.Equal(t, false, obj["exists"])
+		assert.Equal(t, string(enum.ConfidenceLow), obj["confidence"])
+		assert.Contains(t, obj, "duration", "duration key must still be present")
+	})
+
+	t.Run("mixed batch: one named, one unnamed", func(t *testing.T) {
+		var buf bytes.Buffer
+		outputEnumJSONL(&buf, []enum.Result{named, unnamed})
+
+		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+		require.Len(t, lines, 2, "must emit exactly one JSONL line per result")
+
+		var first map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[0]), &first))
+		assert.Equal(t, "john", first["first"])
+		assert.Equal(t, "smith", first["last"])
+
+		var second map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[1]), &second))
+		assert.NotContains(t, second, "first")
+		assert.NotContains(t, second, "last")
+	})
+}

--- a/pkg/enum/enum.go
+++ b/pkg/enum/enum.go
@@ -41,8 +41,15 @@ type Target struct {
 }
 
 // Config defines the configuration for account enumeration.
+//
+// Emails and Targets are two spellings of the same input. Targets is the
+// richer one — it carries the name behind each generated address — and
+// supersedes Emails, which remains for callers that only ever had bare
+// addresses to offer. Exactly one of them is consulted per run; see
+// resolveTargets for the rule.
 type Config struct {
-	Emails    []string      // emails to enumerate
+	Emails    []string      // legacy: addresses without names. Superseded by Targets.
+	Targets   []Target      // addresses to enumerate, with generated names when known
 	Services  []string      // service names to check (empty = all registered)
 	Threads   int           // concurrent workers (default: 10)
 	Timeout   time.Duration // per-check timeout (default: 10s)
@@ -88,7 +95,10 @@ func ProxyURLFromContext(ctx context.Context) string {
 
 // validate checks the configuration and applies defaults.
 func (c *Config) validate() error {
-	if len(c.Emails) == 0 {
+	// Either spelling of the input satisfies this; only supplying neither is a
+	// misconfiguration. The message predates Targets and is kept verbatim
+	// because callers and tests match on it.
+	if len(c.Emails) == 0 && len(c.Targets) == 0 {
 		return errors.New("emails required")
 	}
 	if c.Threads < 0 {
@@ -106,6 +116,27 @@ func (c *Config) validate() error {
 	}
 
 	return nil
+}
+
+// resolveTargets returns the addresses to enumerate, reconciling the two ways a
+// caller can supply them. Targets wins outright when populated — Emails is not
+// merged in — otherwise each Emails entry is promoted to a nameless Target.
+// The promotion leaves First/Last empty rather than deriving them from the
+// local part: a bare address says nothing about whose it is.
+//
+// This is the ONLY place that decides between the two fields. Both
+// EnumerateWithPlugin and runWorkers call it instead of reading either field
+// directly, so the two entry points can never disagree about the input.
+func (c *Config) resolveTargets() []Target {
+	if len(c.Targets) > 0 {
+		return c.Targets
+	}
+
+	targets := make([]Target, 0, len(c.Emails))
+	for _, email := range c.Emails {
+		targets = append(targets, Target{Email: email})
+	}
+	return targets
 }
 
 // EnumerateWithContext runs account enumeration with context support.

--- a/pkg/enum/runner.go
+++ b/pkg/enum/runner.go
@@ -20,9 +20,14 @@ import (
 	"errors"
 )
 
-// EnumerateWithPlugin runs cfg.Emails against a single provided Plugin instance,
-// bypassing the registry. It is used by runtime-constructed oracles (e.g. the
-// custom declarative oracle) that are not registered globally.
+// EnumerateWithPlugin runs the addresses in cfg against a single provided Plugin
+// instance, bypassing the registry. It is used by runtime-constructed oracles
+// (e.g. the custom declarative oracle) that are not registered globally.
+//
+// The addresses come from cfg.resolveTargets(), so a caller may supply either
+// Targets or the legacy Emails. Each Target's First/Last is stamped onto the
+// Result it produced, on every path including errors and panics. The Plugin
+// itself only ever sees the email — see runTasks.
 //
 // The same Plugin instance is shared across all goroutines, so the Plugin MUST
 // be stateless (enum.Plugin contract). cfg.Services is ignored.
@@ -37,10 +42,13 @@ func EnumerateWithPlugin(ctx context.Context, cfg *Config, p Plugin) ([]Result, 
 		return nil, err
 	}
 
-	tasks := make([]enumTask, 0, len(cfg.Emails))
-	for _, subject := range cfg.Emails {
+	targets := cfg.resolveTargets()
+	tasks := make([]enumTask, 0, len(targets))
+	for _, subject := range targets {
 		tasks = append(tasks, enumTask{
-			email:   subject,
+			email:   subject.Email,
+			first:   subject.First,
+			last:    subject.Last,
 			service: p.Name(),
 			plugin:  p,
 		})

--- a/pkg/enum/runner_test.go
+++ b/pkg/enum/runner_test.go
@@ -16,6 +16,8 @@ package enum
 
 import (
 	"context"
+	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -146,4 +148,305 @@ func TestEnumerateWithPlugin_SingleThread(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Len(t, results, 5, "single-threaded must still produce all results")
+}
+
+// ---------------------------------------------------------------------------
+// 10T-535 PR2: Config.Targets carries names through the framework, ADDITIVELY
+// alongside the legacy Config.Emails field. Nothing above this line changes:
+// the tests above still construct Config with only Emails, which is itself
+// the proof that the additive design does not break existing callers.
+//
+// Resolution rule under test: if Targets is non-empty, use it; otherwise
+// promote each Emails entry to a nameless Target{Email: e}. validate() must
+// accept either field being populated and must keep rejecting the case
+// where both are empty.
+// ---------------------------------------------------------------------------
+
+// recordingPlugin is a stub Plugin that records every email it was asked to
+// Check, so tests can assert exactly what the framework passed into the
+// Plugin contract. Safe for concurrent use: checked is protected by mu.
+type recordingPlugin struct {
+	name   string
+	exists bool
+
+	mu      sync.Mutex
+	checked []string
+}
+
+func (r *recordingPlugin) Name() string { return r.name }
+
+func (r *recordingPlugin) Check(_ context.Context, email string, _ time.Duration) *Result {
+	r.mu.Lock()
+	r.checked = append(r.checked, email)
+	r.mu.Unlock()
+
+	return &Result{
+		Service:    r.name,
+		Email:      email,
+		Exists:     r.exists,
+		Confidence: ConfidenceHigh,
+	}
+}
+
+// erroringPlugin is a stub Plugin that always returns a service error from
+// Check, used to verify that name-stamping survives the error path.
+type erroringPlugin struct {
+	name string
+}
+
+func (e *erroringPlugin) Name() string { return e.name }
+
+func (e *erroringPlugin) Check(_ context.Context, email string, _ time.Duration) *Result {
+	return &Result{
+		Service: e.name,
+		Email:   email,
+		Error:   errors.New("service unavailable"),
+	}
+}
+
+// TestEnumerateWithPlugin_NameCorrelation is THE CORE TEST for name
+// propagation: EnumerateWithPlugin must stamp each Result with the
+// First/Last of the Target that actually produced it, not just "some" name
+// drawn from the batch. Using >=2 targets with DIFFERENT names is
+// deliberate — a bug that stamped every Result with (say) the first
+// target's name would still make a weaker "a name is present" assertion
+// pass, but fails this one because each result is correlated back to its
+// originating Target by Email.
+//
+// Correlating by Email rather than by result index is deliberate: runTasks
+// appends results from concurrent goroutines under a mutex with no ordering
+// guarantee relative to submission order (see TestEnumerateWithPlugin_FanOut
+// and TestEnumerateWithPlugin_SingleThread above, which make the same
+// no-order-guarantee assumption).
+func TestEnumerateWithPlugin_NameCorrelation(t *testing.T) {
+	t.Parallel()
+	p := &stubPlugin{name: "name-oracle", exists: true}
+
+	targets := []Target{
+		{Email: "alice@example.com", First: "Alice", Last: "Anderson"},
+		{Email: "bob@example.com", First: "Bob", Last: "Baker"},
+	}
+
+	results, err := EnumerateWithPlugin(context.Background(), &Config{
+		Targets: targets,
+		Threads: 2,
+		Timeout: 5 * time.Second,
+	}, p)
+
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	byEmail := make(map[string]Result, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	aliceResult, ok := byEmail["alice@example.com"]
+	require.True(t, ok, "result for alice@example.com must be present")
+	assert.Equal(t, "Alice", aliceResult.First, "alice's result must carry Alice's First, not another target's")
+	assert.Equal(t, "Anderson", aliceResult.Last, "alice's result must carry Alice's Last, not another target's")
+
+	bobResult, ok := byEmail["bob@example.com"]
+	require.True(t, ok, "result for bob@example.com must be present")
+	assert.Equal(t, "Bob", bobResult.First, "bob's result must carry Bob's First, not another target's")
+	assert.Equal(t, "Baker", bobResult.Last, "bob's result must carry Bob's Last, not another target's")
+}
+
+// TestEnumerateWithPlugin_EmptyNameYieldsEmptyResult verifies that a Target
+// with no First/Last (the --email-file case: an address supplied directly
+// rather than generated) produces a Result with empty First/Last. The
+// framework must not invent or derive a name when the Target didn't carry
+// one.
+func TestEnumerateWithPlugin_EmptyNameYieldsEmptyResult(t *testing.T) {
+	t.Parallel()
+	p := &stubPlugin{name: "supplied-oracle", exists: true}
+
+	results, err := EnumerateWithPlugin(context.Background(), &Config{
+		Targets: []Target{{Email: "supplied@example.com"}},
+		Threads: 1,
+		Timeout: 5 * time.Second,
+	}, p)
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "supplied@example.com", results[0].Email)
+	assert.Empty(t, results[0].First, "First must be empty for a supplied (non-generated) address")
+	assert.Empty(t, results[0].Last, "Last must be empty for a supplied (non-generated) address")
+}
+
+// TestEnumerateWithPlugin_MixedNamedAndUnnamed verifies that in a batch
+// containing both generated (named) and supplied (unnamed) targets, each
+// Result carries exactly what its own Target had — no cross-contamination
+// in either direction.
+func TestEnumerateWithPlugin_MixedNamedAndUnnamed(t *testing.T) {
+	t.Parallel()
+	p := &stubPlugin{name: "mixed-oracle", exists: true}
+
+	targets := []Target{
+		{Email: "named@example.com", First: "Carol", Last: "Chen"},
+		{Email: "unnamed@example.com"},
+	}
+
+	results, err := EnumerateWithPlugin(context.Background(), &Config{
+		Targets: targets,
+		Threads: 2,
+		Timeout: 5 * time.Second,
+	}, p)
+
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	byEmail := make(map[string]Result, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	named, ok := byEmail["named@example.com"]
+	require.True(t, ok, "result for named@example.com must be present")
+	assert.Equal(t, "Carol", named.First, "named target's result must carry its First")
+	assert.Equal(t, "Chen", named.Last, "named target's result must carry its Last")
+
+	unnamed, ok := byEmail["unnamed@example.com"]
+	require.True(t, ok, "result for unnamed@example.com must be present")
+	assert.Empty(t, unnamed.First, "unnamed target's result must not have an invented First")
+	assert.Empty(t, unnamed.Last, "unnamed target's result must not have an invented Last")
+}
+
+// TestEnumerateWithPlugin_EmailsOnlyBackCompat is THE KEY NEW TEST for the
+// additive design: a Config using ONLY the legacy Emails field (no Targets
+// at all) must still enumerate every address, and every Result must carry
+// EMPTY First/Last. This proves both halves of the promotion path in one
+// test — existing callers (who only ever set Emails) keep working exactly
+// as before, AND the promotion never invents a name for an address that
+// arrived without one.
+func TestEnumerateWithPlugin_EmailsOnlyBackCompat(t *testing.T) {
+	t.Parallel()
+	p := &stubPlugin{name: "back-compat-oracle", exists: true}
+
+	results, err := EnumerateWithPlugin(context.Background(), &Config{
+		Emails:  []string{"legacy1@example.com", "legacy2@example.com"},
+		Threads: 2,
+		Timeout: 5 * time.Second,
+	}, p)
+
+	require.NoError(t, err)
+	require.Len(t, results, 2, "every legacy Emails entry must still be enumerated")
+
+	emails := make(map[string]bool, len(results))
+	for _, r := range results {
+		emails[r.Email] = true
+		assert.Empty(t, r.First, "a legacy Emails entry promoted to a Target must not invent a First name")
+		assert.Empty(t, r.Last, "a legacy Emails entry promoted to a Target must not invent a Last name")
+	}
+	assert.True(t, emails["legacy1@example.com"], "legacy1@example.com must be enumerated")
+	assert.True(t, emails["legacy2@example.com"], "legacy2@example.com must be enumerated")
+}
+
+// TestEnumerateWithPlugin_TargetsWinsOverEmails verifies that when both
+// Emails and Targets are populated, Targets wins outright — Emails is not
+// merged in, appended, or otherwise consulted. The two fixtures below use
+// disjoint, easily distinguishable email addresses so the assertion is
+// unambiguous: if Emails were consulted at all, "legacy-only@example.com"
+// would appear in the results.
+func TestEnumerateWithPlugin_TargetsWinsOverEmails(t *testing.T) {
+	t.Parallel()
+	p := &stubPlugin{name: "precedence-oracle", exists: true}
+
+	results, err := EnumerateWithPlugin(context.Background(), &Config{
+		Emails: []string{"legacy-only@example.com"},
+		Targets: []Target{
+			{Email: "target-only@example.com", First: "Target", Last: "Wins"},
+		},
+		Threads: 1,
+		Timeout: 5 * time.Second,
+	}, p)
+
+	require.NoError(t, err)
+	require.Len(t, results, 1, "when Targets is non-empty, Emails must be ignored entirely, not merged")
+
+	r := results[0]
+	assert.Equal(t, "target-only@example.com", r.Email,
+		"result must come from Targets; legacy-only@example.com from Emails must not appear")
+	assert.Equal(t, "Target", r.First, "name must come from the Targets entry")
+	assert.Equal(t, "Wins", r.Last, "name must come from the Targets entry")
+}
+
+// TestConfigValidate_AcceptsEitherEmailsOrTargets verifies that validate()
+// accepts either Emails or Targets being the populated one, and still
+// rejects the case where both are empty with the pre-existing "emails
+// required" error message (pinned by TestEnumerateWithPlugin_EmptyEmails
+// above via EnumerateWithPlugin; this test exercises validate() directly).
+func TestConfigValidate_AcceptsEitherEmailsOrTargets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("only Emails populated is valid", func(t *testing.T) {
+		cfg := &Config{Emails: []string{"a@example.com"}}
+		assert.NoError(t, cfg.validate(), "Emails alone must satisfy validate()")
+	})
+
+	t.Run("only Targets populated is valid", func(t *testing.T) {
+		cfg := &Config{Targets: []Target{{Email: "a@example.com"}}}
+		assert.NoError(t, cfg.validate(), "Targets alone must satisfy validate()")
+	})
+
+	t.Run("both empty still errors with emails required", func(t *testing.T) {
+		cfg := &Config{}
+		err := cfg.validate()
+		require.Error(t, err, "both Emails and Targets empty must still be rejected")
+		assert.Contains(t, err.Error(), "emails required",
+			"error message must be preserved for the both-empty case")
+	})
+}
+
+// TestEnumerateWithPlugin_PluginReceivesOnlyEmail verifies that the Plugin
+// interface is unaffected by name propagation: the fake plugin in this
+// harness observes only the email string passed to Check, proving the
+// framework attaches First/Last to the Result AFTER Check returns rather
+// than threading names into the Plugin contract. No per-service checker
+// needs to know about names.
+func TestEnumerateWithPlugin_PluginReceivesOnlyEmail(t *testing.T) {
+	t.Parallel()
+	p := &recordingPlugin{name: "recording-oracle", exists: true}
+
+	targets := []Target{
+		{Email: "dana@example.com", First: "Dana", Last: "Diaz"},
+		{Email: "erin@example.com"},
+	}
+
+	results, err := EnumerateWithPlugin(context.Background(), &Config{
+		Targets: targets,
+		Threads: 2,
+		Timeout: 5 * time.Second,
+	}, p)
+
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	p.mu.Lock()
+	checked := append([]string(nil), p.checked...)
+	p.mu.Unlock()
+
+	assert.ElementsMatch(t, []string{"dana@example.com", "erin@example.com"}, checked,
+		"plugin must observe exactly the target emails and nothing name-shaped — the name path is additive")
+}
+
+// TestEnumerateWithPlugin_ErrorPathPreservesName verifies that name-stamping
+// survives the error path: a Target whose Check returns a service error
+// still gets First/Last on its Result. The name is a property of the
+// address being checked, not of the check outcome.
+func TestEnumerateWithPlugin_ErrorPathPreservesName(t *testing.T) {
+	t.Parallel()
+	p := &erroringPlugin{name: "erroring-oracle"}
+
+	results, err := EnumerateWithPlugin(context.Background(), &Config{
+		Targets: []Target{{Email: "failing@example.com", First: "Frank", Last: "Foster"}},
+		Threads: 1,
+		Timeout: 5 * time.Second,
+	}, p)
+
+	require.NoError(t, err, "EnumerateWithPlugin itself must not error for a per-check service error")
+	require.Len(t, results, 1)
+	assert.Error(t, results[0].Error, "result must carry the service error")
+	assert.Equal(t, "Frank", results[0].First, "name must be stamped even when the check errored")
+	assert.Equal(t, "Foster", results[0].Last, "name must be stamped even when the check errored")
 }

--- a/pkg/enum/workers.go
+++ b/pkg/enum/workers.go
@@ -29,8 +29,14 @@ import (
 )
 
 // enumTask represents a single enumeration check to perform.
+//
+// first/last carry the name the email was generated from (empty for supplied
+// addresses) so runTasks can stamp it onto the resulting Result. They are
+// never passed to the Plugin.
 type enumTask struct {
 	email   string
+	first   string
+	last    string
 	service string
 	plugin  Plugin
 }
@@ -44,16 +50,18 @@ func runWorkers(ctx context.Context, cfg *Config) ([]Result, error) {
 		services = ListPlugins()
 	}
 
-	// Build task list: emails x services
+	// Build task list: targets x services
 	var tasks []enumTask
-	for _, email := range cfg.Emails {
+	for _, target := range cfg.resolveTargets() {
 		for _, svcName := range services {
 			plug, err := GetPlugin(svcName)
 			if err != nil {
 				return nil, fmt.Errorf("resolving service %q: %w", svcName, err)
 			}
 			tasks = append(tasks, enumTask{
-				email:   email,
+				email:   target.Email,
+				first:   target.First,
+				last:    target.Last,
 				service: svcName,
 				plugin:  plug,
 			})
@@ -114,6 +122,8 @@ func runTasks(ctx context.Context, cfg *Config, tasks []enumTask) ([]Result, err
 					results = append(results, Result{
 						Service: task.service,
 						Email:   task.email,
+						First:   task.first,
+						Last:    task.last,
 						Error:   fmt.Errorf("plugin panicked: %v", r),
 					})
 					mu.Unlock()
@@ -141,7 +151,9 @@ func runTasks(ctx context.Context, cfg *Config, tasks []enumTask) ([]Result, err
 				}
 			}
 
-			// Execute check
+			// Execute check. The Plugin receives only the email — names are
+			// stamped on afterwards, which is what keeps the Plugin interface
+			// (and every per-service checker) unaware of them.
 			result := task.plugin.Check(ctx, task.email, cfg.Timeout)
 			if result == nil {
 				result = &Result{
@@ -150,6 +162,13 @@ func runTasks(ctx context.Context, cfg *Config, tasks []enumTask) ([]Result, err
 					Error:   fmt.Errorf("plugin returned nil result"),
 				}
 			}
+
+			// Stamp the generated name onto the result. A name is a property of
+			// the address, not of the check outcome, so this applies on every
+			// path: clean checks, plugin errors, and the nil-result substitute
+			// above (the panic path stamps it in the deferred recover).
+			result.First = task.first
+			result.Last = task.last
 
 			if cfg.Verbose && result.Error != nil {
 				fmt.Fprintf(os.Stderr, "enum: error checking %s on %s: %v\n",


### PR DESCRIPTION
**2 of 8** for 10T-535. Builds on #304. **Nothing breaking.**

The framework now stamps the generated name onto each `Result`, so a name brutus produced never has to be reverse-derived downstream.

## Additive, not a rename

`Config` gains `Targets` **alongside** the existing `Emails`:

```go
type Config struct {
    Emails  []string   // legacy: addresses without names. Superseded by Targets.
    Targets []Target   // addresses with generated names when known
    ...
}
```

`resolveTargets` is the single place that reconciles them — `Targets` wins outright when populated, otherwise each `Emails` entry is promoted to a nameless `Target`. Both `EnumerateWithPlugin` and `runWorkers` call it rather than reading either field, so the two entry points can't disagree about the input.

Every existing caller keeps working and gets nameless results. `TestEnumerateWithPlugin_EmailsOnlyBackCompat` proves it using only the legacy field, and the five pre-existing `TestEnumerateWithPlugin_*` tests pass **untouched** — their `Config{Emails: ...}` literals are the back-compat proof.

`validate()` accepts either and keeps its `"emails required"` message verbatim, since tests and callers match on that string.

Promotion deliberately leaves `First`/`Last` **empty** rather than deriving them from the local part. A bare address says nothing about whose it is.

## Stamping covers every path

Clean check, plugin error, the nil-result substitute, and the deferred panic recovery — a name is a property of the address, not of the check outcome.

**The `Plugin` interface is byte-identical to `main`** (`git diff origin/main -- pkg/enum/plugin.go` is empty). Plugins receive only an email; the framework attaches the name after `Check` returns. That's what keeps all six per-service checkers untouched here and in the PRs that follow.

## JSONL

`outputEnumJSONL` emits `first`/`last` with **omitempty**, so an unnamed address omits the keys entirely:

```jsonc
{"type":"enum","service":"github","email":"jsmith@acme.com","exists":true,"first":"john","last":"smith"}
{"type":"enum","service":"github","email":"someone@acme.com","exists":true}
```

The test asserts key **absence** via `map[string]any`, so deleting `omitempty` fails rather than quietly emitting empty strings.

## Ordering left alone

`runTasks` appends under a mutex from an `errgroup`, so order is unspecified and I did not add a guarantee. Tests correlate by email — which matters twice: index correlation would be flaky, *and* it would let a bug that stamps every result with the first target's name pass.

## Verification

```
go build ./...                     exit 0
go vet ./pkg/enum/... ./cmd/...    exit 0
go test ./pkg/enum/ -v -count=1    8 new + 5 pre-existing all PASS
go test ./... -count=1             60 packages ok, 0 FAIL
gofmt -l (changed files)           clean
```

## Scope

Untouched: every per-service command, the oracles/custom consumers, and all checkers. `Config.Emails` is removed in 8/8.

## One thing for a reviewer

`runTasks` stamps `First`/`Last` **unconditionally** after `Check` returns, so a Plugin that set them itself would be overwritten. Verified that clobbers nothing today — no `enum.Plugin` implementation sets `Result.First`. Worth remembering when per-service checkers migrate later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
