### PR TITLE
refactor(enum): extract a shared TargetWorker and migrate google/m365 (10T-535, 1/3)

### DIFF
--- a/pkg/enum/google/google.go
+++ b/pkg/enum/google/google.go
@@ -23,17 +23,10 @@ package google
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"net/http"
 	"net/url"
-	"os"
-	"runtime/debug"
 	"strings"
-	"sync"
 	"time"
-
-	"golang.org/x/sync/errgroup"
-	"golang.org/x/time/rate"
 
 	"github.com/praetorian-inc/brutus/pkg/brutus"
 	"github.com/praetorian-inc/brutus/pkg/enum"
@@ -143,6 +136,26 @@ func (e *Enumerator) EnumerateWith(ctx context.Context, emails []string, threads
 	return e.EnumerateTargetsWith(ctx, targets, threads, rateLimit, jitter, onResult)
 }
 
+// newError builds the Result for failures the worker pool detects rather than
+// the probe: cancellation, a rate-limiter error, and panic recovery. google's
+// failure results carry no fields beyond the address and the error.
+func newError(email string, err error) Result {
+	return Result{Email: email, Error: err}
+}
+
+// worker returns the shared bounded worker pool configured for this
+// enumerator. It is a method (rather than inline in EnumerateTargetsWith) so
+// tests can assert the four hooks — in particular the Label that drives the
+// panic diagnostics, and newError's field shape — without running a pool.
+func (e *Enumerator) worker() enum.TargetWorker[Result] {
+	return enum.TargetWorker[Result]{
+		Label:     "google enum",
+		Check:     e.CheckAccount,
+		NewError:  newError,
+		StampName: func(r *Result, t enum.Target) { r.First, r.Last = t.First, t.Last },
+	}
+}
+
 // EnumerateTargetsWith runs enumeration with bounded concurrency over targets
 // that carry the name behind each address, and invokes onResult (if non-nil) for
 // each completed result, serialized so callers can print/stream safely. It
@@ -165,95 +178,10 @@ func (e *Enumerator) EnumerateWith(ctx context.Context, emails []string, threads
 // must therefore be cheap and self-contained: it may write to an io.Writer or
 // update counters, but it must NOT call back into the Enumerator (doing so risks
 // deadlock and defeats the serialization guarantee).
+//
+// The pool itself is enum.TargetWorker; see its doc comment for the full contract.
 func (e *Enumerator) EnumerateTargetsWith(ctx context.Context, targets []enum.Target, threads int, rateLimit float64, jitter time.Duration, onResult func(Result)) []Result {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	g, ctx := errgroup.WithContext(ctx)
-	// Normalize thread count: 0 would deadlock errgroup.SetLimit (no goroutine
-	// can ever run) and a negative value means unbounded. Clamp to a safe
-	// positive default of 1 (serial execution).
-	if threads <= 0 {
-		threads = 1
-	}
-	g.SetLimit(threads)
-
-	var limiter *rate.Limiter
-	if rateLimit > 0 {
-		limiter = rate.NewLimiter(rate.Limit(rateLimit), 1)
-	}
-
-	results := make([]Result, len(targets))
-	var mu sync.Mutex
-
-	// record stamps the originating target's name onto the result, stores it and,
-	// under the same lock, invokes the caller's callback so streamed output is
-	// serialized and slice-safe.
-	//
-	// The stamp lives here, at the single point every outcome funnels through, so
-	// that error and panic-recovery results carry their name too. Stamping at the
-	// individual call sites instead is how names end up on successes but not
-	// failures. targets is read-only, so the copy needs no lock.
-	record := func(i int, res Result) {
-		res.First, res.Last = targets[i].First, targets[i].Last
-
-		mu.Lock()
-		defer mu.Unlock()
-		results[i] = res
-		if onResult != nil {
-			onResult(res)
-		}
-	}
-
-	for i, t := range targets {
-		email := t.Email
-		g.Go(func() error {
-			defer func() {
-				if r := recover(); r != nil {
-					fmt.Fprintf(os.Stderr, "google enum: panic checking %s: %v\n%s\n", email, r, debug.Stack())
-					record(i, Result{
-						Email: email,
-						Error: fmt.Errorf("google enum: panicked: %v", r),
-					})
-				}
-			}()
-
-			select {
-			case <-ctx.Done():
-				// Record before returning so every index is filled and the callback fires exactly once per email.
-				record(i, Result{Email: email, Error: ctx.Err()})
-				return nil
-			default:
-			}
-
-			if limiter != nil {
-				if err := limiter.Wait(ctx); err != nil {
-					// Record before returning so every index is filled and the callback fires exactly once per email.
-					record(i, Result{Email: email, Error: err})
-					return nil
-				}
-				if jitter > 0 {
-					delay := time.Duration(rand.Int63n(int64(jitter)))
-					select {
-					case <-time.After(delay):
-					case <-ctx.Done():
-						// Record before returning so every index is filled and the callback fires exactly once per email.
-						record(i, Result{Email: email, Error: ctx.Err()})
-						return nil
-					}
-				}
-			}
-
-			record(i, e.CheckAccount(ctx, email))
-			return nil
-		})
-	}
-
-	// Discarding g.Wait()'s error is deliberate: worker goroutines never return
-	// a non-nil error (per-email failures are encoded in each Result), so the
-	// returned error is always nil.
-	_ = g.Wait()
-	return results
+	return e.worker().Run(ctx, targets, threads, rateLimit, jitter, onResult)
 }
 
 // CheckAccount checks whether a single Google account exists, trying the

--- a/pkg/enum/google/google_hooks_test.go
+++ b/pkg/enum/google/google_hooks_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Per-package hook-wiring tests for google's enum.TargetWorker[Result]
+// configuration (PLAN.md Part 3.3). These are wiring assertions, not a
+// re-test of the pool: TargetWorker's generic behavior (ordering, panic
+// isolation, concurrency bounds, callback serialization, etc.) is covered
+// exactly once in pkg/enum/targetworker_test.go. What cannot be proven there
+// is that THIS package wired its four hooks up correctly -- that Label is
+// the exact string the pre-migration code used (panic diagnostics stay
+// byte-identical), that NewError builds google's real failure shape without
+// dropping or adding a field, and that StampName copies only First/Last.
+// worker() exists precisely so these are testable directly, without driving
+// a live pool (PLAN.md Part 2, Part 3.3).
+package google
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/brutus/pkg/enum"
+)
+
+// ---------------------------------------------------------------------------
+// TestWorker_Label
+// google's pre-migration panic diagnostics were prefixed "google enum",
+// yielding "google enum: panic checking %s: %v" on stderr and "google enum:
+// panicked: %v" on the Result (PLAN.md Part 1.4). The shared worker reproduces
+// that prefix verbatim via Label, so this exact string must never drift --
+// changing it is a log-format change for anything that greps stderr or a
+// Result's Error text, not a cosmetic rename.
+// ---------------------------------------------------------------------------
+
+func TestWorker_Label(t *testing.T) {
+	t.Parallel()
+
+	e, err := NewEnumerator("", time.Second)
+	require.NoError(t, err)
+
+	assert.Equal(t, "google enum", e.worker().Label)
+}
+
+// ---------------------------------------------------------------------------
+// TestWorker_NewErrorShape
+// google's failure results carry no fields beyond Email and Error (PLAN.md
+// Part 0.4). Comparing the full struct -- not just Email/Error individually --
+// is deliberate: it is the same assertion shape that would have caught
+// gravatar's Hash regression had it been applied there, so it must prove a
+// negative (nothing else got set) as well as a positive (Email/Error got
+// set).
+// ---------------------------------------------------------------------------
+
+func TestWorker_NewErrorShape(t *testing.T) {
+	t.Parallel()
+
+	e, err := NewEnumerator("", time.Second)
+	require.NoError(t, err)
+
+	sentinel := errors.New("sentinel")
+	got := e.worker().NewError("a@b.com", sentinel)
+
+	assert.Equal(t, Result{Email: "a@b.com", Error: sentinel}, got)
+}
+
+// ---------------------------------------------------------------------------
+// TestWorker_StampNameCopiesFirstLastOnly
+// StampName's documented contract (targetworker.go) is a one-line copy of
+// First/Last from the originating Target. This asserts both halves of that
+// contract: First/Last land correctly, and every other field on an
+// already-populated Result is left untouched.
+// ---------------------------------------------------------------------------
+
+func TestWorker_StampNameCopiesFirstLastOnly(t *testing.T) {
+	t.Parallel()
+
+	e, err := NewEnumerator("", time.Second)
+	require.NoError(t, err)
+
+	res := Result{
+		Email:  "a@b.com",
+		Exists: true,
+		Method: MethodGmail,
+		IdP:    "unchanged-idp",
+		Error:  errors.New("unchanged-error"),
+	}
+	before := res
+
+	e.worker().StampName(&res, enum.Target{Email: "a@b.com", First: "Jane", Last: "Doe"})
+
+	assert.Equal(t, "Jane", res.First)
+	assert.Equal(t, "Doe", res.Last)
+	assert.Equal(t, before.Email, res.Email, "StampName must not touch Email")
+	assert.Equal(t, before.Exists, res.Exists, "StampName must not touch Exists")
+	assert.Equal(t, before.Method, res.Method, "StampName must not touch Method")
+	assert.Equal(t, before.IdP, res.IdP, "StampName must not touch IdP")
+	assert.Equal(t, before.Error, res.Error, "StampName must not touch Error")
+}

