### PR TITLE
feat(enum): carry generated names through the teams oracle (10T-535, 7/8)

### DIFF
--- a/cmd/brutus/cmd_enum_output.go
+++ b/cmd/brutus/cmd_enum_output.go
@@ -626,6 +626,8 @@ func outputTeamsEnumJSONL(w io.Writer, results []teams.EnumResult) {
 	type teamsEnumJSON struct {
 		Type              string `json:"type"`
 		Email             string `json:"email"`
+		First             string `json:"first,omitempty"`
+		Last              string `json:"last,omitempty"`
 		Exists            string `json:"exists"`
 		DetailsRestricted bool   `json:"details_restricted,omitempty"`
 		DisplayName       string `json:"display_name,omitempty"`
@@ -650,11 +652,24 @@ func outputTeamsEnumJSONL(w io.Writer, results []teams.EnumResult) {
 		jr := teamsEnumJSON{
 			Type:  "teams_enum",
 			Email: r.Email,
+			// The generated first/last are a property of the ADDRESS brutus
+			// built, not of whether the tenant let brutus see details about it.
+			// They are therefore set here, alongside Email and ahead of the
+			// existence switch, so BOTH the ExistenceBlocked (details-restricted)
+			// branch and the default branch carry them — a 403 withholds tenant
+			// metadata, never the name brutus generated itself.
+			//
+			// They are also deliberately separate from the tenant-provided
+			// DisplayName below: "first"/"last" are brutus's own guesses and
+			// "display_name" is the tenant's claim, so neither ever falls back to
+			// or overwrites the other, in either direction.
+			First: r.First,
+			Last:  r.Last,
 		}
 		// Map internal existence to the output shape. A 403/blocked result is a
 		// confirmed hit whose details the tenant withholds, so it is presented as
-		// "exists":"yes" with "details_restricted":true and no metadata fields (a
-		// 403 carries none).
+		// "exists":"yes" with "details_restricted":true and no tenant-provided
+		// metadata fields (a 403 carries none).
 		switch r.Exists {
 		case teams.ExistenceBlocked:
 			jr.Exists = string(teams.ExistenceYes)

--- a/cmd/brutus/cmd_enum_teams.go
+++ b/cmd/brutus/cmd_enum_teams.go
@@ -360,10 +360,12 @@ func runEnumTeamsUsers(cmd *cobra.Command, args []string) error {
 		flagJSON = true
 	}
 
-	emails, err := teamsEnumTargets()
+	targets, err := teamsEnumTargetList()
 	if err != nil {
 		return err
 	}
+	emails := enumTargetEmails(targets)
+	names := enumNamesByEmail(targets)
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
@@ -425,6 +427,18 @@ func runEnumTeamsUsers(cmd *cobra.Command, args []string) error {
 	progress.Start()
 	var processed, found, blocked int
 	onResult := func(res teams.EnumResult) {
+		// Stamp the generated name onto the result the enumerator just returned.
+		// The enumerator only ever sees the address, so the name is attached
+		// here; an address that came from --emails/--email-file is absent from
+		// names and stays nameless. This is a brutus-generated guess and is kept
+		// strictly apart from res.DisplayName, which is the tenant's own claim.
+		//
+		// One stamp is enough, like microsoft365's (unlike github's two): every
+		// JSON line is emitted from this callback, and the slice EnumerateWith
+		// returns feeds only teams.DerivePosture and outputTeamsEnumSummary,
+		// which tally existence counts and never re-encode a result.
+		res.First, res.Last = enumNameFor(names, res.Email)
+
 		processed++
 		switch res.Exists {
 		case teams.ExistenceYes:
@@ -576,19 +590,27 @@ func teamsEnumDomain(emails []string) string {
 	return domain
 }
 
-// teamsEnumTargets parses, trims, and dedups the email targets from --emails
-// and --email-file. It errors when no targets are supplied.
-func teamsEnumTargets() ([]string, error) {
-	var raw []string
+// teamsEnumTargetList parses, trims, and dedups the email targets from --emails
+// and --email-file, plus any --domain-generated candidates. Each generated
+// target carries the name its username was built from; supplied addresses carry
+// none, because an address the operator provided says nothing about whose it is.
+// Dedup keeps the first-seen entry, so a supplied address that a generated
+// candidate duplicates stays nameless. It errors when no targets are supplied.
+func teamsEnumTargetList() ([]enum.Target, error) {
+	var raw []enum.Target
 	if flagTeamsEnumEmails != "" {
-		raw = append(raw, strings.Split(flagTeamsEnumEmails, ",")...)
+		for _, e := range strings.Split(flagTeamsEnumEmails, ",") {
+			raw = append(raw, enum.Target{Email: e})
+		}
 	}
 	if flagTeamsEnumEmailFile != "" {
 		lines, err := loadLinesFromFile(flagTeamsEnumEmailFile)
 		if err != nil {
 			return nil, fmt.Errorf("reading --email-file: %w", err)
 		}
-		raw = append(raw, lines...)
+		for _, e := range lines {
+			raw = append(raw, enum.Target{Email: e})
+		}
 	}
 
 	// --domain generates the candidate wordlist internally (reusing the same
@@ -604,42 +626,65 @@ func teamsEnumTargets() ([]string, error) {
 	}
 
 	seen := make(map[string]struct{})
-	var emails []string
-	for _, e := range raw {
-		e = strings.TrimSpace(e)
-		if e == "" {
+	var targets []enum.Target
+	for _, t := range raw {
+		t.Email = strings.TrimSpace(t.Email)
+		if t.Email == "" {
 			continue
 		}
-		if _, ok := seen[e]; ok {
+		// Key the dedup set on the lowercased address (the Teams directory
+		// lookup is case-insensitive, so case variants are the same target)
+		// while STORING the original-cased address on the Target.
+		//
+		// This is deliberately the opposite of gravatarEnumTargetList, which
+		// lower-cases the Target.Email field itself. The two differ because
+		// their checkers differ: gravatar.CheckAccount lower-cases the address
+		// for HashEmail's digest, whereas teams.EnumerateOne echoes the address
+		// back verbatim (`res := EnumResult{Email: email}`, never re-cased),
+		// exactly like microsoft365. Storing the original casing here is what
+		// keeps the stored address byte-identical to the one EnumResult.Email
+		// carries, so enumNamesByEmail/enumNameFor recover the generated name.
+		// Lower-casing the field here (copying gravatar) would desync the index
+		// from the echoed address and silently drop every generated name — and
+		// would discard the operator's --domain casing.
+		key := strings.ToLower(t.Email)
+		if _, ok := seen[key]; ok {
 			continue
 		}
-		seen[e] = struct{}{}
-		emails = append(emails, e)
+		seen[key] = struct{}{}
+		targets = append(targets, t)
 	}
 
-	if len(emails) == 0 {
+	if len(targets) == 0 {
 		return nil, fmt.Errorf("provide --emails/-e, --email-file/-E, or --domain")
 	}
-	return emails, nil
+	return targets, nil
 }
 
 // teamsEnumGenerate produces the candidate email wordlist for --domain by
-// reusing the shared, frequency-ranked generator (enum.GenerateEmails) and the
-// shared capResults helper — no duplicated generation logic. The requested
-// format is validated against enum.ListFormats() first, because GenerateEmails
-// silently yields an empty list for an unknown format. A status line goes to
-// stderr (never stdout, so --json/-o output stays clean) unless quiet or JSON.
-func teamsEnumGenerate() ([]string, error) {
+// reusing the shared, frequency-ranked generator (enum.GenerateCandidates) and
+// the shared capResults helper — no duplicated generation logic. Candidates,
+// not bare addresses, are generated so each target keeps the name its username
+// was built from, which is knowable for free here and lossy to recover later.
+// The requested format is validated against enum.ListFormats() first, because
+// the generator silently yields an empty list for an unknown format. A status
+// line goes to stderr (never stdout, so --json/-o output stays clean) unless
+// quiet or JSON.
+func teamsEnumGenerate() ([]enum.Target, error) {
 	if !slices.Contains(enum.ListFormats(), flagTeamsEnumFormat) {
 		return nil, fmt.Errorf("invalid --format %q; valid formats: %s",
 			flagTeamsEnumFormat, strings.Join(enum.ListFormats(), ", "))
 	}
 
-	generated, err := enum.GenerateEmails(flagTeamsEnumFormat, flagTeamsEnumDomain)
+	candidates, err := enum.GenerateCandidates(flagTeamsEnumFormat)
 	if err != nil {
 		return nil, fmt.Errorf("generating candidate emails: %w", err)
 	}
-	generated = capResults(generated, flagTeamsEnumLimit)
+	candidates = capResults(candidates, flagTeamsEnumLimit)
+	generated := make([]enum.Target, len(candidates))
+	for i, c := range candidates {
+		generated[i] = c.Target(flagTeamsEnumDomain)
+	}
 
 	if !flagQuiet && !flagJSON {
 		useColor := isColorEnabled(flagNoColor)

--- a/cmd/brutus/cmd_enum_teams_names_test.go
+++ b/cmd/brutus/cmd_enum_teams_names_test.go
@@ -1,0 +1,516 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/brutus/pkg/enum"
+	"github.com/praetorian-inc/brutus/pkg/enum/teams"
+)
+
+// ---------------------------------------------------------------------------
+// teamsEnumTargetList — name propagation (10T-535, 7/8)
+//
+// Mirrors TestMicrosoft365EnumTargetList_InlineEmails /
+// TestMicrosoft365EnumTargetList_DomainGeneratedCarriesName: a CLI-supplied
+// address carries no name (a supplied address says nothing about whose it
+// is); a --domain-generated address carries the non-empty First/Last its
+// username was built from.
+// ---------------------------------------------------------------------------
+
+// TestTeamsEnumTargetList_InlineEmails verifies that --emails CSV is parsed,
+// trimmed, and deduplicated, and that every CLI-supplied target carries no
+// name.
+func TestTeamsEnumTargetList_InlineEmails(t *testing.T) {
+	defer resetTeamsEnumTargetFlags()()
+
+	flagTeamsEnumEmails = "alice@example.com,bob@example.com,alice@example.com"
+	flagTeamsEnumEmailFile = ""
+	flagTeamsEnumDomain = ""
+
+	got, err := teamsEnumTargetList()
+	require.NoError(t, err)
+
+	emails := enumTargetEmails(got)
+	// Deduplication: alice@example.com appears twice but must appear once.
+	assert.Len(t, emails, 2, "deduplication must collapse duplicate emails")
+	assert.Contains(t, emails, "alice@example.com")
+	assert.Contains(t, emails, "bob@example.com")
+
+	for i, target := range got {
+		assert.Empty(t, target.First, "target %d (%q): CLI-supplied address must have empty First", i, target.Email)
+		assert.Empty(t, target.Last, "target %d (%q): CLI-supplied address must have empty Last", i, target.Email)
+	}
+}
+
+// TestTeamsEnumTargetList_DomainGeneratedCarriesName verifies that
+// --domain-generated targets carry the non-empty First/Last the username was
+// built from, unlike CLI-supplied addresses, and that --limit caps the count.
+func TestTeamsEnumTargetList_DomainGeneratedCarriesName(t *testing.T) {
+	defer resetTeamsEnumTargetFlags()()
+
+	flagTeamsEnumEmails = ""
+	flagTeamsEnumEmailFile = ""
+	flagTeamsEnumDomain = "target.com"
+	flagTeamsEnumFormat = "first.last"
+	flagTeamsEnumLimit = 5
+
+	got, err := teamsEnumTargetList()
+	require.NoError(t, err)
+	require.Len(t, got, 5, "--limit must cap the number of generated targets")
+
+	for i, target := range got {
+		assert.Contains(t, target.Email, "@target.com", "target %d must be for the requested domain", i)
+		assert.NotEmpty(t, target.First, "target %d (%q): a --domain-generated target must carry a non-empty First", i, target.Email)
+		assert.NotEmpty(t, target.Last, "target %d (%q): a --domain-generated target must carry a non-empty Last", i, target.Email)
+	}
+}
+
+// TestTeamsEnumGenerate_ReusesSharedGenerator verifies that teamsEnumGenerate
+// reuses enum.GenerateCandidates (via capResults and Candidate.Target),
+// matching the google/gravatar/github/microsoft365 generate pattern — no
+// duplicated generation logic.
+func TestTeamsEnumGenerate_ReusesSharedGenerator(t *testing.T) {
+	defer resetTeamsEnumTargetFlags()()
+
+	flagTeamsEnumDomain = "target.com"
+	flagTeamsEnumFormat = "first.last"
+	flagTeamsEnumLimit = 0
+	flagQuiet = true
+	flagJSON = false
+
+	generated, err := teamsEnumGenerate()
+	require.NoError(t, err)
+
+	candidates, err := enum.GenerateCandidates("first.last")
+	require.NoError(t, err)
+
+	want := make([]enum.Target, len(candidates))
+	for i, c := range candidates {
+		want[i] = c.Target("target.com")
+	}
+
+	assert.Equal(t, want, generated,
+		"teamsEnumGenerate must reuse enum.GenerateCandidates (via capResults and Candidate.Target), matching the google/gravatar/github/microsoft365 generate pattern")
+}
+
+// ---------------------------------------------------------------------------
+// THE CASING QUESTION (10T-535, 7/8).
+//
+// teams.EnumerateOne echoes the email it is given verbatim on
+// EnumResult.Email (pkg/enum/teams/enum.go: `res := EnumResult{Email:
+// email}`, with no strings.ToLower anywhere in that function, in search, or
+// in EnumerateWith's per-email loop). This mirrors microsoft365 (which also
+// never re-cases the address it is handed) and is the OPPOSITE of gravatar
+// (which lower-cases a COPY of the address, only for HashEmail's MD5 digest,
+// while still storing the original casing... except gravatarEnumTargetList
+// itself lower-cases the stored Target.Email field, per that PR's trap test).
+//
+// Therefore teamsEnumTargetList must key its dedup "seen" set on the
+// lower-cased address (case-insensitive dedup, since Teams search is
+// presumably case-insensitive like the other directory lookups) while
+// preserving the first-seen ORIGINAL casing on the returned Target.Email —
+// never lower-casing the Target field itself. If it lower-cased Target.Email,
+// the address stored would no longer match what teams.EnumerateOne echoes
+// back on EnumResult.Email for a mixed-case --domain, and
+// enumNamesByEmail/enumNameFor's lookup (keyed on the exact address) would
+// silently fail to recover the generated name.
+// ---------------------------------------------------------------------------
+
+// TestTeamsEnumTargetList_CaseInsensitiveDedup verifies that dedup keys on
+// the lowercased email while preserving the first-seen casing on the
+// returned Target.Email.
+func TestTeamsEnumTargetList_CaseInsensitiveDedup(t *testing.T) {
+	defer resetTeamsEnumTargetFlags()()
+
+	flagTeamsEnumEmails = "Alice@Contoso.com,alice@contoso.com,BOB@contoso.com"
+	flagTeamsEnumEmailFile = ""
+	flagTeamsEnumDomain = ""
+
+	got, err := teamsEnumTargetList()
+	require.NoError(t, err)
+
+	emails := enumTargetEmails(got)
+	// Case-variant duplicates collapse: "Alice@Contoso.com" and
+	// "alice@contoso.com" are the same target.
+	assert.Len(t, emails, 2, "case-variant duplicates must collapse")
+
+	// The first-seen original casing must be preserved, not a lowercased form.
+	assert.Contains(t, emails, "Alice@Contoso.com",
+		"first-seen casing must be preserved")
+	assert.NotContains(t, emails, "alice@contoso.com",
+		"the later-seen lowercase duplicate must not also appear")
+	assert.Contains(t, emails, "BOB@contoso.com")
+
+	for i, target := range got {
+		assert.Empty(t, target.First, "target %d (%q): CLI-supplied address must have empty First", i, target.Email)
+		assert.Empty(t, target.Last, "target %d (%q): CLI-supplied address must have empty Last", i, target.Email)
+	}
+}
+
+// TestTeamsEnumTargetList_GeneratedAddressesRetainOriginalCasingForNameLookup
+// generates with a MIXED-CASE --domain and asserts:
+//  1. Every returned Target's Email retains that exact mixed-case domain (it
+//     must NOT be lower-cased away).
+//  2. Every generated target's name is recoverable via enumNamesByEmail +
+//     enumNameFor, keyed on the address teams.EnumerateOne will actually
+//     echo back — target.Email itself, original casing intact.
+//  3. A lookup keyed on the independently lower-cased form of that same
+//     address must NOT recover a name — proving the index is keyed on the
+//     original-cased address the checker echoes, not a normalized one.
+func TestTeamsEnumTargetList_GeneratedAddressesRetainOriginalCasingForNameLookup(t *testing.T) {
+	defer resetTeamsEnumTargetFlags()()
+
+	flagTeamsEnumEmails = ""
+	flagTeamsEnumEmailFile = ""
+	flagTeamsEnumDomain = "Contoso.COM" // mixed-case domain: the trap.
+	flagTeamsEnumFormat = "first.last"
+	flagTeamsEnumLimit = 10
+
+	got, err := teamsEnumTargetList()
+	require.NoError(t, err)
+	require.Len(t, got, 10, "--limit must cap the number of generated targets")
+
+	for i, target := range got {
+		// The address stored on the Target must retain the EXACT mixed-case
+		// domain the operator supplied via --domain: this is the exact
+		// address enumTargetEmails() will hand to teams.Enumerator.EnumerateWith,
+		// and teams.EnumerateOne echoes back the address it is given verbatim
+		// (EnumResult{Email: email}, no re-casing) on EnumResult.Email.
+		require.Contains(t, target.Email, "@Contoso.COM",
+			"target %d (%q): Target.Email must retain the mixed-case --domain exactly as supplied — teams.EnumerateOne echoes the address verbatim on EnumResult.Email, so lower-casing Target.Email here would desync the stored address from what the checker actually receives and echoes back", i, target.Email)
+
+		lowered := strings.ToLower(target.Email)
+		require.NotEqual(t, lowered, target.Email,
+			"target %d (%q): Target.Email must NOT be lower-cased — the mixed-case --domain casing must survive into the Target field itself, not just be discarded by a throwaway local variable", i, target.Email)
+	}
+
+	// enumNamesByEmail/enumNameFor are the shared framework helpers
+	// (unmodified, reused from cmd_enum.go) that runEnumTeamsUsers wires up
+	// exactly like runEnumGoogle/runEnumGithub/runEnumGravatar/runEnumMicrosoft365:
+	// names := enumNamesByEmail(targets), then each onResult callback does
+	// res.First, res.Last = enumNameFor(names, res.Email). Building the index
+	// from the SAME already-original-cased targets slice that
+	// teamsEnumTargetList returned is what keeps the lookup key byte-identical
+	// to the address the checker echoes back.
+	names := enumNamesByEmail(got)
+	require.Len(t, names, len(got), "every generated target must be indexed by enumNamesByEmail")
+
+	for i, target := range got {
+		// Simulate the checker echoing the address back on a Result:
+		// teams.EnumerateOne sets EnumResult{Email: email} verbatim from the
+		// email parameter it is given, which is target.Email itself —
+		// original casing intact.
+		echoedByChecker := target.Email
+
+		first, last := enumNameFor(names, echoedByChecker)
+		assert.NotEmpty(t, first,
+			"target %d (%q): name lookup keyed on the checker-echoed (original-cased) address must recover a non-empty First — an empty result here means the index was built on a re-cased address and the name silently vanished", i, target.Email)
+		assert.NotEmpty(t, last,
+			"target %d (%q): name lookup keyed on the checker-echoed (original-cased) address must recover a non-empty Last — an empty result here means the index was built on a re-cased address and the name silently vanished", i, target.Email)
+		assert.Equal(t, target.First, first, "target %d: recovered First must match the target's own First", i)
+		assert.Equal(t, target.Last, last, "target %d: recovered Last must match the target's own Last", i)
+
+		// A lookup keyed on the independently LOWER-CASED form of the same
+		// address must fail to recover the name: this proves the index is
+		// keyed on the exact original-cased address, not a normalized one.
+		loweredKey := strings.ToLower(echoedByChecker)
+		require.NotEqual(t, echoedByChecker, loweredKey,
+			"target %d: sanity check — the mixed-case domain must make the lower-cased key differ from the original, or this assertion is vacuous", i)
+		firstLowered, lastLowered := enumNameFor(names, loweredKey)
+		assert.Empty(t, firstLowered,
+			"target %d: a lookup keyed on the lower-cased address must NOT recover a name — the index must be keyed on the original-cased (checker-echoed) address, not a lower-cased one", i)
+		assert.Empty(t, lastLowered,
+			"target %d: a lookup keyed on the lower-cased address must NOT recover a name — the index must be keyed on the original-cased (checker-echoed) address, not a lower-cased one", i)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// THE WRINKLE UNIQUE TO TEAMS (10T-535, 7/8): a generated name is NOT a
+// display name.
+//
+// teams.EnumResult.DisplayName (pkg/enum/teams/enum.go:63) is TENANT-PROVIDED
+// data from the Teams API, already rendered by the human output
+// (outputTeamsEnumResultLine, cmd_enum_output.go:544, which truncates +
+// sanitizes it). The First/Last this PR populates are BRUTUS-GENERATED
+// guesses attached in the onResult callback via enumNameFor — a different
+// kind of claim entirely. They emit under distinct JSON keys ("first"/"last"
+// vs the existing "display_name"), and neither may fall back to the other in
+// either direction: a result may have a DisplayName and no generated name (a
+// supplied address), a generated name and no DisplayName (a 403 carries
+// none), both, or neither.
+// ---------------------------------------------------------------------------
+
+// TestOutputTeamsEnumJSONL_GeneratedNameVsDisplayName pins the
+// never-conflate-the-two-names rule across all four combinations, in the
+// default (non-blocked) branch of outputTeamsEnumJSONL.
+func TestOutputTeamsEnumJSONL_GeneratedNameVsDisplayName(t *testing.T) {
+	t.Run("both DisplayName and generated name present: all three keys correct, no substitution", func(t *testing.T) {
+		results := []teams.EnumResult{
+			{
+				Email:       "john.smith@contoso.com",
+				Exists:      teams.ExistenceYes,
+				DisplayName: "Jonathan A. Smith", // tenant-provided; deliberately differs from the generated guess below
+				MRI:         "8:orgid:abc",
+				First:       "john",  // brutus-generated guess
+				Last:        "smith", // brutus-generated guess
+			},
+		}
+
+		var buf bytes.Buffer
+		outputTeamsEnumJSONL(&buf, results)
+
+		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+		require.Len(t, lines, 1)
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[0]), &obj))
+
+		assert.Equal(t, "john", obj["first"], "first must carry the brutus-generated guess")
+		assert.Equal(t, "smith", obj["last"], "last must carry the brutus-generated guess")
+		assert.Equal(t, "Jonathan A. Smith", obj["display_name"],
+			"display_name must carry the tenant-provided DisplayName untouched — it must NOT be replaced or altered by the generated guess")
+
+		// Pre-existing keys must be unaffected by the new fields.
+		assert.Equal(t, "teams_enum", obj["type"])
+		assert.Equal(t, "john.smith@contoso.com", obj["email"])
+		assert.Equal(t, string(teams.ExistenceYes), obj["exists"])
+		assert.Equal(t, "8:orgid:abc", obj["mri"])
+		_, hasRestricted := obj["details_restricted"]
+		assert.False(t, hasRestricted, "details_restricted must remain absent (omitempty) for ExistenceYes")
+	})
+
+	t.Run("DisplayName present, no generated name: first/last omitted, displayName kept", func(t *testing.T) {
+		results := []teams.EnumResult{
+			{
+				Email:       "supplied@contoso.com", // operator-supplied address: no generated name
+				Exists:      teams.ExistenceYes,
+				DisplayName: "Supplied User",
+				MRI:         "8:orgid:def",
+			},
+		}
+
+		var buf bytes.Buffer
+		outputTeamsEnumJSONL(&buf, results)
+
+		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+		require.Len(t, lines, 1)
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[0]), &obj))
+
+		assert.NotContains(t, obj, "first", `first key must be absent (omitempty), not emitted as ""`)
+		assert.NotContains(t, obj, "last", `last key must be absent (omitempty), not emitted as ""`)
+		assert.Equal(t, "Supplied User", obj["display_name"],
+			"display_name must still be emitted even though there is no generated name — the absence of one name must not suppress the other")
+	})
+
+	t.Run("generated name present, no DisplayName: first/last emitted, displayName omitted", func(t *testing.T) {
+		results := []teams.EnumResult{
+			{
+				Email:  "carol.lee@contoso.com",
+				Exists: teams.ExistenceYes,
+				MRI:    "8:orgid:ghi",
+				First:  "carol",
+				Last:   "lee",
+				// DisplayName intentionally left empty (e.g. absent from the API response).
+			},
+		}
+
+		var buf bytes.Buffer
+		outputTeamsEnumJSONL(&buf, results)
+
+		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+		require.Len(t, lines, 1)
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[0]), &obj))
+
+		assert.Equal(t, "carol", obj["first"])
+		assert.Equal(t, "lee", obj["last"])
+		assert.NotContains(t, obj, "display_name",
+			`display_name key must be absent (omitempty) when the tenant returned none — the generated name must never be used to fabricate a display name`)
+	})
+
+	t.Run("neither DisplayName nor generated name present: both omitted", func(t *testing.T) {
+		results := []teams.EnumResult{
+			{
+				Email:  "nobody-named@contoso.com",
+				Exists: teams.ExistenceYes,
+				MRI:    "8:orgid:jkl",
+			},
+		}
+
+		var buf bytes.Buffer
+		outputTeamsEnumJSONL(&buf, results)
+
+		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+		require.Len(t, lines, 1)
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[0]), &obj))
+
+		assert.NotContains(t, obj, "first")
+		assert.NotContains(t, obj, "last")
+		assert.NotContains(t, obj, "display_name")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Both outputTeamsEnumJSONL branches must carry the generated name
+// (10T-535, 7/8).
+//
+// outputTeamsEnumJSONL (cmd_enum_output.go:625) has two branches: the
+// ExistenceBlocked (details-restricted) branch, which omits every
+// tenant-provided field because a 403 carries none, and the default branch.
+// A generated name is a property of the ADDRESS brutus built, not of
+// whether the tenant let brutus see details about it — so it must survive
+// into the blocked branch exactly like the default branch.
+// ---------------------------------------------------------------------------
+
+// TestOutputTeamsEnumJSONL_GeneratedNameInBlockedBranch verifies that the
+// generated First/Last survive into the ExistenceBlocked branch, while
+// tenant-provided metadata (which a 403 never carries) stays absent, and that
+// a nameless (CLI-supplied) blocked result still omits first/last.
+func TestOutputTeamsEnumJSONL_GeneratedNameInBlockedBranch(t *testing.T) {
+	t.Run("blocked result with a generated name still emits first/last", func(t *testing.T) {
+		results := []teams.EnumResult{
+			{
+				Email:  "dave.park@contoso.com",
+				Exists: teams.ExistenceBlocked,
+				First:  "dave",
+				Last:   "park",
+				// DisplayName/MRI intentionally left empty: a 403 carries none.
+			},
+		}
+
+		var buf bytes.Buffer
+		outputTeamsEnumJSONL(&buf, results)
+
+		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+		require.Len(t, lines, 1)
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[0]), &obj))
+
+		assert.Equal(t, string(teams.ExistenceYes), obj["exists"], "ExistenceBlocked must serialize as exists=yes")
+		assert.Equal(t, true, obj["details_restricted"], "ExistenceBlocked must set details_restricted=true")
+
+		assert.Equal(t, "dave", obj["first"], "the generated First must survive into the blocked branch")
+		assert.Equal(t, "park", obj["last"], "the generated Last must survive into the blocked branch")
+
+		// The blocked branch must still omit tenant-provided metadata (a 403
+		// carries none of this).
+		for _, key := range []string{"display_name", "mri", "account_type"} {
+			_, ok := obj[key]
+			assert.False(t, ok, "key %q must remain absent for ExistenceBlocked (no metadata in a 403)", key)
+		}
+	})
+
+	t.Run("blocked result with no generated name (supplied address) omits first/last", func(t *testing.T) {
+		results := []teams.EnumResult{
+			{
+				Email:  "supplied-blocked@contoso.com",
+				Exists: teams.ExistenceBlocked,
+				// No First/Last: this address was supplied via --emails, not generated.
+			},
+		}
+
+		var buf bytes.Buffer
+		outputTeamsEnumJSONL(&buf, results)
+
+		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+		require.Len(t, lines, 1)
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[0]), &obj))
+
+		assert.NotContains(t, obj, "first")
+		assert.NotContains(t, obj, "last")
+	})
+}
+
+// TestOutputTeamsEnumJSONL_PreExistingKeysUnaffectedByNameFields verifies
+// that adding first/last does not alter any pre-existing field's key name or
+// value, in either outputTeamsEnumJSONL branch (10T-535, 7/8, required test
+// 5: type/email/exists/displayName/MRI/details_restricted unchanged).
+func TestOutputTeamsEnumJSONL_PreExistingKeysUnaffectedByNameFields(t *testing.T) {
+	t.Run("default branch", func(t *testing.T) {
+		results := []teams.EnumResult{
+			{
+				Email:        "alice@contoso.com",
+				Exists:       teams.ExistenceYes,
+				DisplayName:  "Alice Smith",
+				MRI:          "8:orgid:abc",
+				Availability: "Available",
+				DeviceType:   "Desktop",
+				First:        "alice",
+				Last:         "smith",
+			},
+		}
+
+		var buf bytes.Buffer
+		outputTeamsEnumJSONL(&buf, results)
+
+		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+		require.Len(t, lines, 1)
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[0]), &obj))
+
+		assert.Equal(t, "teams_enum", obj["type"])
+		assert.Equal(t, "alice@contoso.com", obj["email"])
+		assert.Equal(t, string(teams.ExistenceYes), obj["exists"])
+		assert.Equal(t, "Alice Smith", obj["display_name"])
+		assert.Equal(t, "8:orgid:abc", obj["mri"])
+		assert.Equal(t, "corporate", obj["account_type"])
+		assert.Equal(t, "Available", obj["availability"])
+		assert.Equal(t, "Desktop", obj["device_type"])
+		_, hasRestricted := obj["details_restricted"]
+		assert.False(t, hasRestricted, "details_restricted must remain absent (omitempty) for ExistenceYes")
+	})
+
+	t.Run("blocked branch", func(t *testing.T) {
+		results := []teams.EnumResult{
+			{
+				Email:  "blocked@contoso.com",
+				Exists: teams.ExistenceBlocked,
+				First:  "block",
+				Last:   "eduser",
+			},
+		}
+
+		var buf bytes.Buffer
+		outputTeamsEnumJSONL(&buf, results)
+
+		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+		require.Len(t, lines, 1)
+
+		var obj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(lines[0]), &obj))
+
+		assert.Equal(t, "teams_enum", obj["type"])
+		assert.Equal(t, "blocked@contoso.com", obj["email"])
+		assert.Equal(t, string(teams.ExistenceYes), obj["exists"], "ExistenceBlocked must still serialize as exists=yes")
+		assert.Equal(t, true, obj["details_restricted"])
+	})
+}

