### PR TITLE
feat(enum): carry generated names through the github oracle (10T-535, 3/8)

### DIFF
--- a/cmd/brutus/cmd_enum.go
+++ b/cmd/brutus/cmd_enum.go
@@ -169,12 +169,48 @@ func runEnumGenerate(cmd *cobra.Command, args []string) error {
 }
 
 // capResults returns the first limit elements of results (the most likely,
-// since results are frequency-ranked). A limit <= 0 means no cap.
-func capResults(results []string, limit int) []string {
+// since results are frequency-ranked). A limit <= 0 means no cap. It is generic
+// so the same cap applies whether a command carries bare addresses or the
+// enum.Candidate/enum.Target values that keep each address's generated name.
+func capResults[T any](results []T, limit int) []T {
 	if limit <= 0 || limit >= len(results) {
 		return results
 	}
 	return results[:limit]
+}
+
+// enumTargetEmails returns just the addresses of targets, in order, for the
+// per-service checkers (which take a []string of addresses).
+func enumTargetEmails(targets []enum.Target) []string {
+	emails := make([]string, len(targets))
+	for i, t := range targets {
+		emails[i] = t.Email
+	}
+	return emails
+}
+
+// enumNamesByEmail indexes the GENERATED targets by address, so a per-service
+// Result can be stamped with the name behind its address once the check
+// returns. Addresses the operator supplied (--emails/--email-file) carry no
+// name and are deliberately omitted: a supplied address says nothing about
+// whose it is, so a lookup for one must yield nothing rather than a guess.
+func enumNamesByEmail(targets []enum.Target) map[string]enum.Target {
+	names := make(map[string]enum.Target, len(targets))
+	for _, t := range targets {
+		if t.First == "" && t.Last == "" {
+			continue
+		}
+		names[t.Email] = t
+	}
+	return names
+}
+
+// enumNameFor returns the generated name behind email, or empty strings when
+// the address was not generated. Nothing invents a name here: an address that
+// is absent from names simply has none.
+func enumNameFor(names map[string]enum.Target, email string) (first, last string) {
+	t := names[email]
+	return t.First, t.Last
 }
 
 // pageSizeForLimit derives an API page size from a --limit total cap: min(limit,100),

--- a/cmd/brutus/cmd_enum_github.go
+++ b/cmd/brutus/cmd_enum_github.go
@@ -120,10 +120,12 @@ func runEnumGithub(cmd *cobra.Command, args []string) error {
 		flagJSON = true
 	}
 
-	emails, err := githubEnumTargets()
+	targets, err := githubEnumTargetList()
 	if err != nil {
 		return err
 	}
+	emails := enumTargetEmails(targets)
+	names := enumNamesByEmail(targets)
 
 	token := resolveGithubToken(flagGithubEnumToken, useColor)
 
@@ -159,6 +161,12 @@ func runEnumGithub(cmd *cobra.Command, args []string) error {
 	progress.Start()
 	var processed, found int
 	onResult := func(res githubenum.Result) {
+		// Stamp the generated name onto the result the enumerator just returned.
+		// The enumerator only ever sees the address, so the name is attached
+		// here; an address that came from --emails/--email-file is absent from
+		// names and stays nameless.
+		res.First, res.Last = enumNameFor(names, res.Email)
+
 		processed++
 		if res.Exists {
 			found++
@@ -207,6 +215,8 @@ func runEnumGithub(cmd *cobra.Command, args []string) error {
 	results := enumerator.EnumerateWith(ctx, emails, flagThreads, flagRateLimit, flagJitter, onResult)
 	progress.Stop()
 
+	stampGithubResultNames(results, names)
+
 	// Username reveal: only when not disabled, a token is set, and at least one
 	// account exists.
 	existing := existingEmails(results)
@@ -250,11 +260,12 @@ func runEnumGithub(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// githubEnumTargets parses, trims, and dedups the email targets from --emails
-// and --email-file, plus any --domain-generated candidates. It errors when no
-// targets are supplied.
-func githubEnumTargets() ([]string, error) {
-	var generated []string
+// githubEnumTargetList resolves the email targets from --emails and
+// --email-file, plus any --domain-generated candidates, each generated target
+// carrying the name its username was built from. It errors when no targets are
+// supplied.
+func githubEnumTargetList() ([]enum.Target, error) {
+	var generated []enum.Target
 	if flagGithubEnumDomain != "" {
 		g, err := githubEnumGenerate()
 		if err != nil {
@@ -263,65 +274,93 @@ func githubEnumTargets() ([]string, error) {
 		generated = g
 	}
 
-	return collectGithubEmails(flagGithubEnumEmails, flagGithubEnumEmailFile, generated,
+	return collectGithubTargets(flagGithubEnumEmails, flagGithubEnumEmailFile, generated,
 		fmt.Errorf("provide --emails/-e, --email-file/-E, or --domain"))
 }
 
-// collectGithubEmails parses, trims, and dedups email targets from an --emails
-// CSV and an --email-file (preserving first-seen order), then appends any
-// pre-generated candidates. noSourceErr is returned verbatim when no targets
-// resolve, letting each subcommand phrase its own guidance (the parent allows
-// --domain; the map subcommand does not).
+// collectGithubEmails returns just the addresses resolved by
+// collectGithubTargets. The map subcommand uses it: it never generates, so none
+// of its addresses have a name to carry.
 func collectGithubEmails(emailsCSV, emailFile string, generated []string, noSourceErr error) ([]string, error) {
-	var raw []string
+	targets := make([]enum.Target, len(generated))
+	for i, e := range generated {
+		targets[i] = enum.Target{Email: e}
+	}
+	resolved, err := collectGithubTargets(emailsCSV, emailFile, targets, noSourceErr)
+	if err != nil {
+		return nil, err
+	}
+	return enumTargetEmails(resolved), nil
+}
+
+// collectGithubTargets parses, trims, and dedups email targets from an --emails
+// CSV and an --email-file (preserving first-seen order), then appends any
+// pre-generated candidates. Supplied addresses carry no name, because an address
+// the operator provided says nothing about whose it is; dedup keeps the
+// first-seen entry, so a supplied address that a generated candidate duplicates
+// stays nameless. noSourceErr is returned verbatim when no targets resolve,
+// letting each subcommand phrase its own guidance (the parent allows --domain;
+// the map subcommand does not).
+func collectGithubTargets(emailsCSV, emailFile string, generated []enum.Target, noSourceErr error) ([]enum.Target, error) {
+	var raw []enum.Target
 	if emailsCSV != "" {
-		raw = append(raw, strings.Split(emailsCSV, ",")...)
+		for _, e := range strings.Split(emailsCSV, ",") {
+			raw = append(raw, enum.Target{Email: e})
+		}
 	}
 	if emailFile != "" {
 		lines, err := loadLinesFromFile(emailFile)
 		if err != nil {
 			return nil, fmt.Errorf("reading --email-file: %w", err)
 		}
-		raw = append(raw, lines...)
+		for _, e := range lines {
+			raw = append(raw, enum.Target{Email: e})
+		}
 	}
 	raw = append(raw, generated...)
 
 	seen := make(map[string]struct{})
-	var emails []string
-	for _, e := range raw {
-		e = strings.TrimSpace(e)
-		if e == "" {
+	var targets []enum.Target
+	for _, t := range raw {
+		t.Email = strings.TrimSpace(t.Email)
+		if t.Email == "" {
 			continue
 		}
-		if _, ok := seen[e]; ok {
+		if _, ok := seen[t.Email]; ok {
 			continue
 		}
-		seen[e] = struct{}{}
-		emails = append(emails, e)
+		seen[t.Email] = struct{}{}
+		targets = append(targets, t)
 	}
 
-	if len(emails) == 0 {
+	if len(targets) == 0 {
 		return nil, noSourceErr
 	}
-	return emails, nil
+	return targets, nil
 }
 
 // githubEnumGenerate produces the candidate email wordlist for --domain by
-// reusing the shared, frequency-ranked generator (enum.GenerateEmails) and the
-// shared capResults helper — no duplicated generation logic. The format is
-// validated against enum.ListFormats() first. A status line goes to stderr
-// (never stdout) unless quiet or JSON.
-func githubEnumGenerate() ([]string, error) {
+// reusing the shared, frequency-ranked generator (enum.GenerateCandidates) and
+// the shared capResults helper — no duplicated generation logic. Candidates, not
+// bare addresses, are generated so each target keeps the name its username was
+// built from, which is knowable for free here and lossy to recover later. The
+// format is validated against enum.ListFormats() first. A status line goes to
+// stderr (never stdout) unless quiet or JSON.
+func githubEnumGenerate() ([]enum.Target, error) {
 	if !slices.Contains(enum.ListFormats(), flagGithubEnumFormat) {
 		return nil, fmt.Errorf("invalid --format %q; valid formats: %s",
 			flagGithubEnumFormat, strings.Join(enum.ListFormats(), ", "))
 	}
 
-	generated, err := enum.GenerateEmails(flagGithubEnumFormat, flagGithubEnumDomain)
+	candidates, err := enum.GenerateCandidates(flagGithubEnumFormat)
 	if err != nil {
 		return nil, fmt.Errorf("generating candidate emails: %w", err)
 	}
-	generated = capResults(generated, flagGithubEnumLimit)
+	candidates = capResults(candidates, flagGithubEnumLimit)
+	generated := make([]enum.Target, len(candidates))
+	for i, c := range candidates {
+		generated[i] = c.Target(flagGithubEnumDomain)
+	}
 
 	if !flagQuiet && !flagJSON {
 		useColor := isColorEnabled(flagNoColor)
@@ -350,6 +389,26 @@ func resolveGithubToken(flagValue string, useColor bool) string {
 		return flagValue
 	}
 	return os.Getenv("GITHUB_TOKEN")
+}
+
+// stampGithubResultNames stamps each result's generated First/Last from names,
+// mutating the caller's slice in place. Results whose address is absent from
+// names are left nameless; no name is ever derived.
+//
+// This is a SECOND stamping pass, run after EnumerateWith, and it is not
+// redundant with the stamp in the onResult callback. EnumerateWith does
+// `results[i] = res; onResult(res)` — the callback and the returned slice each
+// receive their own copy of the Result, so a name stamped inside the callback
+// never reaches the slice EnumerateWith returns. github is the only command
+// that re-encodes JSON from that returned slice (its post-reveal record), so
+// the returned slice has to be stamped directly.
+//
+// The index-based loop is load-bearing: `for _, r := range results` would
+// mutate only the loop's local copy and leave the caller's slice unstamped.
+func stampGithubResultNames(results []githubenum.Result, names map[string]enum.Target) {
+	for i := range results {
+		results[i].First, results[i].Last = enumNameFor(names, results[i].Email)
+	}
 }
 
 // existingEmails returns the emails whose existence check confirmed an account.

--- a/cmd/brutus/cmd_enum_github_output.go
+++ b/cmd/brutus/cmd_enum_github_output.go
@@ -133,9 +133,13 @@ func firstGithubEnumError(results []githubenum.Result) string {
 // control characters, so no sanitization is needed.
 func outputGithubEnumJSONL(w io.Writer, results []githubenum.Result) {
 	type githubEnumJSON struct {
-		Type     string `json:"type"`
-		Email    string `json:"email"`
-		Exists   bool   `json:"exists"`
+		Type   string `json:"type"`
+		Email  string `json:"email"`
+		Exists bool   `json:"exists"`
+		// First/Last are omitempty on purpose: an address the operator supplied
+		// has no name, and emitting "" would assert a name we do not have.
+		First    string `json:"first,omitempty"`
+		Last     string `json:"last,omitempty"`
 		Username string `json:"username,omitempty"`
 		Error    string `json:"error,omitempty"`
 	}
@@ -147,6 +151,8 @@ func outputGithubEnumJSONL(w io.Writer, results []githubenum.Result) {
 			Type:     "github_account",
 			Email:    r.Email,
 			Exists:   r.Exists,
+			First:    r.First,
+			Last:     r.Last,
 			Username: r.Username,
 		}
 		if r.Error != nil {

--- a/cmd/brutus/cmd_enum_github_test.go
+++ b/cmd/brutus/cmd_enum_github_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/praetorian-inc/brutus/pkg/enum"
 	githubenum "github.com/praetorian-inc/brutus/pkg/enum/github"
 )
 
@@ -146,54 +147,134 @@ func TestEnumGithubCmd_NoRevealFlag(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// githubEnumTargets
+// githubEnumTargetList
+//
+// 10T-535 (3/8): githubEnumTargets() ([]string, error) is retargeted onto
+// githubEnumTargetList() ([]enum.Target, error) — the Target-returning
+// function that carries each generated address's name. Every prior
+// assertion (dedup, "provide" error) is preserved; the tests are
+// strengthened to also assert the never-invent-a-name rule for
+// CLI-supplied addresses.
 // ---------------------------------------------------------------------------
 
-// TestGithubEnumTargets_InlineEmails verifies that --emails CSV is parsed,
-// trimmed, and deduplicated.
-func TestGithubEnumTargets_InlineEmails(t *testing.T) {
+func resetGithubEnumTargetFlags() (restore func()) {
 	origEmails := flagGithubEnumEmails
 	origEmailFile := flagGithubEnumEmailFile
 	origDomain := flagGithubEnumDomain
-	defer func() {
+	origFormat := flagGithubEnumFormat
+	origLimit := flagGithubEnumLimit
+	return func() {
 		flagGithubEnumEmails = origEmails
 		flagGithubEnumEmailFile = origEmailFile
 		flagGithubEnumDomain = origDomain
-	}()
+		flagGithubEnumFormat = origFormat
+		flagGithubEnumLimit = origLimit
+	}
+}
+
+// TestGithubEnumTargetList_InlineEmails verifies that --emails CSV is
+// parsed, trimmed, and deduplicated, and that every CLI-supplied target
+// carries no name (a supplied address says nothing about whose it is).
+func TestGithubEnumTargetList_InlineEmails(t *testing.T) {
+	defer resetGithubEnumTargetFlags()()
 
 	flagGithubEnumEmails = "alice@example.com,bob@example.com,alice@example.com"
 	flagGithubEnumEmailFile = ""
 	flagGithubEnumDomain = ""
 
-	emails, err := githubEnumTargets()
+	got, err := githubEnumTargetList()
 	require.NoError(t, err)
 
+	emails := enumTargetEmails(got)
 	// Dedup: alice appears twice but must appear once.
 	assert.Len(t, emails, 2, "deduplication must collapse duplicate emails")
 	assert.Contains(t, emails, "alice@example.com")
 	assert.Contains(t, emails, "bob@example.com")
+
+	for i, target := range got {
+		assert.Empty(t, target.First, "target %d (%q): CLI-supplied address must have empty First", i, target.Email)
+		assert.Empty(t, target.Last, "target %d (%q): CLI-supplied address must have empty Last", i, target.Email)
+	}
 }
 
-// TestGithubEnumTargets_NoSource verifies that an error is returned (and
+// TestGithubEnumTargetList_NoSource verifies that an error is returned (and
 // mentions "provide") when no --emails, --email-file, or --domain is given.
-func TestGithubEnumTargets_NoSource(t *testing.T) {
-	origEmails := flagGithubEnumEmails
-	origEmailFile := flagGithubEnumEmailFile
-	origDomain := flagGithubEnumDomain
-	defer func() {
-		flagGithubEnumEmails = origEmails
-		flagGithubEnumEmailFile = origEmailFile
-		flagGithubEnumDomain = origDomain
-	}()
+func TestGithubEnumTargetList_NoSource(t *testing.T) {
+	defer resetGithubEnumTargetFlags()()
 
 	flagGithubEnumEmails = ""
 	flagGithubEnumEmailFile = ""
 	flagGithubEnumDomain = ""
 
-	_, err := githubEnumTargets()
-	require.Error(t, err, "githubEnumTargets must fail when no source is supplied")
+	_, err := githubEnumTargetList()
+	require.Error(t, err, "githubEnumTargetList must fail when no source is supplied")
 	assert.Contains(t, err.Error(), "provide",
 		"error must guide the user to supply a target source")
+}
+
+// TestGithubEnumTargetList_DomainGeneratedCarriesName verifies that
+// --domain-generated targets carry the non-empty First/Last the username
+// was built from, unlike CLI-supplied addresses.
+func TestGithubEnumTargetList_DomainGeneratedCarriesName(t *testing.T) {
+	defer resetGithubEnumTargetFlags()()
+
+	flagGithubEnumEmails = ""
+	flagGithubEnumEmailFile = ""
+	flagGithubEnumDomain = "target.com"
+	flagGithubEnumFormat = "first.last"
+	flagGithubEnumLimit = 5
+
+	got, err := githubEnumTargetList()
+	require.NoError(t, err)
+	require.Len(t, got, 5, "--limit must cap the number of generated targets")
+
+	for i, target := range got {
+		assert.Contains(t, target.Email, "@target.com", "target %d must be for the requested domain", i)
+		assert.NotEmpty(t, target.First, "target %d (%q): a --domain-generated target must carry a non-empty First", i, target.Email)
+		assert.NotEmpty(t, target.Last, "target %d (%q): a --domain-generated target must carry a non-empty Last", i, target.Email)
+	}
+}
+
+// TestGithubEnumTargetList_DedupPrecedence verifies that when a
+// CLI-supplied address duplicates a --domain-generated one, the
+// first-seen (CLI-supplied) entry wins and stays nameless — dedup keeps
+// first-seen order/precedence rather than letting a later generated
+// duplicate overwrite it with a name.
+func TestGithubEnumTargetList_DedupPrecedence(t *testing.T) {
+	defer resetGithubEnumTargetFlags()()
+
+	flagGithubEnumFormat = "first.last"
+	flagGithubEnumLimit = 5
+	flagGithubEnumDomain = "target.com"
+
+	// First, discover what the first generated candidate's address would be,
+	// so we can supply that exact address via --emails ahead of generation.
+	generated, err := githubEnumGenerate()
+	require.NoError(t, err)
+	require.NotEmpty(t, generated, "domain generation must produce at least one candidate for this test to be meaningful")
+	dupe := generated[0].Email
+
+	flagGithubEnumEmails = dupe
+
+	got, err := githubEnumTargetList()
+	require.NoError(t, err)
+
+	emails := enumTargetEmails(got)
+	assert.Equal(t, dupe, emails[0], "the CLI-supplied address must retain its first-seen position")
+
+	// Count occurrences of dupe: dedup must collapse it to exactly one entry.
+	var count int
+	for _, target := range got {
+		if target.Email == dupe {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "a supplied address duplicating a generated one must be deduplicated to a single entry")
+
+	// The surviving entry must be the CLI-supplied (nameless) one, not the
+	// generated (named) duplicate.
+	assert.Empty(t, got[0].First, "the surviving deduplicated entry must be the CLI-supplied one and carry no name")
+	assert.Empty(t, got[0].Last, "the surviving deduplicated entry must be the CLI-supplied one and carry no name")
 }
 
 // ---------------------------------------------------------------------------
@@ -358,6 +439,95 @@ func TestOutputGithubEnumJSONL(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// outputGithubEnumJSONL — First/Last name propagation (10T-535, 3/8)
+// ---------------------------------------------------------------------------
+
+// TestOutputGithubEnumJSONL_NameFields pins the never-invent-a-name rule: a
+// Result carrying First/Last (from --domain generation) must emit
+// "first"/"last" in the JSONL row, while a Result with empty First/Last
+// (supplied via --emails or --email-file) must OMIT both keys entirely
+// rather than emit them as "". Pre-existing fields (type/email/exists/
+// username) must be unaffected by the addition.
+func TestOutputGithubEnumJSONL_NameFields(t *testing.T) {
+	named := githubenum.Result{
+		Email:    "john.smith@example.com",
+		Exists:   true,
+		Username: "jsmith-gh",
+		First:    "john",
+		Last:     "smith",
+	}
+	unnamed := githubenum.Result{
+		Email:    "supplied@example.com",
+		Exists:   true,
+		Username: "supplied-gh",
+	}
+
+	t.Run("named result emits first and last", func(t *testing.T) {
+		var buf bytes.Buffer
+		outputGithubEnumJSONL(&buf, []githubenum.Result{named})
+
+		line := strings.TrimSpace(buf.String())
+		require.NotEmpty(t, line, "outputGithubEnumJSONL must produce a JSONL line")
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(line), &obj),
+			"JSONL output must be valid JSON: %q", line)
+
+		assert.Equal(t, "john", obj["first"], `first field must be "john"`)
+		assert.Equal(t, "smith", obj["last"], `last field must be "smith"`)
+
+		// Pre-existing fields must remain unaffected by the new ones.
+		assert.Equal(t, "github_account", obj["type"])
+		assert.Equal(t, named.Email, obj["email"])
+		assert.Equal(t, true, obj["exists"])
+		assert.Equal(t, "jsmith-gh", obj["username"])
+	})
+
+	t.Run("unnamed result omits first and last keys", func(t *testing.T) {
+		var buf bytes.Buffer
+		outputGithubEnumJSONL(&buf, []githubenum.Result{unnamed})
+
+		line := strings.TrimSpace(buf.String())
+		require.NotEmpty(t, line, "outputGithubEnumJSONL must produce a JSONL line")
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(line), &obj),
+			"JSONL output must be valid JSON: %q", line)
+
+		assert.NotContains(t, obj, "first",
+			`first key must be absent (omitempty), not emitted as ""`)
+		assert.NotContains(t, obj, "last",
+			`last key must be absent (omitempty), not emitted as ""`)
+
+		// Pre-existing fields must remain unaffected.
+		assert.Equal(t, "github_account", obj["type"])
+		assert.Equal(t, unnamed.Email, obj["email"])
+		assert.Equal(t, true, obj["exists"])
+		assert.Equal(t, "supplied-gh", obj["username"])
+	})
+
+	t.Run("mixed batch: one named, one unnamed", func(t *testing.T) {
+		var buf bytes.Buffer
+		outputGithubEnumJSONL(&buf, []githubenum.Result{named, unnamed})
+
+		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+		require.Len(t, lines, 2, "must emit exactly one JSONL line per result")
+
+		var first map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[0]), &first))
+		assert.Equal(t, "john", first["first"])
+		assert.Equal(t, "smith", first["last"])
+
+		var second map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[1]), &second))
+		assert.NotContains(t, second, "first",
+			`second (unnamed) line must not carry a "first" key`)
+		assert.NotContains(t, second, "last",
+			`second (unnamed) line must not carry a "last" key`)
+	})
+}
+
+// ---------------------------------------------------------------------------
 // outputGithubEnumResultLine
 // ---------------------------------------------------------------------------
 
@@ -451,5 +621,137 @@ func TestFirstGithubEnumError(t *testing.T) {
 		}
 
 		assert.Equal(t, "", firstGithubEnumError(results))
+	})
+}
+
+// ---------------------------------------------------------------------------
+// stampGithubResultNames (10T-535, 3/8)
+//
+// pkg/enum/github/existence.go's EnumerateWith does `results[i] = res;
+// onResult(res)` — onResult and the returned slice each get their OWN copy.
+// Stamping a name inside onResult never reaches the slice EnumerateWith
+// returns. github is the only command that re-encodes JSON from that
+// returned slice (its post-reveal record), so runEnumGithub needs a SECOND,
+// in-place stamping pass over the returned slice after EnumerateWith. That
+// pass is extracted here as stampGithubResultNames so it is unit-testable
+// without a network call. These tests pin exactly the property the loop
+// exists for: index-based, in-place mutation of the caller's slice — a
+// by-value `for _, r := range results` "simplification" must fail them.
+// ---------------------------------------------------------------------------
+
+// TestStampGithubResultNames_HitStampsNameFromIndex verifies that a result
+// whose email is present in the index gets its First/Last stamped from the
+// indexed enum.Target.
+func TestStampGithubResultNames_HitStampsNameFromIndex(t *testing.T) {
+	results := []githubenum.Result{
+		{Email: "john.smith@example.com", Exists: true},
+	}
+	names := enumNamesByEmail([]enum.Target{
+		{Email: "john.smith@example.com", First: "john", Last: "smith"},
+	})
+
+	stampGithubResultNames(results, names)
+
+	assert.Equal(t, "john", results[0].First, "a result whose email is in the index must be stamped with the indexed First")
+	assert.Equal(t, "smith", results[0].Last, "a result whose email is in the index must be stamped with the indexed Last")
+}
+
+// TestStampGithubResultNames_MissLeavesEmptyNeverDerived verifies that a
+// result whose email is NOT present in the index is left with empty
+// First/Last — the framework must never invent or derive a name.
+func TestStampGithubResultNames_MissLeavesEmptyNeverDerived(t *testing.T) {
+	results := []githubenum.Result{
+		{Email: "supplied@example.com", Exists: true},
+	}
+	names := enumNamesByEmail([]enum.Target{
+		{Email: "someone-else@example.com", First: "jane", Last: "doe"},
+	})
+
+	stampGithubResultNames(results, names)
+
+	assert.Empty(t, results[0].First, "a result whose email is absent from the index must keep an empty First, never a derived guess")
+	assert.Empty(t, results[0].Last, "a result whose email is absent from the index must keep an empty Last, never a derived guess")
+}
+
+// TestStampGithubResultNames_MixedSlice_EachElementGetsItsOwnName verifies
+// that each element of a mixed slice is stamped with ITS OWN name from the
+// index — not, for example, every element getting the first element's name.
+// Two entries with distinct names are used so a "stamp everyone with the
+// first name" bug is caught rather than passing by coincidence.
+func TestStampGithubResultNames_MixedSlice_EachElementGetsItsOwnName(t *testing.T) {
+	results := []githubenum.Result{
+		{Email: "john.smith@example.com", Exists: true},
+		{Email: "jane.doe@example.com", Exists: true},
+	}
+	names := enumNamesByEmail([]enum.Target{
+		{Email: "john.smith@example.com", First: "john", Last: "smith"},
+		{Email: "jane.doe@example.com", First: "jane", Last: "doe"},
+	})
+
+	stampGithubResultNames(results, names)
+
+	assert.Equal(t, "john", results[0].First, "element 0 must be stamped with its own First")
+	assert.Equal(t, "smith", results[0].Last, "element 0 must be stamped with its own Last")
+	assert.Equal(t, "jane", results[1].First, "element 1 must be stamped with ITS OWN First, not element 0's")
+	assert.Equal(t, "doe", results[1].Last, "element 1 must be stamped with ITS OWN Last, not element 0's")
+}
+
+// TestStampGithubResultNames_MutatesCallerSliceInPlace verifies that
+// stamping mutates the caller's slice in place (by index), which is exactly
+// what makes the extracted helper usable where the EnumerateWith callback's
+// copy semantics do not reach the returned slice. A helper that ranged by
+// value (`for _, r := range results { r.First = ... }`) would mutate only
+// the loop's local copy and leave the caller's slice unchanged — this test
+// must fail against such an implementation.
+func TestStampGithubResultNames_MutatesCallerSliceInPlace(t *testing.T) {
+	results := []githubenum.Result{
+		{Email: "john.smith@example.com", Exists: true},
+	}
+	names := enumNamesByEmail([]enum.Target{
+		{Email: "john.smith@example.com", First: "john", Last: "smith"},
+	})
+
+	// Sanity precondition: unstamped before the call.
+	require.Empty(t, results[0].First, "precondition: result must start unstamped")
+
+	stampGithubResultNames(results, names)
+
+	// Assert against the SAME slice variable the caller passed in — this is
+	// the assertion a by-value range would fail, since it mutates only its
+	// own loop-local copy and never touches the backing array `results`
+	// points at.
+	require.NotEmpty(t, results[0].First, "the caller's original slice must be mutated in place, not left unstamped")
+	assert.Equal(t, "john", results[0].First)
+	assert.Equal(t, "smith", results[0].Last)
+}
+
+// TestStampGithubResultNames_EmptyIndexIsNoop verifies that stamping against
+// an empty/nil index leaves every result's First/Last empty, without
+// panicking.
+func TestStampGithubResultNames_EmptyIndexIsNoop(t *testing.T) {
+	results := []githubenum.Result{
+		{Email: "a@x.com", Exists: true},
+		{Email: "b@x.com", Exists: true},
+	}
+
+	assert.NotPanics(t, func() {
+		stampGithubResultNames(results, map[string]enum.Target{})
+	})
+
+	for i, r := range results {
+		assert.Empty(t, r.First, "result %d must remain unstamped against an empty index", i)
+		assert.Empty(t, r.Last, "result %d must remain unstamped against an empty index", i)
+	}
+}
+
+// TestStampGithubResultNames_EmptySliceIsNoop verifies that stamping an
+// empty/nil results slice does not panic.
+func TestStampGithubResultNames_EmptySliceIsNoop(t *testing.T) {
+	names := enumNamesByEmail([]enum.Target{
+		{Email: "john.smith@example.com", First: "john", Last: "smith"},
+	})
+
+	assert.NotPanics(t, func() {
+		stampGithubResultNames(nil, names)
 	})
 }

--- a/cmd/brutus/cmd_enum_test.go
+++ b/cmd/brutus/cmd_enum_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/praetorian-inc/brutus/pkg/enum"
+)
+
+// ---------------------------------------------------------------------------
+// capResults — generic type parameter (10T-535, 3/8)
+//
+// cmd_enum_generate_test.go already exercises capResults over []string
+// (its original, non-generic shape). This test exercises the generic
+// signature (capResults[T any]) over a non-string element type, so the type
+// parameter itself — not just the []string instantiation — is verified.
+// ---------------------------------------------------------------------------
+
+// TestCapResults_GenericOverNonStringType verifies that capResults works over
+// a non-string type (enum.Target), proving it is generic rather than
+// []string-specific.
+func TestCapResults_GenericOverNonStringType(t *testing.T) {
+	t.Parallel()
+
+	input := []enum.Target{
+		{Email: "alice@example.com", First: "alice", Last: "a"},
+		{Email: "bob@example.com", First: "bob", Last: "b"},
+		{Email: "carol@example.com", First: "carol", Last: "c"},
+	}
+
+	got := capResults(input, 2)
+	assert.Equal(t, input[:2], got,
+		"capResults[enum.Target] must cap to the first N elements, same as capResults[string]")
+}
+
+// ---------------------------------------------------------------------------
+// enumTargetEmails
+// ---------------------------------------------------------------------------
+
+// TestEnumTargetEmails_PreservesOrder verifies that enumTargetEmails projects
+// []enum.Target -> []string of addresses, preserving input order.
+func TestEnumTargetEmails_PreservesOrder(t *testing.T) {
+	t.Parallel()
+
+	targets := []enum.Target{
+		{Email: "carol@example.com", First: "carol", Last: "c"},
+		{Email: "alice@example.com", First: "alice", Last: "a"},
+		{Email: "bob@example.com"},
+	}
+
+	got := enumTargetEmails(targets)
+	assert.Equal(t,
+		[]string{"carol@example.com", "alice@example.com", "bob@example.com"},
+		got,
+		"enumTargetEmails must preserve the input order of targets")
+}
+
+// TestEnumTargetEmails_EmptyInput verifies that an empty/nil target slice
+// yields an empty (not nil-panicking) result.
+func TestEnumTargetEmails_EmptyInput(t *testing.T) {
+	t.Parallel()
+
+	got := enumTargetEmails(nil)
+	assert.Empty(t, got, "enumTargetEmails on a nil slice must return an empty slice")
+}
+
+// ---------------------------------------------------------------------------
+// enumNamesByEmail / enumNameFor
+// ---------------------------------------------------------------------------
+
+// TestEnumNamesByEmail_IndexesGeneratedTargets verifies that
+// enumNamesByEmail builds an address -> name index from generated targets
+// (non-empty First/Last), and omits targets that carry no name (as supplied
+// --emails/--email-file addresses do).
+func TestEnumNamesByEmail_IndexesGeneratedTargets(t *testing.T) {
+	t.Parallel()
+
+	targets := []enum.Target{
+		{Email: "generated@example.com", First: "john", Last: "smith"},
+		{Email: "supplied@example.com"}, // no name: CLI-supplied address
+	}
+
+	index := enumNamesByEmail(targets)
+
+	require := assert.New(t)
+	require.Len(index, 1, "enumNamesByEmail must only index targets that carry a name")
+	got, ok := index["generated@example.com"]
+	require.True(ok, "the generated target's address must be present in the index")
+	require.Equal("john", got.First)
+	require.Equal("smith", got.Last)
+
+	_, ok = index["supplied@example.com"]
+	require.False(ok, "a nameless (CLI-supplied) target must not appear in the index")
+}
+
+// TestEnumNameFor_HitReturnsIndexedName verifies that enumNameFor returns the
+// indexed First/Last for an address present in the index.
+func TestEnumNameFor_HitReturnsIndexedName(t *testing.T) {
+	t.Parallel()
+
+	index := enumNamesByEmail([]enum.Target{
+		{Email: "jane@example.com", First: "jane", Last: "doe"},
+	})
+
+	first, last := enumNameFor(index, "jane@example.com")
+	assert.Equal(t, "jane", first)
+	assert.Equal(t, "doe", last)
+}
+
+// TestEnumNameFor_MissReturnsEmptyNeverDerived verifies that looking up an
+// address absent from the index returns empty First/Last — the framework
+// must never invent or derive a name for an address it didn't generate.
+func TestEnumNameFor_MissReturnsEmptyNeverDerived(t *testing.T) {
+	t.Parallel()
+
+	index := enumNamesByEmail([]enum.Target{
+		{Email: "jane@example.com", First: "jane", Last: "doe"},
+	})
+
+	// "unknown@example.com" was never generated and is absent from the index.
+	first, last := enumNameFor(index, "unknown@example.com")
+	assert.Empty(t, first, "a miss must yield an empty First, never a derived guess")
+	assert.Empty(t, last, "a miss must yield an empty Last, never a derived guess")
+}
+
+// TestEnumNameFor_EmptyIndexReturnsEmpty verifies enumNameFor against a
+// nil/empty index (e.g. no addresses were generated at all).
+func TestEnumNameFor_EmptyIndexReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	first, last := enumNameFor(map[string]enum.Target{}, "anyone@example.com")
+	assert.Empty(t, first)
+	assert.Empty(t, last)
+}


### PR DESCRIPTION
**3 of 8** for 10T-535 — first per-service migration, plus the shared helpers PRs 4–7 reuse. Builds on #304 and #309.

## github

Generates via `GenerateCandidates` → `.Target(domain)`, keeps an address→name index, stamps `First`/`Last` onto each result. `outputGithubEnumJSONL` emits them with **omitempty**:

```jsonc
{"type":"github_account","email":"jsmith@acme.com","exists":true,"username":"jsmith","first":"john","last":"smith"}
{"type":"github_account","email":"someone@acme.com","exists":true}
```

Addresses from `-e`/`-E` are **nameless** — a supplied address says nothing about whose it is, and `enumNameFor` returns empty on a miss rather than deriving anything.

## Shared helpers

`capResults` is now generic so one helper serves `[]string` and `[]enum.Target` instead of a near-duplicate; the five existing `[]string` call sites infer `T=string` unchanged. Plus `enumTargetEmails`, `enumNamesByEmail`, `enumNameFor`.

## The second stamp — the interesting part

`pkg/enum/github/existence.go` does:

```go
results[i] = res
if onResult != nil { onResult(res) }   // ← two independent copies
```

The callback and the returned slice each get their **own copy**, so a name stamped inside the callback never reaches the slice `EnumerateWith` returns. github is the only command that re-encodes JSON from that slice — for its post-reveal record — so the slice is stamped directly.

That loop was previously inline and **unpinned**: deleting it left the entire suite green while silently emitting nameless post-reveal rows. It's now `stampGithubResultNames` with six tests, including one asserting the caller's own slice is mutated in place.

**Verified by mutation.** Switching the helper to `for _, r := range results` fails 3 of the 6:

```
--- FAIL: TestStampGithubResultNames_HitStampsNameFromIndex
        expected: "john"   actual: ""
--- FAIL: TestStampGithubResultNames_MixedSlice_EachElementGetsItsOwnName
        element 1 must be stamped with ITS OWN First, not element 0's
--- FAIL: TestStampGithubResultNames_MutatesCallerSliceInPlace
        the caller's original slice must be mutated in place, not left unstamped
```

The 3 that still pass under the bug assert emptiness or absence of panic, so they can't discriminate between the two implementations by construction — correct for what they pin, not a gap.

## Dead code removed, not shipped

`githubEnumTargets` is **deleted** rather than left as an adapter kept alive by its own tests — its tests were retargeted onto `githubEnumTargetList` with every assertion preserved. `collectGithubEmails` **stays**: the `github map` subcommand still calls it and never generates.

## Scope, verified

- `pkg/` **entirely untouched** — no checker changed, including github's
- No other service's cmd file changed
- `Config.Emails` retained until 8/8

```
go build ./...                exit 0
go vet ./cmd/... ./pkg/enum/  exit 0
go test ./cmd/... -count=1    25 targeted tests PASS
go test ./... -count=1        56 packages ok, 0 FAIL
gofmt -l (changed files)      clean
```

## Next

4) google · 5) gravatar · 6) microsoft365 · 7) teams · 8) delete the `Config.Emails` shim. Each of 4–7 is independent of the others and reuses the helpers landed here unmodified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
