### PR TITLE
feat(enum): carry generated names through the google oracle (10T-535, 4/8)

### DIFF
--- a/cmd/brutus/cmd_enum_google.go
+++ b/cmd/brutus/cmd_enum_google.go
@@ -101,10 +101,12 @@ func runEnumGoogle(cmd *cobra.Command, args []string) error {
 		flagJSON = true
 	}
 
-	emails, err := googleEnumTargets()
+	targets, err := googleEnumTargetList()
 	if err != nil {
 		return err
 	}
+	emails := enumTargetEmails(targets)
+	names := enumNamesByEmail(targets)
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
@@ -136,6 +138,16 @@ func runEnumGoogle(cmd *cobra.Command, args []string) error {
 	progress.Start()
 	var processed, found int
 	onResult := func(res google.Result) {
+		// Stamp the generated name onto the result the enumerator just returned.
+		// The enumerator only ever sees the address, so the name is attached
+		// here; an address that came from --emails/--email-file is absent from
+		// names and stays nameless.
+		//
+		// One stamp is enough: google emits JSON only from this callback, and the
+		// slice EnumerateWith returns feeds outputGoogleEnumSummary alone (which
+		// counts existence and errors), so it is never re-encoded.
+		res.First, res.Last = enumNameFor(names, res.Email)
+
 		processed++
 		if res.Exists {
 			found++
@@ -162,20 +174,28 @@ func runEnumGoogle(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// googleEnumTargets parses, trims, and dedups the email targets from --emails
-// and --email-file, plus any --domain-generated candidates. It errors when no
+// googleEnumTargetList parses, trims, and dedups the email targets from
+// --emails and --email-file, plus any --domain-generated candidates. Each
+// generated target carries the name its username was built from; supplied
+// addresses carry none, because an address the operator provided says nothing
+// about whose it is. Dedup keeps the first-seen entry, so a supplied address
+// that a generated candidate duplicates stays nameless. It errors when no
 // targets are supplied.
-func googleEnumTargets() ([]string, error) {
-	var raw []string
+func googleEnumTargetList() ([]enum.Target, error) {
+	var raw []enum.Target
 	if flagGoogleEnumEmails != "" {
-		raw = append(raw, strings.Split(flagGoogleEnumEmails, ",")...)
+		for _, e := range strings.Split(flagGoogleEnumEmails, ",") {
+			raw = append(raw, enum.Target{Email: e})
+		}
 	}
 	if flagGoogleEnumEmailFile != "" {
 		lines, err := loadLinesFromFile(flagGoogleEnumEmailFile)
 		if err != nil {
 			return nil, fmt.Errorf("reading --email-file: %w", err)
 		}
-		raw = append(raw, lines...)
+		for _, e := range lines {
+			raw = append(raw, enum.Target{Email: e})
+		}
 	}
 
 	// --domain generates the candidate wordlist internally (reusing the same
@@ -191,42 +211,49 @@ func googleEnumTargets() ([]string, error) {
 	}
 
 	seen := make(map[string]struct{})
-	var emails []string
-	for _, e := range raw {
-		e = strings.TrimSpace(e)
-		if e == "" {
+	var targets []enum.Target
+	for _, t := range raw {
+		t.Email = strings.TrimSpace(t.Email)
+		if t.Email == "" {
 			continue
 		}
-		if _, ok := seen[e]; ok {
+		if _, ok := seen[t.Email]; ok {
 			continue
 		}
-		seen[e] = struct{}{}
-		emails = append(emails, e)
+		seen[t.Email] = struct{}{}
+		targets = append(targets, t)
 	}
 
-	if len(emails) == 0 {
+	if len(targets) == 0 {
 		return nil, fmt.Errorf("provide --emails/-e, --email-file/-E, or --domain")
 	}
-	return emails, nil
+	return targets, nil
 }
 
 // googleEnumGenerate produces the candidate email wordlist for --domain by
-// reusing the shared, frequency-ranked generator (enum.GenerateEmails) and the
-// shared capResults helper — no duplicated generation logic. The requested
-// format is validated against enum.ListFormats() first, because GenerateEmails
-// silently yields an empty list for an unknown format. A status line goes to
-// stderr (never stdout, so --json/-o output stays clean) unless quiet or JSON.
-func googleEnumGenerate() ([]string, error) {
+// reusing the shared, frequency-ranked generator (enum.GenerateCandidates) and
+// the shared capResults helper — no duplicated generation logic. Candidates,
+// not bare addresses, are generated so each target keeps the name its username
+// was built from, which is knowable for free here and lossy to recover later.
+// The requested format is validated against enum.ListFormats() first, because
+// the generator silently yields an empty list for an unknown format. A status
+// line goes to stderr (never stdout, so --json/-o output stays clean) unless
+// quiet or JSON.
+func googleEnumGenerate() ([]enum.Target, error) {
 	if !slices.Contains(enum.ListFormats(), flagGoogleEnumFormat) {
 		return nil, fmt.Errorf("invalid --format %q; valid formats: %s",
 			flagGoogleEnumFormat, strings.Join(enum.ListFormats(), ", "))
 	}
 
-	generated, err := enum.GenerateEmails(flagGoogleEnumFormat, flagGoogleEnumDomain)
+	candidates, err := enum.GenerateCandidates(flagGoogleEnumFormat)
 	if err != nil {
 		return nil, fmt.Errorf("generating candidate emails: %w", err)
 	}
-	generated = capResults(generated, flagGoogleEnumLimit)
+	candidates = capResults(candidates, flagGoogleEnumLimit)
+	generated := make([]enum.Target, len(candidates))
+	for i, c := range candidates {
+		generated[i] = c.Target(flagGoogleEnumDomain)
+	}
 
 	if !flagQuiet && !flagJSON {
 		useColor := isColorEnabled(flagNoColor)

--- a/cmd/brutus/cmd_enum_google_test.go
+++ b/cmd/brutus/cmd_enum_google_test.go
@@ -193,6 +193,97 @@ func TestOutputGoogleEnumJSONL(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// outputGoogleEnumJSONL — First/Last name propagation (10T-535, 4/8)
+// ---------------------------------------------------------------------------
+
+// TestOutputGoogleEnumJSONL_NameFields pins the never-invent-a-name rule: a
+// Result carrying First/Last (from --domain generation) must emit
+// "first"/"last" in the JSONL row, while a Result with empty First/Last
+// (supplied via --emails or --email-file) must OMIT both keys entirely
+// rather than emit them as "". Pre-existing fields (type/email/exists/
+// method/idp) must be unaffected by the addition.
+func TestOutputGoogleEnumJSONL_NameFields(t *testing.T) {
+	named := google.Result{
+		Email:  "john.smith@example.com",
+		Exists: true,
+		Method: google.MethodWorkspaceSSO,
+		IdP:    "login.okta.com",
+		First:  "john",
+		Last:   "smith",
+	}
+	unnamed := google.Result{
+		Email:  "supplied@example.com",
+		Exists: true,
+		Method: google.MethodGmail,
+	}
+
+	t.Run("named result emits first and last", func(t *testing.T) {
+		var buf bytes.Buffer
+		outputGoogleEnumJSONL(&buf, []google.Result{named})
+
+		line := strings.TrimSpace(buf.String())
+		require.NotEmpty(t, line, "outputGoogleEnumJSONL must produce a JSONL line")
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(line), &obj),
+			"JSONL output must be valid JSON: %q", line)
+
+		assert.Equal(t, "john", obj["first"], `first field must be "john"`)
+		assert.Equal(t, "smith", obj["last"], `last field must be "smith"`)
+
+		// Pre-existing fields must remain unaffected by the new ones.
+		assert.Equal(t, "google_account", obj["type"])
+		assert.Equal(t, named.Email, obj["email"])
+		assert.Equal(t, true, obj["exists"])
+		assert.Equal(t, "workspace-sso", obj["method"])
+		assert.Equal(t, "login.okta.com", obj["idp"])
+	})
+
+	t.Run("unnamed result omits first and last keys", func(t *testing.T) {
+		var buf bytes.Buffer
+		outputGoogleEnumJSONL(&buf, []google.Result{unnamed})
+
+		line := strings.TrimSpace(buf.String())
+		require.NotEmpty(t, line, "outputGoogleEnumJSONL must produce a JSONL line")
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(line), &obj),
+			"JSONL output must be valid JSON: %q", line)
+
+		assert.NotContains(t, obj, "first",
+			`first key must be absent (omitempty), not emitted as ""`)
+		assert.NotContains(t, obj, "last",
+			`last key must be absent (omitempty), not emitted as ""`)
+
+		// Pre-existing fields must remain unaffected.
+		assert.Equal(t, "google_account", obj["type"])
+		assert.Equal(t, unnamed.Email, obj["email"])
+		assert.Equal(t, true, obj["exists"])
+		assert.Equal(t, "gmail", obj["method"])
+	})
+
+	t.Run("mixed batch: one named, one unnamed", func(t *testing.T) {
+		var buf bytes.Buffer
+		outputGoogleEnumJSONL(&buf, []google.Result{named, unnamed})
+
+		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+		require.Len(t, lines, 2, "must emit exactly one JSONL line per result")
+
+		var first map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[0]), &first))
+		assert.Equal(t, "john", first["first"])
+		assert.Equal(t, "smith", first["last"])
+
+		var second map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[1]), &second))
+		assert.NotContains(t, second, "first",
+			`second (unnamed) line must not carry a "first" key`)
+		assert.NotContains(t, second, "last",
+			`second (unnamed) line must not carry a "last" key`)
+	})
+}
+
+// ---------------------------------------------------------------------------
 // TestOutputGoogleEnumResultLine
 // Verifies human-readable line output for EXISTS, gmail, and ANSI safety.
 // ---------------------------------------------------------------------------
@@ -271,51 +362,131 @@ func TestOutputGoogleEnumResultLine(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// TestGoogleEnumTargets
-// Exercises googleEnumTargets() using the file-local flag variables directly,
-// saving and restoring them with defer.
+// googleEnumTargetList
+//
+// 10T-535 (4/8): googleEnumTargets() ([]string, error) is retargeted onto
+// googleEnumTargetList() ([]enum.Target, error) — the Target-returning
+// function that carries each generated address's name. Every prior
+// assertion (dedup, "provide" error) is preserved; the tests are
+// strengthened to also assert the never-invent-a-name rule for
+// CLI-supplied addresses.
 // ---------------------------------------------------------------------------
 
-func TestGoogleEnumTargets_InlineEmails(t *testing.T) {
-	// Save and restore flag globals.
+func resetGoogleEnumTargetFlags() (restore func()) {
 	origEmails := flagGoogleEnumEmails
 	origEmailFile := flagGoogleEnumEmailFile
 	origDomain := flagGoogleEnumDomain
-	defer func() {
+	origFormat := flagGoogleEnumFormat
+	origLimit := flagGoogleEnumLimit
+	return func() {
 		flagGoogleEnumEmails = origEmails
 		flagGoogleEnumEmailFile = origEmailFile
 		flagGoogleEnumDomain = origDomain
-	}()
+		flagGoogleEnumFormat = origFormat
+		flagGoogleEnumLimit = origLimit
+	}
+}
+
+// TestGoogleEnumTargetList_InlineEmails verifies that --emails CSV is parsed,
+// trimmed, and deduplicated, and that every CLI-supplied target carries no
+// name (a supplied address says nothing about whose it is).
+func TestGoogleEnumTargetList_InlineEmails(t *testing.T) {
+	defer resetGoogleEnumTargetFlags()()
 
 	flagGoogleEnumEmails = "alice@example.com,bob@example.com,alice@example.com"
 	flagGoogleEnumEmailFile = ""
 	flagGoogleEnumDomain = ""
 
-	emails, err := googleEnumTargets()
+	got, err := googleEnumTargetList()
 	require.NoError(t, err)
 
+	emails := enumTargetEmails(got)
 	// Deduplication: alice@example.com appears twice but must appear once.
 	assert.Len(t, emails, 2, "deduplication must collapse duplicate emails")
 	assert.Contains(t, emails, "alice@example.com")
 	assert.Contains(t, emails, "bob@example.com")
+
+	for i, target := range got {
+		assert.Empty(t, target.First, "target %d (%q): CLI-supplied address must have empty First", i, target.Email)
+		assert.Empty(t, target.Last, "target %d (%q): CLI-supplied address must have empty Last", i, target.Email)
+	}
 }
 
-func TestGoogleEnumTargets_NoSource(t *testing.T) {
-	origEmails := flagGoogleEnumEmails
-	origEmailFile := flagGoogleEnumEmailFile
-	origDomain := flagGoogleEnumDomain
-	defer func() {
-		flagGoogleEnumEmails = origEmails
-		flagGoogleEnumEmailFile = origEmailFile
-		flagGoogleEnumDomain = origDomain
-	}()
+// TestGoogleEnumTargetList_NoSource verifies that an error is returned (and
+// mentions "provide") when no --emails, --email-file, or --domain is given.
+func TestGoogleEnumTargetList_NoSource(t *testing.T) {
+	defer resetGoogleEnumTargetFlags()()
 
 	flagGoogleEnumEmails = ""
 	flagGoogleEnumEmailFile = ""
 	flagGoogleEnumDomain = ""
 
-	_, err := googleEnumTargets()
-	require.Error(t, err, "googleEnumTargets must fail when no source is supplied")
+	_, err := googleEnumTargetList()
+	require.Error(t, err, "googleEnumTargetList must fail when no source is supplied")
 	assert.Contains(t, err.Error(), "provide",
 		"error message must guide the user to supply a target source")
+}
+
+// TestGoogleEnumTargetList_DomainGeneratedCarriesName verifies that
+// --domain-generated targets carry the non-empty First/Last the username was
+// built from, unlike CLI-supplied addresses.
+func TestGoogleEnumTargetList_DomainGeneratedCarriesName(t *testing.T) {
+	defer resetGoogleEnumTargetFlags()()
+
+	flagGoogleEnumEmails = ""
+	flagGoogleEnumEmailFile = ""
+	flagGoogleEnumDomain = "target.com"
+	flagGoogleEnumFormat = "first.last"
+	flagGoogleEnumLimit = 5
+
+	got, err := googleEnumTargetList()
+	require.NoError(t, err)
+	require.Len(t, got, 5, "--limit must cap the number of generated targets")
+
+	for i, target := range got {
+		assert.Contains(t, target.Email, "@target.com", "target %d must be for the requested domain", i)
+		assert.NotEmpty(t, target.First, "target %d (%q): a --domain-generated target must carry a non-empty First", i, target.Email)
+		assert.NotEmpty(t, target.Last, "target %d (%q): a --domain-generated target must carry a non-empty Last", i, target.Email)
+	}
+}
+
+// TestGoogleEnumTargetList_DedupPrecedence verifies that when a CLI-supplied
+// address duplicates a --domain-generated one, the first-seen (CLI-supplied)
+// entry wins and stays nameless — dedup keeps first-seen order/precedence
+// rather than letting a later generated duplicate overwrite it with a name.
+func TestGoogleEnumTargetList_DedupPrecedence(t *testing.T) {
+	defer resetGoogleEnumTargetFlags()()
+
+	flagGoogleEnumFormat = "first.last"
+	flagGoogleEnumLimit = 5
+	flagGoogleEnumDomain = "target.com"
+
+	// First, discover what the first generated candidate's address would be,
+	// so we can supply that exact address via --emails ahead of generation.
+	generated, err := googleEnumGenerate()
+	require.NoError(t, err)
+	require.NotEmpty(t, generated, "domain generation must produce at least one candidate for this test to be meaningful")
+	dupe := generated[0].Email
+
+	flagGoogleEnumEmails = dupe
+
+	got, err := googleEnumTargetList()
+	require.NoError(t, err)
+
+	emails := enumTargetEmails(got)
+	assert.Equal(t, dupe, emails[0], "the CLI-supplied address must retain its first-seen position")
+
+	// Count occurrences of dupe: dedup must collapse it to exactly one entry.
+	var count int
+	for _, target := range got {
+		if target.Email == dupe {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "a supplied address duplicating a generated one must be deduplicated to a single entry")
+
+	// The surviving entry must be the CLI-supplied (nameless) one, not the
+	// generated (named) duplicate.
+	assert.Empty(t, got[0].First, "the surviving deduplicated entry must be the CLI-supplied one and carry no name")
+	assert.Empty(t, got[0].Last, "the surviving deduplicated entry must be the CLI-supplied one and carry no name")
 }

--- a/cmd/brutus/cmd_enum_output.go
+++ b/cmd/brutus/cmd_enum_output.go
@@ -977,9 +977,14 @@ func outputGoogleEnumSummary(w io.Writer, results []google.Result, useColor bool
 // outputGoogleEnumJSONL writes one JSON object per result. encoding/json escapes
 // control characters, so no sanitization is needed.
 func outputGoogleEnumJSONL(w io.Writer, results []google.Result) {
+	// First/Last carry the generated name behind the address. They are omitempty
+	// because an address the operator supplied has no name, and an empty string
+	// would read as a claim that it does.
 	type googleEnumJSON struct {
 		Type   string `json:"type"`
 		Email  string `json:"email"`
+		First  string `json:"first,omitempty"`
+		Last   string `json:"last,omitempty"`
 		Exists bool   `json:"exists"`
 		Method string `json:"method,omitempty"`
 		IdP    string `json:"idp,omitempty"`
@@ -992,6 +997,8 @@ func outputGoogleEnumJSONL(w io.Writer, results []google.Result) {
 		jr := googleEnumJSON{
 			Type:   "google_account",
 			Email:  r.Email,
+			First:  r.First,
+			Last:   r.Last,
 			Exists: r.Exists,
 			Method: string(r.Method),
 			IdP:    r.IdP,


### PR DESCRIPTION
**4 of 8** for 10T-535 — google. Same shape as the merged github change (#311), reusing its shared helpers unmodified. **3 files, +248/−43.**

## What changed

`googleEnumGenerate` returns `[]enum.Target` from `GenerateCandidates` → `.Target(domain)`, and `googleEnumTargetList` replaces `googleEnumTargets`. `-e`/`-E` entries are **nameless**; generated ones carry names. Trim, dedup, first-seen order, precedence and the no-source error message are preserved verbatim.

`outputGoogleEnumJSONL` emits `first`/`last` with **omitempty**:

```jsonc
{"type":"google_account","email":"jsmith@acme.com","exists":true,"method":"gmail","first":"john","last":"smith"}
{"type":"google_account","email":"someone@acme.com","exists":true,"method":"gmail"}
```

## One stamp, not two — deliberately

github needed a **second** index-based pass because its post-reveal path re-encodes the slice `EnumerateWith` returns, and that slice holds copies the callback never touched.

google has no reveal step. Its returned slice feeds `outputGoogleEnumSummary` only, which reads `Error`/`Exists` and never re-encodes. So the callback stamp is sufficient and `stampGoogleResultNames` would be dead code.

Verified in source rather than inferred from the github pattern, and recorded as a comment at the stamp site so nobody later "fixes" the asymmetry by adding a pass that does nothing.

## Dead code removed

`googleEnumTargets` is **deleted**, not left as an adapter kept alive by its own tests — those were retargeted onto `googleEnumTargetList` with every assertion preserved, plus new ones asserting generated targets carry names and supplied ones don't.

## Scope, verified

| | |
|---|---|
| `pkg/` | untouched — no checker changed |
| `cmd_enum.go` | unchanged — shared helpers reused as-is |
| gravatar / m365 / teams / github | untouched |
| `Config.Emails` | retained until 8/8 |

```
go build ./...                exit 0
go vet ./cmd/... ./pkg/enum/  exit 0
go test ./... -count=1        56 packages ok, 0 FAIL
gofmt -l                      clean
```

## Noted, not done here

google's dedup loop is now near-identical to github's `collectGithubTargets`. That's two occurrences, and github's exists partly to give its `map` subcommand a different no-source error — so extracting a shared collector is left as a follow-up once more services land and the shape is proven. Rule of Three rather than premature.

## Next

5) gravatar · 6) microsoft365 · 7) teams · 8) delete the `Config.Emails` shim.

Staying sequential rather than parallel: google, m365 and teams all encode in `cmd_enum_output.go`, so concurrent branches would conflict there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
