### PR TITLE
feat(enum): carry names through the google and microsoft365 enumerators (10T-535)

### DIFF
--- a/pkg/enum/google/google.go
+++ b/pkg/enum/google/google.go
@@ -60,9 +60,13 @@ const (
 // output layer. There are no secrets in this flow, so Error carries the raw
 // transport error.
 type Result struct {
-	Email  string
-	First  string // generated given name; empty if the address was supplied
-	Last   string // generated surname; empty if the address was supplied
+	Email string
+	// First and Last are copied from the originating enum.Target when
+	// enumerating via EnumerateTargetsWith. They are empty when the address
+	// arrived through EnumerateWith, which takes bare addresses and so has no
+	// name to carry. This package never derives a name from the local part.
+	First  string
+	Last   string
 	Exists bool
 	Method Method
 	IdP    string
@@ -123,16 +127,45 @@ func (e *Enumerator) Enumerate(ctx context.Context, emails []string, threads int
 	return e.EnumerateWith(ctx, emails, threads, rateLimit, jitter, nil)
 }
 
-// EnumerateWith runs enumeration with bounded concurrency and invokes onResult
-// (if non-nil) for each completed result, serialized so callers can print/stream
-// safely. It still returns all results in input order.
+// EnumerateWith runs enumeration over bare addresses. It is a thin adapter over
+// EnumerateTargetsWith, which holds the single implementation: each address is
+// promoted to a nameless enum.Target. Because a bare address says nothing about
+// whose it is, every returned Result has empty First/Last — callers that know
+// the name behind an address should use EnumerateTargetsWith instead.
+//
+// The signature, ordering and callback semantics are unchanged; see
+// EnumerateTargetsWith for the callback contract.
+func (e *Enumerator) EnumerateWith(ctx context.Context, emails []string, threads int, rateLimit float64, jitter time.Duration, onResult func(Result)) []Result {
+	targets := make([]enum.Target, len(emails))
+	for i, email := range emails {
+		targets[i] = enum.Target{Email: email}
+	}
+	return e.EnumerateTargetsWith(ctx, targets, threads, rateLimit, jitter, onResult)
+}
+
+// EnumerateTargetsWith runs enumeration with bounded concurrency over targets
+// that carry the name behind each address, and invokes onResult (if non-nil) for
+// each completed result, serialized so callers can print/stream safely. It
+// returns all results in input order.
+//
+// The name travels with the target rather than being recovered afterwards, so a
+// consumer of this package never has to reverse-derive a name from the local
+// part — a lossy guess for initial-based formats, where "jsmith" could be John,
+// James or Jane. Each Result is stamped with the name of the target that
+// produced it (never a neighboring target's).
+//
+// A name is a property of the address, not of the check outcome, so the stamp is
+// applied on every path: a completed check, context cancellation, a rate-limiter
+// error, cancellation during jitter, and panic recovery. A failed probe still
+// reports whose address failed. Targets without a name (operator-supplied
+// addresses) stay nameless; no name is ever invented.
 //
 // onResult is called under the same mutex that guards the results slice, so
 // callback invocations never interleave and never race the slice. The callback
 // must therefore be cheap and self-contained: it may write to an io.Writer or
 // update counters, but it must NOT call back into the Enumerator (doing so risks
 // deadlock and defeats the serialization guarantee).
-func (e *Enumerator) EnumerateWith(ctx context.Context, emails []string, threads int, rateLimit float64, jitter time.Duration, onResult func(Result)) []Result {
+func (e *Enumerator) EnumerateTargetsWith(ctx context.Context, targets []enum.Target, threads int, rateLimit float64, jitter time.Duration, onResult func(Result)) []Result {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -150,12 +183,20 @@ func (e *Enumerator) EnumerateWith(ctx context.Context, emails []string, threads
 		limiter = rate.NewLimiter(rate.Limit(rateLimit), 1)
 	}
 
-	results := make([]Result, len(emails))
+	results := make([]Result, len(targets))
 	var mu sync.Mutex
 
-	// record stores a completed result and, under the same lock, invokes the
-	// caller's callback so streamed output is serialized and slice-safe.
+	// record stamps the originating target's name onto the result, stores it and,
+	// under the same lock, invokes the caller's callback so streamed output is
+	// serialized and slice-safe.
+	//
+	// The stamp lives here, at the single point every outcome funnels through, so
+	// that error and panic-recovery results carry their name too. Stamping at the
+	// individual call sites instead is how names end up on successes but not
+	// failures. targets is read-only, so the copy needs no lock.
 	record := func(i int, res Result) {
+		res.First, res.Last = targets[i].First, targets[i].Last
+
 		mu.Lock()
 		defer mu.Unlock()
 		results[i] = res
@@ -164,8 +205,8 @@ func (e *Enumerator) EnumerateWith(ctx context.Context, emails []string, threads
 		}
 	}
 
-	for i, email := range emails {
-		i, email := i, email
+	for i, t := range targets {
+		email := t.Email
 		g.Go(func() error {
 			defer func() {
 				if r := recover(); r != nil {

--- a/pkg/enum/google/google_targets_test.go
+++ b/pkg/enum/google/google_targets_test.go
@@ -1,0 +1,312 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// RED-phase tests for EnumerateTargetsWith, the Target-accepting sibling of
+// EnumerateWith. These tests assert that names travel with their originating
+// enum.Target all the way through to the Result that address produced,
+// correlated by email (never by index/order, since the worker pool is
+// concurrent). EnumerateTargetsWith does not exist yet; this file is expected
+// to fail to compile until it is added to google.go.
+package google
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/brutus/pkg/enum"
+)
+
+// newTargetsMockServer builds an httptest.Server that reports every account as
+// existing via the GXLU Gmail probe (AccountChooser always reports
+// not-found, so every check falls through to GXLU). Emails whose local part
+// contains "fail" cause the GXLU request to be hijacked and the underlying
+// connection closed without a response, producing a genuine transport-level
+// error out of CheckAccount -- used to prove a name survives the error path.
+func newTargetsMockServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/AccountChooser", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", "https://accounts.google.com/ServiceLogin")
+		w.WriteHeader(http.StatusFound)
+	})
+
+	mux.HandleFunc("/mail/gxlu", func(w http.ResponseWriter, r *http.Request) {
+		email := r.URL.Query().Get("email")
+		if strings.Contains(email, "fail") {
+			if hj, ok := w.(http.Hijacker); ok {
+				if conn, _, err := hj.Hijack(); err == nil {
+					_ = conn.Close()
+				}
+				return
+			}
+		}
+		http.SetCookie(w, &http.Cookie{Name: "GMAIL_AT", Value: "tok"})
+		w.WriteHeader(http.StatusOK)
+	})
+
+	return httptest.NewServer(mux)
+}
+
+// ---------------------------------------------------------------------------
+// TestGoogleEnumerateTargetsWith_NamesRideOnResult
+// Core test: 3 targets with distinct names against a stub that reports
+// existence for all of them. Each returned Result must carry the name of the
+// target that produced it, correlated by email. An implementation that
+// stamps every Result with the first target's name fails this test.
+// ---------------------------------------------------------------------------
+
+func TestGoogleEnumerateTargetsWith_NamesRideOnResult(t *testing.T) {
+	t.Parallel()
+	srv := newTargetsMockServer(t)
+	t.Cleanup(srv.Close)
+
+	e := newTestEnumerator(t, srv)
+
+	targets := []enum.Target{
+		{Email: "jsmith@x.com", First: "john", Last: "smith"},
+		{Email: "dsmith@x.com", First: "david", Last: "smith"},
+		{Email: "msmith@x.com", First: "michael", Last: "smith"},
+	}
+
+	results := e.EnumerateTargetsWith(context.Background(), targets, 4, 0, 0, nil)
+	require.Len(t, results, len(targets), "one Result per Target")
+
+	byEmail := make(map[string]Result, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	for _, tgt := range targets {
+		r, ok := byEmail[tgt.Email]
+		require.True(t, ok, "result for %q must be present", tgt.Email)
+		assert.Equal(t, tgt.First, r.First, "First for %q must match its own Target, not another target's", tgt.Email)
+		assert.Equal(t, tgt.Last, r.Last, "Last for %q must match its own Target, not another target's", tgt.Email)
+		assert.NoError(t, r.Error, "%q must succeed against the stub", tgt.Email)
+		assert.True(t, r.Exists, "%q must be reported as existing by the stub", tgt.Email)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestGoogleEnumerateTargetsWith_NamelessTargetStaysNameless
+// A Target with no name (address supplied by the operator, not generated)
+// must yield First=="" && Last=="". The library must never invent a name.
+// ---------------------------------------------------------------------------
+
+func TestGoogleEnumerateTargetsWith_NamelessTargetStaysNameless(t *testing.T) {
+	t.Parallel()
+	srv := newTargetsMockServer(t)
+	t.Cleanup(srv.Close)
+
+	e := newTestEnumerator(t, srv)
+
+	targets := []enum.Target{{Email: "supplied@x.com"}}
+
+	results := e.EnumerateTargetsWith(context.Background(), targets, 1, 0, 0, nil)
+	require.Len(t, results, 1)
+	assert.Empty(t, results[0].First, "First must stay empty for a nameless Target")
+	assert.Empty(t, results[0].Last, "Last must stay empty for a nameless Target")
+}
+
+// ---------------------------------------------------------------------------
+// TestGoogleEnumerateWith_StillWorksAndYieldsEmptyNames
+// Pins that the existing EnumerateWith([]string) entry point is unaffected by
+// the refactor: it still returns correct results, and since bare addresses
+// carry no name, First/Last must be empty.
+// ---------------------------------------------------------------------------
+
+func TestGoogleEnumerateWith_StillWorksAndYieldsEmptyNames(t *testing.T) {
+	t.Parallel()
+	srv := newTargetsMockServer(t)
+	t.Cleanup(srv.Close)
+
+	e := newTestEnumerator(t, srv)
+
+	emails := []string{"a@x.com", "b@x.com", "c@x.com"}
+	results := e.EnumerateWith(context.Background(), emails, 3, 0, 0, nil)
+	require.Len(t, results, len(emails))
+
+	byEmail := make(map[string]Result, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	for _, email := range emails {
+		r, ok := byEmail[email]
+		require.True(t, ok, "result for %q must be present", email)
+		assert.NoError(t, r.Error, "%q must succeed against the stub", email)
+		assert.True(t, r.Exists, "%q must be reported as existing by the stub", email)
+		assert.Empty(t, r.First, "EnumerateWith must never invent a name")
+		assert.Empty(t, r.Last, "EnumerateWith must never invent a name")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestGoogleEnumerateTargetsWith_NamesSurviveErrorPath
+// A name is a property of the address, not of the check outcome. Drive a
+// Result whose Error is non-nil (GXLU connection hijacked/closed) and assert
+// the name is still stamped.
+// ---------------------------------------------------------------------------
+
+func TestGoogleEnumerateTargetsWith_NamesSurviveErrorPath(t *testing.T) {
+	t.Parallel()
+	srv := newTargetsMockServer(t)
+	t.Cleanup(srv.Close)
+
+	e := newTestEnumerator(t, srv)
+
+	targets := []enum.Target{
+		{Email: "failure@x.com", First: "erin", Last: "fail"},
+	}
+
+	results := e.EnumerateTargetsWith(context.Background(), targets, 1, 0, 0, nil)
+	require.Len(t, results, 1)
+
+	r := results[0]
+	assert.Equal(t, "failure@x.com", r.Email)
+	require.Error(t, r.Error, "the hijacked GXLU connection must surface as a transport error")
+	assert.Equal(t, "erin", r.First, "name must survive even when the probe errors")
+	assert.Equal(t, "fail", r.Last, "name must survive even when the probe errors")
+}
+
+// ---------------------------------------------------------------------------
+// TestGoogleEnumerateTargetsWith_MixedNamedAndUnnamed
+// A single batch containing both named and unnamed targets: each Result must
+// get exactly its own target's name, or empty for the unnamed ones.
+// ---------------------------------------------------------------------------
+
+func TestGoogleEnumerateTargetsWith_MixedNamedAndUnnamed(t *testing.T) {
+	t.Parallel()
+	srv := newTargetsMockServer(t)
+	t.Cleanup(srv.Close)
+
+	e := newTestEnumerator(t, srv)
+
+	targets := []enum.Target{
+		{Email: "named1@x.com", First: "anna", Last: "lee"},
+		{Email: "unnamed1@x.com"},
+		{Email: "named2@x.com", First: "bob", Last: "wu"},
+		{Email: "unnamed2@x.com"},
+	}
+
+	results := e.EnumerateTargetsWith(context.Background(), targets, 4, 0, 0, nil)
+	require.Len(t, results, len(targets))
+
+	byEmail := make(map[string]Result, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	for _, tgt := range targets {
+		r, ok := byEmail[tgt.Email]
+		require.True(t, ok, "result for %q must be present", tgt.Email)
+		assert.Equal(t, tgt.First, r.First, "First for %q", tgt.Email)
+		assert.Equal(t, tgt.Last, r.Last, "Last for %q", tgt.Email)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestGoogleEnumerateTargetsWith_OrderingAndLength
+// len(results) == len(targets) and every index is filled even when some
+// probes fail. Completion order is not asserted (the worker pool is
+// concurrent); correlation is by email.
+// ---------------------------------------------------------------------------
+
+func TestGoogleEnumerateTargetsWith_OrderingAndLength(t *testing.T) {
+	t.Parallel()
+	srv := newTargetsMockServer(t)
+	t.Cleanup(srv.Close)
+
+	e := newTestEnumerator(t, srv)
+
+	targets := []enum.Target{
+		{Email: "ok1@x.com", First: "carl", Last: "one"},
+		{Email: "fail1@x.com", First: "dana", Last: "two"},
+		{Email: "ok2@x.com", First: "ella", Last: "three"},
+		{Email: "fail2@x.com", First: "finn", Last: "four"},
+	}
+
+	results := e.EnumerateTargetsWith(context.Background(), targets, 4, 0, 0, nil)
+	require.Len(t, results, len(targets), "one result per target regardless of probe failures")
+
+	byEmail := make(map[string]Result, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	for _, tgt := range targets {
+		r, ok := byEmail[tgt.Email]
+		require.True(t, ok, "no dropped slot for %q", tgt.Email)
+		assert.Equal(t, tgt.First, r.First)
+		assert.Equal(t, tgt.Last, r.Last)
+	}
+
+	// Confirm the engineered failures actually failed and the others didn't,
+	// proving this test exercises a genuinely mixed batch.
+	assert.Error(t, byEmail["fail1@x.com"].Error)
+	assert.Error(t, byEmail["fail2@x.com"].Error)
+	assert.NoError(t, byEmail["ok1@x.com"].Error)
+	assert.NoError(t, byEmail["ok2@x.com"].Error)
+}
+
+// ---------------------------------------------------------------------------
+// TestGoogleEnumerateTargetsWith_NamesSurviveCancelledContext
+// Chokepoint test: with the context already canceled before the call, every
+// goroutine takes the <-ctx.Done() early-return branch and calls
+// record(i, Result{Email: email, Error: ctx.Err()}) WITHOUT ever calling
+// CheckAccount. If the name stamp lived only at the CheckAccount call site
+// (record(i, e.CheckAccount(...))) rather than inside record() itself, these
+// Results would come back nameless. This is what makes record() the enforced
+// chokepoint rather than an incidental detail.
+// ---------------------------------------------------------------------------
+
+func TestGoogleEnumerateTargetsWith_NamesSurviveCancelledContext(t *testing.T) {
+	t.Parallel()
+	srv := newTargetsMockServer(t)
+	t.Cleanup(srv.Close)
+
+	e := newTestEnumerator(t, srv)
+
+	targets := []enum.Target{
+		{Email: "one@x.com", First: "gwen", Last: "alpha"},
+		{Email: "two@x.com", First: "hank", Last: "beta"},
+		{Email: "three@x.com", First: "iris", Last: "gamma"},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // canceled BEFORE the call
+
+	results := e.EnumerateTargetsWith(ctx, targets, 1, 0, 0, nil)
+	require.Len(t, results, len(targets))
+
+	byEmail := make(map[string]Result, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	for _, tgt := range targets {
+		r, ok := byEmail[tgt.Email]
+		require.True(t, ok, "result for %q must be present", tgt.Email)
+		require.Error(t, r.Error, "an already-canceled context must surface as a non-nil Error for %q", tgt.Email)
+		assert.Equal(t, tgt.First, r.First, "First for %q must survive the ctx.Done() early return", tgt.Email)
+		assert.Equal(t, tgt.Last, r.Last, "Last for %q must survive the ctx.Done() early return", tgt.Email)
+	}
+}

--- a/pkg/enum/microsoft365/microsoft365.go
+++ b/pkg/enum/microsoft365/microsoft365.go
@@ -59,9 +59,13 @@ type credTypeResponse struct {
 // Result is the outcome of checking a single email against the
 // GetCredentialType API.
 type Result struct {
-	Email          string
-	First          string // generated given name; empty if the address was supplied
-	Last           string // generated surname; empty if the address was supplied
+	Email string
+	// First and Last are copied from the originating enum.Target when
+	// enumerating via EnumerateTargetsWith. They are empty when the address
+	// arrived through EnumerateWith, which takes bare addresses and so has no
+	// name to carry. This package never derives a name from the local part.
+	First          string
+	Last           string
 	Exists         bool
 	IfExistsResult int
 	Federated      bool
@@ -112,16 +116,45 @@ func (c *Checker) Enumerate(ctx context.Context, emails []string, threads int, r
 	return c.EnumerateWith(ctx, emails, threads, rateLimit, jitter, nil)
 }
 
-// EnumerateWith runs enumeration with bounded concurrency and invokes onResult
-// (if non-nil) for each completed result, serialized so callers can print/stream
-// safely. It still returns all results in input order.
+// EnumerateWith runs enumeration over bare addresses. It is a thin adapter over
+// EnumerateTargetsWith, which holds the single implementation: each address is
+// promoted to a nameless enum.Target. Because a bare address says nothing about
+// whose it is, every returned Result has empty First/Last — callers that know
+// the name behind an address should use EnumerateTargetsWith instead.
+//
+// The signature, ordering and callback semantics are unchanged; see
+// EnumerateTargetsWith for the callback contract.
+func (c *Checker) EnumerateWith(ctx context.Context, emails []string, threads int, rateLimit float64, jitter time.Duration, onResult func(Result)) []Result {
+	targets := make([]enum.Target, len(emails))
+	for i, email := range emails {
+		targets[i] = enum.Target{Email: email}
+	}
+	return c.EnumerateTargetsWith(ctx, targets, threads, rateLimit, jitter, onResult)
+}
+
+// EnumerateTargetsWith runs enumeration with bounded concurrency over targets
+// that carry the name behind each address, and invokes onResult (if non-nil) for
+// each completed result, serialized so callers can print/stream safely. It
+// returns all results in input order.
+//
+// The name travels with the target rather than being recovered afterwards, so a
+// consumer of this package never has to reverse-derive a name from the local
+// part — a lossy guess for initial-based formats, where "jsmith" could be John,
+// James or Jane. Each Result is stamped with the name of the target that
+// produced it (never a neighboring target's).
+//
+// A name is a property of the address, not of the check outcome, so the stamp is
+// applied on every path: a completed check, context cancellation, a rate-limiter
+// error, cancellation during jitter, a nil result from CheckAccount, and panic
+// recovery. A failed probe still reports whose address failed. Targets without a
+// name (operator-supplied addresses) stay nameless; no name is ever invented.
 //
 // onResult is called under the same mutex that guards the results slice, so
 // callback invocations never interleave and never race the slice. The callback
 // must therefore be cheap and self-contained: it may write to an io.Writer or
 // update counters, but it must NOT call back into the Checker (doing so risks
 // deadlock and defeats the serialization guarantee).
-func (c *Checker) EnumerateWith(ctx context.Context, emails []string, threads int, rateLimit float64, jitter time.Duration, onResult func(Result)) []Result {
+func (c *Checker) EnumerateTargetsWith(ctx context.Context, targets []enum.Target, threads int, rateLimit float64, jitter time.Duration, onResult func(Result)) []Result {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -139,12 +172,20 @@ func (c *Checker) EnumerateWith(ctx context.Context, emails []string, threads in
 		limiter = rate.NewLimiter(rate.Limit(rateLimit), 1)
 	}
 
-	results := make([]Result, len(emails))
+	results := make([]Result, len(targets))
 	var mu sync.Mutex
 
-	// record stores a completed result and, under the same lock, invokes the
-	// caller's callback so streamed output is serialized and slice-safe.
+	// record stamps the originating target's name onto the result, stores it and,
+	// under the same lock, invokes the caller's callback so streamed output is
+	// serialized and slice-safe.
+	//
+	// The stamp lives here, at the single point every outcome funnels through, so
+	// that error and panic-recovery results carry their name too. Stamping at the
+	// individual call sites instead is how names end up on successes but not
+	// failures. targets is read-only, so the copy needs no lock.
 	record := func(i int, res Result) {
+		res.First, res.Last = targets[i].First, targets[i].Last
+
 		mu.Lock()
 		defer mu.Unlock()
 		results[i] = res
@@ -153,8 +194,8 @@ func (c *Checker) EnumerateWith(ctx context.Context, emails []string, threads in
 		}
 	}
 
-	for i, email := range emails {
-		i, email := i, email
+	for i, t := range targets {
+		email := t.Email
 		g.Go(func() error {
 			defer func() {
 				if r := recover(); r != nil {

--- a/pkg/enum/microsoft365/microsoft365_targets_test.go
+++ b/pkg/enum/microsoft365/microsoft365_targets_test.go
@@ -1,0 +1,319 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// RED-phase tests for EnumerateTargetsWith, the Target-accepting sibling of
+// EnumerateWith. These tests assert that names travel with their originating
+// enum.Target all the way through to the Result that address produced,
+// correlated by email (never by index/order, since the worker pool is
+// concurrent). EnumerateTargetsWith does not exist yet; this file is expected
+// to fail to compile until it is added to microsoft365.go.
+package microsoft365
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/brutus/pkg/enum"
+)
+
+// newTargetsMockServer builds an httptest.Server that reports every account
+// as existing (IfExistsResult=0), except usernames whose local part contains
+// "fail", which get a 500 response -- CheckAccount turns that into a genuine
+// non-nil Result.Error ("unexpected status: 500") -- used to prove a name
+// survives the error path.
+func newTargetsMockServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		var req credTypeRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		if strings.Contains(req.Username, "fail") {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(credTypeResponse{IfExistsResult: IfExistsResultExists})
+	}))
+}
+
+// ---------------------------------------------------------------------------
+// TestEnumerateTargetsWith_NamesRideOnResult
+// Core test: 3 targets with distinct names against a stub that reports
+// existence for all of them. Each returned Result must carry the name of the
+// target that produced it, correlated by email. An implementation that
+// stamps every Result with the first target's name fails this test.
+// ---------------------------------------------------------------------------
+
+func TestEnumerateTargetsWith_NamesRideOnResult(t *testing.T) {
+	t.Parallel()
+	srv := newTargetsMockServer(t)
+	t.Cleanup(srv.Close)
+
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
+
+	targets := []enum.Target{
+		{Email: "jsmith@x.com", First: "john", Last: "smith"},
+		{Email: "dsmith@x.com", First: "david", Last: "smith"},
+		{Email: "msmith@x.com", First: "michael", Last: "smith"},
+	}
+
+	results := c.EnumerateTargetsWith(context.Background(), targets, 4, 0, 0, nil)
+	require.Len(t, results, len(targets), "one Result per Target")
+
+	byEmail := make(map[string]Result, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	for _, tgt := range targets {
+		r, ok := byEmail[tgt.Email]
+		require.True(t, ok, "result for %q must be present", tgt.Email)
+		assert.Equal(t, tgt.First, r.First, "First for %q must match its own Target, not another target's", tgt.Email)
+		assert.Equal(t, tgt.Last, r.Last, "Last for %q must match its own Target, not another target's", tgt.Email)
+		assert.NoError(t, r.Error, "%q must succeed against the stub", tgt.Email)
+		assert.True(t, r.Exists, "%q must be reported as existing by the stub", tgt.Email)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestEnumerateTargetsWith_NamelessTargetStaysNameless
+// A Target with no name (address supplied by the operator, not generated)
+// must yield First=="" && Last=="". The library must never invent a name.
+// ---------------------------------------------------------------------------
+
+func TestEnumerateTargetsWith_NamelessTargetStaysNameless(t *testing.T) {
+	t.Parallel()
+	srv := newTargetsMockServer(t)
+	t.Cleanup(srv.Close)
+
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
+
+	targets := []enum.Target{{Email: "supplied@x.com"}}
+
+	results := c.EnumerateTargetsWith(context.Background(), targets, 1, 0, 0, nil)
+	require.Len(t, results, 1)
+	assert.Empty(t, results[0].First, "First must stay empty for a nameless Target")
+	assert.Empty(t, results[0].Last, "Last must stay empty for a nameless Target")
+}
+
+// ---------------------------------------------------------------------------
+// TestEnumerateWith_StillWorksAndYieldsEmptyNames
+// Pins that the existing EnumerateWith([]string) entry point is unaffected by
+// the refactor: it still returns correct results, and since bare addresses
+// carry no name, First/Last must be empty.
+// ---------------------------------------------------------------------------
+
+func TestEnumerateWith_StillWorksAndYieldsEmptyNames(t *testing.T) {
+	t.Parallel()
+	srv := newTargetsMockServer(t)
+	t.Cleanup(srv.Close)
+
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
+
+	emails := []string{"a@x.com", "b@x.com", "c@x.com"}
+	results := c.EnumerateWith(context.Background(), emails, 3, 0, 0, nil)
+	require.Len(t, results, len(emails))
+
+	byEmail := make(map[string]Result, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	for _, email := range emails {
+		r, ok := byEmail[email]
+		require.True(t, ok, "result for %q must be present", email)
+		assert.NoError(t, r.Error, "%q must succeed against the stub", email)
+		assert.True(t, r.Exists, "%q must be reported as existing by the stub", email)
+		assert.Empty(t, r.First, "EnumerateWith must never invent a name")
+		assert.Empty(t, r.Last, "EnumerateWith must never invent a name")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestEnumerateTargetsWith_NamesSurviveErrorPath
+// A name is a property of the address, not of the check outcome. Drive a
+// Result whose Error is non-nil (stub returns 500 -> "unexpected status") and
+// assert the name is still stamped.
+// ---------------------------------------------------------------------------
+
+func TestEnumerateTargetsWith_NamesSurviveErrorPath(t *testing.T) {
+	t.Parallel()
+	srv := newTargetsMockServer(t)
+	t.Cleanup(srv.Close)
+
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
+
+	targets := []enum.Target{
+		{Email: "failure@x.com", First: "erin", Last: "fail"},
+	}
+
+	results := c.EnumerateTargetsWith(context.Background(), targets, 1, 0, 0, nil)
+	require.Len(t, results, 1)
+
+	r := results[0]
+	assert.Equal(t, "failure@x.com", r.Email)
+	require.Error(t, r.Error, "the 500 response must surface as a non-nil Result.Error")
+	assert.Equal(t, "erin", r.First, "name must survive even when the probe errors")
+	assert.Equal(t, "fail", r.Last, "name must survive even when the probe errors")
+}
+
+// ---------------------------------------------------------------------------
+// TestEnumerateTargetsWith_MixedNamedAndUnnamed
+// A single batch containing both named and unnamed targets: each Result must
+// get exactly its own target's name, or empty for the unnamed ones.
+// ---------------------------------------------------------------------------
+
+func TestEnumerateTargetsWith_MixedNamedAndUnnamed(t *testing.T) {
+	t.Parallel()
+	srv := newTargetsMockServer(t)
+	t.Cleanup(srv.Close)
+
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
+
+	targets := []enum.Target{
+		{Email: "named1@x.com", First: "anna", Last: "lee"},
+		{Email: "unnamed1@x.com"},
+		{Email: "named2@x.com", First: "bob", Last: "wu"},
+		{Email: "unnamed2@x.com"},
+	}
+
+	results := c.EnumerateTargetsWith(context.Background(), targets, 4, 0, 0, nil)
+	require.Len(t, results, len(targets))
+
+	byEmail := make(map[string]Result, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	for _, tgt := range targets {
+		r, ok := byEmail[tgt.Email]
+		require.True(t, ok, "result for %q must be present", tgt.Email)
+		assert.Equal(t, tgt.First, r.First, "First for %q", tgt.Email)
+		assert.Equal(t, tgt.Last, r.Last, "Last for %q", tgt.Email)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestEnumerateTargetsWith_OrderingAndLength
+// len(results) == len(targets) and every index is filled even when some
+// probes fail. Completion order is not asserted (the worker pool is
+// concurrent); correlation is by email.
+// ---------------------------------------------------------------------------
+
+func TestEnumerateTargetsWith_OrderingAndLength(t *testing.T) {
+	t.Parallel()
+	srv := newTargetsMockServer(t)
+	t.Cleanup(srv.Close)
+
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
+
+	targets := []enum.Target{
+		{Email: "ok1@x.com", First: "carl", Last: "one"},
+		{Email: "fail1@x.com", First: "dana", Last: "two"},
+		{Email: "ok2@x.com", First: "ella", Last: "three"},
+		{Email: "fail2@x.com", First: "finn", Last: "four"},
+	}
+
+	results := c.EnumerateTargetsWith(context.Background(), targets, 4, 0, 0, nil)
+	require.Len(t, results, len(targets), "one result per target regardless of probe failures")
+
+	byEmail := make(map[string]Result, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	for _, tgt := range targets {
+		r, ok := byEmail[tgt.Email]
+		require.True(t, ok, "no dropped slot for %q", tgt.Email)
+		assert.Equal(t, tgt.First, r.First)
+		assert.Equal(t, tgt.Last, r.Last)
+	}
+
+	// Confirm the engineered failures actually failed and the others didn't,
+	// proving this test exercises a genuinely mixed batch.
+	assert.Error(t, byEmail["fail1@x.com"].Error)
+	assert.Error(t, byEmail["fail2@x.com"].Error)
+	assert.NoError(t, byEmail["ok1@x.com"].Error)
+	assert.NoError(t, byEmail["ok2@x.com"].Error)
+}
+
+// ---------------------------------------------------------------------------
+// TestEnumerateTargetsWith_NamesSurviveCancelledContext
+// Chokepoint test: with the context already canceled before the call, every
+// goroutine takes the <-ctx.Done() early-return branch and calls
+// record(i, Result{Email: email, Error: ctx.Err()}) WITHOUT ever calling
+// CheckAccount. If the name stamp lived only at the CheckAccount call site
+// (record(i, *c.CheckAccount(...))) rather than inside record() itself, these
+// Results would come back nameless. This is what makes record() the enforced
+// chokepoint rather than an incidental detail.
+// ---------------------------------------------------------------------------
+
+func TestEnumerateTargetsWith_NamesSurviveCancelledContext(t *testing.T) {
+	t.Parallel()
+	srv := newTargetsMockServer(t)
+	t.Cleanup(srv.Close)
+
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
+
+	targets := []enum.Target{
+		{Email: "one@x.com", First: "gwen", Last: "alpha"},
+		{Email: "two@x.com", First: "hank", Last: "beta"},
+		{Email: "three@x.com", First: "iris", Last: "gamma"},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // canceled BEFORE the call
+
+	results := c.EnumerateTargetsWith(ctx, targets, 1, 0, 0, nil)
+	require.Len(t, results, len(targets))
+
+	byEmail := make(map[string]Result, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	for _, tgt := range targets {
+		r, ok := byEmail[tgt.Email]
+		require.True(t, ok, "result for %q must be present", tgt.Email)
+		require.Error(t, r.Error, "an already-canceled context must surface as a non-nil Error for %q", tgt.Email)
+		assert.Equal(t, tgt.First, r.First, "First for %q must survive the ctx.Done() early return", tgt.Email)
+		assert.Equal(t, tgt.Last, r.Last, "Last for %q must survive the ctx.Done() early return", tgt.Email)
+	}
+}


### PR DESCRIPTION
Makes `Result.First`/`Last` in the google and microsoft365 enumerators actually work, so a library consumer never has to reverse-derive a name from a local-part.

## The bug is a field that lies

Both packages declare these on their `Result`:

```go
First  string // generated given name; empty if the address was supplied
Last   string // generated surname; empty if the address was supplied
```

That comment describes a working field. **Neither package ever assigns them** — `grep 'First:' pkg/enum/google/google.go` returns nothing. The only code that fills them is `cmd/brutus` (`cmd_enum_google.go:149`), after the library returns.

So the CLI shows names, and anyone importing the package directly reads `r.First`, gets `""`, and has nothing to explain why. No compile error, no runtime error. Guard is exactly that consumer, and only avoided shipping blank names because we read this source rather than trusting the field.

The root cause is the batch API: `EnumerateWith` takes `[]string`, so a name cannot reach the library even in principle.

## The fix

```go
// new — the name travels with the address
func (e *Enumerator) EnumerateTargetsWith(ctx, targets []enum.Target, threads int, rateLimit float64, jitter time.Duration, onResult func(Result)) []Result

// existing — signature untouched, now a thin adapter
func (e *Enumerator) EnumerateWith(ctx, emails []string, ...) []Result
```

`enum.Target` is the `{Email, First, Last}` type `pkg/enum` already defines and documents as superseding bare address lists. `EnumerateWith` promotes each address to a nameless `Target` and delegates, so there's **one** implementation and **zero** impact on existing callers — including the CLI, which keeps its own stamping (same values, harmless; removing it is follow-up).

## Why the stamp lives in `record`

```go
record := func(i int, res Result) {
	res.First, res.Last = targets[i].First, targets[i].Last
	mu.Lock()
	...
```

`record` is the single point every outcome funnels through, which is the only reason one line covers them all:

| Path | google | microsoft365 |
|---|---|---|
| completed check | ✓ | ✓ |
| `ctx.Done()` early return | ✓ | ✓ |
| rate-limiter error | ✓ | ✓ |
| cancellation during jitter | ✓ | ✓ |
| panic recovery | ✓ | ✓ |
| `nil` result guard after `CheckAccount` | — | ✓ |

Five sites in google, six in m365 — only m365's `CheckAccount` returns a pointer. A name is a property of the address, not of the check outcome, so a failed probe still reports whose address failed. Stamping at the individual call sites is how you get names on successes but not failures.

Indexed `targets[i]`, not a captured loop variable, so each Result gets **its own** target's name.

## The field comments are corrected

They now say what's true: copied from the originating `Target` under `EnumerateTargetsWith`, empty under `EnumerateWith` which has no name to carry, and never derived from the local-part. Fixing the mechanism while leaving the misleading comment would have solved half the problem.

## Tests

12 functions plus 2 chokepoint tests, 6+ per package: names riding on the Result **correlated by email rather than by index** (so stamping every result with the first target's name fails), nameless targets staying nameless, `EnumerateWith` still yielding empty names, names surviving the error path, mixed named/unnamed batches, and length/every-slot-filled without asserting completion order — the concurrent pool doesn't guarantee it.

**One test earns its place specifically.** An already-cancelled context reaches `record` without ever calling `CheckAccount`, which is what pins the stamp to the chokepoint. It was added after a mutation test showed the placement was justified only by reasoning: the errors the error-path test engineers originate *inside* `CheckAccount` and return normally, so they travel the same call site as successes — moving the stamp out of `record` left the whole suite green. With the cancelled-context test, that mutation now fails in both packages.

Mutations verified, each reverted:

| Mutation | Result |
|---|---|
| stamp from `targets[0]` not `targets[i]` | `NamesRideOnResult` fails, both packages |
| stamp at the `CheckAccount` call site only | `NamesSurviveCancelledContext` fails, both packages |
| nameless target derives from local-part | `NamelessTargetStaysNameless` fails, both packages |

## Verification

```
golangci-lint run ./...            0 issues.   (cold cache)
go test ./... -count=1             56 ok, 0 FAIL
go build ./...                     exit 0
go vet ./pkg/enum/... ./cmd/...    exit 0
gofmt -l                           clean
go test -race (both packages)      ok
```

golangci-lint was run cold and caught two real defects during development (a `misspell` in the implementation, three more in tests) — worth noting because an earlier change in this series was merged with a `gocritic hugeParam` regression precisely because only `go vet` and `gofmt` were run locally.

## Scope

google and microsoft365 only — the two with a library consumer. Deliberately **not** here:

- **github, gravatar, teams** keep the same latent issue. The CLI still stamps them correctly, so nothing breaks.
- **`cmd/brutus`'s stamping** stays. Once the library populates the fields it's redundant for these two, but removing it is a separate change.
- **The two `EnumerateTargetsWith` bodies are near-identical ~70-line twins.** Extracting a shared worker into `pkg/enum` is genuinely DRY-er and worth doing, but it's a cross-package refactor that belongs with the three remaining services rather than bundled here.

## What this unblocks

guard's PR #7605 currently builds its own address→name index because the library can't carry names. With this merged and released, both capabilities drop that helper entirely and read `r.First`/`r.Last` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
