### PR TITLE
refactor(enum): migrate gravatar onto the shared TargetWorker (10T-535, 2/3)

### DIFF
--- a/pkg/enum/gravatar/gravatar.go
+++ b/pkg/enum/gravatar/gravatar.go
@@ -23,16 +23,9 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
-	"math/rand"
 	"net/http"
-	"os"
-	"runtime/debug"
 	"strings"
-	"sync"
 	"time"
-
-	"golang.org/x/sync/errgroup"
-	"golang.org/x/time/rate"
 
 	"github.com/praetorian-inc/brutus/pkg/enum"
 )
@@ -51,9 +44,13 @@ func HashEmail(email string) string {
 // Result is the outcome of checking a single email against the Gravatar avatar
 // endpoint.
 type Result struct {
-	Email    string
-	First    string // generated given name; empty if the address was supplied
-	Last     string // generated surname; empty if the address was supplied
+	Email string
+	// First and Last are copied from the originating enum.Target when
+	// enumerating via EnumerateTargetsWith. They are empty when the address
+	// arrived through EnumerateWith, which takes bare addresses and so has no
+	// name to carry. This package never derives a name from the local part.
+	First    string
+	Last     string
 	Hash     string
 	Exists   bool
 	Error    error
@@ -103,106 +100,86 @@ func (c *Checker) Enumerate(ctx context.Context, emails []string, threads int, r
 	return c.EnumerateWith(ctx, emails, threads, rateLimit, jitter, nil)
 }
 
-// EnumerateWith runs enumeration with bounded concurrency and invokes onResult
-// (if non-nil) for each completed result, serialized so callers can print/stream
-// safely. It still returns all results in input order.
+// EnumerateWith runs enumeration over bare addresses. It is a thin adapter over
+// EnumerateTargetsWith, which holds the single implementation: each address is
+// promoted to a nameless enum.Target. Because a bare address says nothing about
+// whose it is, every returned Result has empty First/Last — callers that know
+// the name behind an address should use EnumerateTargetsWith instead.
+//
+// The signature, ordering and callback semantics are unchanged; see
+// EnumerateTargetsWith for the callback contract.
+func (c *Checker) EnumerateWith(ctx context.Context, emails []string, threads int, rateLimit float64, jitter time.Duration, onResult func(Result)) []Result {
+	targets := make([]enum.Target, len(emails))
+	for i, email := range emails {
+		targets[i] = enum.Target{Email: email}
+	}
+	return c.EnumerateTargetsWith(ctx, targets, threads, rateLimit, jitter, onResult)
+}
+
+// newError builds the Result for failures the worker pool detects rather than
+// the probe: cancellation, a rate-limiter error, a nil result from CheckAccount,
+// and panic recovery.
+//
+// Hash is NOT decorative and must not be dropped: a gravatar Result identifies
+// its subject by the avatar hash as well as the address, and every failure
+// result this package produced before the shared-worker refactor carried it. A
+// generic zero-value construction in the worker would silently erase it, which
+// is exactly why NewError is a per-package hook. Note the deliberate asymmetry:
+// Email echoes the caller's input verbatim while Hash is computed from the
+// normalized (lower-cased, trimmed) form, because that is what the avatar API
+// keys on.
+func newError(email string, err error) Result {
+	return Result{Email: email, Hash: HashEmail(email), Error: err}
+}
+
+// worker returns the shared bounded worker pool configured for this checker. It
+// is a method (rather than inline in EnumerateTargetsWith) so tests can assert
+// the four hooks — in particular the Label that drives the panic diagnostics,
+// and newError's field shape — without running a pool.
+func (c *Checker) worker() enum.TargetWorker[Result] {
+	return enum.TargetWorker[Result]{
+		Label: "gravatar enum",
+		// CheckAccount returns *Result, so the nil guard lives here rather than
+		// in the shared worker: the message is this package's text, and keeping
+		// Check value-returning keeps a pointer/value duality out of the generic.
+		Check: func(ctx context.Context, email string) Result {
+			r := c.CheckAccount(ctx, email)
+			if r == nil {
+				return newError(email, fmt.Errorf("gravatar enum: nil result for %s", email))
+			}
+			return *r
+		},
+		NewError:  newError,
+		StampName: func(r *Result, t enum.Target) { r.First, r.Last = t.First, t.Last },
+	}
+}
+
+// EnumerateTargetsWith runs enumeration with bounded concurrency over targets
+// that carry the name behind each address, and invokes onResult (if non-nil) for
+// each completed result, serialized so callers can print/stream safely. It
+// returns all results in input order.
+//
+// The name travels with the target rather than being recovered afterwards, so a
+// consumer of this package never has to reverse-derive a name from the local
+// part — a lossy guess for initial-based formats, where "jsmith" could be John,
+// James or Jane. Each Result is stamped with the name of the target that
+// produced it (never a neighboring target's).
+//
+// A name is a property of the address, not of the check outcome, so the stamp is
+// applied on every path: a completed check, context cancellation, a rate-limiter
+// error, cancellation during jitter, a nil result from CheckAccount, and panic
+// recovery. A failed probe still reports whose address failed. Targets without a
+// name (operator-supplied addresses) stay nameless; no name is ever invented.
 //
 // onResult is called under the same mutex that guards the results slice, so
 // callback invocations never interleave and never race the slice. The callback
 // must therefore be cheap and self-contained: it may write to an io.Writer or
 // update counters, but it must NOT call back into the Checker (doing so risks
 // deadlock and defeats the serialization guarantee).
-func (c *Checker) EnumerateWith(ctx context.Context, emails []string, threads int, rateLimit float64, jitter time.Duration, onResult func(Result)) []Result {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	g, ctx := errgroup.WithContext(ctx)
-	// Normalize thread count: 0 would deadlock errgroup.SetLimit (no goroutine
-	// can ever run) and a negative value means unbounded. Clamp to a safe
-	// positive default of 1 (serial execution).
-	if threads <= 0 {
-		threads = 1
-	}
-	g.SetLimit(threads)
-
-	var limiter *rate.Limiter
-	if rateLimit > 0 {
-		limiter = rate.NewLimiter(rate.Limit(rateLimit), 1)
-	}
-
-	results := make([]Result, len(emails))
-	var mu sync.Mutex
-
-	// record stores a completed result and, under the same lock, invokes the
-	// caller's callback so streamed output is serialized and slice-safe.
-	record := func(i int, res Result) {
-		mu.Lock()
-		defer mu.Unlock()
-		results[i] = res
-		if onResult != nil {
-			onResult(res)
-		}
-	}
-
-	for i, email := range emails {
-		i, email := i, email
-		g.Go(func() error {
-			defer func() {
-				if r := recover(); r != nil {
-					fmt.Fprintf(os.Stderr, "gravatar enum: panic checking %s: %v\n%s\n", email, r, debug.Stack())
-					record(i, Result{
-						Email: email,
-						Hash:  HashEmail(email),
-						Error: fmt.Errorf("gravatar enum: panicked: %v", r),
-					})
-				}
-			}()
-
-			select {
-			case <-ctx.Done():
-				// Record before returning so every index is filled and the callback fires exactly once per email.
-				record(i, Result{Email: email, Hash: HashEmail(email), Error: ctx.Err()})
-				return nil
-			default:
-			}
-
-			if limiter != nil {
-				if err := limiter.Wait(ctx); err != nil {
-					// Record before returning so every index is filled and the callback fires exactly once per email.
-					record(i, Result{Email: email, Hash: HashEmail(email), Error: err})
-					return nil
-				}
-				if jitter > 0 {
-					delay := time.Duration(rand.Int63n(int64(jitter)))
-					select {
-					case <-time.After(delay):
-					case <-ctx.Done():
-						// Record before returning so every index is filled and the callback fires exactly once per email.
-						record(i, Result{Email: email, Hash: HashEmail(email), Error: ctx.Err()})
-						return nil
-					}
-				}
-			}
-
-			r := c.CheckAccount(ctx, email)
-			if r == nil {
-				record(i, Result{
-					Email: email,
-					Hash:  HashEmail(email),
-					Error: fmt.Errorf("gravatar enum: nil result for %s", email),
-				})
-				return nil
-			}
-			record(i, *r)
-			return nil
-		})
-	}
-
-	// Discarding g.Wait()'s error is deliberate: worker goroutines never return
-	// a non-nil error (per-email failures are encoded in each Result), so the
-	// returned error is always nil.
-	_ = g.Wait()
-	return results
+//
+// The pool itself is enum.TargetWorker; see its doc comment for the full contract.
+func (c *Checker) EnumerateTargetsWith(ctx context.Context, targets []enum.Target, threads int, rateLimit float64, jitter time.Duration, onResult func(Result)) []Result {
+	return c.worker().Run(ctx, targets, threads, rateLimit, jitter, onResult)
 }
 
 // CheckAccount tests if an email account has a registered Gravatar by requesting

--- a/pkg/enum/gravatar/gravatar_hooks_test.go
+++ b/pkg/enum/gravatar/gravatar_hooks_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Per-package hook-wiring tests for gravatar's enum.TargetWorker[Result]
+// configuration (PLAN.md Part 3.3). These are wiring assertions, not a
+// re-test of the pool: TargetWorker's generic behavior (ordering, panic
+// isolation, concurrency bounds, callback serialization, etc.) is covered
+// exactly once in pkg/enum/targetworker_test.go. What cannot be proven there
+// is that THIS package wired its four hooks up correctly -- that Label is
+// the exact string the pre-migration code used (panic diagnostics stay
+// byte-identical), that NewError builds gravatar's real failure shape
+// (Email, Hash, Error -- NOT dropping or adding a field), and that StampName
+// copies only First/Last. worker() exists precisely so these are testable
+// directly, without driving a live pool (PLAN.md Part 2, Part 3.3).
+package gravatar
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/brutus/pkg/enum"
+)
+
+// ---------------------------------------------------------------------------
+// TestWorker_Label
+// gravatar's pre-migration panic diagnostics were prefixed "gravatar enum"
+// (gravatar.go:152,156), yielding "gravatar enum: panic checking %s: %v" on
+// stderr and "gravatar enum: panicked: %v" on the Result. The shared worker
+// reproduces that prefix verbatim via Label, so this exact string must never
+// drift -- changing it is a log-format change for anything that greps stderr
+// or a Result's Error text, not a cosmetic rename.
+// ---------------------------------------------------------------------------
+
+func TestWorker_Label(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewChecker("", "", time.Second)
+	require.NoError(t, err)
+
+	assert.Equal(t, "gravatar enum", c.worker().Label)
+}
+
+// ---------------------------------------------------------------------------
+// TestWorker_NewErrorShape
+//
+// gravatar's failure results carry Email, Hash AND Error -- Hash is the one
+// field a naive generic construction ("R{} + error field") would silently
+// drop (PLAN.md Part 0.4, Part 2.3). Comparing the full struct -- not just
+// Email/Error individually -- is deliberate and load-bearing here: an
+// assertion that checked only Email and Error would pass even if Hash were
+// missing, defeating the entire point of this test. Full-struct equality
+// fails loudly on a dropped OR an unexpectedly added field.
+// ---------------------------------------------------------------------------
+
+func TestWorker_NewErrorShape(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewChecker("", "", time.Second)
+	require.NoError(t, err)
+
+	sentinel := errors.New("sentinel")
+	got := c.worker().NewError("a@b.com", sentinel)
+
+	assert.Equal(t, Result{Email: "a@b.com", Hash: HashEmail("a@b.com"), Error: sentinel}, got)
+}
+
+// ---------------------------------------------------------------------------
+// TestWorker_NewErrorShape_HashIsNormalizedNotVerbatimEmail
+//
+// HashEmail lowercases and trims internally, but Result.Email echoes the
+// input verbatim. So a mixed-case/whitespace-padded address must produce a
+// Result whose Email is untouched but whose Hash is computed from the
+// normalized form -- an asymmetry worth pinning explicitly, since it is
+// exactly the kind of thing a future "fix" might flatten by accident.
+// ---------------------------------------------------------------------------
+
+func TestWorker_NewErrorShape_HashIsNormalizedNotVerbatimEmail(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewChecker("", "", time.Second)
+	require.NoError(t, err)
+
+	const raw = "  John.Smith@Example.com  "
+	sentinel := errors.New("sentinel")
+	got := c.worker().NewError(raw, sentinel)
+
+	assert.Equal(t, raw, got.Email, "Email must echo the input verbatim, uncased/untrimmed")
+	assert.Equal(t, HashEmail(raw), got.Hash, "Hash must be computed from the normalized form")
+	assert.NotEqual(t, got.Email, got.Hash)
+}
+
+// ---------------------------------------------------------------------------
+// TestWorker_StampNameCopiesFirstLastOnly
+// StampName's documented contract (targetworker.go) is a one-line copy of
+// First/Last from the originating Target. This asserts both halves of that
+// contract: First/Last land correctly, and every other field on an
+// already-populated Result -- including Hash, gravatar's own extra field --
+// is left untouched.
+// ---------------------------------------------------------------------------
+
+func TestWorker_StampNameCopiesFirstLastOnly(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewChecker("", "", time.Second)
+	require.NoError(t, err)
+
+	res := Result{
+		Email:    "a@b.com",
+		Hash:     HashEmail("a@b.com"),
+		Exists:   true,
+		Error:    errors.New("unchanged-error"),
+		Duration: 42 * time.Millisecond,
+	}
+	before := res
+
+	c.worker().StampName(&res, enum.Target{Email: "a@b.com", First: "Jane", Last: "Doe"})
+
+	assert.Equal(t, "Jane", res.First)
+	assert.Equal(t, "Doe", res.Last)
+	assert.Equal(t, before.Email, res.Email, "StampName must not touch Email")
+	assert.Equal(t, before.Hash, res.Hash, "StampName must not touch Hash")
+	assert.Equal(t, before.Exists, res.Exists, "StampName must not touch Exists")
+	assert.Equal(t, before.Error, res.Error, "StampName must not touch Error")
+	assert.Equal(t, before.Duration, res.Duration, "StampName must not touch Duration")
+}

--- a/pkg/enum/gravatar/gravatar_targets_test.go
+++ b/pkg/enum/gravatar/gravatar_targets_test.go
@@ -1,0 +1,381 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// RED-phase tests for EnumerateTargetsWith, the Target-accepting sibling of
+// EnumerateWith. These tests assert that names travel with their originating
+// enum.Target all the way through to the Result that address produced,
+// correlated by email (never by index/order, since the worker pool is
+// concurrent) -- mirroring pkg/enum/google/google_targets_test.go.
+//
+// gravatar carries one asymmetry the other migrated packages do not: every
+// Result also carries a Hash, computed from the normalized (lower-cased,
+// trimmed) email even though Result.Email echoes the input verbatim. A
+// generic "R{} + error" construction inside newError would silently drop
+// Hash on every failure result. TestGravatarEnumerateTargetsWith_
+// HashSurvivesFailingProbe is the dedicated regression guard for that; see
+// its comment for why it is the single most valuable test in this file.
+//
+// EnumerateTargetsWith, worker() and newError do not exist yet on *Checker;
+// this file is expected to fail to compile until they are added to
+// gravatar.go (PLAN.md Part 2.3).
+package gravatar
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/brutus/pkg/enum"
+)
+
+// failingEmail is the address whose Gravatar hash the target-test mock server
+// answers with a genuine 500, giving CheckAccount a real (non-nil) Error to
+// propagate. This is what lets these tests drive a real error path through
+// EnumerateTargetsWith without inventing an injectable probe seam.
+// registeredEmail (declared in gravatar_test.go, same package) is reused
+// unchanged for the "exists" case.
+const failingEmail = "failing-target@example.com"
+
+// newTargetsMockServer builds an httptest.Server keyed by avatar hash, in the
+// same style as newMockServer (gravatar_test.go:64 -- the package's existing
+// HTTP-stubbing seam): registeredEmail's hash answers 200 (exists),
+// failingEmail's hash answers 500 (a genuine CheckAccount error, same shape as
+// TestCheckAccount_ServerError in gravatar_test.go), and every other hash
+// 404s (not exists, no error). This is the minimal extension of the existing
+// seam needed for the target tests below; no fake/injected probe is used and
+// no real network call is made.
+func newTargetsMockServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	registeredHash := HashEmail(registeredEmail)
+	failingHash := HashEmail(failingEmail)
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wantPrefix := "/avatar/"
+		if !strings.HasPrefix(r.URL.Path, wantPrefix) {
+			http.NotFound(w, r)
+			return
+		}
+		hash := strings.TrimPrefix(r.URL.Path, wantPrefix)
+		switch hash {
+		case failingHash:
+			w.WriteHeader(http.StatusInternalServerError)
+		case registeredHash:
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+// ---------------------------------------------------------------------------
+// TestGravatarEnumerateTargetsWith_NamesRideOnResult
+// Core test: 3 targets with distinct names against a stub that reports
+// existence for all of them. Each returned Result must carry the name of the
+// target that produced it, correlated by email. An implementation that
+// stamps every Result with the first target's name fails this test.
+// ---------------------------------------------------------------------------
+
+func TestGravatarEnumerateTargetsWith_NamesRideOnResult(t *testing.T) {
+	t.Parallel()
+	srv := newTargetsMockServer(t)
+	t.Cleanup(srv.Close)
+
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
+
+	targets := []enum.Target{
+		{Email: registeredEmail, First: "john", Last: "smith"},
+		{Email: "notexists1@example.com", First: "david", Last: "smith"},
+		{Email: "notexists2@example.com", First: "michael", Last: "smith"},
+	}
+
+	results := c.EnumerateTargetsWith(context.Background(), targets, 4, 0, 0, nil)
+	require.Len(t, results, len(targets), "one Result per Target")
+
+	byEmail := make(map[string]Result, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	for _, tgt := range targets {
+		r, ok := byEmail[tgt.Email]
+		require.True(t, ok, "result for %q must be present", tgt.Email)
+		assert.NoError(t, r.Error, "%q must succeed against the stub", tgt.Email)
+		assert.Equal(t, tgt.First, r.First, "First for %q must match its own Target, not another target's", tgt.Email)
+		assert.Equal(t, tgt.Last, r.Last, "Last for %q must match its own Target, not another target's", tgt.Email)
+	}
+	assert.True(t, byEmail[registeredEmail].Exists, "registeredEmail must be reported as existing by the stub")
+}
+
+// ---------------------------------------------------------------------------
+// TestGravatarEnumerateTargetsWith_NamelessTargetStaysNameless
+// A Target with no name (address supplied by the operator, not generated)
+// must yield First=="" && Last=="". The library must never invent a name.
+// ---------------------------------------------------------------------------
+
+func TestGravatarEnumerateTargetsWith_NamelessTargetStaysNameless(t *testing.T) {
+	t.Parallel()
+	srv := newTargetsMockServer(t)
+	t.Cleanup(srv.Close)
+
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
+
+	targets := []enum.Target{{Email: "supplied@example.com"}}
+
+	results := c.EnumerateTargetsWith(context.Background(), targets, 1, 0, 0, nil)
+	require.Len(t, results, 1)
+	assert.Empty(t, results[0].First, "First must stay empty for a nameless Target")
+	assert.Empty(t, results[0].Last, "Last must stay empty for a nameless Target")
+}
+
+// ---------------------------------------------------------------------------
+// TestGravatarEnumerateWith_StillWorksAndYieldsEmptyNames
+// Pins that the existing EnumerateWith([]string) entry point is unaffected by
+// the refactor: it still returns correct results, and since bare addresses
+// carry no name, First/Last must be empty.
+// ---------------------------------------------------------------------------
+
+func TestGravatarEnumerateWith_StillWorksAndYieldsEmptyNames(t *testing.T) {
+	t.Parallel()
+	srv := newTargetsMockServer(t)
+	t.Cleanup(srv.Close)
+
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
+
+	emails := []string{registeredEmail, "notexists1@example.com", "notexists2@example.com"}
+	results := c.EnumerateWith(context.Background(), emails, 3, 0, 0, nil)
+	require.Len(t, results, len(emails))
+
+	byEmail := make(map[string]Result, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	for _, email := range emails {
+		r, ok := byEmail[email]
+		require.True(t, ok, "result for %q must be present", email)
+		assert.NoError(t, r.Error, "%q must succeed against the stub", email)
+		assert.Empty(t, r.First, "EnumerateWith must never invent a name")
+		assert.Empty(t, r.Last, "EnumerateWith must never invent a name")
+	}
+	assert.True(t, byEmail[registeredEmail].Exists, "registeredEmail must be reported as existing by the stub")
+}
+
+// ---------------------------------------------------------------------------
+// TestGravatarEnumerateTargetsWith_NamesSurviveErrorPath
+// A name is a property of the address, not of the check outcome. Drive a
+// Result whose Error is non-nil (the mock server's 500 for failingEmail) and
+// assert the name is still stamped.
+// ---------------------------------------------------------------------------
+
+func TestGravatarEnumerateTargetsWith_NamesSurviveErrorPath(t *testing.T) {
+	t.Parallel()
+	srv := newTargetsMockServer(t)
+	t.Cleanup(srv.Close)
+
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
+
+	targets := []enum.Target{
+		{Email: failingEmail, First: "erin", Last: "fail"},
+	}
+
+	results := c.EnumerateTargetsWith(context.Background(), targets, 1, 0, 0, nil)
+	require.Len(t, results, 1)
+
+	r := results[0]
+	assert.Equal(t, failingEmail, r.Email)
+	require.Error(t, r.Error, "the 500 response must surface as a genuine CheckAccount error")
+	assert.Equal(t, "erin", r.First, "name must survive even when the probe errors")
+	assert.Equal(t, "fail", r.Last, "name must survive even when the probe errors")
+}
+
+// ---------------------------------------------------------------------------
+// TestGravatarEnumerateTargetsWith_MixedNamedAndUnnamed
+// A single batch containing both named and unnamed targets: each Result must
+// get exactly its own target's name, or empty for the unnamed ones.
+// ---------------------------------------------------------------------------
+
+func TestGravatarEnumerateTargetsWith_MixedNamedAndUnnamed(t *testing.T) {
+	t.Parallel()
+	srv := newTargetsMockServer(t)
+	t.Cleanup(srv.Close)
+
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
+
+	targets := []enum.Target{
+		{Email: "named1@example.com", First: "anna", Last: "lee"},
+		{Email: "unnamed1@example.com"},
+		{Email: "named2@example.com", First: "bob", Last: "wu"},
+		{Email: "unnamed2@example.com"},
+	}
+
+	results := c.EnumerateTargetsWith(context.Background(), targets, 4, 0, 0, nil)
+	require.Len(t, results, len(targets))
+
+	byEmail := make(map[string]Result, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	for _, tgt := range targets {
+		r, ok := byEmail[tgt.Email]
+		require.True(t, ok, "result for %q must be present", tgt.Email)
+		assert.Equal(t, tgt.First, r.First, "First for %q", tgt.Email)
+		assert.Equal(t, tgt.Last, r.Last, "Last for %q", tgt.Email)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestGravatarEnumerateTargetsWith_EveryTargetSlotFilled
+// len(results) == len(targets) and every target is present even when some
+// probes fail. Completion order is not asserted (the worker pool is
+// concurrent); correlation is by email only.
+// ---------------------------------------------------------------------------
+
+func TestGravatarEnumerateTargetsWith_EveryTargetSlotFilled(t *testing.T) {
+	t.Parallel()
+	srv := newTargetsMockServer(t)
+	t.Cleanup(srv.Close)
+
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
+
+	targets := []enum.Target{
+		{Email: registeredEmail, First: "carl", Last: "one"},
+		{Email: failingEmail, First: "dana", Last: "two"},
+		{Email: "notexists@example.com", First: "ella", Last: "three"},
+	}
+
+	results := c.EnumerateTargetsWith(context.Background(), targets, 4, 0, 0, nil)
+	require.Len(t, results, len(targets), "one result per target regardless of probe failures")
+
+	byEmail := make(map[string]Result, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	for _, tgt := range targets {
+		r, ok := byEmail[tgt.Email]
+		require.True(t, ok, "no dropped slot for %q", tgt.Email)
+		assert.Equal(t, tgt.First, r.First)
+		assert.Equal(t, tgt.Last, r.Last)
+	}
+
+	// Confirm the engineered failure actually failed and the others didn't,
+	// proving this test exercises a genuinely mixed batch.
+	assert.Error(t, byEmail[failingEmail].Error)
+	assert.NoError(t, byEmail[registeredEmail].Error)
+	assert.NoError(t, byEmail["notexists@example.com"].Error)
+}
+
+// ---------------------------------------------------------------------------
+// TestGravatarEnumerateTargetsWith_NamesSurviveCancelledContext
+// Chokepoint test: with the context already canceled before the call, every
+// goroutine takes the <-ctx.Done() early-return branch and records via
+// newError WITHOUT ever calling CheckAccount. If the name stamp lived only at
+// the CheckAccount call site rather than at the single funnel every outcome
+// passes through, these Results would come back nameless.
+// ---------------------------------------------------------------------------
+
+func TestGravatarEnumerateTargetsWith_NamesSurviveCancelledContext(t *testing.T) {
+	t.Parallel()
+	srv := newTargetsMockServer(t)
+	t.Cleanup(srv.Close)
+
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
+
+	targets := []enum.Target{
+		{Email: "one@example.com", First: "gwen", Last: "alpha"},
+		{Email: "two@example.com", First: "hank", Last: "beta"},
+		{Email: "three@example.com", First: "iris", Last: "gamma"},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // canceled BEFORE the call
+
+	results := c.EnumerateTargetsWith(ctx, targets, 1, 0, 0, nil)
+	require.Len(t, results, len(targets))
+
+	byEmail := make(map[string]Result, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	for _, tgt := range targets {
+		r, ok := byEmail[tgt.Email]
+		require.True(t, ok, "result for %q must be present", tgt.Email)
+		require.Error(t, r.Error, "an already-canceled context must surface as a non-nil Error for %q", tgt.Email)
+		assert.Equal(t, tgt.First, r.First, "First for %q must survive the ctx.Done() early return", tgt.Email)
+		assert.Equal(t, tgt.Last, r.Last, "Last for %q must survive the ctx.Done() early return", tgt.Email)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestGravatarEnumerateTargetsWith_HashSurvivesFailingProbe
+//
+// This is the single most valuable test in this file (PLAN.md Part 3.3): every
+// gravatar Result -- success or failure -- carries a Hash computed from the
+// normalized email, even though Result.Email echoes the input verbatim. If
+// newError is written as a bare Result{Email: email, Error: err}, every
+// failed probe silently loses its hash: no compile error, no other test
+// failure. This test would catch exactly that regression.
+//
+// Two cases, both required:
+//   - a genuine probe failure (mock server 500) -- Hash must survive the path
+//     through CheckAccount's own error return.
+//   - an already-canceled context -- this path never reaches CheckAccount at
+//     all, so newError alone is responsible for the Hash on this Result. If
+//     Hash is dropped, this is the case that proves it.
+// ---------------------------------------------------------------------------
+
+func TestGravatarEnumerateTargetsWith_HashSurvivesFailingProbe(t *testing.T) {
+	t.Parallel()
+	srv := newTargetsMockServer(t)
+	t.Cleanup(srv.Close)
+
+	c, err := NewChecker(srv.URL, "", 5*time.Second)
+	require.NoError(t, err)
+
+	// Case 1: a genuine probe failure (500 from the mock server).
+	failTargets := []enum.Target{{Email: failingEmail, First: "hank", Last: "hash"}}
+	failResults := c.EnumerateTargetsWith(context.Background(), failTargets, 1, 0, 0, nil)
+	require.Len(t, failResults, 1)
+	require.Error(t, failResults[0].Error, "the 500 response must surface as a genuine CheckAccount error")
+	assert.Equal(t, HashEmail(failingEmail), failResults[0].Hash,
+		"Hash must survive on a failing probe result -- a newError that drops Hash breaks this")
+
+	// Case 2: an already-canceled context, which never reaches CheckAccount at
+	// all and is recorded entirely by newError inside the worker.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	cancelTargets := []enum.Target{{Email: "canceled-target@example.com", First: "iris", Last: "cancel"}}
+	cancelResults := c.EnumerateTargetsWith(ctx, cancelTargets, 1, 0, 0, nil)
+	require.Len(t, cancelResults, 1)
+	require.Error(t, cancelResults[0].Error)
+	assert.True(t, errors.Is(cancelResults[0].Error, context.Canceled))
+	assert.Equal(t, HashEmail("canceled-target@example.com"), cancelResults[0].Hash,
+		"Hash must survive on the ctx.Done() abort path too -- this is the path that never calls "+
+			"CheckAccount, so newError is the ONLY place Hash can come from")
+}


### PR DESCRIPTION
**PR 2 of 3.** Moves gravatar onto the shared pool from #318 and gives it `EnumerateTargetsWith`. **Semantically inert** — nothing observable changes.

Branched fresh from `main` after #318 merged; nothing stacked.

## What changes

`newError`, `worker()`, and `EnumerateTargetsWith` are added; `EnumerateWith` keeps its **byte-identical signature** and becomes a thin adapter promoting each address to a nameless `enum.Target`. The `First`/`Last` field doc comments — which claimed the package populated fields it never touched — are corrected. Exported API is purely additive.

```
gravatar.go   100 deleted, 77 added   →  net −23 production lines
grep -c errgroup gravatar.go          →  0   (pool gone)
```

## Why gravatar is its own PR

Every gravatar result carries a `Hash`, and its failure results are built as

```go
Result{Email: email, Hash: HashEmail(email), Error: ...}
```

at **five** sites: panic recovery, `ctx.Done()`, limiter error, jitter cancellation, and the nil-result substitute.

google and microsoft365 are the templates for this migration, and **their result types have no `Hash`**. So copying their `newError` verbatim compiles cleanly and silently drops the hash from every failed probe. That's a one-line mistake that would be nearly invisible inside a five-package refactor, which is exactly why gravatar is reviewed alone.

```go
func newError(email string, err error) Result {
	return Result{Email: email, Hash: HashEmail(email), Error: err}
}
```

**A related asymmetry is preserved, not tidied.** `HashEmail` lowercases and trims internally, but `Result.Email` echoes the input verbatim — so the email keeps its casing while the hash is computed from a normalized form. It looks like an inconsistency and isn't; there's now a test naming it so it doesn't get "fixed" later.

## Tests

**8 target tests** mirroring google's: names riding on the Result correlated **by email not index**, nameless targets staying nameless, the existing `EnumerateWith` still yielding empty names, names surviving the error path, mixed named/unnamed batches, every slot filled, names surviving an already-canceled context — plus a gravatar-specific `HashSurvivesFailingProbe`.

**4 hook tests**: `Label` exact, full `newError` struct equality **including `Hash`**, the normalized-hash asymmetry, and `StampName` touching only `First`/`Last`.

Mutations, both reverted:

| Mutation | Failed |
|---|---|
| drop `Hash` from `newError` | `NewErrorShape`, `NewErrorShape_HashIsNormalized...`, `HashSurvivesFailingProbe` |
| stamp from `targets[0]` not `targets[i]` | `NamesRideOnResult`, `NamesSurviveCancelledContext`, `MixedNamedAndUnnamed`, `EveryTargetSlotFilled` |

**One detail from mutation 1 worth knowing.** Only the *canceled-context* case failed — the mock-500 case still passed, because `CheckAccount` populates `Hash` itself before returning its error, so a real probe failure never reaches `newError`. The abort path is the only place `newError` is solely responsible for the hash. That makes the cancel case load-bearing rather than a duplicate of the 500 case.

## Verification

```
golangci-lint run ./...              0 issues.   (cold cache)
go test ./... -count=1               56 ok, 0 FAIL
go test -race ./pkg/enum/gravatar/   ok
go build ./...                       exit 0
go vet ./pkg/enum/... ./cmd/...      exit 0
gofmt -l                             clean
EnumerateWith signature              byte-identical to 4cff968
gravatar_test.go                     unmodified, passing
```

`gravatar_test.go` passing untouched is the regression net — in particular `TestEnumerateWith_CanceledContextRecordsAllSlots`, which is the direct proof that abort-path recording didn't change.

## One untestable site, stated plainly

The nil-result substitute inside `Check` is the one remaining place a dropped `Hash` would go unnoticed: `CheckAccount` cannot return `nil` through any reachable path today, so that branch is defensive and no test can drive it. It routes through `newError`, which is what keeps it correct. Adding an injectable seam purely to reach it would be test-only complexity in production code.

## Notes for the next PR

Three things in the internal plan didn't survive contact with the code, recorded so PR 3's estimates get read with the right correction:

- **Line estimate was optimistic** — planned −42, actual −23. The gap is comment volume: the migration copies google's 22-line method doc and microsoft365's adapter doc verbatim. Expect the same ~20-line-per-package correction in PR 3.
- **A planned verification command is broken**: `go doc ./pkg/enum/gravatar | grep -c EnumerateTargetsWith` returns 0, because `go doc` without `-all` prints only a package summary. The working form is `go doc -all ./pkg/enum/gravatar | grep -c "func (c \*Checker) EnumerateTargetsWith"`.
- **The `Result` doc-comment fix reflows gofmt alignment** — moving comments above the fields un-pads `Email string`. Cosmetic, matches both templates.

**PR 3 (github + teams) is the one that changes behavior.** Those two do *not* record on abort paths — they `return nil`, leaving a zero-value result and never firing `onResult`. That's a real change to interrupt-path output and will be reviewed on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