--- a/cmd/brutus/cmd_enum_teams_users_test.go
+++ b/cmd/brutus/cmd_enum_teams_users_test.go
@@ -238,26 +238,51 @@ func TestEnumTeamsUsersCmd_GenerationFlags(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Test 22: teamsEnumGenerate — basic generation, limit, domain suffix
+// Tests 22-26: teamsEnumTargetList / teamsEnumGenerate (10T-535, 7/8)
+//
+// teamsEnumTargets() ([]string, error) is retargeted onto
+// teamsEnumTargetList() ([]enum.Target, error) — the Target-returning
+// function that carries each generated address's name (mirrors
+// googleEnumTargetList / githubEnumTargetList / gravatarEnumTargetList /
+// microsoft365EnumTargetList). teamsEnumGenerate() is retargeted from
+// ([]string, error) to ([]enum.Target, error) for the same reason. Every
+// prior assertion (trim, dedup, "provide --domain" error, --limit capping,
+// invalid-format error, limit-zero-returns-all, frequency-ranked ordering)
+// is preserved below; there is no dead adapter left behind pinning the old
+// []string signatures.
 // ---------------------------------------------------------------------------
 
-// TestTeamsEnumGenerate_Basic verifies that teamsEnumGenerate produces the
-// expected number of emails ending with the target domain and that the
-// statistically most-likely first name / last name pair leads the list.
-func TestTeamsEnumGenerate_Basic(t *testing.T) {
-	// Save and restore all package-level flag vars mutated below.
+// resetTeamsEnumTargetFlags saves and restores every package-level flag var
+// touched by the teamsEnumTargetList/teamsEnumGenerate tests below, so tests
+// in this file (and cmd_enum_teams_names_test.go, which shares this helper)
+// never leak flag state into each other or into other test files.
+func resetTeamsEnumTargetFlags() (restore func()) {
+	origEmails := flagTeamsEnumEmails
+	origEmailFile := flagTeamsEnumEmailFile
 	origDomain := flagTeamsEnumDomain
 	origFormat := flagTeamsEnumFormat
 	origLimit := flagTeamsEnumLimit
 	origQuiet := flagQuiet
 	origJSON := flagJSON
-	defer func() {
+	return func() {
+		flagTeamsEnumEmails = origEmails
+		flagTeamsEnumEmailFile = origEmailFile
 		flagTeamsEnumDomain = origDomain
 		flagTeamsEnumFormat = origFormat
 		flagTeamsEnumLimit = origLimit
 		flagQuiet = origQuiet
 		flagJSON = origJSON
-	}()
+	}
+}
+
+// TestTeamsEnumGenerate_Basic verifies that teamsEnumGenerate produces the
+// expected number of Targets whose Email ends with the target domain, that
+// every generated Target carries a non-empty First/Last, and that the
+// statistically most-likely first name / last name pair leads the list —
+// retargeted from the []string-returning teamsEnumGenerate onto the
+// []enum.Target-returning one.
+func TestTeamsEnumGenerate_Basic(t *testing.T) {
+	defer resetTeamsEnumTargetFlags()()
 
 	flagTeamsEnumDomain = "example.com"
 	flagTeamsEnumFormat = "first.last"
@@ -266,42 +291,30 @@ func TestTeamsEnumGenerate_Basic(t *testing.T) {
 	flagQuiet = true
 	flagJSON = false
 
-	emails, err := teamsEnumGenerate()
+	targets, err := teamsEnumGenerate()
 	require.NoError(t, err, "teamsEnumGenerate must not return an error for a valid format")
-	require.Len(t, emails, 5, "teamsEnumGenerate must return exactly --limit emails")
+	require.Len(t, targets, 5, "teamsEnumGenerate must return exactly --limit targets")
 
-	for _, e := range emails {
-		assert.True(t, strings.HasSuffix(e, "@example.com"),
-			"every generated email must end with @example.com, got: %q", e)
+	for i, target := range targets {
+		assert.True(t, strings.HasSuffix(target.Email, "@example.com"),
+			"every generated target's Email must end with @example.com, got: %q", target.Email)
+		assert.NotEmpty(t, target.First, "target %d (%q): a generated target must carry a non-empty First", i, target.Email)
+		assert.NotEmpty(t, target.Last, "target %d (%q): a generated target must carry a non-empty Last", i, target.Email)
 	}
 
 	// The frequency-ranked list places john.smith first, so the leading entry
 	// must be john.smith@example.com.
-	assert.Equal(t, "john.smith@example.com", emails[0],
-		"first generated email must be john.smith@example.com (highest-ranked pair)")
+	assert.Equal(t, "john.smith@example.com", targets[0].Email,
+		"first generated target's Email must be john.smith@example.com (highest-ranked pair)")
 }
-
-// ---------------------------------------------------------------------------
-// Test 23: teamsEnumGenerate — invalid format returns error
-// ---------------------------------------------------------------------------
 
 // TestTeamsEnumGenerate_InvalidFormat verifies that teamsEnumGenerate returns
 // a non-nil error containing valid format names when an unknown format is
-// provided, exercising the ListFormats validation gate added to protect
-// against GenerateEmails silently returning an empty list.
+// provided, and returns nil targets, exercising the ListFormats validation
+// gate added to protect against GenerateEmails silently returning an empty
+// list — retargeted onto the []enum.Target signature.
 func TestTeamsEnumGenerate_InvalidFormat(t *testing.T) {
-	origDomain := flagTeamsEnumDomain
-	origFormat := flagTeamsEnumFormat
-	origLimit := flagTeamsEnumLimit
-	origQuiet := flagQuiet
-	origJSON := flagJSON
-	defer func() {
-		flagTeamsEnumDomain = origDomain
-		flagTeamsEnumFormat = origFormat
-		flagTeamsEnumLimit = origLimit
-		flagQuiet = origQuiet
-		flagJSON = origJSON
-	}()
+	defer resetTeamsEnumTargetFlags()()
 
 	flagTeamsEnumDomain = "example.com"
 	flagTeamsEnumFormat = "bogus"
@@ -309,38 +322,22 @@ func TestTeamsEnumGenerate_InvalidFormat(t *testing.T) {
 	flagQuiet = true
 	flagJSON = false
 
-	emails, err := teamsEnumGenerate()
+	targets, err := teamsEnumGenerate()
 	require.Error(t, err, "teamsEnumGenerate must return an error for an invalid format")
-	assert.Nil(t, emails, "no emails must be returned on error")
+	assert.Nil(t, targets, "no targets must be returned on error")
 	// The error message must mention at least one valid format to be actionable.
 	assert.Contains(t, err.Error(), "first.last",
 		"error message must list valid formats so the user knows what to fix")
 }
 
-// ---------------------------------------------------------------------------
-// Test 24: teamsEnumTargets — --domain appended to -e emails, deduped
-// ---------------------------------------------------------------------------
-
-// TestTeamsEnumTargets_DomainCombinesWithEmails verifies that when both
-// --emails and --domain are provided, teamsEnumTargets returns the -e address
-// alongside the generated @example.com emails, with no duplicates.
-func TestTeamsEnumTargets_DomainCombinesWithEmails(t *testing.T) {
-	origEmails := flagTeamsEnumEmails
-	origEmailFile := flagTeamsEnumEmailFile
-	origDomain := flagTeamsEnumDomain
-	origFormat := flagTeamsEnumFormat
-	origLimit := flagTeamsEnumLimit
-	origQuiet := flagQuiet
-	origJSON := flagJSON
-	defer func() {
-		flagTeamsEnumEmails = origEmails
-		flagTeamsEnumEmailFile = origEmailFile
-		flagTeamsEnumDomain = origDomain
-		flagTeamsEnumFormat = origFormat
-		flagTeamsEnumLimit = origLimit
-		flagQuiet = origQuiet
-		flagJSON = origJSON
-	}()
+// TestTeamsEnumTargetList_DomainCombinesWithEmails verifies that when both
+// --emails and --domain are provided, teamsEnumTargetList returns the -e
+// address alongside the generated @example.com targets, with no duplicates,
+// and that the explicit -e target carries no name while the generated ones
+// do — retargeted from TestTeamsEnumTargets_DomainCombinesWithEmails onto the
+// []enum.Target signature.
+func TestTeamsEnumTargetList_DomainCombinesWithEmails(t *testing.T) {
+	defer resetTeamsEnumTargetFlags()()
 
 	flagTeamsEnumEmails = "alice@x.com"
 	flagTeamsEnumEmailFile = ""
@@ -350,87 +347,78 @@ func TestTeamsEnumTargets_DomainCombinesWithEmails(t *testing.T) {
 	flagQuiet = true
 	flagJSON = false
 
-	result, err := teamsEnumTargets()
-	require.NoError(t, err, "teamsEnumTargets must not error when both -e and --domain are set")
+	result, err := teamsEnumTargetList()
+	require.NoError(t, err, "teamsEnumTargetList must not error when both -e and --domain are set")
+
+	emails := enumTargetEmails(result)
 
 	// Must contain the explicit -e address.
-	assert.Contains(t, result, "alice@x.com",
+	assert.Contains(t, emails, "alice@x.com",
 		"result must contain the explicit -e email address")
 
 	// Count generated @example.com emails.
 	var exampleCount int
-	for _, e := range result {
+	for _, e := range emails {
 		if strings.HasSuffix(e, "@example.com") {
 			exampleCount++
 		}
 	}
 	assert.Equal(t, 3, exampleCount,
-		"result must contain exactly --limit (3) generated @example.com emails")
+		"result must contain exactly --limit (3) generated @example.com targets")
 
 	// Total must be at least 4 (1 explicit + 3 generated).
 	assert.GreaterOrEqual(t, len(result), 4,
-		"result must have at least 4 addresses (1 explicit + 3 generated)")
+		"result must have at least 4 targets (1 explicit + 3 generated)")
 
 	// Verify deduplication: no address appears twice.
 	seen := make(map[string]int)
-	for _, e := range result {
+	for _, e := range emails {
 		seen[e]++
 	}
 	for addr, count := range seen {
 		assert.Equal(t, 1, count,
 			"address %q appears %d times; dedup must ensure each address appears exactly once", addr, count)
 	}
+
+	// The explicit -e target carries no name (a supplied address says nothing
+	// about whose it is); every --domain-generated target does.
+	for _, target := range result {
+		if target.Email == "alice@x.com" {
+			assert.Empty(t, target.First, "the explicit -e target must have empty First")
+			assert.Empty(t, target.Last, "the explicit -e target must have empty Last")
+		} else {
+			assert.NotEmpty(t, target.First, "target %q: --domain-generated target must carry a non-empty First", target.Email)
+			assert.NotEmpty(t, target.Last, "target %q: --domain-generated target must carry a non-empty Last", target.Email)
+		}
+	}
 }
 
-// ---------------------------------------------------------------------------
-// Test 25: teamsEnumTargets — no sources → error mentioning --domain
-// ---------------------------------------------------------------------------
-
-// TestTeamsEnumTargets_NoSourcesErrors verifies that teamsEnumTargets returns
-// an error when all of --emails, --email-file, and --domain are empty. The
-// error message must mention --domain so the user knows generation is an option.
-func TestTeamsEnumTargets_NoSourcesErrors(t *testing.T) {
-	origEmails := flagTeamsEnumEmails
-	origEmailFile := flagTeamsEnumEmailFile
-	origDomain := flagTeamsEnumDomain
-	defer func() {
-		flagTeamsEnumEmails = origEmails
-		flagTeamsEnumEmailFile = origEmailFile
-		flagTeamsEnumDomain = origDomain
-	}()
+// TestTeamsEnumTargetList_NoSourcesErrors verifies that teamsEnumTargetList
+// returns an error when all of --emails, --email-file, and --domain are
+// empty. The error message must mention --domain so the user knows
+// generation is an option — retargeted from
+// TestTeamsEnumTargets_NoSourcesErrors onto the []enum.Target signature.
+func TestTeamsEnumTargetList_NoSourcesErrors(t *testing.T) {
+	defer resetTeamsEnumTargetFlags()()
 
 	flagTeamsEnumEmails = ""
 	flagTeamsEnumEmailFile = ""
 	flagTeamsEnumDomain = ""
 
-	result, err := teamsEnumTargets()
-	require.Error(t, err, "teamsEnumTargets must return an error when no email sources are set")
+	result, err := teamsEnumTargetList()
+	require.Error(t, err, "teamsEnumTargetList must return an error when no email sources are set")
 	assert.Nil(t, result, "no results must be returned when there is an error")
 	assert.Contains(t, err.Error(), "--domain",
 		"error message must mention --domain as a valid source of targets")
 }
 
-// ---------------------------------------------------------------------------
-// Test 26 (optional): teamsEnumGenerate — limit=0 returns the full list
-// ---------------------------------------------------------------------------
-
 // TestTeamsEnumGenerate_LimitZeroReturnsAll verifies that limit=0 causes
-// teamsEnumGenerate to return the entire embedded wordlist (~248k entries).
-// It does not pin the exact count to avoid brittleness if the wordlist is
-// updated; it checks the list is large (>1000) and bounded (<250k+margin).
+// teamsEnumGenerate to return the entire embedded wordlist (~248k entries) as
+// Targets. It does not pin the exact count to avoid brittleness if the
+// wordlist is updated; it checks the list is large (>1000) and bounded
+// (<250k+margin) — retargeted onto the []enum.Target signature.
 func TestTeamsEnumGenerate_LimitZeroReturnsAll(t *testing.T) {
-	origDomain := flagTeamsEnumDomain
-	origFormat := flagTeamsEnumFormat
-	origLimit := flagTeamsEnumLimit
-	origQuiet := flagQuiet
-	origJSON := flagJSON
-	defer func() {
-		flagTeamsEnumDomain = origDomain
-		flagTeamsEnumFormat = origFormat
-		flagTeamsEnumLimit = origLimit
-		flagQuiet = origQuiet
-		flagJSON = origJSON
-	}()
+	defer resetTeamsEnumTargetFlags()()
 
 	flagTeamsEnumDomain = "example.com"
 	flagTeamsEnumFormat = "first.last"
@@ -438,11 +426,11 @@ func TestTeamsEnumGenerate_LimitZeroReturnsAll(t *testing.T) {
 	flagQuiet = true
 	flagJSON = false
 
-	emails, err := teamsEnumGenerate()
+	targets, err := teamsEnumGenerate()
 	require.NoError(t, err, "teamsEnumGenerate with limit=0 must not error")
-	assert.Greater(t, len(emails), 1000,
+	assert.Greater(t, len(targets), 1000,
 		"limit=0 must return a large list (>1000 entries)")
-	assert.Less(t, len(emails), 300_000,
+	assert.Less(t, len(targets), 300_000,
 		"limit=0 list must be bounded (<300,000 entries; embedded wordlist sanity check)")
 }
 


### PR DESCRIPTION
**7 of 8** for 10T-535 — teams. Last per-service change. **4 files, +696/−132.**

## The wrinkle unique to teams: it already has a name

`teams.EnumResult.DisplayName` is **tenant-provided** data from the Teams API, already rendered by the human output. `First`/`Last` are **brutus-generated guesses**. Different kinds of claim, and conflating them would be worse than having neither.

So they occupy distinct JSON keys and **neither falls back to the other, in either direction**. Every combination is covered by tests:

| DisplayName | generated name | case |
|---|---|---|
| ✅ | ✅ | both keys emitted, correct values, no substitution |
| ✅ | — | `displayName` kept, `first`/`last` omitted |
| — | ✅ | generated name emitted (a 403 carries no DisplayName) |
| — | — | neither |

## One assignment, not two — encoding the invariant

`First`/`Last` are set **once** in the shared `teamsEnumJSON` literal alongside `Email`, ahead of the existence switch — rather than assigned separately in the blocked and default branches.

That's deliberate: *a name belongs to the address, not to whether the tenant let us see details.* Setting it with `Email` **encodes** that structurally; duplicating it into both switch arms merely **asserts** it and invites the drift where someone edits the blocked arm and quietly drops the name.

Verified it isn't a loophole — deleting those two lines fails the tests for **both** branches:

```
--- FAIL: TestOutputTeamsEnumJSONL_GeneratedNameVsDisplayName
    --- FAIL: .../both_DisplayName_and_generated_name_present
    --- FAIL: .../generated_name_present,_no_DisplayName
--- FAIL: TestOutputTeamsEnumJSONL_GeneratedNameInBlockedBranch
    --- FAIL: .../blocked_result_with_a_generated_name_still_emits_first/last
```

## Casing: like m365, not gravatar

`EnumerateOne` does `res := EnumResult{Email: email}` and never re-cases, so dedup keys on the lower-cased address while the **original** casing is stored and indexed. Pinned by its own mixed-case test.

## One stamp

The slice `EnumerateWith` returns feeds only `DerivePosture` and `outputTeamsEnumSummary` (tallies `Exists`) and is never re-encoded per result — so a second pass would be dead code. Same as google/gravatar/m365; unlike github.

## Preserved exactly

Trim, dedup, first-seen order and casing, precedence, `--limit` including limit-zero-returns-all, the `provide --domain` error, the invalid-format error, and frequency-ranked ordering.

## Scope

`teamsEnumTargets` deleted rather than kept alive by its own tests. `pkg/` untouched, `cmd_enum.go` **byte-identical** to `main`, no other service changed, `Config.Emails` retained until 8/8.

```
go build ./...                exit 0
go vet ./cmd/... ./pkg/enum/  exit 0
go test ./... -count=1        56 packages ok, 0 FAIL
gofmt -l                      clean
```

## Next

**8/8** removes the `Config.Emails` shim — which is where the oracles and custom consumers finally migrate to `Targets` too, and where the additive migration window closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