--- a/pkg/enum/microsoft365/microsoft365.go
+++ b/pkg/enum/microsoft365/microsoft365.go
@@ -23,15 +23,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"net/http"
-	"os"
-	"runtime/debug"
-	"sync"
 	"time"
-
-	"golang.org/x/sync/errgroup"
-	"golang.org/x/time/rate"
 
 	"github.com/praetorian-inc/brutus/pkg/enum"
 )
@@ -132,6 +125,36 @@ func (c *Checker) EnumerateWith(ctx context.Context, emails []string, threads in
 	return c.EnumerateTargetsWith(ctx, targets, threads, rateLimit, jitter, onResult)
 }
 
+// newError builds the Result for failures the worker pool detects rather than
+// the probe: cancellation, a rate-limiter error, a nil result from CheckAccount,
+// and panic recovery. microsoft365's failure results carry no fields beyond the
+// address and the error.
+func newError(email string, err error) Result {
+	return Result{Email: email, Error: err}
+}
+
+// worker returns the shared bounded worker pool configured for this checker. It
+// is a method (rather than inline in EnumerateTargetsWith) so tests can assert
+// the four hooks — in particular the Label that drives the panic diagnostics,
+// and newError's field shape — without running a pool.
+func (c *Checker) worker() enum.TargetWorker[Result] {
+	return enum.TargetWorker[Result]{
+		Label: "microsoft365 enum",
+		// CheckAccount returns *Result, so the nil guard lives here rather than
+		// in the shared worker: the message is this package's text, and keeping
+		// Check value-returning keeps a pointer/value duality out of the generic.
+		Check: func(ctx context.Context, email string) Result {
+			r := c.CheckAccount(ctx, email)
+			if r == nil {
+				return newError(email, fmt.Errorf("microsoft365 enum: nil result for %s", email))
+			}
+			return *r
+		},
+		NewError:  newError,
+		StampName: func(r *Result, t enum.Target) { r.First, r.Last = t.First, t.Last },
+	}
+}
+
 // EnumerateTargetsWith runs enumeration with bounded concurrency over targets
 // that carry the name behind each address, and invokes onResult (if non-nil) for
 // each completed result, serialized so callers can print/stream safely. It
