### PR TITLE
feat(enum): carry generated names through the gravatar oracle (10T-535, 5/8)

### DIFF
--- a/cmd/brutus/cmd_enum_gravatar.go
+++ b/cmd/brutus/cmd_enum_gravatar.go
@@ -101,10 +101,12 @@ func runEnumGravatar(cmd *cobra.Command, args []string) error {
 		flagJSON = true
 	}
 
-	emails, err := gravatarEnumTargets()
+	targets, err := gravatarEnumTargetList()
 	if err != nil {
 		return err
 	}
+	emails := enumTargetEmails(targets)
+	names := enumNamesByEmail(targets)
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
@@ -136,6 +138,20 @@ func runEnumGravatar(cmd *cobra.Command, args []string) error {
 	progress.Start()
 	var processed, found int
 	onResult := func(res gravatar.Result) {
+		// Stamp the generated name onto the result the checker just returned.
+		// The checker only ever sees the address, so the name is attached here;
+		// an address that came from --emails/--email-file is absent from names
+		// and stays nameless.
+		//
+		// One stamp is enough, unlike github's two: the slice EnumerateWith
+		// returns feeds outputGravatarEnumSummary alone, which only counts
+		// Exists/Error and never re-encodes JSON. gravatar also has no
+		// reveal/re-emit step, so stamping that returned slice would be dead
+		// code. (github needs the second pass precisely because it re-encodes
+		// JSON from the returned slice for its post-reveal record, and the
+		// callback mutates its own copy of the Result.)
+		res.First, res.Last = enumNameFor(names, res.Email)
+
 		processed++
 		if res.Exists {
 			found++
@@ -162,20 +178,28 @@ func runEnumGravatar(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// gravatarEnumTargets parses, trims, lower-cases, and dedups the email targets
-// from --emails and --email-file, plus any --domain-generated candidates. It
+// gravatarEnumTargetList parses, trims, lower-cases, and dedups the email
+// targets from --emails and --email-file, plus any --domain-generated
+// candidates. Each generated target carries the name its username was built
+// from; supplied addresses carry none, because an address the operator provided
+// says nothing about whose it is. Dedup keeps the first-seen entry, so a
+// supplied address that a generated candidate duplicates stays nameless. It
 // errors when no targets are supplied.
-func gravatarEnumTargets() ([]string, error) {
-	var raw []string
+func gravatarEnumTargetList() ([]enum.Target, error) {
+	var raw []enum.Target
 	if flagGravatarEnumEmails != "" {
-		raw = append(raw, strings.Split(flagGravatarEnumEmails, ",")...)
+		for _, e := range strings.Split(flagGravatarEnumEmails, ",") {
+			raw = append(raw, enum.Target{Email: e})
+		}
 	}
 	if flagGravatarEnumEmailFile != "" {
 		lines, err := loadLinesFromFile(flagGravatarEnumEmailFile)
 		if err != nil {
 			return nil, fmt.Errorf("reading --email-file: %w", err)
 		}
-		raw = append(raw, lines...)
+		for _, e := range lines {
+			raw = append(raw, enum.Target{Email: e})
+		}
 	}
 
 	// --domain generates the candidate wordlist internally (reusing the same
@@ -191,42 +215,57 @@ func gravatarEnumTargets() ([]string, error) {
 	}
 
 	seen := make(map[string]struct{})
-	var emails []string
-	for _, e := range raw {
-		e = strings.ToLower(strings.TrimSpace(e))
-		if e == "" {
+	var targets []enum.Target
+	for _, t := range raw {
+		// Normalize the Target's Email FIELD, not a throwaway local: this is the
+		// exact address enumTargetEmails hands to the checker, and CheckAccount
+		// echoes the address it is given back verbatim on Result.Email (it
+		// lower-cases only a copy, for HashEmail's digest). Keeping the stored
+		// address byte-identical to the echoed one is what lets
+		// enumNamesByEmail/enumNameFor recover the generated name; indexing on a
+		// pre-normalization address (e.g. a mixed-case --domain's
+		// j.smith@Example.COM) would miss every lookup and drop names silently.
+		t.Email = strings.ToLower(strings.TrimSpace(t.Email))
+		if t.Email == "" {
 			continue
 		}
-		if _, ok := seen[e]; ok {
+		if _, ok := seen[t.Email]; ok {
 			continue
 		}
-		seen[e] = struct{}{}
-		emails = append(emails, e)
+		seen[t.Email] = struct{}{}
+		targets = append(targets, t)
 	}
 
-	if len(emails) == 0 {
+	if len(targets) == 0 {
 		return nil, fmt.Errorf("provide --emails/-e, --email-file/-E, or --domain")
 	}
-	return emails, nil
+	return targets, nil
 }
 
 // gravatarEnumGenerate produces the candidate email wordlist for --domain by
-// reusing the shared, frequency-ranked generator (enum.GenerateEmails) and the
-// shared capResults helper — no duplicated generation logic. The requested
-// format is validated against enum.ListFormats() first, because GenerateEmails
-// silently yields an empty list for an unknown format. A status line goes to
-// stderr (never stdout, so --json/-o output stays clean) unless quiet or JSON.
-func gravatarEnumGenerate() ([]string, error) {
+// reusing the shared, frequency-ranked generator (enum.GenerateCandidates) and
+// the shared capResults helper — no duplicated generation logic. Candidates,
+// not bare addresses, are generated so each target keeps the name its username
+// was built from, which is knowable for free here and lossy to recover later.
+// The requested format is validated against enum.ListFormats() first, because
+// the generator silently yields an empty list for an unknown format. A status
+// line goes to stderr (never stdout, so --json/-o output stays clean) unless
+// quiet or JSON.
+func gravatarEnumGenerate() ([]enum.Target, error) {
 	if !slices.Contains(enum.ListFormats(), flagGravatarEnumFormat) {
 		return nil, fmt.Errorf("invalid --format %q; valid formats: %s",
 			flagGravatarEnumFormat, strings.Join(enum.ListFormats(), ", "))
 	}
 
-	generated, err := enum.GenerateEmails(flagGravatarEnumFormat, flagGravatarEnumDomain)
+	candidates, err := enum.GenerateCandidates(flagGravatarEnumFormat)
 	if err != nil {
 		return nil, fmt.Errorf("generating candidate emails: %w", err)
 	}
-	generated = capResults(generated, flagGravatarEnumLimit)
+	candidates = capResults(candidates, flagGravatarEnumLimit)
+	generated := make([]enum.Target, len(candidates))
+	for i, c := range candidates {
+		generated[i] = c.Target(flagGravatarEnumDomain)
+	}
 
 	if !flagQuiet && !flagJSON {
 		useColor := isColorEnabled(flagNoColor)

--- a/cmd/brutus/cmd_enum_gravatar_output.go
+++ b/cmd/brutus/cmd_enum_gravatar_output.go
@@ -76,8 +76,14 @@ func outputGravatarEnumSummary(w io.Writer, results []gravatar.Result, useColor 
 
 // gravatarEnumJSON is the JSONL row shape for a Gravatar enumeration result. The
 // avatar URL is derived from the hash for convenience.
+//
+// first/last are omitempty because a supplied address (--emails/--email-file)
+// has no known name: the keys are absent rather than emitted as "", so a
+// consumer can never mistake an unknown name for an empty one.
 type gravatarEnumJSON struct {
 	Email     string `json:"email"`
+	First     string `json:"first,omitempty"`
+	Last      string `json:"last,omitempty"`
 	Hash      string `json:"hash"`
 	Exists    bool   `json:"exists"`
 	AvatarURL string `json:"avatar_url"`
@@ -88,6 +94,8 @@ type gravatarEnumJSON struct {
 func encodeGravatarEnumResult(r gravatar.Result) gravatarEnumJSON {
 	jr := gravatarEnumJSON{
 		Email:     r.Email,
+		First:     r.First,
+		Last:      r.Last,
 		Hash:      r.Hash,
 		Exists:    r.Exists,
 		AvatarURL: fmt.Sprintf("https://www.gravatar.com/avatar/%s", r.Hash),

--- a/cmd/brutus/cmd_enum_gravatar_test.go
+++ b/cmd/brutus/cmd_enum_gravatar_test.go
@@ -15,19 +15,30 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/praetorian-inc/brutus/pkg/enum"
+	"github.com/praetorian-inc/brutus/pkg/enum/gravatar"
 )
 
 // ---------------------------------------------------------------------------
-// TestGravatarEnumTargets
-// Exercises gravatarEnumTargets() using the file-local flag variables
-// directly, saving and restoring them with defer (mirrors
-// TestGoogleEnumTargets_InlineEmails).
+// gravatarEnumTargetList / gravatarEnumGenerate
+//
+// 10T-535 (5/8): gravatarEnumTargets() ([]string, error) is retargeted onto
+// gravatarEnumTargetList() ([]enum.Target, error) — the Target-returning
+// function that carries each generated address's name (mirrors
+// googleEnumTargetList / githubEnumTargetList). gravatarEnumGenerate() is
+// retargeted from ([]string, error) to ([]enum.Target, error) for the same
+// reason. Every prior assertion (trim, case-insensitive dedup, "provide"
+// error, --limit capping, invalid-format error) is preserved; there is no
+// dead adapter left behind pinning the old []string signatures.
 // ---------------------------------------------------------------------------
 
 func resetGravatarEnumFlags() (restore func()) {
@@ -45,38 +56,187 @@ func resetGravatarEnumFlags() (restore func()) {
 	}
 }
 
-func TestGravatarEnumTargets_InlineEmails(t *testing.T) {
+// TestGravatarEnumTargetList_InlineEmails verifies that --emails CSV is parsed,
+// trimmed, lower-cased, and deduplicated (case-insensitively), and that every
+// CLI-supplied target carries no name (a supplied address says nothing about
+// whose it is) — mirrors TestGoogleEnumTargetList_InlineEmails /
+// TestGithubEnumTargetList equivalents.
+func TestGravatarEnumTargetList_InlineEmails(t *testing.T) {
 	defer resetGravatarEnumFlags()()
 
 	flagGravatarEnumEmails = "Alice@Example.com, Bob@Example.com ,alice@example.com"
 	flagGravatarEnumEmailFile = ""
 	flagGravatarEnumDomain = ""
 
-	emails, err := gravatarEnumTargets()
+	got, err := gravatarEnumTargetList()
 	require.NoError(t, err)
 
+	emails := enumTargetEmails(got)
 	// Deduplication (case-insensitive) and lower-casing/trimming: Alice and
 	// alice must collapse to one lower-cased, trimmed entry.
 	assert.Len(t, emails, 2, "deduplication must collapse case-insensitive duplicate emails")
 	assert.Contains(t, emails, "alice@example.com")
 	assert.Contains(t, emails, "bob@example.com")
+
+	for i, target := range got {
+		assert.Empty(t, target.First, "target %d (%q): CLI-supplied address must have empty First", i, target.Email)
+		assert.Empty(t, target.Last, "target %d (%q): CLI-supplied address must have empty Last", i, target.Email)
+	}
 }
 
-func TestGravatarEnumTargets_NoSource(t *testing.T) {
+// TestGravatarEnumTargetList_CaseInsensitiveDedup pins the specific example
+// called out for PR5: A@x.com and a@x.com must collapse to a single
+// lower-cased entry.
+func TestGravatarEnumTargetList_CaseInsensitiveDedup(t *testing.T) {
+	defer resetGravatarEnumFlags()()
+
+	flagGravatarEnumEmails = "A@x.com,a@x.com"
+	flagGravatarEnumEmailFile = ""
+	flagGravatarEnumDomain = ""
+
+	got, err := gravatarEnumTargetList()
+	require.NoError(t, err)
+
+	emails := enumTargetEmails(got)
+	require.Len(t, emails, 1, "A@x.com and a@x.com must collapse to a single entry")
+	assert.Equal(t, "a@x.com", emails[0], "the surviving entry must be lower-cased")
+	assert.Empty(t, got[0].First, "the surviving CLI-supplied entry must carry no name")
+	assert.Empty(t, got[0].Last, "the surviving CLI-supplied entry must carry no name")
+}
+
+// TestGravatarEnumTargetList_NoSource verifies that an error is returned (and
+// mentions "provide") when no --emails, --email-file, or --domain is given.
+func TestGravatarEnumTargetList_NoSource(t *testing.T) {
 	defer resetGravatarEnumFlags()()
 
 	flagGravatarEnumEmails = ""
 	flagGravatarEnumEmailFile = ""
 	flagGravatarEnumDomain = ""
 
-	_, err := gravatarEnumTargets()
-	require.Error(t, err, "gravatarEnumTargets must fail when no source is supplied")
+	_, err := gravatarEnumTargetList()
+	require.Error(t, err, "gravatarEnumTargetList must fail when no source is supplied")
 	assert.Contains(t, err.Error(), "provide",
 		"error message must guide the user to supply a target source")
 }
 
+// TestGravatarEnumTargetList_DomainGeneratedCarriesName verifies that
+// --domain-generated targets carry the non-empty First/Last the username was
+// built from, unlike CLI-supplied addresses, and that --limit caps the count.
+func TestGravatarEnumTargetList_DomainGeneratedCarriesName(t *testing.T) {
+	defer resetGravatarEnumFlags()()
+
+	flagGravatarEnumEmails = ""
+	flagGravatarEnumEmailFile = ""
+	flagGravatarEnumDomain = "target.com"
+	flagGravatarEnumFormat = "first.last"
+	flagGravatarEnumLimit = 5
+
+	got, err := gravatarEnumTargetList()
+	require.NoError(t, err)
+	require.Len(t, got, 5, "--limit must cap the number of generated targets")
+
+	for i, target := range got {
+		assert.Contains(t, target.Email, "@target.com", "target %d must be for the requested domain", i)
+		assert.NotEmpty(t, target.First, "target %d (%q): a --domain-generated target must carry a non-empty First", i, target.Email)
+		assert.NotEmpty(t, target.Last, "target %d (%q): a --domain-generated target must carry a non-empty Last", i, target.Email)
+	}
+}
+
 // ---------------------------------------------------------------------------
-// TestGravatarEnumGenerate
+// THE CRITICAL TRAP (10T-535, 5/8)
+//
+// cmd_enum_gravatar.go's target-building/dedup loop (formerly line ~196 of
+// gravatarEnumTargets, now inside gravatarEnumTargetList) lower-cases every
+// address: e = strings.ToLower(strings.TrimSpace(e)). That normalization must
+// land on the Target's Email FIELD itself — the exact address that
+// enumTargetEmails() hands to gravatar.Checker.EnumerateWith and that
+// gravatar.CheckAccount echoes back verbatim on Result.Email (CheckAccount
+// never re-cases the address it is given; it only lower-cases a COPY for
+// HashEmail's MD5 digest).
+//
+// If the loop normalizes a throwaway local variable (e.g. only the key used
+// for the dedup "seen" set) but appends the ORIGINAL, un-normalized Candidate
+// address onto the returned Target, then any code path that independently
+// re-derives the checker's input by re-normalizing (rather than reusing
+// enumTargetEmails on the same targets slice) will diverge from the
+// un-normalized Target.Email that enumNamesByEmail indexes by. The generated
+// name then vanishes silently on lookup: no error, no warning, just no name
+// in the output.
+//
+// This test generates with a MIXED-CASE --domain ("Example.COM") and asserts:
+//  1. Every returned Target's Email is already lower-cased (the domain's
+//     mixed case must not survive into Target.Email).
+//  2. Every generated target's name is recoverable via enumNamesByEmail +
+//     enumNameFor, keyed on the address gravatar.Checker will actually
+//     receive and echo back (target.Email itself, and independently its
+//     lower-cased form — asserting these are identical is exactly the
+//     invariant the fix must hold).
+// ---------------------------------------------------------------------------
+
+func TestGravatarEnumTargetList_GeneratedAddressesAreLowerCasedForNameLookup(t *testing.T) {
+	defer resetGravatarEnumFlags()()
+
+	flagGravatarEnumEmails = ""
+	flagGravatarEnumEmailFile = ""
+	flagGravatarEnumDomain = "Example.COM" // mixed-case domain: the trap.
+	flagGravatarEnumFormat = "first.last"
+	flagGravatarEnumLimit = 10
+
+	got, err := gravatarEnumTargetList()
+	require.NoError(t, err)
+	require.Len(t, got, 10, "--limit must cap the number of generated targets")
+
+	for i, target := range got {
+		// The address stored on the Target must ALREADY be lower-cased: this is
+		// the exact address enumTargetEmails() will hand to
+		// gravatar.Checker.EnumerateWith, and CheckAccount echoes back the
+		// address it is given verbatim on Result.Email.
+		lowered := strings.ToLower(strings.TrimSpace(target.Email))
+		require.Equal(t, lowered, target.Email,
+			"target %d: Target.Email must already be lower-cased/trimmed inside gravatarEnumTargetList's target-building loop, matching what gravatar.CheckAccount will echo back on Result.Email", i)
+		require.NotContains(t, target.Email, "Example.COM",
+			"target %d (%q): Target.Email must not retain the mixed-case domain the operator supplied via --domain — the merge loop's lower-casing must apply to the Target field itself, not just a discarded local variable", i, target.Email)
+	}
+
+	// enumNamesByEmail/enumNameFor are the shared framework helpers (unmodified,
+	// reused from cmd_enum.go) that runEnumGravatar wires up exactly like
+	// runEnumGoogle/runEnumGithub: names := enumNamesByEmail(targets), then each
+	// onResult callback does res.First, res.Last = enumNameFor(names, res.Email).
+	// Building the index from the SAME already-normalized targets slice that
+	// gravatarEnumTargetList returned is what keeps the lookup key
+	// byte-identical to the address the checker echoes back.
+	names := enumNamesByEmail(got)
+	require.Len(t, names, len(got), "every generated target must be indexed by enumNamesByEmail")
+
+	for i, target := range got {
+		// Simulate the checker echoing the address back on a Result: gravatar's
+		// CheckAccount sets Result{Email: email} verbatim from the email
+		// parameter it is given, which is target.Email itself.
+		echoedByChecker := target.Email
+
+		first, last := enumNameFor(names, echoedByChecker)
+		assert.NotEmpty(t, first,
+			"target %d (%q): name lookup keyed on the checker-echoed (lower-cased) address must recover a non-empty First — an empty result here means the index was built on an un-normalized address and the name silently vanished", i, target.Email)
+		assert.NotEmpty(t, last,
+			"target %d (%q): name lookup keyed on the checker-echoed (lower-cased) address must recover a non-empty Last — an empty result here means the index was built on an un-normalized address and the name silently vanished", i, target.Email)
+		assert.Equal(t, target.First, first, "target %d: recovered First must match the target's own First", i)
+		assert.Equal(t, target.Last, last, "target %d: recovered Last must match the target's own Last", i)
+
+		// The lookup must also succeed when keyed by the independently
+		// lower-cased form of the address — proving the stored key and the
+		// checker-echoed address are byte-identical, not just coincidentally
+		// equal in this test's construction.
+		independentlyLowered := strings.ToLower(strings.TrimSpace(target.Email))
+		firstAgain, lastAgain := enumNameFor(names, independentlyLowered)
+		assert.Equal(t, first, firstAgain,
+			"target %d: lookup keyed on the independently-lower-cased address must match the lookup keyed on target.Email itself", i)
+		assert.Equal(t, last, lastAgain,
+			"target %d: lookup keyed on the independently-lower-cased address must match the lookup keyed on target.Email itself", i)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// gravatarEnumGenerate
 // ---------------------------------------------------------------------------
 
 func TestGravatarEnumGenerate_ProducesCandidatesForDomain(t *testing.T) {
@@ -89,13 +249,20 @@ func TestGravatarEnumGenerate_ProducesCandidatesForDomain(t *testing.T) {
 	generated, err := gravatarEnumGenerate()
 	require.NoError(t, err)
 
-	want, err := enum.GenerateEmails("first.last", "target.com")
+	candidates, err := enum.GenerateCandidates("first.last")
 	require.NoError(t, err)
 
+	want := make([]enum.Target, len(candidates))
+	for i, c := range candidates {
+		want[i] = c.Target("target.com")
+	}
+
 	assert.Equal(t, want, generated,
-		"gravatarEnumGenerate must reuse enum.GenerateEmails and return the same candidates")
-	for _, e := range generated {
-		assert.Contains(t, e, "@target.com", "every generated candidate must be for the requested domain")
+		"gravatarEnumGenerate must reuse enum.GenerateCandidates (via capResults and Candidate.Target), matching the google/github generate pattern")
+	for i, target := range generated {
+		assert.Contains(t, target.Email, "@target.com", "target %d must be for the requested domain", i)
+		assert.NotEmpty(t, target.First, "target %d: generated target must carry a non-empty First", i)
+		assert.NotEmpty(t, target.Last, "target %d: generated target must carry a non-empty Last", i)
 	}
 }
 
@@ -111,10 +278,15 @@ func TestGravatarEnumGenerate_RespectsLimit(t *testing.T) {
 
 	assert.Len(t, generated, 3, "--limit must cap the number of generated candidates")
 
-	want, err := enum.GenerateEmails("first.last", "target.com")
+	candidates, err := enum.GenerateCandidates("first.last")
 	require.NoError(t, err)
-	require.GreaterOrEqual(t, len(want), 3, "full generated list must have at least 3 candidates for this assertion to be meaningful")
-	assert.Equal(t, want[:3], generated, "--limit must keep the first (most-likely) N candidates")
+	require.GreaterOrEqual(t, len(candidates), 3, "full generated list must have at least 3 candidates for this assertion to be meaningful")
+
+	want := make([]enum.Target, 3)
+	for i := 0; i < 3; i++ {
+		want[i] = candidates[i].Target("target.com")
+	}
+	assert.Equal(t, want, generated, "--limit must keep the first (most-likely) N candidates")
 }
 
 func TestGravatarEnumGenerate_InvalidFormatRejected(t *testing.T) {
@@ -127,4 +299,93 @@ func TestGravatarEnumGenerate_InvalidFormatRejected(t *testing.T) {
 	_, err := gravatarEnumGenerate()
 	require.Error(t, err, "an invalid --format must be rejected")
 	assert.Contains(t, err.Error(), "invalid --format")
+}
+
+// ---------------------------------------------------------------------------
+// outputGravatarEnumJSONL — First/Last name propagation (10T-535, 5/8)
+// ---------------------------------------------------------------------------
+
+// TestOutputGravatarEnumJSONL_NameFields pins the never-invent-a-name rule: a
+// Result carrying First/Last (from --domain generation) must emit
+// "first"/"last" in the JSONL row, while a Result with empty First/Last
+// (supplied via --emails or --email-file) must OMIT both keys entirely rather
+// than emit them as "". Pre-existing fields (email/hash/exists/avatar_url)
+// must be unaffected by the addition — mirrors
+// TestOutputGoogleEnumJSONL_NameFields.
+func TestOutputGravatarEnumJSONL_NameFields(t *testing.T) {
+	named := gravatar.Result{
+		Email:  "john.smith@example.com",
+		Hash:   gravatar.HashEmail("john.smith@example.com"),
+		Exists: true,
+		First:  "john",
+		Last:   "smith",
+	}
+	unnamed := gravatar.Result{
+		Email:  "supplied@example.com",
+		Hash:   gravatar.HashEmail("supplied@example.com"),
+		Exists: true,
+	}
+
+	t.Run("named result emits first and last", func(t *testing.T) {
+		var buf bytes.Buffer
+		outputGravatarEnumJSONL(&buf, []gravatar.Result{named})
+
+		line := strings.TrimSpace(buf.String())
+		require.NotEmpty(t, line, "outputGravatarEnumJSONL must produce a JSONL line")
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(line), &obj),
+			"JSONL output must be valid JSON: %q", line)
+
+		assert.Equal(t, "john", obj["first"], `first field must be "john"`)
+		assert.Equal(t, "smith", obj["last"], `last field must be "smith"`)
+
+		// Pre-existing fields must remain unaffected by the new ones.
+		assert.Equal(t, named.Email, obj["email"])
+		assert.Equal(t, named.Hash, obj["hash"], "hash field must be unaffected by first/last")
+		assert.Equal(t, true, obj["exists"])
+		assert.Equal(t, fmt.Sprintf("https://www.gravatar.com/avatar/%s", named.Hash), obj["avatar_url"])
+	})
+
+	t.Run("unnamed result omits first and last keys", func(t *testing.T) {
+		var buf bytes.Buffer
+		outputGravatarEnumJSONL(&buf, []gravatar.Result{unnamed})
+
+		line := strings.TrimSpace(buf.String())
+		require.NotEmpty(t, line, "outputGravatarEnumJSONL must produce a JSONL line")
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(line), &obj),
+			"JSONL output must be valid JSON: %q", line)
+
+		assert.NotContains(t, obj, "first",
+			`first key must be absent (omitempty), not emitted as ""`)
+		assert.NotContains(t, obj, "last",
+			`last key must be absent (omitempty), not emitted as ""`)
+
+		// Pre-existing fields must remain unaffected.
+		assert.Equal(t, unnamed.Email, obj["email"])
+		assert.Equal(t, unnamed.Hash, obj["hash"], "hash field must be unaffected by first/last")
+		assert.Equal(t, true, obj["exists"])
+	})
+
+	t.Run("mixed batch: one named, one unnamed", func(t *testing.T) {
+		var buf bytes.Buffer
+		outputGravatarEnumJSONL(&buf, []gravatar.Result{named, unnamed})
+
+		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+		require.Len(t, lines, 2, "must emit exactly one JSONL line per result")
+
+		var first map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[0]), &first))
+		assert.Equal(t, "john", first["first"])
+		assert.Equal(t, "smith", first["last"])
+
+		var second map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[1]), &second))
+		assert.NotContains(t, second, "first",
+			`second (unnamed) line must not carry a "first" key`)
+		assert.NotContains(t, second, "last",
+			`second (unnamed) line must not carry a "last" key`)
+	})
 }


### PR DESCRIPTION
**5 of 8** for 10T-535 — gravatar. **3 files, +349/−41.**

Same shape as google (#312), but gravatar has a normalization hazard the other services don't, so it gets a dedicated test.

## The hazard

`cmd_enum_gravatar.go` lower-cases and trims every address inside its merge loop — applied to **both** supplied and generated entries. So the address handed to the checker, and echoed back on `Result.Email`, is lower-cased.

An address→name index keyed on the *pre-normalized* generated address — `Candidate.Target("Example.COM")` yielding `j.smith@Example.COM` — misses on **every** lookup. Every name disappears. No error, no warning, nothing in the output to suggest anything went wrong.

## The fix, and why it's on the field

Normalize `Target.Email` **itself** inside the target-building loop, not merely a dedup key, so it's byte-identical to what the checker receives and echoes.

That invariant was confirmed from the checker source rather than assumed:

* `pkg/enum/gravatar/gravatar.go:45-49` — `HashEmail` lower-cases only a **copy** for the MD5 digest
* `pkg/enum/gravatar/gravatar.go:219` — `Result{Email: email, ...}` echoes the given address **verbatim**

`gravatarEnumGenerate` deliberately does *not* normalize — that's the merge loop's job — and separate tests pin each half.

## Proof the test catches it

Keying the index on the un-normalized address:

```
--- FAIL: TestGravatarEnumTargetList_GeneratedAddressesAreLowerCasedForNameLookup
        expected: "john.smith@example.com"
        actual  : "john.smith@Example.COM"
        Messages: Target.Email must already be lower-cased/trimmed inside
                  gravatarEnumTargetList's target-building loop, matching what
                  gravatar.CheckAccount will echo back on Result.Email
```

Restored and confirmed byte-identical by SHA-256 against a pre-change backup. So the silent-name-loss bug can't reappear unnoticed.

## One stamp

The slice `EnumerateWith` returns reaches only `outputGravatarEnumSummary`, which counts `Exists`/`Error` and never re-encodes — a second pass would be dead code. github needs one because its post-reveal path re-encodes that slice; gravatar has no reveal step. The stamp site records why.

## JSONL

`encodeGravatarEnumResult` emits `first`/`last` with **omitempty**; `hash` and the other pre-existing keys unchanged.

## Preserved exactly

Trim, lower-casing, case-insensitive dedup, first-seen order and precedence (a supplied address duplicated by a generated candidate stays **nameless**), `--limit` capping, both existing error messages, and the sanitized stderr status line.

## Scope

`gravatarEnumTargets` deleted rather than left as a test-pinned adapter. `pkg/` untouched, `cmd_enum.go` unchanged, no other service touched, `Config.Emails` retained until 8/8.

```
go build ./...                exit 0
go vet ./cmd/... ./pkg/enum/  exit 0
go test ./... -count=1        56 packages ok, 0 FAIL
gofmt -l                      clean
```

## Next

6) microsoft365 — the other normalization trap: dedups on a lowercased key but echoes first-seen casing · 7) teams · 8) delete the `Config.Emails` shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
