### PR TITLE
feat(enum): carry generated names through the microsoft365 oracle (10T-535, 6/8)

### DIFF
--- a/cmd/brutus/cmd_enum_microsoft365.go
+++ b/cmd/brutus/cmd_enum_microsoft365.go
@@ -103,10 +103,12 @@ func runEnumMicrosoft365(cmd *cobra.Command, args []string) error {
 		flagJSON = true
 	}
 
-	emails, err := microsoft365EnumTargets()
+	targets, err := microsoft365EnumTargetList()
 	if err != nil {
 		return err
 	}
+	emails := enumTargetEmails(targets)
+	names := enumNamesByEmail(targets)
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
@@ -143,6 +145,17 @@ func runEnumMicrosoft365(cmd *cobra.Command, args []string) error {
 	progress.Start()
 	var processed, found int
 	onResult := func(res m365.Result) {
+		// Stamp the generated name onto the result the checker just returned.
+		// The checker only ever sees the address, so the name is attached here;
+		// an address that came from --emails/--email-file is absent from names
+		// and stays nameless.
+		//
+		// One stamp is enough, like google's and gravatar's (unlike github's
+		// two): all JSON is emitted from this callback, and the slice
+		// EnumerateWith returns feeds outputMicrosoft365EnumSummary alone,
+		// which only counts Error/Exists/Federated and never re-encodes.
+		res.First, res.Last = enumNameFor(names, res.Email)
+
 		processed++
 		if res.Exists {
 			found++
@@ -169,20 +182,28 @@ func runEnumMicrosoft365(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// microsoft365EnumTargets parses, trims, and dedups the email targets from
-// --emails and --email-file, plus any --domain-generated candidates. It errors
-// when no targets are supplied.
-func microsoft365EnumTargets() ([]string, error) {
-	var raw []string
+// microsoft365EnumTargetList parses, trims, and dedups the email targets from
+// --emails and --email-file, plus any --domain-generated candidates. Each
+// generated target carries the name its username was built from; supplied
+// addresses carry none, because an address the operator provided says nothing
+// about whose it is. Dedup keeps the first-seen entry, so a supplied address
+// that a generated candidate duplicates stays nameless. It errors when no
+// targets are supplied.
+func microsoft365EnumTargetList() ([]enum.Target, error) {
+	var raw []enum.Target
 	if flagM365EnumEmails != "" {
-		raw = append(raw, strings.Split(flagM365EnumEmails, ",")...)
+		for _, e := range strings.Split(flagM365EnumEmails, ",") {
+			raw = append(raw, enum.Target{Email: e})
+		}
 	}
 	if flagM365EnumEmailFile != "" {
 		lines, err := loadLinesFromFile(flagM365EnumEmailFile)
 		if err != nil {
 			return nil, fmt.Errorf("reading --email-file: %w", err)
 		}
-		raw = append(raw, lines...)
+		for _, e := range lines {
+			raw = append(raw, enum.Target{Email: e})
+		}
 	}
 
 	// --domain generates the candidate wordlist internally (reusing the same
@@ -198,45 +219,65 @@ func microsoft365EnumTargets() ([]string, error) {
 	}
 
 	seen := make(map[string]struct{})
-	var emails []string
-	for _, e := range raw {
-		e = strings.TrimSpace(e)
-		if e == "" {
+	var targets []enum.Target
+	for _, t := range raw {
+		t.Email = strings.TrimSpace(t.Email)
+		if t.Email == "" {
 			continue
 		}
-		// Key on the lowercased address (the API is case-insensitive) while
-		// appending the original-cased email to the results.
-		key := strings.ToLower(e)
+		// Key the dedup set on the lowercased address (GetCredentialType is
+		// case-insensitive, so case variants are the same target) while STORING
+		// the original-cased address on the Target.
+		//
+		// This is deliberately the opposite of gravatarEnumTargetList, which
+		// lower-cases the Target.Email field itself. The two differ because
+		// their checkers differ: gravatar.CheckAccount lower-cases the address
+		// for HashEmail's digest, whereas microsoft365.CheckAccount echoes the
+		// address back verbatim (`result := &Result{Email: email}`, never
+		// re-cased). Storing the original casing here is what keeps the stored
+		// address byte-identical to the one Result.Email carries, so
+		// enumNamesByEmail/enumNameFor recover the generated name. Lower-casing
+		// the field here (copying gravatar) would desync the index from the
+		// echoed address and silently drop every generated name — and would
+		// discard the operator's --domain casing.
+		key := strings.ToLower(t.Email)
 		if _, ok := seen[key]; ok {
 			continue
 		}
 		seen[key] = struct{}{}
-		emails = append(emails, e)
+		targets = append(targets, t)
 	}
 
-	if len(emails) == 0 {
+	if len(targets) == 0 {
 		return nil, fmt.Errorf("provide --emails/-e, --email-file/-E, or --domain")
 	}
-	return emails, nil
+	return targets, nil
 }
 
 // microsoft365EnumGenerate produces the candidate email wordlist for --domain by
-// reusing the shared, frequency-ranked generator (enum.GenerateEmails) and the
-// shared capResults helper — no duplicated generation logic. The requested
-// format is validated against enum.ListFormats() first, because GenerateEmails
-// silently yields an empty list for an unknown format. A status line goes to
-// stderr (never stdout, so --json/-o output stays clean) unless quiet or JSON.
-func microsoft365EnumGenerate() ([]string, error) {
+// reusing the shared, frequency-ranked generator (enum.GenerateCandidates) and
+// the shared capResults helper — no duplicated generation logic. Candidates,
+// not bare addresses, are generated so each target keeps the name its username
+// was built from, which is knowable for free here and lossy to recover later.
+// The requested format is validated against enum.ListFormats() first, because
+// the generator silently yields an empty list for an unknown format. A status
+// line goes to stderr (never stdout, so --json/-o output stays clean) unless
+// quiet or JSON.
+func microsoft365EnumGenerate() ([]enum.Target, error) {
 	if !slices.Contains(enum.ListFormats(), flagM365EnumFormat) {
 		return nil, fmt.Errorf("invalid --format %q; valid formats: %s",
 			flagM365EnumFormat, strings.Join(enum.ListFormats(), ", "))
 	}
 
-	generated, err := enum.GenerateEmails(flagM365EnumFormat, flagM365EnumDomain)
+	candidates, err := enum.GenerateCandidates(flagM365EnumFormat)
 	if err != nil {
 		return nil, fmt.Errorf("generating candidate emails: %w", err)
 	}
-	generated = capResults(generated, flagM365EnumLimit)
+	candidates = capResults(candidates, flagM365EnumLimit)
+	generated := make([]enum.Target, len(candidates))
+	for i, c := range candidates {
+		generated[i] = c.Target(flagM365EnumDomain)
+	}
 
 	if !flagQuiet && !flagJSON {
 		useColor := isColorEnabled(flagNoColor)

--- a/cmd/brutus/cmd_enum_microsoft365_test.go
+++ b/cmd/brutus/cmd_enum_microsoft365_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/praetorian-inc/brutus/pkg/enum"
 	m365 "github.com/praetorian-inc/brutus/pkg/enum/microsoft365"
 )
 
@@ -359,75 +360,96 @@ func TestOutputMicrosoft365EnumResultLine(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// TestMicrosoft365EnumTargets
-// Exercises microsoft365EnumTargets() using the file-local flag variables
-// directly, saving and restoring them with defer.
+// microsoft365EnumTargetList / microsoft365EnumGenerate
+//
+// 10T-535 (6/8): microsoft365EnumTargets() ([]string, error) is retargeted
+// onto microsoft365EnumTargetList() ([]enum.Target, error) — the
+// Target-returning function that carries each generated address's name
+// (mirrors googleEnumTargetList / githubEnumTargetList /
+// gravatarEnumTargetList). microsoft365EnumGenerate() is retargeted from
+// ([]string, error) to ([]enum.Target, error) for the same reason. Every
+// prior assertion (trim, case-insensitive dedup, first-seen casing
+// preserved, "provide" error, --limit capping, invalid-format error) is
+// preserved; there is no dead adapter left behind pinning the old []string
+// signatures.
 // ---------------------------------------------------------------------------
 
-func TestMicrosoft365EnumTargets_InlineEmails(t *testing.T) {
-	// Save and restore flag globals.
+func resetMicrosoft365EnumFlags() (restore func()) {
 	origEmails := flagM365EnumEmails
 	origEmailFile := flagM365EnumEmailFile
 	origDomain := flagM365EnumDomain
-	defer func() {
+	origFormat := flagM365EnumFormat
+	origLimit := flagM365EnumLimit
+	return func() {
 		flagM365EnumEmails = origEmails
 		flagM365EnumEmailFile = origEmailFile
 		flagM365EnumDomain = origDomain
-	}()
+		flagM365EnumFormat = origFormat
+		flagM365EnumLimit = origLimit
+	}
+}
+
+// TestMicrosoft365EnumTargetList_InlineEmails verifies that --emails CSV is
+// parsed, trimmed, and deduplicated (case-insensitively) while preserving the
+// ORIGINAL casing of the first-seen address, and that every CLI-supplied
+// target carries no name (a supplied address says nothing about whose it is)
+// — mirrors TestGravatarEnumTargetList_InlineEmails, except microsoft365 must
+// NOT lower-case the stored address (see the trap test below for why).
+func TestMicrosoft365EnumTargetList_InlineEmails(t *testing.T) {
+	defer resetMicrosoft365EnumFlags()()
 
 	flagM365EnumEmails = "alice@example.com,bob@example.com,alice@example.com"
 	flagM365EnumEmailFile = ""
 	flagM365EnumDomain = ""
 
-	emails, err := microsoft365EnumTargets()
+	got, err := microsoft365EnumTargetList()
 	require.NoError(t, err)
 
+	emails := enumTargetEmails(got)
 	// Deduplication: alice@example.com appears twice but must appear once.
 	assert.Len(t, emails, 2, "deduplication must collapse duplicate emails")
 	assert.Contains(t, emails, "alice@example.com")
 	assert.Contains(t, emails, "bob@example.com")
+
+	for i, target := range got {
+		assert.Empty(t, target.First, "target %d (%q): CLI-supplied address must have empty First", i, target.Email)
+		assert.Empty(t, target.Last, "target %d (%q): CLI-supplied address must have empty Last", i, target.Email)
+	}
 }
 
-func TestMicrosoft365EnumTargets_NoSource(t *testing.T) {
-	origEmails := flagM365EnumEmails
-	origEmailFile := flagM365EnumEmailFile
-	origDomain := flagM365EnumDomain
-	defer func() {
-		flagM365EnumEmails = origEmails
-		flagM365EnumEmailFile = origEmailFile
-		flagM365EnumDomain = origDomain
-	}()
+// TestMicrosoft365EnumTargetList_NoSource verifies that an error is returned
+// (and mentions "provide") when no --emails, --email-file, or --domain is
+// given.
+func TestMicrosoft365EnumTargetList_NoSource(t *testing.T) {
+	defer resetMicrosoft365EnumFlags()()
 
 	flagM365EnumEmails = ""
 	flagM365EnumEmailFile = ""
 	flagM365EnumDomain = ""
 
-	_, err := microsoft365EnumTargets()
-	require.Error(t, err, "microsoft365EnumTargets must fail when no source is supplied")
+	_, err := microsoft365EnumTargetList()
+	require.Error(t, err, "microsoft365EnumTargetList must fail when no source is supplied")
 	assert.Contains(t, err.Error(), "provide",
 		"error message must guide the user to supply a target source")
 }
 
-// TestMicrosoft365EnumTargets_CaseInsensitiveDedup verifies that dedup keys on
-// the lowercased email (the GetCredentialType API is case-insensitive) while
-// preserving the first-seen casing in the returned results.
-func TestMicrosoft365EnumTargets_CaseInsensitiveDedup(t *testing.T) {
-	origEmails := flagM365EnumEmails
-	origEmailFile := flagM365EnumEmailFile
-	origDomain := flagM365EnumDomain
-	defer func() {
-		flagM365EnumEmails = origEmails
-		flagM365EnumEmailFile = origEmailFile
-		flagM365EnumDomain = origDomain
-	}()
+// TestMicrosoft365EnumTargetList_CaseInsensitiveDedup verifies that dedup
+// keys on the lowercased email (the GetCredentialType API is
+// case-insensitive) while preserving the first-seen casing on the returned
+// Target.Email — this is the existing, pre-PR6 behavior
+// (TestMicrosoft365EnumTargets_CaseInsensitiveDedup) retargeted onto
+// microsoft365EnumTargetList.
+func TestMicrosoft365EnumTargetList_CaseInsensitiveDedup(t *testing.T) {
+	defer resetMicrosoft365EnumFlags()()
 
 	flagM365EnumEmails = "Alice@Example.com,alice@example.com,BOB@example.com"
 	flagM365EnumEmailFile = ""
 	flagM365EnumDomain = ""
 
-	emails, err := microsoft365EnumTargets()
+	got, err := microsoft365EnumTargetList()
 	require.NoError(t, err)
 
+	emails := enumTargetEmails(got)
 	// Case-variant duplicates collapse: "Alice@Example.com" and
 	// "alice@example.com" are the same target.
 	assert.Len(t, emails, 2, "case-variant duplicates must collapse")
@@ -438,4 +460,316 @@ func TestMicrosoft365EnumTargets_CaseInsensitiveDedup(t *testing.T) {
 	assert.NotContains(t, emails, "alice@example.com",
 		"the later-seen lowercase duplicate must not also appear")
 	assert.Contains(t, emails, "BOB@example.com")
+
+	for i, target := range got {
+		assert.Empty(t, target.First, "target %d (%q): CLI-supplied address must have empty First", i, target.Email)
+		assert.Empty(t, target.Last, "target %d (%q): CLI-supplied address must have empty Last", i, target.Email)
+	}
+}
+
+// TestMicrosoft365EnumTargetList_DomainGeneratedCarriesName verifies that
+// --domain-generated targets carry the non-empty First/Last the username was
+// built from, unlike CLI-supplied addresses, and that --limit caps the
+// count — mirrors TestGravatarEnumTargetList_DomainGeneratedCarriesName.
+func TestMicrosoft365EnumTargetList_DomainGeneratedCarriesName(t *testing.T) {
+	defer resetMicrosoft365EnumFlags()()
+
+	flagM365EnumEmails = ""
+	flagM365EnumEmailFile = ""
+	flagM365EnumDomain = "target.com"
+	flagM365EnumFormat = "first.last"
+	flagM365EnumLimit = 5
+
+	got, err := microsoft365EnumTargetList()
+	require.NoError(t, err)
+	require.Len(t, got, 5, "--limit must cap the number of generated targets")
+
+	for i, target := range got {
+		assert.Contains(t, target.Email, "@target.com", "target %d must be for the requested domain", i)
+		assert.NotEmpty(t, target.First, "target %d (%q): a --domain-generated target must carry a non-empty First", i, target.Email)
+		assert.NotEmpty(t, target.Last, "target %d (%q): a --domain-generated target must carry a non-empty Last", i, target.Email)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// THE CRITICAL TRAP (10T-535, 6/8) — INVERSE of gravatar's (5/8) trap.
+//
+// gravatar.CheckAccount lower-cases a COPY of the address it is given (only
+// for HashEmail's MD5 digest) but microsoft365.CheckAccount does NOT: it sets
+// Result{Email: email} verbatim from whatever address it is handed, and never
+// re-cases it (see pkg/enum/microsoft365/microsoft365.go CheckAccount:
+// `result := &Result{Email: email}`, with no strings.ToLower anywhere in that
+// function or in EnumerateWith's per-email loop).
+//
+// cmd_enum_microsoft365.go's PRE-PR6 target-building/dedup loop (formerly
+// line ~209 of microsoft365EnumTargets) already gets this right for
+// CLI-supplied addresses: it keys the dedup "seen" set on
+// strings.ToLower(e) but appends the ORIGINAL-CASED e to the result. That
+// existing behavior must carry over unchanged into
+// microsoft365EnumTargetList's Target-based loop, and it must ALSO apply to
+// --domain-generated addresses (enum.Candidate.Email concatenates the
+// (lower-cased) username with the domain AS SUPPLIED, so a mixed-case
+// --domain lands mixed-case in the generated Target.Email).
+//
+// If someone "fixes" the loop by copying gravatar's normalization —
+// `t.Email = strings.ToLower(strings.TrimSpace(t.Email))` applied to the
+// Target field itself — every generated (and CLI-supplied) address is
+// lower-cased. That contradicts what microsoft365.CheckAccount actually
+// echoes back on Result.Email for an address that was never lower-cased to
+// begin with, and it silently discards the operator-supplied --domain
+// casing.
+//
+// This test generates with a MIXED-CASE --domain ("Example.COM") and
+// asserts:
+//  1. Every returned Target's Email retains that exact mixed-case domain
+//     (the domain's casing must NOT be lower-cased away).
+//  2. Every generated target's name is recoverable via enumNamesByEmail +
+//     enumNameFor, keyed on the address microsoft365.CheckAccount will
+//     actually receive and echo back (target.Email itself, original casing
+//     intact).
+//  3. A lookup keyed on the independently lower-cased form of that same
+//     address must NOT recover a name — proving the index is keyed on the
+//     original-cased address the checker echoes, not a normalized one.
+// ---------------------------------------------------------------------------
+
+func TestMicrosoft365EnumTargetList_GeneratedAddressesRetainOriginalCasingForNameLookup(t *testing.T) {
+	defer resetMicrosoft365EnumFlags()()
+
+	flagM365EnumEmails = ""
+	flagM365EnumEmailFile = ""
+	flagM365EnumDomain = "Example.COM" // mixed-case domain: the trap.
+	flagM365EnumFormat = "first.last"
+	flagM365EnumLimit = 10
+
+	got, err := microsoft365EnumTargetList()
+	require.NoError(t, err)
+	require.Len(t, got, 10, "--limit must cap the number of generated targets")
+
+	for i, target := range got {
+		// The address stored on the Target must retain the EXACT mixed-case
+		// domain the operator supplied via --domain: this is the exact
+		// address enumTargetEmails() will hand to
+		// microsoft365.Checker.EnumerateWith, and CheckAccount echoes back
+		// the address it is given verbatim (unlike gravatar, it never
+		// re-cases it) on Result.Email.
+		require.Contains(t, target.Email, "@Example.COM",
+			"target %d (%q): Target.Email must retain the mixed-case --domain exactly as supplied — microsoft365.CheckAccount echoes the address verbatim on Result.Email, so lower-casing Target.Email here (copying gravatar's normalization) would desync the stored address from what the checker actually receives and echoes back", i, target.Email)
+
+		lowered := strings.ToLower(target.Email)
+		require.NotEqual(t, lowered, target.Email,
+			"target %d (%q): Target.Email must NOT be lower-cased — the mixed-case --domain casing must survive into the Target field itself, not just be discarded by a throwaway local variable", i, target.Email)
+	}
+
+	// enumNamesByEmail/enumNameFor are the shared framework helpers
+	// (unmodified, reused from cmd_enum.go) that runEnumMicrosoft365 wires up
+	// exactly like runEnumGoogle/runEnumGithub/runEnumGravatar: names :=
+	// enumNamesByEmail(targets), then each onResult callback does
+	// res.First, res.Last = enumNameFor(names, res.Email). Building the
+	// index from the SAME already-original-cased targets slice that
+	// microsoft365EnumTargetList returned is what keeps the lookup key
+	// byte-identical to the address the checker echoes back.
+	names := enumNamesByEmail(got)
+	require.Len(t, names, len(got), "every generated target must be indexed by enumNamesByEmail")
+
+	for i, target := range got {
+		// Simulate the checker echoing the address back on a Result:
+		// microsoft365.CheckAccount sets Result{Email: email} verbatim from
+		// the email parameter it is given, which is target.Email itself —
+		// original casing intact.
+		echoedByChecker := target.Email
+
+		first, last := enumNameFor(names, echoedByChecker)
+		assert.NotEmpty(t, first,
+			"target %d (%q): name lookup keyed on the checker-echoed (original-cased) address must recover a non-empty First — an empty result here means the index was built on a re-cased address and the name silently vanished", i, target.Email)
+		assert.NotEmpty(t, last,
+			"target %d (%q): name lookup keyed on the checker-echoed (original-cased) address must recover a non-empty Last — an empty result here means the index was built on a re-cased address and the name silently vanished", i, target.Email)
+		assert.Equal(t, target.First, first, "target %d: recovered First must match the target's own First", i)
+		assert.Equal(t, target.Last, last, "target %d: recovered Last must match the target's own Last", i)
+
+		// A lookup keyed on the independently LOWER-CASED form of the same
+		// address must fail to recover the name: this proves the index is
+		// keyed on the exact original-cased address, not a normalized one.
+		loweredKey := strings.ToLower(echoedByChecker)
+		require.NotEqual(t, echoedByChecker, loweredKey,
+			"target %d: sanity check — the mixed-case domain must make the lower-cased key differ from the original, or this assertion is vacuous", i)
+		firstLowered, lastLowered := enumNameFor(names, loweredKey)
+		assert.Empty(t, firstLowered,
+			"target %d: a lookup keyed on the lower-cased address must NOT recover a name — the index must be keyed on the original-cased (checker-echoed) address, not a lower-cased one", i)
+		assert.Empty(t, lastLowered,
+			"target %d: a lookup keyed on the lower-cased address must NOT recover a name — the index must be keyed on the original-cased (checker-echoed) address, not a lower-cased one", i)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// microsoft365EnumGenerate
+// ---------------------------------------------------------------------------
+
+func TestMicrosoft365EnumGenerate_ProducesCandidatesForDomain(t *testing.T) {
+	defer resetMicrosoft365EnumFlags()()
+
+	flagM365EnumDomain = "target.com"
+	flagM365EnumFormat = "first.last"
+	flagM365EnumLimit = 0
+
+	generated, err := microsoft365EnumGenerate()
+	require.NoError(t, err)
+
+	candidates, err := enum.GenerateCandidates("first.last")
+	require.NoError(t, err)
+
+	want := make([]enum.Target, len(candidates))
+	for i, c := range candidates {
+		want[i] = c.Target("target.com")
+	}
+
+	assert.Equal(t, want, generated,
+		"microsoft365EnumGenerate must reuse enum.GenerateCandidates (via capResults and Candidate.Target), matching the google/gravatar/github generate pattern")
+	for i, target := range generated {
+		assert.Contains(t, target.Email, "@target.com", "target %d must be for the requested domain", i)
+		assert.NotEmpty(t, target.First, "target %d: generated target must carry a non-empty First", i)
+		assert.NotEmpty(t, target.Last, "target %d: generated target must carry a non-empty Last", i)
+	}
+}
+
+func TestMicrosoft365EnumGenerate_RespectsLimit(t *testing.T) {
+	defer resetMicrosoft365EnumFlags()()
+
+	flagM365EnumDomain = "target.com"
+	flagM365EnumFormat = "first.last"
+	flagM365EnumLimit = 3
+
+	generated, err := microsoft365EnumGenerate()
+	require.NoError(t, err)
+
+	assert.Len(t, generated, 3, "--limit must cap the number of generated candidates")
+
+	candidates, err := enum.GenerateCandidates("first.last")
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(candidates), 3, "full generated list must have at least 3 candidates for this assertion to be meaningful")
+
+	want := make([]enum.Target, 3)
+	for i := 0; i < 3; i++ {
+		want[i] = candidates[i].Target("target.com")
+	}
+	assert.Equal(t, want, generated, "--limit must keep the first (most-likely) N candidates")
+}
+
+func TestMicrosoft365EnumGenerate_InvalidFormatRejected(t *testing.T) {
+	defer resetMicrosoft365EnumFlags()()
+
+	flagM365EnumDomain = "target.com"
+	flagM365EnumFormat = "not-a-real-format"
+	flagM365EnumLimit = 0
+
+	_, err := microsoft365EnumGenerate()
+	require.Error(t, err, "an invalid --format must be rejected")
+	assert.Contains(t, err.Error(), "invalid --format")
+}
+
+// ---------------------------------------------------------------------------
+// encodeMicrosoft365EnumResult — First/Last name propagation (10T-535, 6/8)
+// ---------------------------------------------------------------------------
+
+// TestEncodeMicrosoft365EnumResult_NameFields pins the never-invent-a-name
+// rule: a Result carrying First/Last (from --domain generation) must emit
+// "first"/"last" in the JSONL row, while a Result with empty First/Last
+// (supplied via --emails or --email-file) must OMIT both keys entirely
+// rather than emit them as "". Pre-existing fields (type/email/exists/
+// if_exists_result/federated/federation_url) must be unaffected by the
+// addition — mirrors TestOutputGoogleEnumJSONL_NameFields /
+// TestOutputGravatarEnumJSONL_NameFields, adapted for
+// encodeMicrosoft365EnumResult's one-result-at-a-time signature.
+func TestEncodeMicrosoft365EnumResult_NameFields(t *testing.T) {
+	named := m365.Result{
+		Email:          "john.smith@example.com",
+		Exists:         true,
+		IfExistsResult: m365.IfExistsResultExists,
+		First:          "john",
+		Last:           "smith",
+	}
+	unnamed := m365.Result{
+		Email:          "supplied@example.com",
+		Exists:         true,
+		IfExistsResult: m365.IfExistsResultDifferentTenant,
+		Federated:      true,
+		FederationURL:  "https://login.okta.com/x",
+	}
+
+	t.Run("named result emits first and last", func(t *testing.T) {
+		var buf bytes.Buffer
+		enc := json.NewEncoder(&buf)
+		encodeMicrosoft365EnumResult(enc, named)
+
+		line := strings.TrimSpace(buf.String())
+		require.NotEmpty(t, line, "encodeMicrosoft365EnumResult must produce a JSONL line")
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(line), &obj),
+			"JSONL output must be valid JSON: %q", line)
+
+		assert.Equal(t, "john", obj["first"], `first field must be "john"`)
+		assert.Equal(t, "smith", obj["last"], `last field must be "smith"`)
+
+		// Pre-existing fields must remain unaffected by the new ones.
+		assert.Equal(t, "microsoft365_account", obj["type"])
+		assert.Equal(t, named.Email, obj["email"])
+		assert.Equal(t, true, obj["exists"])
+		require.Contains(t, obj, "if_exists_result",
+			"if_exists_result must always be present (not omitempty)")
+		gotIfExists, ok := obj["if_exists_result"].(float64)
+		require.True(t, ok, "if_exists_result must be numeric")
+		assert.Equal(t, m365.IfExistsResultExists, int(gotIfExists))
+		assert.NotContains(t, obj, "federated",
+			"federated key must be absent when false (omitempty)")
+	})
+
+	t.Run("unnamed result omits first and last keys", func(t *testing.T) {
+		var buf bytes.Buffer
+		enc := json.NewEncoder(&buf)
+		encodeMicrosoft365EnumResult(enc, unnamed)
+
+		line := strings.TrimSpace(buf.String())
+		require.NotEmpty(t, line, "encodeMicrosoft365EnumResult must produce a JSONL line")
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(line), &obj),
+			"JSONL output must be valid JSON: %q", line)
+
+		assert.NotContains(t, obj, "first",
+			`first key must be absent (omitempty), not emitted as ""`)
+		assert.NotContains(t, obj, "last",
+			`last key must be absent (omitempty), not emitted as ""`)
+
+		// Pre-existing fields must remain unaffected.
+		assert.Equal(t, "microsoft365_account", obj["type"])
+		assert.Equal(t, unnamed.Email, obj["email"])
+		assert.Equal(t, true, obj["exists"])
+		assert.Equal(t, true, obj["federated"])
+		assert.Equal(t, unnamed.FederationURL, obj["federation_url"])
+		gotIfExists, ok := obj["if_exists_result"].(float64)
+		require.True(t, ok, "if_exists_result must be numeric")
+		assert.Equal(t, m365.IfExistsResultDifferentTenant, int(gotIfExists))
+	})
+
+	t.Run("mixed batch: one named, one unnamed", func(t *testing.T) {
+		var buf bytes.Buffer
+		enc := json.NewEncoder(&buf)
+		encodeMicrosoft365EnumResult(enc, named)
+		encodeMicrosoft365EnumResult(enc, unnamed)
+
+		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+		require.Len(t, lines, 2, "must emit exactly one JSONL line per result")
+
+		var first map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[0]), &first))
+		assert.Equal(t, "john", first["first"])
+		assert.Equal(t, "smith", first["last"])
+
+		var second map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[1]), &second))
+		assert.NotContains(t, second, "first",
+			`second (unnamed) line must not carry a "first" key`)
+		assert.NotContains(t, second, "last",
+			`second (unnamed) line must not carry a "last" key`)
+	})
 }

--- a/cmd/brutus/cmd_enum_output.go
+++ b/cmd/brutus/cmd_enum_output.go
@@ -1126,9 +1126,16 @@ func outputMicrosoft365EnumSummary(w io.Writer, results []m365.Result, useColor 
 // an actual API code was decoded (i.e. no error): on a pre-response failure the
 // zero value 0 would otherwise be indistinguishable from the API's "account
 // exists" code, contradicting the accompanying error.
+//
+// first/last carry the generated name behind the address. They are omitempty
+// because an address the operator supplied (--emails/--email-file) has no known
+// name: the keys are absent rather than emitted as "", so a consumer can never
+// mistake an unknown name for an empty one.
 type microsoft365EnumJSON struct {
 	Type           string `json:"type"`
 	Email          string `json:"email"`
+	First          string `json:"first,omitempty"`
+	Last           string `json:"last,omitempty"`
 	Exists         bool   `json:"exists"`
 	IfExistsResult *int   `json:"if_exists_result,omitempty"`
 	Federated      bool   `json:"federated,omitempty"`
@@ -1145,6 +1152,8 @@ func encodeMicrosoft365EnumResult(enc *json.Encoder, r m365.Result) { //nolint:g
 	jr := microsoft365EnumJSON{
 		Type:          "microsoft365_account",
 		Email:         r.Email,
+		First:         r.First,
+		Last:          r.Last,
 		Exists:        r.Exists,
 		Federated:     r.Federated,
 		FederationURL: r.FederationURL,


### PR DESCRIPTION
**6 of 8** for 10T-535 — microsoft365. **3 files, +442/−58.**

Same shape as google (#312) and gravatar (#313), but m365's casing requirement is the **exact inverse** of gravatar's — so the two are easy to conflate, and each now has a test that fails under the other's fix.

## The inverse trap

| Service | Stored address | Why | Index must key on |
|---|---|---|---|
| **gravatar** | lower-cased | `CheckAccount` lower-cases only a copy for the MD5 digest | the **lower-cased** form |
| **microsoft365** | original casing | `CheckAccount` does `result := &Result{Email: email}`, no re-casing — echoes **verbatim** | the **original** casing |

m365 dedups on `strings.ToLower(t.Email)` but stores `t.Email` unchanged. Applying gravatar's normalization here would make every lookup miss and every name vanish silently.

The dedup site carries a comment naming the contrast, so the opposite requirements read as deliberate rather than as an inconsistency someone should "clean up."

## Proof the tests distinguish them

Temporarily applying gravatar's fix (`t.Email = strings.ToLower(...)`) fails **two** tests — caught from both directions:

```
--- FAIL: TestMicrosoft365EnumTargetList_CaseInsensitiveDedup
        []string{"alice@example.com", ...} does not contain "Alice@Example.com"
        Messages: first-seen casing must be preserved

--- FAIL: TestMicrosoft365EnumTargetList_GeneratedAddressesRetainOriginalCasingForNameLookup
        "john.smith@example.com" does not contain "@Example.COM"
        Messages: Target.Email must retain the mixed-case --domain exactly as supplied —
                  microsoft365.CheckAccount echoes the address verbatim on Result.Email
```

Restored and confirmed byte-identical by hash before the reported verification run.

## The rest

`microsoft365EnumGenerate` returns `[]enum.Target`; `microsoft365EnumTargetList` replaces `microsoft365EnumTargets`. `-e`/`-E` nameless, generated named. Trim, dedup, first-seen casing, order, precedence, `--limit` and both error messages preserved.

**One stamp**, in `onResult` — the returned slice feeds only `outputMicrosoft365EnumSummary` (counts `Error`/`Exists`/`Federated`, never re-encodes). Same as google and gravatar; unlike github.

`encodeMicrosoft365EnumResult` emits `first`/`last` with **omitempty**; `ifExistsResult` and `federated` untouched.

## Scope

`microsoft365EnumTargets` deleted rather than kept alive by its own tests. `pkg/` untouched, `cmd_enum.go` identical to `main`, no other service changed, `Config.Emails` retained until 8/8.

```
go build ./...                exit 0
go vet ./cmd/... ./pkg/enum/  exit 0
go test ./... -count=1        all packages ok, 0 FAIL
gofmt -l                      clean
```

## Pre-existing nit, deliberately not touched

`microsoft365EnumGenerate`'s stderr status line prints `--domain` raw, while `gravatarEnumGenerate` wraps it in `sanitizeTerminal(...)`. That asymmetry predates this PR, is unchanged from `main`, and no test covers it. Worth a separate look — `--domain` is operator-supplied so the risk is low, but the inconsistency is real.

## Next

7) teams · 8) delete the `Config.Emails` shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