@@ -154,103 +177,10 @@ func (c *Checker) EnumerateWith(ctx context.Context, emails []string, threads in
 // must therefore be cheap and self-contained: it may write to an io.Writer or
 // update counters, but it must NOT call back into the Checker (doing so risks
 // deadlock and defeats the serialization guarantee).
+//
+// The pool itself is enum.TargetWorker; see its doc comment for the full contract.
 func (c *Checker) EnumerateTargetsWith(ctx context.Context, targets []enum.Target, threads int, rateLimit float64, jitter time.Duration, onResult func(Result)) []Result {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	g, ctx := errgroup.WithContext(ctx)
-	// Normalize thread count: 0 would deadlock errgroup.SetLimit (no goroutine
-	// can ever run) and a negative value means unbounded. Clamp to a safe
-	// positive default of 1 (serial execution).
-	if threads <= 0 {
-		threads = 1
-	}
-	g.SetLimit(threads)
-
-	var limiter *rate.Limiter
-	if rateLimit > 0 {
-		limiter = rate.NewLimiter(rate.Limit(rateLimit), 1)
-	}
-
-	results := make([]Result, len(targets))
-	var mu sync.Mutex
-
-	// record stamps the originating target's name onto the result, stores it and,
-	// under the same lock, invokes the caller's callback so streamed output is
-	// serialized and slice-safe.
-	//
-	// The stamp lives here, at the single point every outcome funnels through, so
-	// that error and panic-recovery results carry their name too. Stamping at the
-	// individual call sites instead is how names end up on successes but not
-	// failures. targets is read-only, so the copy needs no lock.
-	record := func(i int, res Result) {
-		res.First, res.Last = targets[i].First, targets[i].Last
-
-		mu.Lock()
-		defer mu.Unlock()
-		results[i] = res
-		if onResult != nil {
-			onResult(res)
-		}
-	}
-
-	for i, t := range targets {
-		email := t.Email
-		g.Go(func() error {
-			defer func() {
-				if r := recover(); r != nil {
-					fmt.Fprintf(os.Stderr, "microsoft365 enum: panic checking %s: %v\n%s\n", email, r, debug.Stack())
-					record(i, Result{
-						Email: email,
-						Error: fmt.Errorf("microsoft365 enum: panicked: %v", r),
-					})
-				}
-			}()
-
-			select {
-			case <-ctx.Done():
-				// Record before returning so every index is filled and the callback fires exactly once per email.
-				record(i, Result{Email: email, Error: ctx.Err()})
-				return nil
-			default:
-			}
-
-			if limiter != nil {
-				if err := limiter.Wait(ctx); err != nil {
-					// Record before returning so every index is filled and the callback fires exactly once per email.
-					record(i, Result{Email: email, Error: err})
-					return nil
-				}
-				if jitter > 0 {
-					delay := time.Duration(rand.Int63n(int64(jitter)))
-					select {
-					case <-time.After(delay):
-					case <-ctx.Done():
-						// Record before returning so every index is filled and the callback fires exactly once per email.
-						record(i, Result{Email: email, Error: ctx.Err()})
-						return nil
-					}
-				}
-			}
-
-			r := c.CheckAccount(ctx, email)
-			if r == nil {
-				record(i, Result{
-					Email: email,
-					Error: fmt.Errorf("microsoft365 enum: nil result for %s", email),
-				})
-				return nil
-			}
-			record(i, *r)
-			return nil
-		})
-	}
-
-	// Discarding g.Wait()'s error is deliberate: worker goroutines never return
-	// a non-nil error (per-email failures are encoded in each Result), so the
-	// returned error is always nil.
-	_ = g.Wait()
-	return results
+	return c.worker().Run(ctx, targets, threads, rateLimit, jitter, onResult)
 }
 
 // CheckAccount tests if an email account exists on Microsoft 365 via the

--- a/pkg/enum/microsoft365/microsoft365_hooks_test.go
+++ b/pkg/enum/microsoft365/microsoft365_hooks_test.go
@@ -1,0 +1,161 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Per-package hook-wiring tests for microsoft365's enum.TargetWorker[Result]
+// configuration (PLAN.md Part 3.3). These are wiring assertions, not a
+// re-test of the pool: TargetWorker's generic behavior (ordering, panic
+// isolation, concurrency bounds, callback serialization, etc.) is covered
+// exactly once in pkg/enum/targetworker_test.go. What cannot be proven there
+// is that THIS package wired its four hooks up correctly -- that Label is
+// the exact string the pre-migration code used (panic diagnostics stay
+// byte-identical), that NewError builds microsoft365's real failure shape
+// without dropping or adding a field, that StampName copies only
+// First/Last, and that the nil-result guard in worker()'s Check adapter
+// routes through the package's own newError rather than a bare struct
+// literal. worker() exists precisely so these are testable directly,
+// without driving a live pool (PLAN.md Part 2, Part 3.3).
+package microsoft365
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/brutus/pkg/enum"
+)
+
+// ---------------------------------------------------------------------------
+// TestWorker_Label
+// microsoft365's pre-migration panic diagnostics were prefixed
+// "microsoft365 enum", yielding "microsoft365 enum: panic checking %s: %v"
+// on stderr and "microsoft365 enum: panicked: %v" on the Result (PLAN.md
+// Part 1.4). The shared worker reproduces that prefix verbatim via Label, so
+// this exact string must never drift -- changing it is a log-format change
+// for anything that greps stderr or a Result's Error text, not a cosmetic
+// rename.
+// ---------------------------------------------------------------------------
+
+func TestWorker_Label(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewChecker("", "", time.Second)
+	require.NoError(t, err)
+
+	assert.Equal(t, "microsoft365 enum", c.worker().Label)
+}
+
+// ---------------------------------------------------------------------------
+// TestWorker_NewErrorShape
+// microsoft365's failure results carry no fields beyond Email and Error
+// (PLAN.md Part 0.4). Comparing the full struct -- not just Email/Error
+// individually -- is deliberate: it is the same assertion shape that would
+// have caught gravatar's Hash regression had it been applied there, so it
+// must prove a negative (nothing else got set) as well as a positive
+// (Email/Error got set).
+// ---------------------------------------------------------------------------
+
+func TestWorker_NewErrorShape(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewChecker("", "", time.Second)
+	require.NoError(t, err)
+
+	sentinel := errors.New("sentinel")
+	got := c.worker().NewError("a@b.com", sentinel)
+
+	assert.Equal(t, Result{Email: "a@b.com", Error: sentinel}, got)
+}
+
+// ---------------------------------------------------------------------------
+// TestWorker_StampNameCopiesFirstLastOnly
+// StampName's documented contract (targetworker.go) is a one-line copy of
+// First/Last from the originating Target. This asserts both halves of that
+// contract: First/Last land correctly, and every other field on an
+// already-populated Result is left untouched.
+// ---------------------------------------------------------------------------
+
+func TestWorker_StampNameCopiesFirstLastOnly(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewChecker("", "", time.Second)
+	require.NoError(t, err)
+
+	res := Result{
+		Email:          "a@b.com",
+		Exists:         true,
+		IfExistsResult: 1,
+		Federated:      true,
+		FederationURL:  "https://unchanged.example.com",
+		Error:          errors.New("unchanged-error"),
+		Duration:       5 * time.Second,
+	}
+	before := res
+
+	c.worker().StampName(&res, enum.Target{Email: "a@b.com", First: "Jane", Last: "Doe"})
+
+	assert.Equal(t, "Jane", res.First)
+	assert.Equal(t, "Doe", res.Last)
+	assert.Equal(t, before.Email, res.Email, "StampName must not touch Email")
+	assert.Equal(t, before.Exists, res.Exists, "StampName must not touch Exists")
+	assert.Equal(t, before.IfExistsResult, res.IfExistsResult, "StampName must not touch IfExistsResult")
+	assert.Equal(t, before.Federated, res.Federated, "StampName must not touch Federated")
+	assert.Equal(t, before.FederationURL, res.FederationURL, "StampName must not touch FederationURL")
+	assert.Equal(t, before.Error, res.Error, "StampName must not touch Error")
+	assert.Equal(t, before.Duration, res.Duration, "StampName must not touch Duration")
+}
+
+// ---------------------------------------------------------------------------
+// TestWorker_NilResultGuardRoutesThroughNewError
+//
+// PLAN.md Part 3.3 requires that microsoft365's nil-result substitute route
+// through the package's own newError rather than a bare struct literal, so
+// the failure shape stays identical to every other failure this package
+// produces (in particular, so a future field added to newError is not
+// silently skipped on this one path).
+//
+// This test does NOT exercise the `if r == nil` branch inside worker()'s
+// Check closure. That branch has no reachable seam: CheckAccount cannot be
+// made to return nil through microsoft365's public API today (confirmed
+// against source, PLAN.md Part 3.3), and worker() does not expose an
+// injectable probe function -- inventing one (e.g. a checkAccountFn field)
+// solely to reach an otherwise-unreachable defensive branch would be
+// complexity added for a test's benefit, not the product's
+// (preferring-simple-solutions). So what this test asserts instead is that
+// the exact substitute the guard is documented to construct --
+// newError(email, fmt.Errorf("microsoft365 enum: nil result for %s",
+// email)) -- produces the real, undamaged failure shape when run through
+// the package's real NewError. It is the strongest assertion reachable
+// without contorting the production code for testability; it does not prove
+// the guard itself is reached.
+// ---------------------------------------------------------------------------
+
+func TestWorker_NilResultGuardRoutesThroughNewError(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewChecker("", "", time.Second)
+	require.NoError(t, err)
+
+	email := "a@b.com"
+	wantErr := fmt.Errorf("microsoft365 enum: nil result for %s", email)
+
+	got := c.worker().NewError(email, wantErr)
+
+	assert.Equal(t, Result{Email: email, Error: wantErr}, got)
+	require.Error(t, got.Error)
+	assert.Equal(t, "microsoft365 enum: nil result for a@b.com", got.Error.Error())
+}

