### PR TITLE
fix(lint): pass enum Results by pointer to satisfy gocritic hugeParam

### DIFF
--- a/cmd/brutus/cmd_enum_github.go
+++ b/cmd/brutus/cmd_enum_github.go
@@ -182,7 +182,7 @@ func runEnumGithub(cmd *cobra.Command, args []string) error {
 			// Clear the in-place bar before printing a result row so the bar's
 			// partial line doesn't corrupt it; the bar redraws on the next tick.
 			progress.Clear()
-			outputGithubEnumResultLine(os.Stdout, res, useColor)
+			outputGithubEnumResultLine(os.Stdout, &res, useColor)
 		}
 
 		progress.Update(processed, fmt.Sprintf("%d found", found))

--- a/cmd/brutus/cmd_enum_github_map.go
+++ b/cmd/brutus/cmd_enum_github_map.go
@@ -136,7 +136,7 @@ func runEnumGithubMap(cmd *cobra.Command, args []string) error {
 
 	for i := range results {
 		if results[i].Exists || flagVerbose {
-			outputGithubEnumResultLine(os.Stdout, results[i], useColor)
+			outputGithubEnumResultLine(os.Stdout, &results[i], useColor)
 		}
 	}
 	outputGithubEnumSummary(os.Stdout, results, useColor)

--- a/cmd/brutus/cmd_enum_github_output.go
+++ b/cmd/brutus/cmd_enum_github_output.go
@@ -28,7 +28,7 @@ import (
 // any) as " (<username>)". Not-found rows render as "[ ] not found". The
 // server-/user-derived email and username are sanitized via sanitizeTerminal
 // (P0-4) before rendering. Callers decide which results to print.
-func outputGithubEnumResultLine(w io.Writer, r githubenum.Result, useColor bool) {
+func outputGithubEnumResultLine(w io.Writer, r *githubenum.Result, useColor bool) {
 	email := truncate(sanitizeTerminal(r.Email), 40)
 
 	if r.Error != nil {

--- a/cmd/brutus/cmd_enum_github_test.go
+++ b/cmd/brutus/cmd_enum_github_test.go
@@ -542,7 +542,7 @@ func TestOutputGithubEnumResultLine_Error(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	outputGithubEnumResultLine(&buf, r, false)
+	outputGithubEnumResultLine(&buf, &r, false)
 	out := buf.String()
 
 	assert.Contains(t, out, SymbolError, "error row must show the error symbol")
@@ -561,7 +561,7 @@ func TestOutputGithubEnumResultLine_NotFoundStillWorks(t *testing.T) {
 	r := githubenum.Result{Email: "b@x.com"}
 
 	var buf bytes.Buffer
-	outputGithubEnumResultLine(&buf, r, false)
+	outputGithubEnumResultLine(&buf, &r, false)
 	out := buf.String()
 
 	assert.Contains(t, out, "[ ] not found", "a result with no error/no match must render the not-found row")

--- a/cmd/brutus/cmd_enum_google.go
+++ b/cmd/brutus/cmd_enum_google.go
@@ -159,7 +159,7 @@ func runEnumGoogle(cmd *cobra.Command, args []string) error {
 			// Clear the in-place bar before printing a result row so the bar's
 			// partial line doesn't corrupt it; the bar redraws on the next tick.
 			progress.Clear()
-			outputGoogleEnumResultLine(os.Stdout, res, useColor)
+			outputGoogleEnumResultLine(os.Stdout, &res, useColor)
 		}
 
 		progress.Update(processed, fmt.Sprintf("%d found", found))

--- a/cmd/brutus/cmd_enum_google_test.go
+++ b/cmd/brutus/cmd_enum_google_test.go
@@ -297,7 +297,7 @@ func TestOutputGoogleEnumResultLine(t *testing.T) {
 			IdP:    "login.okta.com",
 		}
 		var buf bytes.Buffer
-		outputGoogleEnumResultLine(&buf, r, false /* useColor */)
+		outputGoogleEnumResultLine(&buf, &r, false /* useColor */)
 		out := buf.String()
 
 		assert.Contains(t, out, "EXISTS",
@@ -315,7 +315,7 @@ func TestOutputGoogleEnumResultLine(t *testing.T) {
 			Method: google.MethodGmail,
 		}
 		var buf bytes.Buffer
-		outputGoogleEnumResultLine(&buf, r, false)
+		outputGoogleEnumResultLine(&buf, &r, false)
 		out := buf.String()
 
 		assert.Contains(t, out, "EXISTS",
@@ -332,7 +332,7 @@ func TestOutputGoogleEnumResultLine(t *testing.T) {
 			Exists: false,
 		}
 		var buf bytes.Buffer
-		outputGoogleEnumResultLine(&buf, r, false)
+		outputGoogleEnumResultLine(&buf, &r, false)
 		out := buf.String()
 
 		assert.Contains(t, out, "not found",
@@ -352,7 +352,7 @@ func TestOutputGoogleEnumResultLine(t *testing.T) {
 			IdP:    maliciousIdP,
 		}
 		var buf bytes.Buffer
-		outputGoogleEnumResultLine(&buf, r, false)
+		outputGoogleEnumResultLine(&buf, &r, false)
 		out := buf.String()
 
 		// Raw ESC byte must not appear in the output.

--- a/cmd/brutus/cmd_enum_gravatar.go
+++ b/cmd/brutus/cmd_enum_gravatar.go
@@ -163,7 +163,7 @@ func runEnumGravatar(cmd *cobra.Command, args []string) error {
 			// Clear the in-place bar before printing a result row so the bar's
 			// partial line doesn't corrupt it; the bar redraws on the next tick.
 			progress.Clear()
-			outputGravatarEnumResultLine(os.Stdout, res, useColor)
+			outputGravatarEnumResultLine(os.Stdout, &res, useColor)
 		}
 
 		progress.Update(processed, fmt.Sprintf("%d found", found))

--- a/cmd/brutus/cmd_enum_gravatar_output.go
+++ b/cmd/brutus/cmd_enum_gravatar_output.go
@@ -31,7 +31,7 @@ import (
 // EXISTS rows show the email and an "[+] EXISTS" label; not-found rows render as
 // "[ ] not found". Callers decide which results to print (e.g. EXISTS only,
 // unless verbose); this helper renders whatever it is given.
-func outputGravatarEnumResultLine(w io.Writer, r gravatar.Result, useColor bool) {
+func outputGravatarEnumResultLine(w io.Writer, r *gravatar.Result, useColor bool) {
 	email := truncate(sanitizeTerminal(r.Email), 40)
 
 	if !r.Exists {
@@ -91,7 +91,7 @@ type gravatarEnumJSON struct {
 }
 
 // encodeGravatarEnumResult maps a gravatar.Result to its JSONL row.
-func encodeGravatarEnumResult(r gravatar.Result) gravatarEnumJSON {
+func encodeGravatarEnumResult(r *gravatar.Result) gravatarEnumJSON {
 	jr := gravatarEnumJSON{
 		Email:     r.Email,
 		First:     r.First,
@@ -111,7 +111,7 @@ func encodeGravatarEnumResult(r gravatar.Result) gravatarEnumJSON {
 func outputGravatarEnumJSONL(w io.Writer, results []gravatar.Result) {
 	enc := json.NewEncoder(w)
 	for i := range results {
-		if err := enc.Encode(encodeGravatarEnumResult(results[i])); err != nil {
+		if err := enc.Encode(encodeGravatarEnumResult(&results[i])); err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "Error encoding gravatar enum JSON: %v\n", err)
 		}
 	}

--- a/cmd/brutus/cmd_enum_output.go
+++ b/cmd/brutus/cmd_enum_output.go
@@ -933,7 +933,7 @@ func presence(token string) string {
 // The server-controlled IdP host is sanitized via sanitizeTerminal (P0-4).
 // Callers decide which results to print (e.g. EXISTS only, unless verbose); this
 // helper renders whatever it is given.
-func outputGoogleEnumResultLine(w io.Writer, r google.Result, useColor bool) {
+func outputGoogleEnumResultLine(w io.Writer, r *google.Result, useColor bool) {
 	email := truncate(sanitizeTerminal(r.Email), 40)
 
 	if !r.Exists {


### PR DESCRIPTION
Fixes the failing **CI Lint** job on `main`. **9 files, +15/−15.**

## Cause — mine, from 10T-535 1/8

CI Lint has been failing since `0158718` (#304). That PR added `First`/`Last` to the per-service `Result` structs, which pushed four of them past `gocritic`'s `hugeParam` threshold, so functions taking them by value started tripping the linter:

| Function | Size |
|---|---|
| `cmd_enum_github_output.go:31` `outputGithubEnumResultLine` | 88 bytes |
| `cmd_enum_gravatar_output.go:34` `outputGravatarEnumResultLine` | 96 bytes |
| `cmd_enum_gravatar_output.go:94` `encodeGravatarEnumResult` | 96 bytes |
| `cmd_enum_output.go:936` `outputGoogleEnumResultLine` | 104 bytes |

CI Lint was green at `5c7d7eb` (#299) and red from `0158718` onward, so this is squarely a regression from that series rather than anything pre-existing.

## Fix

All four now take a **pointer**, matching `outputTeamsEnumResultLine` which already did — same file, existing convention.

Pointers rather than `//nolint:gocritic` deliberately: it's the actual fix, it matches the neighbouring code, and it removes suppression debt instead of adding more. **Zero `nolint` directives added.**

Signatures and call sites only. The diff contains **no** string-literal or format-verb changes, so rendered output is byte-identical.

One note on the three `&res` sites: they're inside `onResult := func(res T)` callbacks, so `res` is a per-invocation parameter copy rather than a range variable — no aliasing hazard. Indexed sites use `&results[i]`.

## Verification

```
golangci-lint run ./...   0 issues   (verified on a CLEARED cache)
go build ./...            exit 0
go vet ./cmd/... ./pkg/enum/...   exit 0
go test ./... -count=1    all packages ok, 0 FAIL
gofmt -l (9 files)        clean
```

The cleared-cache run matters here: an identical-content sibling worktree was serving cached lint results under *its* paths, which masked the real baseline as a single `typecheck` error rather than the 4 `hugeParam` ones. Baseline was reproduced against pristine `f121406` to confirm the byte sizes above.

## Deliberately out of scope

`outputMicrosoft365EnumResultLine` and `encodeMicrosoft365EnumResult` keep their by-value signatures and existing `//nolint:gocritic` suppressions. They're pre-existing and CI-green, and converting them would churn 14 call sites inside what should be a narrow build fix.

Worth a follow-up though — and worth knowing that their suppression comments justify themselves as *"to mirror the Google enum output helpers"*, which is **stale as of this PR**, since Google now takes a pointer. Unifying on pointers everywhere would let both suppressions go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