--- a/pkg/enum/targetworker.go
+++ b/pkg/enum/targetworker.go
@@ -1,0 +1,242 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// pkg/enum/targetworker.go
+package enum
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"runtime/debug"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/time/rate"
+)
+
+// TargetWorker is the one bounded worker pool shared by the account-existence
+// enumerators in pkg/enum/*. It runs exactly one probe per Target with bounded
+// concurrency, optional rate limiting and optional jitter, and returns one
+// result per input Target in input order.
+//
+// It exists because google, microsoft365, github, gravatar and teams each grew
+// their own copy of the same ~90-line pool. The copies drifted: three recorded a
+// result on context cancellation and two silently dropped it, two guarded a nil
+// probe result and three did not, and one of the five carried an extra field on
+// its failure results that a naive shared implementation would have erased.
+// Consolidating the pool here removes the drift surface; the four hook fields
+// below are precisely the parts that legitimately differ per package, and
+// nothing else is configurable.
+//
+// # Contract
+//
+// Run fills results[i] for EVERY i in 0..len(targets)-1 and invokes onResult
+// exactly once per target — on a completed probe, on an already-canceled
+// context, on a rate-limiter error, on cancellation during jitter, and on panic
+// recovery. There is no path on which a slot is left as a dropped zero value.
+// The returned slice is in input order; completion order is not, so callers
+// (and tests) must correlate a streamed result with its input by email, never
+// by arrival position.
+//
+// onResult is invoked while holding the same mutex that guards the results
+// slice, so callbacks never interleave with each other and never race the
+// slice. A callback must therefore be cheap and self-contained: it may write to
+// an io.Writer or bump a counter, but it must NOT call back into the enumerator
+// that owns this worker (that risks deadlock and defeats the serialization
+// guarantee).
+//
+// # Concurrency and pacing
+//
+// threads <= 0 is clamped to 1. This clamp is load-bearing: errgroup.SetLimit(0)
+// permits zero concurrent goroutines, so no worker could ever run and Run would
+// hang forever, while a negative limit means unbounded — neither is what a
+// caller passing 0 wants.
+//
+// rateLimit <= 0 disables the limiter. jitter is applied ONLY when a limiter is
+// active; jitter with rateLimit == 0 is silently ignored. That is inherited
+// behavior from all five original pools and is preserved deliberately rather
+// than "fixed", because changing it would alter the pacing of every existing
+// caller. See TestRun_JitterIgnoredWithoutRateLimit.
+//
+// # Panics
+//
+// A panic inside Check is recovered per goroutine. The worker writes a
+// diagnostic to os.Stderr and records NewError(email, <formatted panic>) for
+// that target, so one bad probe cannot take down a run. A panic raised inside
+// the caller's onResult is also caught by the same recover and will produce a
+// second record for that index — a pre-existing hazard in all five original
+// pools, preserved here unchanged.
+type TargetWorker[R any] struct {
+	// Label prefixes the two panic diagnostics this worker emits:
+	//
+	//	os.Stderr: "<Label>: panic checking <email>: <value>\n<stack>\n"
+	//	result:    "<Label>: panicked: <value>"
+	//
+	// It must be the package's existing diagnostic prefix with NO trailing
+	// colon — "google enum", "microsoft365 enum", "github enum",
+	// "gravatar enum", "teams enum" — so that the emitted text stays
+	// byte-identical to what each package produced before consolidation.
+	// External tooling greps these lines; changing a Label is a log-format
+	// change, not a cosmetic one.
+	Label string
+
+	// Check performs exactly one probe and returns its outcome. Required.
+	//
+	// It must encode every failure in R's own error field and must never return
+	// an error out of band. It must not populate the name fields — Run stamps
+	// those via StampName, at the single point every outcome funnels through, so
+	// that failure results carry a name too.
+	//
+	// A package whose underlying probe returns a POINTER (microsoft365's and
+	// gravatar's CheckAccount) adapts it here and substitutes NewError for a nil
+	// return. The nil guard lives in the package rather than in this worker
+	// because its message is package-specific text ("<pkg> enum: nil result for
+	// <email>") and because keeping Check value-returning avoids a pointer/value
+	// duality in the generic signature.
+	Check func(ctx context.Context, email string) R
+
+	// NewError builds the result for every failure the WORKER detects rather
+	// than the probe: an already-canceled context, a rate-limiter error,
+	// cancellation during jitter, and panic recovery. Required.
+	//
+	// It is a per-package hook, not a generic zero-value construction, because
+	// "zero value plus an error" is not a valid result everywhere. gravatar's
+	// failure results must carry Hash: HashEmail(email) — a generic construction
+	// would silently drop the hash. teams' must carry Exists: ExistenceUnknown —
+	// a generic construction would leave the tri-state empty, an invalid value
+	// that DerivePosture reads. Those are load-bearing, not decorative.
+	//
+	// A package should route its own nil-result substitute through this same
+	// function (inside Check) so that every failure result the package can
+	// produce has exactly one shape.
+	NewError func(email string, err error) R
+
+	// StampName copies the originating Target's name onto a result. Required.
+	// Implementations are one line: func(r *R, t Target) { r.First, r.Last = t.First, t.Last }
+	//
+	// This is a callback rather than an interface method because Go generics
+	// cannot read or write a type parameter's struct fields. An interface would
+	// require a second type parameter constrained on the pointer type
+	// ("[R any, P interface{ *R; NameSetter }]"), which propagates into every
+	// call site's instantiation, plus a new exported mutator method on all five
+	// result types — a wider public API and a mutator on a value type that
+	// invites misuse — all to replace five one-line closures. The closures win
+	// on both line count and blast radius.
+	StampName func(res *R, t Target)
+}
+
+// Run executes one Check per target using a bounded worker pool.
+//
+// See the TargetWorker doc comment for the full contract: every slot is filled,
+// onResult fires exactly once per target under the results mutex, the returned
+// slice is in input order, threads <= 0 clamps to 1, and jitter applies only
+// when rateLimit > 0.
+func (w TargetWorker[R]) Run(ctx context.Context, targets []Target, threads int, rateLimit float64, jitter time.Duration, onResult func(R)) []R {
+	// Fail fast and loudly on a misconfigured worker. Without this, a nil hook
+	// nil-panics inside a worker goroutine, gets swallowed by the per-goroutine
+	// recover, and surfaces as one confusing "panicked" result per email instead
+	// of one obvious programmer error.
+	if w.Check == nil || w.NewError == nil || w.StampName == nil {
+		panic("enum: TargetWorker requires Check, NewError and StampName")
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	g, ctx := errgroup.WithContext(ctx)
+	// Normalize thread count: 0 would deadlock errgroup.SetLimit (no goroutine
+	// can ever run) and a negative value means unbounded. Clamp to a safe
+	// positive default of 1 (serial execution).
+	if threads <= 0 {
+		threads = 1
+	}
+	g.SetLimit(threads)
+
+	var limiter *rate.Limiter
+	if rateLimit > 0 {
+		limiter = rate.NewLimiter(rate.Limit(rateLimit), 1)
+	}
+
+	results := make([]R, len(targets))
+	var mu sync.Mutex
+
+	// record stamps the originating target's name onto the result, stores it and,
+	// under the same lock, invokes the caller's callback so streamed output is
+	// serialized and slice-safe.
+	//
+	// The stamp lives here, at the single point every outcome funnels through, so
+	// that error and panic-recovery results carry their name too. Stamping at the
+	// individual call sites instead is how names end up on successes but not
+	// failures. targets is read-only, so the copy needs no lock.
+	record := func(i int, res R) {
+		w.StampName(&res, targets[i])
+
+		mu.Lock()
+		defer mu.Unlock()
+		results[i] = res
+		if onResult != nil {
+			onResult(res)
+		}
+	}
+
+	for i, t := range targets {
+		email := t.Email
+		g.Go(func() error {
+			defer func() {
+				if r := recover(); r != nil {
+					fmt.Fprintf(os.Stderr, "%s: panic checking %s: %v\n%s\n", w.Label, email, r, debug.Stack())
+					record(i, w.NewError(email, fmt.Errorf("%s: panicked: %v", w.Label, r)))
+				}
+			}()
+
+			select {
+			case <-ctx.Done():
+				// Record before returning so every index is filled and the callback fires exactly once per email.
+				record(i, w.NewError(email, ctx.Err()))
+				return nil
+			default:
+			}
+
+			if limiter != nil {
+				if err := limiter.Wait(ctx); err != nil {
+					// Record before returning so every index is filled and the callback fires exactly once per email.
+					record(i, w.NewError(email, err))
+					return nil
+				}
+				if jitter > 0 {
+					delay := time.Duration(rand.Int63n(int64(jitter)))
+					select {
+					case <-time.After(delay):
+					case <-ctx.Done():
+						// Record before returning so every index is filled and the callback fires exactly once per email.
+						record(i, w.NewError(email, ctx.Err()))
+						return nil
+					}
+				}
+			}
+
+			record(i, w.Check(ctx, email))
+			return nil
+		})
+	}
+
+	// Discarding g.Wait()'s error is deliberate: worker goroutines never return
+	// a non-nil error (per-email failures are encoded in each result), so the
+	// returned error is always nil.
+	_ = g.Wait()
+	return results
+}

--- a/pkg/enum/targetworker_test.go
+++ b/pkg/enum/targetworker_test.go
@@ -1,0 +1,721 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// RED-phase tests for the shared enum.TargetWorker pool (10T-535, PR 1 of 3).
+// TargetWorker does not exist yet; this file is expected to fail to compile
+// until pkg/enum/targetworker.go adds it (PLAN.md Part 1). See PLAN.md
+// Part 3.2 for the full worker-level test-plan rationale (tests W1-W16
+// below); this is the ONE place these properties are tested -- google and
+// microsoft365's own target tests are the regression net for the migration,
+// not a place to re-test the pool.
+//
+// fakeResult is a local stand-in for the five real result types (google's
+// Result, microsoft365's Result, etc.) so these tests exercise Run directly,
+// independent of any enumerator package. Sentinel proves NewError -- not a
+// generic zero value -- built a failure result: if Run ever constructed R
+// without calling the hook, Sentinel would come back empty and the relevant
+// assertions would fail.
+package enum
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeResult stands in for the five real result types.
+type fakeResult struct {
+	Email       string
+	First, Last string
+	Err         error
+	Sentinel    string
+}
+
+// fakeWorker builds a TargetWorker[fakeResult] configured the way every real
+// package configures one: a Label, the supplied Check, a NewError that marks
+// itself with Sentinel so tests can prove the worker used the hook rather
+// than a zero value, and a StampName that copies the Target's name.
+func fakeWorker(check func(context.Context, string) fakeResult) TargetWorker[fakeResult] {
+	return TargetWorker[fakeResult]{
+		Label: "fake enum",
+		Check: check,
+		NewError: func(email string, err error) fakeResult {
+			return fakeResult{Email: email, Err: err, Sentinel: "from-newerror"}
+		},
+		StampName: func(r *fakeResult, t Target) { r.First, r.Last = t.First, t.Last },
+	}
+}
+
+// ---------------------------------------------------------------------------
+// W1 - TestRun_ReturnsInputOrder
+// ---------------------------------------------------------------------------
+
+func TestRun_ReturnsInputOrder(t *testing.T) {
+	t.Parallel()
+
+	const n = 6
+	targets := make([]Target, n)
+	sleepFor := make(map[string]time.Duration, n)
+	for i := 0; i < n; i++ {
+		email := fmt.Sprintf("t%d@x.com", i)
+		targets[i] = Target{Email: email}
+		// Earlier indices sleep longer, so completion order is the reverse
+		// of input order -- the ordering assertion below cannot pass by
+		// accident of scheduling.
+		sleepFor[email] = time.Duration(n-i) * 5 * time.Millisecond
+	}
+
+	w := fakeWorker(func(ctx context.Context, email string) fakeResult {
+		time.Sleep(sleepFor[email])
+		return fakeResult{Email: email}
+	})
+
+	results := w.Run(context.Background(), targets, 8, 0, 0, nil)
+	require.Len(t, results, n)
+	for i, tgt := range targets {
+		assert.Equal(t, tgt.Email, results[i].Email,
+			"results[%d].Email must match targets[%d].Email regardless of completion order", i, i)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// W2 - TestRun_EverySlotFilledAndCallbackOncePerTarget
+// ---------------------------------------------------------------------------
+
+func TestRun_EverySlotFilledAndCallbackOncePerTarget(t *testing.T) {
+	t.Parallel()
+
+	const n = 8
+	targets := make([]Target, n)
+	shouldFail := make(map[string]bool, n)
+	for i := 0; i < n; i++ {
+		email := fmt.Sprintf("u%d@x.com", i)
+		targets[i] = Target{Email: email}
+		shouldFail[email] = i%2 == 1
+	}
+
+	w := fakeWorker(func(ctx context.Context, email string) fakeResult {
+		if shouldFail[email] {
+			return fakeResult{Email: email, Err: errors.New("probe failed")}
+		}
+		return fakeResult{Email: email}
+	})
+
+	var mu sync.Mutex
+	seen := make(map[string]int, n)
+	results := w.Run(context.Background(), targets, 4, 0, 0, func(r fakeResult) {
+		mu.Lock()
+		seen[r.Email]++
+		mu.Unlock()
+	})
+
+	require.Len(t, results, n)
+	for i, tgt := range targets {
+		r := results[i]
+		assert.Equal(t, tgt.Email, r.Email, "results[%d] must not be a dropped zero-value slot", i)
+		assert.NotEmpty(t, r.Email, "results[%d] must never be a zero-value fakeResult", i)
+	}
+
+	assert.Len(t, seen, n, "callback must have fired for every target's email")
+	for email, count := range seen {
+		assert.Equal(t, 1, count, "callback must fire exactly once for %q", email)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// W3 - TestRun_StampsOriginatingTargetName
+// ---------------------------------------------------------------------------
+
+func TestRun_StampsOriginatingTargetName(t *testing.T) {
+	t.Parallel()
+
+	targets := []Target{
+		{Email: "a@x.com", First: "anna", Last: "lee"},
+		{Email: "b@x.com", First: "bob", Last: "wu"},
+		{Email: "c@x.com", First: "carl", Last: "chen"},
+	}
+
+	w := fakeWorker(func(ctx context.Context, email string) fakeResult {
+		return fakeResult{Email: email}
+	})
+
+	results := w.Run(context.Background(), targets, 4, 0, 0, nil)
+	require.Len(t, results, len(targets))
+
+	byEmail := make(map[string]fakeResult, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	for _, tgt := range targets {
+		r, ok := byEmail[tgt.Email]
+		require.True(t, ok, "result for %q must be present", tgt.Email)
+		assert.Equal(t, tgt.First, r.First, "First for %q must match its own target, never a neighbour's", tgt.Email)
+		assert.Equal(t, tgt.Last, r.Last, "Last for %q must match its own target, never a neighbour's", tgt.Email)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// W4 - TestRun_NamelessTargetStaysNameless
+// ---------------------------------------------------------------------------
+
+func TestRun_NamelessTargetStaysNameless(t *testing.T) {
+	t.Parallel()
+
+	targets := []Target{{Email: "supplied@x.com"}}
+
+	w := fakeWorker(func(ctx context.Context, email string) fakeResult {
+		return fakeResult{Email: email}
+	})
+
+	results := w.Run(context.Background(), targets, 1, 0, 0, nil)
+	require.Len(t, results, 1)
+	assert.Empty(t, results[0].First, "First must stay empty for a nameless Target")
+	assert.Empty(t, results[0].Last, "Last must stay empty for a nameless Target")
+}
+
+// ---------------------------------------------------------------------------
+// W5 - TestRun_MixedNamedAndUnnamed
+// ---------------------------------------------------------------------------
+
+func TestRun_MixedNamedAndUnnamed(t *testing.T) {
+	t.Parallel()
+
+	targets := []Target{
+		{Email: "named1@x.com", First: "anna", Last: "lee"},
+		{Email: "unnamed1@x.com"},
+		{Email: "named2@x.com", First: "bob", Last: "wu"},
+		{Email: "unnamed2@x.com"},
+	}
+
+	w := fakeWorker(func(ctx context.Context, email string) fakeResult {
+		return fakeResult{Email: email}
+	})
+
+	results := w.Run(context.Background(), targets, 4, 0, 0, nil)
+	require.Len(t, results, len(targets))
+
+	byEmail := make(map[string]fakeResult, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	for _, tgt := range targets {
+		r, ok := byEmail[tgt.Email]
+		require.True(t, ok, "result for %q must be present", tgt.Email)
+		assert.Equal(t, tgt.First, r.First, "First for %q", tgt.Email)
+		assert.Equal(t, tgt.Last, r.Last, "Last for %q", tgt.Email)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// W6 - TestRun_NameSurvivesEveryAbortPath
+//
+// Table of the four paths that reach record() WITHOUT a normal Check return:
+// an already-canceled context, a rate-limiter error, cancellation during
+// jitter, and panic recovery. Every one must (a) carry the originating
+// target's name and (b) carry Sentinel == "from-newerror", proving the
+// result came from the NewError hook and not a generic zero value.
+// ---------------------------------------------------------------------------
+
+func TestRun_NameSurvivesEveryAbortPath(t *testing.T) {
+	t.Run("already-canceled context", func(t *testing.T) {
+		t.Parallel()
+
+		targets := []Target{{Email: "one@x.com", First: "gwen", Last: "alpha"}}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		var checkCalls atomic.Int32
+		w := fakeWorker(func(ctx context.Context, email string) fakeResult {
+			checkCalls.Add(1)
+			return fakeResult{Email: email}
+		})
+
+		results := w.Run(ctx, targets, 1, 0, 0, nil)
+		require.Len(t, results, 1)
+
+		r := results[0]
+		assert.Equal(t, int32(0), checkCalls.Load(), "Check must not be called when ctx is already canceled")
+		assert.Equal(t, "from-newerror", r.Sentinel, "already-canceled path must go through NewError, not a zero value")
+		require.Error(t, r.Err)
+		assert.Equal(t, "gwen", r.First, "name must survive the already-canceled-context path")
+		assert.Equal(t, "alpha", r.Last)
+	})
+
+	t.Run("rate limiter error", func(t *testing.T) {
+		t.Parallel()
+
+		targets := []Target{
+			{Email: "one@x.com", First: "gwen", Last: "alpha"},
+			{Email: "two@x.com", First: "hank", Last: "beta"},
+		}
+
+		// A short deadline plus an extremely low rate: the token bucket
+		// starts with one burst token, so whichever goroutine claims it
+		// proceeds immediately; the other must wait far longer than the
+		// remaining deadline, and rate.Limiter.Wait returns that error
+		// immediately rather than actually waiting.
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+		defer cancel()
+
+		w := fakeWorker(func(ctx context.Context, email string) fakeResult {
+			return fakeResult{Email: email}
+		})
+
+		results := w.Run(ctx, targets, 2, 0.001, 0, nil)
+		require.Len(t, results, len(targets))
+
+		byEmail := make(map[string]fakeResult, len(results))
+		for _, r := range results {
+			byEmail[r.Email] = r
+		}
+
+		var limited *fakeResult
+		for _, tgt := range targets {
+			r := byEmail[tgt.Email]
+			if r.Sentinel == "from-newerror" {
+				rc := r
+				limited = &rc
+				break
+			}
+		}
+		require.NotNil(t, limited, "at least one target must be rejected by the rate limiter within the short deadline")
+		require.Error(t, limited.Err)
+
+		for _, tgt := range targets {
+			if tgt.Email == limited.Email {
+				assert.Equal(t, tgt.First, limited.First, "name must survive the rate-limiter-error path")
+				assert.Equal(t, tgt.Last, limited.Last, "name must survive the rate-limiter-error path")
+			}
+		}
+	})
+
+	t.Run("jitter cancel", func(t *testing.T) {
+		t.Parallel()
+
+		targets := []Target{{Email: "jit@x.com", First: "iris", Last: "gamma"}}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		time.AfterFunc(10*time.Millisecond, cancel)
+
+		var checkCalls atomic.Int32
+		w := fakeWorker(func(ctx context.Context, email string) fakeResult {
+			checkCalls.Add(1)
+			return fakeResult{Email: email}
+		})
+
+		// rateLimit high enough that the single request's Wait succeeds
+		// immediately (burst token available); jitter large enough that the
+		// random delay is very unlikely to elapse before the 10ms cancel.
+		results := w.Run(ctx, targets, 1, 1000, 2*time.Second, nil)
+		require.Len(t, results, 1)
+
+		r := results[0]
+		assert.Equal(t, int32(0), checkCalls.Load(), "Check must not be called when ctx is canceled during jitter")
+		assert.Equal(t, "from-newerror", r.Sentinel, "jitter-cancel path must go through NewError, not a zero value")
+		require.Error(t, r.Err)
+		assert.Equal(t, "iris", r.First, "name must survive cancellation during jitter")
+		assert.Equal(t, "gamma", r.Last)
+	})
+
+	// Deliberately NOT t.Parallel(): this subtest swaps the package-level
+	// os.Stderr (see TestRun_PanicInCheckIsIsolated below, which does the
+	// same). Running both concurrently with each other would race on that
+	// global under -race.
+	t.Run("panic in Check", func(t *testing.T) {
+		targets := []Target{{Email: "panic@x.com", First: "jill", Last: "delta"}}
+
+		w := fakeWorker(func(ctx context.Context, email string) fakeResult {
+			panic("boom")
+		})
+
+		origStderr := os.Stderr
+		devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+		require.NoError(t, err)
+		os.Stderr = devNull
+		results := w.Run(context.Background(), targets, 1, 0, 0, nil)
+		os.Stderr = origStderr
+		require.NoError(t, devNull.Close())
+
+		require.Len(t, results, 1)
+		r := results[0]
+		assert.Equal(t, "from-newerror", r.Sentinel, "panic path must go through NewError, not a zero value")
+		require.Error(t, r.Err)
+		assert.Equal(t, "jill", r.First, "name must survive a panic inside Check")
+		assert.Equal(t, "delta", r.Last)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// W7 - TestRun_CanceledContextRecordsEveryTarget
+// ---------------------------------------------------------------------------
+
+func TestRun_CanceledContextRecordsEveryTarget(t *testing.T) {
+	t.Parallel()
+
+	targets := []Target{
+		{Email: "one@x.com"},
+		{Email: "two@x.com"},
+		{Email: "three@x.com"},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var checkCalls atomic.Int32
+	w := fakeWorker(func(ctx context.Context, email string) fakeResult {
+		checkCalls.Add(1)
+		return fakeResult{Email: email}
+	})
+
+	var mu sync.Mutex
+	var cbEmails []string
+	results := w.Run(ctx, targets, 4, 0, 0, func(r fakeResult) {
+		mu.Lock()
+		cbEmails = append(cbEmails, r.Email)
+		mu.Unlock()
+	})
+
+	require.Len(t, results, len(targets))
+	assert.Equal(t, int32(0), checkCalls.Load(), "Check must never be called on an already-canceled context")
+	for i, tgt := range targets {
+		assert.Equal(t, tgt.Email, results[i].Email, "results[%d].Email must be set (input order preserved)", i)
+		require.Error(t, results[i].Err)
+		assert.True(t, errors.Is(results[i].Err, context.Canceled), "results[%d].Err must be context.Canceled", i)
+	}
+	assert.Len(t, cbEmails, len(targets), "onResult must fire exactly once per target on the canceled-context path")
+}
+
+// ---------------------------------------------------------------------------
+// W8 - TestRun_ZeroOrNegativeThreadsDoesNotHang
+// ---------------------------------------------------------------------------
+
+func TestRun_ZeroOrNegativeThreadsDoesNotHang(t *testing.T) {
+	for _, threads := range []int{0, -1} {
+		t.Run(fmt.Sprintf("threads=%d", threads), func(t *testing.T) {
+			t.Parallel()
+
+			targets := []Target{{Email: "a@x.com"}, {Email: "b@x.com"}, {Email: "c@x.com"}}
+
+			w := fakeWorker(func(ctx context.Context, email string) fakeResult {
+				return fakeResult{Email: email}
+			})
+
+			done := make(chan []fakeResult, 1)
+			go func() {
+				done <- w.Run(context.Background(), targets, threads, 0, 0, nil)
+			}()
+
+			select {
+			case results := <-done:
+				require.Len(t, results, len(targets))
+				byEmail := make(map[string]fakeResult, len(results))
+				for _, r := range results {
+					byEmail[r.Email] = r
+				}
+				for _, tgt := range targets {
+					_, ok := byEmail[tgt.Email]
+					assert.True(t, ok, "result for %q must be present", tgt.Email)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatalf("Run did not return within 2s for threads=%d; a bad clamp (e.g. SetLimit(0)) would hang forever", threads)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// W9 - TestRun_BoundsConcurrency
+// ---------------------------------------------------------------------------
+
+func TestRun_BoundsConcurrency(t *testing.T) {
+	t.Parallel()
+
+	const threads = 4
+	const n = 40
+
+	targets := make([]Target, n)
+	for i := 0; i < n; i++ {
+		targets[i] = Target{Email: fmt.Sprintf("c%d@x.com", i)}
+	}
+
+	var current, peak atomic.Int32
+	w := fakeWorker(func(ctx context.Context, email string) fakeResult {
+		c := current.Add(1)
+		for {
+			p := peak.Load()
+			if c <= p || peak.CompareAndSwap(p, c) {
+				break
+			}
+		}
+		time.Sleep(2 * time.Millisecond)
+		current.Add(-1)
+		return fakeResult{Email: email}
+	})
+
+	results := w.Run(context.Background(), targets, threads, 0, 0, nil)
+	require.Len(t, results, n)
+	assert.LessOrEqual(t, peak.Load(), int32(threads), "peak concurrent Check calls must not exceed threads")
+}
+
+// ---------------------------------------------------------------------------
+// W10 - TestRun_RateLimitPaces
+// ---------------------------------------------------------------------------
+
+func TestRun_RateLimitPaces(t *testing.T) {
+	t.Parallel()
+
+	const n = 5
+	targets := make([]Target, n)
+	for i := 0; i < n; i++ {
+		targets[i] = Target{Email: fmt.Sprintf("r%d@x.com", i)}
+	}
+
+	w := fakeWorker(func(ctx context.Context, email string) fakeResult {
+		return fakeResult{Email: email}
+	})
+
+	start := time.Now()
+	results := w.Run(context.Background(), targets, n, 20, 0, nil)
+	elapsed := time.Since(start)
+
+	require.Len(t, results, n)
+	// 5 requests at 20/s with burst 1: the first is free, the remaining 4
+	// must each wait ~1/20s, so total elapsed should be at least ~4/20s
+	// (200ms). Use a slightly relaxed floor to absorb scheduler jitter.
+	assert.GreaterOrEqual(t, elapsed, 190*time.Millisecond, "rate limiting must pace requests to roughly the configured rate")
+}
+
+// ---------------------------------------------------------------------------
+// W11 - TestRun_JitterIgnoredWithoutRateLimit
+// ---------------------------------------------------------------------------
+
+func TestRun_JitterIgnoredWithoutRateLimit(t *testing.T) {
+	t.Parallel()
+
+	targets := []Target{{Email: "a@x.com"}, {Email: "b@x.com"}, {Email: "c@x.com"}}
+
+	w := fakeWorker(func(ctx context.Context, email string) fakeResult {
+		return fakeResult{Email: email}
+	})
+
+	start := time.Now()
+	results := w.Run(context.Background(), targets, 3, 0, 2*time.Second, nil)
+	elapsed := time.Since(start)
+
+	require.Len(t, results, len(targets))
+	assert.Less(t, elapsed, 500*time.Millisecond,
+		"jitter must be ignored entirely when rateLimit is 0 -- jitter lives inside the rate-limiter branch, "+
+			"a 2s jitter here must not slow this run down")
+}
+
+// ---------------------------------------------------------------------------
+// W12 - TestRun_NilCallbackIsSafe
+// ---------------------------------------------------------------------------
+
+func TestRun_NilCallbackIsSafe(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		t.Parallel()
+
+		targets := []Target{{Email: "a@x.com"}}
+		w := fakeWorker(func(ctx context.Context, email string) fakeResult {
+			return fakeResult{Email: email}
+		})
+
+		var results []fakeResult
+		assert.NotPanics(t, func() {
+			results = w.Run(context.Background(), targets, 1, 0, 0, nil)
+		})
+		require.Len(t, results, 1)
+	})
+
+	t.Run("canceled context", func(t *testing.T) {
+		t.Parallel()
+
+		targets := []Target{{Email: "b@x.com"}}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		w := fakeWorker(func(ctx context.Context, email string) fakeResult {
+			return fakeResult{Email: email}
+		})
+
+		var results []fakeResult
+		assert.NotPanics(t, func() {
+			results = w.Run(ctx, targets, 1, 0, 0, nil)
+		})
+		require.Len(t, results, 1)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// W13 - TestRun_CallbackIsSerialized
+// ---------------------------------------------------------------------------
+
+func TestRun_CallbackIsSerialized(t *testing.T) {
+	t.Parallel()
+
+	const n = 50
+	targets := make([]Target, n)
+	for i := 0; i < n; i++ {
+		targets[i] = Target{Email: fmt.Sprintf("s%d@x.com", i)}
+	}
+
+	w := fakeWorker(func(ctx context.Context, email string) fakeResult {
+		return fakeResult{Email: email}
+	})
+
+	// inCallback is deliberately unsynchronized: if onResult is ever invoked
+	// concurrently with itself, a plain (non-atomic) read/write race is
+	// exactly what proves the callback is not serialized under the results
+	// mutex, and -race will flag the race even if the boolean logic misses it.
+	var inCallback bool
+	var raced atomic.Bool
+	onResult := func(r fakeResult) {
+		if inCallback {
+			raced.Store(true)
+			return
+		}
+		inCallback = true
+		defer func() { inCallback = false }()
+	}
+
+	results := w.Run(context.Background(), targets, 8, 0, 0, onResult)
+	require.Len(t, results, n)
+	assert.False(t, raced.Load(), "onResult invoked concurrently: callback is not serialized under the results mutex")
+}
+
+// ---------------------------------------------------------------------------
+// W14 - TestRun_PanicInCheckIsIsolated
+//
+// Deliberately NOT t.Parallel(): swaps the package-level os.Stderr, same
+// hazard noted on the "panic in Check" subtest of TestRun_NameSurvivesEvery-
+// AbortPath above.
+// ---------------------------------------------------------------------------
+
+func TestRun_PanicInCheckIsIsolated(t *testing.T) {
+	targets := []Target{
+		{Email: "ok1@x.com"},
+		{Email: "boom@x.com"},
+		{Email: "ok2@x.com"},
+	}
+
+	w := fakeWorker(func(ctx context.Context, email string) fakeResult {
+		if email == "boom@x.com" {
+			panic("kaboom")
+		}
+		return fakeResult{Email: email}
+	})
+
+	origStderr := os.Stderr
+	rpipe, wpipe, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = wpipe
+
+	results := w.Run(context.Background(), targets, 1, 0, 0, nil)
+
+	os.Stderr = origStderr
+	require.NoError(t, wpipe.Close())
+	captured, err := io.ReadAll(rpipe)
+	require.NoError(t, err)
+
+	require.Len(t, results, len(targets))
+	byEmail := make(map[string]fakeResult, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	panicked := byEmail["boom@x.com"]
+	assert.Equal(t, "from-newerror", panicked.Sentinel, "a panic in Check must be recorded via NewError, not a zero value")
+	require.Error(t, panicked.Err)
+	assert.Contains(t, panicked.Err.Error(), "fake enum: panicked:",
+		"Label must prefix the panic result error exactly as every real package's Label does")
+
+	assert.NoError(t, byEmail["ok1@x.com"].Err, "a panic in one target must not affect others")
+	assert.NoError(t, byEmail["ok2@x.com"].Err, "a panic in one target must not affect others")
+
+	assert.Contains(t, string(captured), "fake enum: panic checking boom@x.com:",
+		"Label must prefix the stderr diagnostic exactly as every real package's Label does")
+}
+
+// ---------------------------------------------------------------------------
+// W15 - TestRun_EmptyTargets
+// ---------------------------------------------------------------------------
+
+func TestRun_EmptyTargets(t *testing.T) {
+	t.Parallel()
+
+	var checkCalls atomic.Int32
+	w := fakeWorker(func(ctx context.Context, email string) fakeResult {
+		checkCalls.Add(1)
+		return fakeResult{Email: email}
+	})
+
+	var callbackCalls atomic.Int32
+	results := w.Run(context.Background(), []Target{}, 4, 0, 0, func(r fakeResult) {
+		callbackCalls.Add(1)
+	})
+
+	require.NotNil(t, results, "Run must return a non-nil (empty) slice for zero targets")
+	assert.Len(t, results, 0)
+	assert.Equal(t, int32(0), checkCalls.Load(), "Check must never be called when there are no targets")
+	assert.Equal(t, int32(0), callbackCalls.Load(), "onResult must never fire when there are no targets")
+}
+
+// ---------------------------------------------------------------------------
+// W16 - TestRun_PanicsOnMissingHooks
+// ---------------------------------------------------------------------------
+
+func TestRun_PanicsOnMissingHooks(t *testing.T) {
+	base := func() TargetWorker[fakeResult] {
+		return fakeWorker(func(ctx context.Context, email string) fakeResult {
+			return fakeResult{Email: email}
+		})
+	}
+
+	targets := []Target{{Email: "a@x.com"}}
+
+	tests := []struct {
+		name string
+		mod  func(w *TargetWorker[fakeResult])
+	}{
+		{"nil Check", func(w *TargetWorker[fakeResult]) { w.Check = nil }},
+		{"nil NewError", func(w *TargetWorker[fakeResult]) { w.NewError = nil }},
+		{"nil StampName", func(w *TargetWorker[fakeResult]) { w.StampName = nil }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			w := base()
+			tt.mod(&w)
+
+			assert.PanicsWithValue(t, "enum: TargetWorker requires Check, NewError and StampName", func() {
+				w.Run(context.Background(), targets, 1, 0, 0, nil)
+			})
+		})
+	}
+}


### PR DESCRIPTION
**PR 1 of 3.** Extracts one shared worker pool and moves google + microsoft365 onto it. **Semantically inert** — nothing observable changes.

Sequential, not stacked: PR 2 and PR 3 will each branch from freshly-pulled `main` after this merges, so only one is ever open.

## Why

Five enumerator packages carry near-identical ~70-line pools: errgroup with a clamped `SetLimit`, optional rate limiter, optional jitter, a preallocated `results` slice written by index, a mutex-guarded `record` closure that also serializes `onResult`, deferred panic recovery, and `ctx.Done()` early returns.

#317 added `EnumerateTargetsWith` to two of them. Following it in the other three by copy-paste would leave **five copies** of the same concurrency code. This extracts the pool first.

## The worker

```go
type TargetWorker[R any] struct {
    Label     string                                    // panic-diagnostic prefix, e.g. "google enum"
    Check     func(ctx context.Context, email string) R // one probe
    NewError  func(email string, err error) R           // result for failures the worker detects
    StampName func(res *R, t Target)                    // copy the originating target's name
}
func (w TargetWorker[R]) Run(ctx context.Context, targets []Target, threads int, rateLimit float64, jitter time.Duration, onResult func(R)) []R
```

Three design decisions worth a reviewer's time:

**`NewError` is per-package, not generic.** gravatar's error results carry `Hash: HashEmail(email)`; teams' carry `Exists: ExistenceUnknown` (a zero value would give `""`, an invalid tri-state that `DerivePosture` reads). A generic zero-value construction would silently drop both. Those packages land in later PRs, but the contract has to accommodate them now — which is why microsoft365's nil-result substitute already routes through its own `newError` rather than a bare struct literal.

**`StampName` is a callback, not an interface.** A `NameSetter` interface needs `[R any, P interface{ *R; NameSetter }]`, leaking two type parameters into every instantiation plus five exported mutators on public result types. ~15 lines of permanent API surface to remove 5 lines of closure.

**`Check` is often a bare method value** — `Check: e.CheckAccount` for google, whose signature already matches.

## Why this PR changes nothing

google and microsoft365 already record a result on **every** abort path — completed check, `ctx.Done()`, limiter error, jitter cancellation, panic recovery, plus microsoft365's nil guard. So swapping their hand-rolled pools for the shared one is a pure refactor.

(This is exactly why they go first. github and teams do **not** record on abort paths — they `return nil`, leaving a zero-value result and never firing `onResult`. Unifying those is a real behavior change, isolated into PR 3 where it can be judged on its own.)

Evidence a reviewer can check directly:

| Claim | How to verify |
|---|---|
| all 5 `EnumerateWith` signatures byte-identical | diff each against the base commit — 5/5 identical |
| pools actually gone | `grep -c errgroup` in google.go / microsoft365.go → `0`, `0` |
| behavior unchanged | the **14 target tests from #317 pass unmodified** — `git diff` on those two files is empty |
| panic diagnostics unchanged | all ten sites fit two templates; `Label` reproduces each byte-for-byte |
| `cmd/brutus` unaffected | `git diff --stat -- cmd/` prints nothing |

That fourth row is the real safety net: needing to edit any of those 14 tests would have been proof the pool changed behavior.

## Tests

**16 on the worker** — input ordering, every slot filled, name correlation **by email not index** (so stamping every result with `targets[0]`'s name fails), nameless targets staying nameless, names surviving all four abort paths, `NewError` used rather than a zero value, `Check` never called after cancellation, panic isolation, thread clamping at `0` and `-1`, callback serialization under `-race`, nil callback, empty target list.

**7 per-package hook tests.** The generic tests prove the *pool* is correct; only these prove each package **wired its hooks correctly** — that `Label` is the right string, that `NewError` builds that package's real error shape with no field dropped, that `StampName` touches only `First`/`Last`. A package could wire `NewError` to drop a field and every generic test would still pass. That's the exact failure mode waiting in PRs 2 and 3, so the pattern is established here.

Three mutations, each reverted:

| Mutation | Killed by |
|---|---|
| stamp from `targets[0]` not `targets[i]` | worker suite **and** both packages' existing target tests |
| skip the stamp on the `ctx.Done()` path only | `NameSurvivesEveryAbortPath/already-canceled` + both packages' `NamesSurviveCancelledContext` |
| `append` instead of `results[i] = res` | `ReturnsInputOrder` |

## Verification

```
golangci-lint run ./...                    0 issues.  (cold cache)
go test ./... -count=1                     56 ok, 0 FAIL
go test -race ./pkg/enum/{,google,m365}    ok
go build ./...                             exit 0
go vet ./pkg/enum/... ./cmd/...            exit 0
gofmt -l                                   clean
```

## The line count goes UP, by 100

Stated plainly because it's the honest number: google −72, microsoft365 −70, worker +242. Of those 242, only **81 are code** — the rest is doc comment. The real trade is 188 lines of duplicated pool logic becoming 95.

The total turns negative in PRs 2 and 3, which delete three more pool bodies (~247 lines) against no new shared file. If this series stopped here it would be a net loss; it's justified by what follows.

## Scope

**Excluded: `pkg/enum/workers.go` `runTasks`** — a sixth pool, but genuinely different: its unit of work is email × service, it `append`s rather than indexing so it has **no** ordering guarantee, it returns an error because it owns per-run HTTP client setup, and its panic diagnostics have two subjects.

**Not a bug: `pkg/enum/plugin.go`** carries the byte-identical `// generated given name; empty if the address was supplied` comment, but there it is **correct** — `runTasks` really does assign those fields. Anyone grepping that wording finds four files and should change none of them here.

**`cmd/brutus` untouched.** Its stamping becomes redundant once all five packages populate the fields; removing it is a separate follow-up.

## Two honest limitations

**microsoft365's nil-result guard is not executed by any test.** `CheckAccount` always returns a non-nil pointer, so the branch is unreachable through the public API. The test asserts the substitute the guard constructs has the right shape and exact error string, but cannot prove the branch runs. Adding an injectable seam purely for that would be test-only complexity in production code.

**A pre-existing flake, not from this PR.** `go test -race -count=3 ./...` fails five `cmd/brutus` flag tests (`TestEnumGithubMapCmd_Flags`, `TestEnumGithubCmd_Flags`, `TestEnumGoogleCmd_Flags`, `TestTeamsCommandRegistered`, `TestConnectTimeoutFlagWiring`) on iterations 2 and 3, from global cobra flag/command re-registration rather than concurrency. Reproduced identically at the base commit in a throwaway worktree. Worth its own ticket. The in-scope equivalent is clean: `go test -race -count=3 ./pkg/enum/...` passes all 13 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
