### PR TITLE
refactor(enum): migrate github and teams onto the shared TargetWorker (10T-535, 3/3)

### DIFF
--- a/pkg/enum/github/existence.go
+++ b/pkg/enum/github/existence.go
@@ -18,17 +18,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"math/rand"
 	"net/http"
 	"net/url"
 	"os"
-	"runtime/debug"
 	"strings"
-	"sync"
 	"time"
-
-	"golang.org/x/sync/errgroup"
-	"golang.org/x/time/rate"
 
 	"github.com/praetorian-inc/brutus/pkg/enum"
 )
@@ -44,98 +38,112 @@ func (e *Enumerator) Enumerate(ctx context.Context, emails []string, threads int
 	return e.EnumerateWith(ctx, emails, threads, rateLimit, jitter, nil)
 }
 
-// EnumerateWith runs existence enumeration with bounded concurrency and invokes
-// onResult (if non-nil) for each completed result, serialized so callers can
-// print/stream safely. It still returns all results in input order.
+// EnumerateWith runs existence enumeration over bare addresses. It is a thin
+// adapter over EnumerateTargetsWith, which holds the single implementation: each
+// address is promoted to a nameless enum.Target. Because a bare address says
+// nothing about whose it is, every returned Result has empty First/Last —
+// callers that know the name behind an address should use EnumerateTargetsWith
+// instead.
+//
+// The signature, ordering and callback semantics are unchanged; see
+// EnumerateTargetsWith for the session gate, the callback contract, and for the
+// one deliberate behavior change this delegation brings: abort paths now record
+// a result rather than dropping it.
+func (e *Enumerator) EnumerateWith(ctx context.Context, emails []string, threads int, rateLimit float64, jitter time.Duration, onResult func(Result)) []Result {
+	targets := make([]enum.Target, len(emails))
+	for i, email := range emails {
+		targets[i] = enum.Target{Email: email}
+	}
+	return e.EnumerateTargetsWith(ctx, targets, threads, rateLimit, jitter, onResult)
+}
+
+// newError builds the Result for failures detected outside the probe: session
+// establishment, cancellation, a rate-limiter error, cancellation during jitter,
+// and panic recovery. github's failure results carry no fields beyond the
+// address and the error.
+func newError(email string, err error) Result {
+	return Result{Email: email, Error: err}
+}
+
+// worker returns the shared bounded worker pool bound to an established session.
+// The session is a parameter rather than enumerator state because it is
+// established once per EnumerateTargetsWith call and shared read-only by every
+// worker.
+//
+// It is a method (rather than inline in EnumerateTargetsWith) so tests can
+// assert the four hooks — in particular the Label that drives the panic
+// diagnostics, and newError's field shape — without running a pool or a live
+// join/validity endpoint.
+func (e *Enumerator) worker(sess *session) enum.TargetWorker[Result] {
+	return enum.TargetWorker[Result]{
+		Label: "github enum",
+		Check: func(ctx context.Context, email string) Result {
+			return e.checkEmail(ctx, sess, email)
+		},
+		NewError:  newError,
+		StampName: func(r *Result, t enum.Target) { r.First, r.Last = t.First, t.Last },
+	}
+}
+
+// EnumerateTargetsWith runs existence enumeration with bounded concurrency over
+// targets that carry the name behind each address, and invokes onResult (if
+// non-nil) for each completed result, serialized so callers can print/stream
+// safely. It returns all results in input order.
+//
+// The name travels with the target rather than being recovered afterwards, so a
+// consumer of this package never has to reverse-derive a name from the local
+// part — a lossy guess for initial-based formats, where "jsmith" could be John,
+// James or Jane. Each Result is stamped with the name of the target that
+// produced it (never a neighboring target's).
+//
+// A name is a property of the address, not of the check outcome, so the stamp is
+// applied on every path: a completed check, session-establishment failure,
+// context cancellation, a rate-limiter error, cancellation during jitter, and
+// panic recovery. A failed probe still reports whose address failed. Targets
+// without a name (operator-supplied addresses) stay nameless; no name is ever
+// invented.
 //
 // The session (CSRF token + cookies) is established ONCE before the worker pool
-// and shared read-only across workers. If session establishment fails, every
-// Result is returned carrying that error.
+// and shared read-only across workers. If session establishment fails, no check
+// is possible, so every Target is returned carrying that error — still stamped
+// with its name, and still delivered to onResult exactly once — rather than
+// running a pool that would fail identically for every address.
+//
+// Behavior change (deliberate): before this package delegated to
+// enum.TargetWorker, the pool's own abort paths returned without recording,
+// leaving that slot a zero Result (Email empty, Error nil) and never firing
+// onResult. Every abort now records newError(email, <cause>) and fires onResult
+// exactly once, matching google, microsoft365 and gravatar. An interrupted run
+// therefore emits one error result per un-probed address instead of dropping it
+// silently. The session-failure gate above is unaffected — it always filled
+// every slot.
 //
 // onResult is called under the same mutex that guards the results slice, so
 // callback invocations never interleave and never race the slice. The callback
 // must be cheap and self-contained and must NOT call back into the Enumerator.
-func (e *Enumerator) EnumerateWith(ctx context.Context, emails []string, threads int, rateLimit float64, jitter time.Duration, onResult func(Result)) []Result {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	results := make([]Result, len(emails))
-	var mu sync.Mutex
-	record := func(i int, res Result) {
-		mu.Lock()
-		defer mu.Unlock()
-		results[i] = res
-		if onResult != nil {
-			onResult(res)
-		}
-	}
-
+//
+// The pool itself is enum.TargetWorker; see its doc comment for the full contract.
+func (e *Enumerator) EnumerateTargetsWith(ctx context.Context, targets []enum.Target, threads int, rateLimit float64, jitter time.Duration, onResult func(Result)) []Result {
 	sess, err := e.establishSession(ctx)
 	if err != nil {
 		// Without a session no checks are possible; surface the error on every
 		// result so the caller (and JSONL output) reflects the failure per email.
-		for i, email := range emails {
-			record(i, Result{Email: email, Error: err})
+		// This gate runs before the pool, on this goroutine, so no lock is
+		// needed — but the stamp and the exactly-once callback contract still
+		// hold, exactly as they do inside the pool.
+		results := make([]Result, len(targets))
+		for i, t := range targets {
+			res := newError(t.Email, err)
+			res.First, res.Last = t.First, t.Last
+			results[i] = res
+			if onResult != nil {
+				onResult(res)
+			}
 		}
 		return results
 	}
 
-	g, ctx := errgroup.WithContext(ctx)
-	// Normalize thread count: 0 would deadlock errgroup.SetLimit (no goroutine
-	// can ever run) and a negative value means unbounded. Clamp to a safe
-	// positive default of 1 (serial execution).
-	if threads <= 0 {
-		threads = 1
-	}
-	g.SetLimit(threads)
-
-	var limiter *rate.Limiter
-	if rateLimit > 0 {
-		limiter = rate.NewLimiter(rate.Limit(rateLimit), 1)
-	}
-
-	for i, email := range emails {
-		i, email := i, email
-		g.Go(func() error {
-			defer func() {
-				if r := recover(); r != nil {
-					fmt.Fprintf(os.Stderr, "github enum: panic checking %s: %v\n%s\n", email, r, debug.Stack())
-					record(i, Result{
-						Email: email,
-						Error: fmt.Errorf("github enum: panicked: %v", r),
-					})
-				}
-			}()
-
-			select {
-			case <-ctx.Done():
-				return nil
-			default:
-			}
-
-			if limiter != nil {
-				if err := limiter.Wait(ctx); err != nil {
-					return nil
-				}
-				if jitter > 0 {
-					delay := time.Duration(rand.Int63n(int64(jitter)))
-					select {
-					case <-time.After(delay):
-					case <-ctx.Done():
-						return nil
-					}
-				}
-			}
-
-			record(i, e.checkEmail(ctx, sess, email))
-			return nil
-		})
-	}
-
-	// Worker goroutines never return a non-nil error (per-email failures are
-	// encoded in each Result), so the returned error is always nil.
-	_ = g.Wait()
-	return results
+	return e.worker(sess).Run(ctx, targets, threads, rateLimit, jitter, onResult)
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/enum/github/github.go
+++ b/pkg/enum/github/github.go
@@ -58,9 +58,13 @@ import (
 // author email to an account login. Email and Username are server-/user-derived
 // and are NOT sanitized here; sanitization happens at the output layer.
 type Result struct {
-	Email    string
-	First    string // generated given name; empty if the address was supplied
-	Last     string // generated surname; empty if the address was supplied
+	Email string
+	// First and Last are copied from the originating enum.Target when
+	// enumerating via EnumerateTargetsWith. They are empty when the address
+	// arrived through EnumerateWith, which takes bare addresses and so has no
+	// name to carry. This package never derives a name from the local part.
+	First    string
+	Last     string
 	Exists   bool
 	Username string
 	Error    error

--- a/pkg/enum/github/github_hooks_test.go
+++ b/pkg/enum/github/github_hooks_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Per-package hook-wiring tests for github's enum.TargetWorker[Result]
+// configuration (PLAN.md Part 3.3). These are wiring assertions, not a
+// re-test of the pool: TargetWorker's generic behavior (ordering, panic
+// isolation, concurrency bounds, callback serialization, etc.) is covered
+// exactly once in pkg/enum/targetworker_test.go. What cannot be proven there
+// is that THIS package wired its four hooks up correctly -- that Label is
+// the exact string the pre-migration code used (panic diagnostics stay
+// byte-identical), that NewError builds github's real failure shape (Email,
+// Error -- no extra fields), and that StampName copies only First/Last.
+// worker() exists precisely so these are testable directly, without driving
+// a live pool or an established session (PLAN.md Part 2.5, Part 3.3).
+//
+// worker() is not yet defined on *Enumerator; this file is expected to fail
+// to compile until it, newError and the pkg/enum import are added to
+// existence.go (PLAN.md Part 2.5).
+package github
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/brutus/pkg/enum"
+)
+
+// ---------------------------------------------------------------------------
+// TestWorker_Label
+// github's pre-migration panic diagnostics were prefixed "github enum"
+// (existence.go:102,105), yielding "github enum: panic checking %s: %v" on
+// stderr and "github enum: panicked: %v" on the Result. The shared worker
+// reproduces that prefix verbatim via Label, so this exact string must never
+// drift -- changing it is a log-format change for anything that greps stderr
+// or a Result's Error text, not a cosmetic rename.
+// ---------------------------------------------------------------------------
+
+func TestWorker_Label(t *testing.T) {
+	t.Parallel()
+
+	e, err := NewEnumerator("", time.Second, "", false)
+	require.NoError(t, err)
+
+	// worker takes the already-established session as a parameter (PLAN.md
+	// Part 2.5); Label/NewError/StampName never read it, so a dummy session is
+	// sufficient for this wiring assertion -- no live join/validity endpoint
+	// is needed.
+	assert.Equal(t, "github enum", e.worker(&session{}).Label)
+}
+
+// ---------------------------------------------------------------------------
+// TestWorker_NewErrorShape
+//
+// github's failure results carry ONLY Email and Error -- no extra fields
+// (unlike gravatar's Hash or teams' Exists: ExistenceUnknown). Full-struct
+// equality is deliberate here too: it fails loudly if a future change adds an
+// unexpected field to github's failure shape, not just if Email/Error are
+// individually wrong.
+// ---------------------------------------------------------------------------
+
+func TestWorker_NewErrorShape(t *testing.T) {
+	t.Parallel()
+
+	e, err := NewEnumerator("", time.Second, "", false)
+	require.NoError(t, err)
+
+	sentinel := errors.New("sentinel")
+	got := e.worker(&session{}).NewError("a@b.com", sentinel)
+
+	assert.Equal(t, Result{Email: "a@b.com", Error: sentinel}, got)
+}
+
+// ---------------------------------------------------------------------------
+// TestWorker_StampNameCopiesFirstLastOnly
+// StampName's documented contract (targetworker.go) is a one-line copy of
+// First/Last from the originating Target. This asserts both halves of that
+// contract: First/Last land correctly, and every other field on an
+// already-populated Result -- including Username, github's reveal-only
+// field -- is left untouched.
+// ---------------------------------------------------------------------------
+
+func TestWorker_StampNameCopiesFirstLastOnly(t *testing.T) {
+	t.Parallel()
+
+	e, err := NewEnumerator("", time.Second, "", false)
+	require.NoError(t, err)
+
+	res := Result{
+		Email:    "a@b.com",
+		Exists:   true,
+		Username: "existing-login",
+		Error:    errors.New("unchanged-error"),
+	}
+	before := res
+
+	e.worker(&session{}).StampName(&res, enum.Target{Email: "a@b.com", First: "Jane", Last: "Doe"})
+
+	assert.Equal(t, "Jane", res.First)
+	assert.Equal(t, "Doe", res.Last)
+	assert.Equal(t, before.Email, res.Email, "StampName must not touch Email")
+	assert.Equal(t, before.Exists, res.Exists, "StampName must not touch Exists")
+	assert.Equal(t, before.Username, res.Username, "StampName must not touch Username")
+	assert.Equal(t, before.Error, res.Error, "StampName must not touch Error")
+}

--- a/pkg/enum/github/github_targets_test.go
+++ b/pkg/enum/github/github_targets_test.go
@@ -1,0 +1,408 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// RED-phase tests for EnumerateTargetsWith, the Target-accepting sibling of
+// EnumerateWith. These tests assert that names travel with their originating
+// enum.Target all the way through to the Result that address produced,
+// correlated by email (never by index/order, since the worker pool is
+// concurrent) -- mirroring pkg/enum/gravatar/gravatar_targets_test.go.
+//
+// github carries one structural asymmetry the other four migrated/migrating
+// packages do not: establishSession runs ONCE, synchronously, before the
+// worker pool, and its own error branch has ALWAYS filled every slot
+// (existence.go:74-81), migration or not. That has a direct consequence for
+// how the abort-path behavior change (PLAN.md Part 0.1, 4.5) is observed
+// here: an already-canceled top-level context never reaches the pool's own
+// per-email `<-ctx.Done()` guard for github, because establishSession's very
+// first outbound HTTP call fails immediately on an already-Done context
+// (verified empirically: http.Client.Do on an already-canceled ctx returns
+// "context canceled" without a round trip) and the session-failure branch
+// takes over -- indistinguishable from a 403-blocked join page. See
+// TestGithubEnumerateTargetsWith_SessionFailureFillsEverySlotStamped for that
+// (already-correct, unaffected-by-this-PR) path, and see
+// TestGithubEnumerateWith_CanceledContextNowRecordsEverySlot's doc comment
+// for how the pool's OWN guard is exercised instead.
+//
+// EnumerateTargetsWith, worker() and newError do not exist yet on
+// *Enumerator; this file is expected to fail to compile until they are added
+// to existence.go (PLAN.md Part 2.5).
+package github
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/brutus/pkg/enum"
+)
+
+// ---------------------------------------------------------------------------
+// TestGithubEnumerateTargetsWith_NamesRideOnResult
+// Core test: 3 targets with distinct names against a stub that reports
+// existence per the configured status map. Each returned Result must carry
+// the name of the target that produced it, correlated by email. An
+// implementation that stamps every Result with the first target's name fails
+// this test.
+// ---------------------------------------------------------------------------
+
+func TestGithubEnumerateTargetsWith_NamesRideOnResult(t *testing.T) {
+	t.Parallel()
+
+	statusFor := map[string]int{
+		"exists@example.com": http.StatusUnprocessableEntity, // 422 -> Exists=true
+	}
+	webSrv := newWebServer(t, "csrf-names-ride", statusFor)
+	e := newTestEnumerator(t, webSrv, nil, "")
+
+	targets := []enum.Target{
+		{Email: "exists@example.com", First: "john", Last: "smith"},
+		{Email: "notexists1@example.com", First: "david", Last: "smith"},
+		{Email: "notexists2@example.com", First: "michael", Last: "smith"},
+	}
+
+	results := e.EnumerateTargetsWith(context.Background(), targets, 4, 0, 0, nil)
+	require.Len(t, results, len(targets), "one Result per Target")
+
+	byEmail := make(map[string]Result, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	for _, tgt := range targets {
+		r, ok := byEmail[tgt.Email]
+		require.True(t, ok, "result for %q must be present", tgt.Email)
+		assert.NoError(t, r.Error, "%q must succeed against the stub", tgt.Email)
+		assert.Equal(t, tgt.First, r.First, "First for %q must match its own Target, not another target's", tgt.Email)
+		assert.Equal(t, tgt.Last, r.Last, "Last for %q must match its own Target, not another target's", tgt.Email)
+	}
+	assert.True(t, byEmail["exists@example.com"].Exists, "the 422-mapped email must be reported as existing")
+}
+
+// ---------------------------------------------------------------------------
+// TestGithubEnumerateTargetsWith_NamelessTargetStaysNameless
+// A Target with no name (address supplied by the operator, not generated)
+// must yield First=="" && Last=="". The library must never invent a name.
+// ---------------------------------------------------------------------------
+
+func TestGithubEnumerateTargetsWith_NamelessTargetStaysNameless(t *testing.T) {
+	t.Parallel()
+
+	webSrv := newWebServer(t, "csrf-nameless", map[string]int{})
+	e := newTestEnumerator(t, webSrv, nil, "")
+
+	targets := []enum.Target{{Email: "supplied@example.com"}}
+
+	results := e.EnumerateTargetsWith(context.Background(), targets, 1, 0, 0, nil)
+	require.Len(t, results, 1)
+	assert.Empty(t, results[0].First, "First must stay empty for a nameless Target")
+	assert.Empty(t, results[0].Last, "Last must stay empty for a nameless Target")
+}
+
+// ---------------------------------------------------------------------------
+// TestGithubEnumerateWith_StillWorksAndYieldsEmptyNames
+// Pins that the existing EnumerateWith([]string) entry point is unaffected by
+// the refactor: it still returns correct results, and since bare addresses
+// carry no name, First/Last must be empty.
+// ---------------------------------------------------------------------------
+
+func TestGithubEnumerateWith_StillWorksAndYieldsEmptyNames(t *testing.T) {
+	t.Parallel()
+
+	statusFor := map[string]int{
+		"exists@example.com": http.StatusUnprocessableEntity,
+	}
+	webSrv := newWebServer(t, "csrf-still-works", statusFor)
+	e := newTestEnumerator(t, webSrv, nil, "")
+
+	emails := []string{"exists@example.com", "notexists1@example.com", "notexists2@example.com"}
+	results := e.EnumerateWith(context.Background(), emails, 3, 0, 0, nil)
+	require.Len(t, results, len(emails))
+
+	byEmail := make(map[string]Result, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	for _, email := range emails {
+		r, ok := byEmail[email]
+		require.True(t, ok, "result for %q must be present", email)
+		assert.NoError(t, r.Error, "%q must succeed against the stub", email)
+		assert.Empty(t, r.First, "EnumerateWith must never invent a name")
+		assert.Empty(t, r.Last, "EnumerateWith must never invent a name")
+	}
+	assert.True(t, byEmail["exists@example.com"].Exists, "the 422-mapped email must be reported as existing")
+}
+
+// ---------------------------------------------------------------------------
+// TestGithubEnumerateTargetsWith_NamesSurviveErrorPath
+// A name is a property of the address, not of the check outcome. Drive a
+// Result whose Error is non-nil (an unmapped-status response from the
+// validity endpoint, mirroring postValidity's "default: unexpected status"
+// branch) and assert the name is still stamped.
+// ---------------------------------------------------------------------------
+
+func TestGithubEnumerateTargetsWith_NamesSurviveErrorPath(t *testing.T) {
+	t.Parallel()
+
+	const failingEmail = "failing-target@example.com"
+	statusFor := map[string]int{
+		failingEmail: http.StatusTeapot, // unmapped status -> postValidity error
+	}
+	webSrv := newWebServer(t, "csrf-error-path", statusFor)
+	e := newTestEnumerator(t, webSrv, nil, "")
+
+	targets := []enum.Target{
+		{Email: failingEmail, First: "erin", Last: "fail"},
+	}
+
+	results := e.EnumerateTargetsWith(context.Background(), targets, 1, 0, 0, nil)
+	require.Len(t, results, 1)
+
+	r := results[0]
+	assert.Equal(t, failingEmail, r.Email)
+	require.Error(t, r.Error, "an unexpected validity-endpoint status must surface as a genuine checkEmail error")
+	assert.Equal(t, "erin", r.First, "name must survive even when the probe errors")
+	assert.Equal(t, "fail", r.Last, "name must survive even when the probe errors")
+}
+
+// ---------------------------------------------------------------------------
+// TestGithubEnumerateTargetsWith_MixedNamedAndUnnamed
+// A single batch containing both named and unnamed targets: each Result must
+// get exactly its own target's name, or empty for the unnamed ones.
+// ---------------------------------------------------------------------------
+
+func TestGithubEnumerateTargetsWith_MixedNamedAndUnnamed(t *testing.T) {
+	t.Parallel()
+
+	webSrv := newWebServer(t, "csrf-mixed", map[string]int{})
+	e := newTestEnumerator(t, webSrv, nil, "")
+
+	targets := []enum.Target{
+		{Email: "named1@example.com", First: "anna", Last: "lee"},
+		{Email: "unnamed1@example.com"},
+		{Email: "named2@example.com", First: "bob", Last: "wu"},
+		{Email: "unnamed2@example.com"},
+	}
+
+	results := e.EnumerateTargetsWith(context.Background(), targets, 4, 0, 0, nil)
+	require.Len(t, results, len(targets))
+
+	byEmail := make(map[string]Result, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	for _, tgt := range targets {
+		r, ok := byEmail[tgt.Email]
+		require.True(t, ok, "result for %q must be present", tgt.Email)
+		assert.Equal(t, tgt.First, r.First, "First for %q", tgt.Email)
+		assert.Equal(t, tgt.Last, r.Last, "Last for %q", tgt.Email)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestGithubEnumerateTargetsWith_EveryTargetSlotFilled
+// len(results) == len(targets) and every target is present even when some
+// probes fail. Completion order is not asserted (the worker pool is
+// concurrent); correlation is by email only.
+// ---------------------------------------------------------------------------
+
+func TestGithubEnumerateTargetsWith_EveryTargetSlotFilled(t *testing.T) {
+	t.Parallel()
+
+	const failingEmail = "failing-slot@example.com"
+	statusFor := map[string]int{
+		"exists-slot@example.com": http.StatusUnprocessableEntity,
+		failingEmail:              http.StatusTeapot,
+	}
+	webSrv := newWebServer(t, "csrf-every-slot", statusFor)
+	e := newTestEnumerator(t, webSrv, nil, "")
+
+	targets := []enum.Target{
+		{Email: "exists-slot@example.com", First: "carl", Last: "one"},
+		{Email: failingEmail, First: "dana", Last: "two"},
+		{Email: "notexists-slot@example.com", First: "ella", Last: "three"},
+	}
+
+	results := e.EnumerateTargetsWith(context.Background(), targets, 4, 0, 0, nil)
+	require.Len(t, results, len(targets), "one result per target regardless of probe failures")
+
+	byEmail := make(map[string]Result, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	for _, tgt := range targets {
+		r, ok := byEmail[tgt.Email]
+		require.True(t, ok, "no dropped slot for %q", tgt.Email)
+		assert.Equal(t, tgt.First, r.First)
+		assert.Equal(t, tgt.Last, r.Last)
+	}
+
+	// Confirm the engineered failure actually failed and the others didn't,
+	// proving this test exercises a genuinely mixed batch.
+	assert.Error(t, byEmail[failingEmail].Error)
+	assert.NoError(t, byEmail["exists-slot@example.com"].Error)
+	assert.NoError(t, byEmail["notexists-slot@example.com"].Error)
+}
+
+// ---------------------------------------------------------------------------
+// TestGithubEnumerateTargetsWith_SessionFailureFillsEverySlotStamped
+//
+// github's pre-pool gate: if establishSession fails, every Target is
+// returned carrying that error WITHOUT any worker ever running (PLAN.md Part
+// 2.5). This is already correct today (existence.go:74-81 fills every slot
+// on the pre-migration EnumerateWith too) and stays correct after the
+// migration -- but it is the one path unique to github among the three
+// packages this PR migrates, so it gets its own dedicated test rather than
+// being folded into the generic shape above (PLAN.md Part 3.3's "github
+// only" row).
+//
+// /join always returns 403 (mirrors TestSession_403ExhaustsRetries), so
+// establishSession exhausts its retries and returns a non-nil error before
+// the worker pool is ever constructed. Named targets must still come back
+// stamped with their own name -- proving EnumerateTargetsWith's session-gate
+// branch calls StampName (or an equivalent inline assignment) per target,
+// not just newError.
+// ---------------------------------------------------------------------------
+
+func TestGithubEnumerateTargetsWith_SessionFailureFillsEverySlotStamped(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/join", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	e := newTestEnumerator(t, srv, nil, "")
+	e.existenceMaxRetries = 1
+
+	targets := []enum.Target{
+		{Email: "alice@example.com", First: "alice", Last: "anderson"},
+		{Email: "bob@example.com", First: "bob", Last: "brown"},
+	}
+
+	var mu sync.Mutex
+	var cbResults []Result
+	results := e.EnumerateTargetsWith(context.Background(), targets, 2, 0, 0, func(r Result) {
+		mu.Lock()
+		cbResults = append(cbResults, r)
+		mu.Unlock()
+	})
+
+	require.Len(t, results, len(targets), "every slot must be filled by the session-failure branch")
+
+	byEmail := make(map[string]Result, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+	for _, tgt := range targets {
+		r, ok := byEmail[tgt.Email]
+		require.True(t, ok, "result for %q must be present", tgt.Email)
+		require.Error(t, r.Error, "session establishment failure must surface as an error for %q", tgt.Email)
+		assert.Contains(t, r.Error.Error(), "join page returned HTTP 403",
+			"error for %q must mention the join page HTTP status", tgt.Email)
+		assert.Equal(t, tgt.First, r.First, "First for %q must be stamped even on the session-failure path", tgt.Email)
+		assert.Equal(t, tgt.Last, r.Last, "Last for %q must be stamped even on the session-failure path", tgt.Email)
+	}
+
+	assert.Len(t, cbResults, len(targets), "onResult must fire exactly once per target on the session-failure path too")
+}
+
+// ---------------------------------------------------------------------------
+// TestGithubEnumerateWith_CanceledContextNowRecordsEverySlot
+//
+// THE explicit before/after test for github's abort-path behavior change
+// (PLAN.md Part 0.1, 2.5, 4.5), asserted through the unchanged
+// EnumerateWith([]string) entry point -- the one cmd/brutus actually calls
+// (cmd_enum_github.go:215) and therefore where the change is observable.
+//
+// Unlike gravatar and teams, github cannot demonstrate this with a context
+// canceled BEFORE the call: establishSession runs first and its own error
+// branch has ALWAYS filled every slot (existence.go:74-81), so an
+// already-Done context just looks like any other session failure -- proven
+// by construction (an already-canceled ctx makes http.Client.Do return
+// "context canceled" with no round trip at all) and already covered by
+// TestGithubEnumerateTargetsWith_SessionFailureFillsEverySlotStamped above.
+// That path is NOT the bug this PR fixes and was never silently dropped.
+//
+// The actual bug is the pool's OWN per-email `<-ctx.Done()` guard
+// (existence.go:110-114), which only matters once a session already exists.
+// To reach it, the context must be canceled AFTER establishSession succeeds
+// but before later targets' goroutines run their guard. This is done
+// deterministically -- no wall-clock race -- mirroring the existing
+// TestReveal_DeletesEvenWhenContextCancelled idiom (github_test.go:535):
+// e.sleep is overridden to cancel ctx and return context.Canceled.
+//
+// emails[0] is mapped to HTTP 429, forcing its postValidity retry to call
+// e.sleep (and so cancel ctx) before any later email's goroutine starts --
+// guaranteed by threads=1, which serializes worker goroutines one at a time
+// via errgroup's semaphore (g.Go blocks the submitting loop until a slot
+// frees), so emails[1] and emails[2] do not begin until emails[0]'s goroutine
+// has already returned. By the time emails[1]/emails[2] start, ctx is
+// already Done, so their `select { case <-ctx.Done(): ... }` guard fires
+// deterministically -- this is exactly the branch that used to `return nil`
+// with no record call at all.
+// ---------------------------------------------------------------------------
+
+func TestGithubEnumerateWith_CanceledContextNowRecordsEverySlot(t *testing.T) {
+	t.Parallel()
+
+	emails := []string{"first@example.com", "second@example.com", "third@example.com"}
+
+	statusFor := map[string]int{
+		emails[0]: http.StatusTooManyRequests, // forces a retry -> e.sleep
+	}
+	webSrv := newWebServer(t, "csrf-cancel-mid-run", statusFor)
+	e := newTestEnumerator(t, webSrv, nil, "")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	e.sleep = func(_ context.Context, _ time.Duration) error {
+		cancel()
+		return context.Canceled
+	}
+
+	var mu sync.Mutex
+	var cbResults []Result
+	results := e.EnumerateWith(ctx, emails, 1, 0, 0, func(r Result) {
+		mu.Lock()
+		cbResults = append(cbResults, r)
+		mu.Unlock()
+	})
+
+	require.Len(t, results, len(emails), "every slot must be filled even when ctx is canceled mid-run")
+	for i, r := range results {
+		assert.Equal(t, emails[i], r.Email, "results[%d].Email must be set, not a dropped zero-value slot", i)
+		assert.Error(t, r.Error, "results[%d] must carry an error, not be silently dropped", i)
+	}
+
+	// emails[1] and emails[2] must specifically carry the ctx-cancellation
+	// error from the pool's own <-ctx.Done() guard -- the exact path that
+	// used to drop the result entirely.
+	assert.True(t, errors.Is(results[1].Error, context.Canceled),
+		"results[1] must carry context.Canceled from the pool's own ctx.Done() guard")
+	assert.True(t, errors.Is(results[2].Error, context.Canceled),
+		"results[2] must carry context.Canceled from the pool's own ctx.Done() guard")
+
+	assert.Len(t, cbResults, len(emails), "onResult must fire exactly once per email, even for the formerly-dropped slots")
+}

--- a/pkg/enum/teams/enum.go
+++ b/pkg/enum/teams/enum.go
@@ -20,19 +20,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/rand"
 	"net/http"
 	"net/url"
-	"os"
-	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
 
-	"golang.org/x/sync/errgroup"
-	"golang.org/x/time/rate"
-
 	"github.com/praetorian-inc/brutus/pkg/brutus"
+	"github.com/praetorian-inc/brutus/pkg/enum"
 )
 
 // Existence is the tri-state (plus unknown) result of a Teams user lookup.
@@ -56,9 +51,13 @@ const (
 // sanitization happens at the output layer. Token values never appear in this
 // struct, in logs, or in Error.
 type EnumResult struct {
-	Email        string
-	First        string // generated given name; empty if the address was supplied
-	Last         string // generated surname; empty if the address was supplied
+	Email string
+	// First and Last are copied from the originating enum.Target when
+	// enumerating via EnumerateTargetsWith. They are empty when the address
+	// arrived through EnumerateWith, which takes bare addresses and so has no
+	// name to carry. This package never derives a name from the local part.
+	First        string
+	Last         string
 	Exists       Existence
 	DisplayName  string
 	MRI          string
@@ -178,91 +177,88 @@ func (e *Enumerator) Enumerate(ctx context.Context, emails []string, threads int
 	return e.EnumerateWith(ctx, emails, threads, rateLimit, jitter, nil)
 }
 
-// EnumerateWith runs enumeration with bounded concurrency and invokes onResult
-// (if non-nil) for each completed result, serialized so callers can print/stream
-// safely. It still returns all results in input order.
+// EnumerateWith runs enumeration over bare addresses. It is a thin adapter over
+// EnumerateTargetsWith, which holds the single implementation: each address is
+// promoted to a nameless enum.Target. Because a bare address says nothing about
+// whose it is, every returned EnumResult has empty First/Last — callers that
+// know the name behind an address should use EnumerateTargetsWith instead.
+//
+// The signature, ordering and callback semantics are unchanged; see
+// EnumerateTargetsWith for the callback contract and for the one deliberate
+// behavior change this delegation brings: abort paths now record a result
+// rather than dropping it.
+func (e *Enumerator) EnumerateWith(ctx context.Context, emails []string, threads int, rateLimit float64, jitter time.Duration, onResult func(EnumResult)) []EnumResult {
+	targets := make([]enum.Target, len(emails))
+	for i, email := range emails {
+		targets[i] = enum.Target{Email: email}
+	}
+	return e.EnumerateTargetsWith(ctx, targets, threads, rateLimit, jitter, onResult)
+}
+
+// newError builds the EnumResult for failures the worker pool detects rather
+// than the lookup: cancellation, a rate-limiter error, cancellation during
+// jitter, and panic recovery.
+//
+// Exists: ExistenceUnknown is load-bearing, not decorative. Existence is a
+// tri-state plus unknown, and a result whose Exists is the empty string is not a
+// valid member of that set — DerivePosture reads the field. A generic
+// zero-value construction in the shared worker would produce exactly that
+// invalid value, which is why NewError is a per-package hook.
+func newError(email string, err error) EnumResult {
+	return EnumResult{Email: email, Exists: ExistenceUnknown, Error: err}
+}
+
+// worker returns the shared bounded worker pool configured for this enumerator.
+// It is a method (rather than inline in EnumerateTargetsWith) so tests can
+// assert the four hooks — in particular the Label that drives the panic
+// diagnostics, and newError's field shape — without running a pool.
+func (e *Enumerator) worker() enum.TargetWorker[EnumResult] {
+	return enum.TargetWorker[EnumResult]{
+		Label: "teams enum",
+		// EnumerateOne's signature already matches Check exactly, so it is used
+		// as a method value with no adapter closure: it takes (ctx, email) and
+		// returns an EnumResult by value, encoding every failure in that
+		// result's own Exists/Error fields.
+		Check:     e.EnumerateOne,
+		NewError:  newError,
+		StampName: func(r *EnumResult, t enum.Target) { r.First, r.Last = t.First, t.Last },
+	}
+}
+
+// EnumerateTargetsWith runs enumeration with bounded concurrency over targets
+// that carry the name behind each address, and invokes onResult (if non-nil) for
+// each completed result, serialized so callers can print/stream safely. It
+// returns all results in input order.
+//
+// The name travels with the target rather than being recovered afterwards, so a
+// consumer of this package never has to reverse-derive a name from the local
+// part — a lossy guess for initial-based formats, where "jsmith" could be John,
+// James or Jane. Each EnumResult is stamped with the name of the target that
+// produced it (never a neighboring target's).
+//
+// A name is a property of the address, not of the check outcome, so the stamp is
+// applied on every path: a completed lookup, context cancellation, a
+// rate-limiter error, cancellation during jitter, and panic recovery. A failed
+// lookup still reports whose address failed. Targets without a name
+// (operator-supplied addresses) stay nameless; no name is ever invented.
+//
+// Behavior change (deliberate): before this package delegated to
+// enum.TargetWorker, its abort paths returned without recording, leaving that
+// slot a zero EnumResult — Email empty and Exists the empty string, which is not
+// a valid member of the Existence set — and never firing onResult. Every abort
+// now records newError(email, <cause>) and fires onResult exactly once, matching
+// google, microsoft365 and gravatar. An interrupted run therefore emits one
+// error result per un-probed address instead of dropping it silently.
 //
 // onResult is called under the same mutex that guards the results slice, so
 // callback invocations never interleave and never race the slice. The callback
 // must therefore be cheap and self-contained: it may write to an io.Writer or
 // update counters, but it must NOT call back into the Enumerator (doing so risks
 // deadlock and defeats the serialization guarantee).
-func (e *Enumerator) EnumerateWith(ctx context.Context, emails []string, threads int, rateLimit float64, jitter time.Duration, onResult func(EnumResult)) []EnumResult {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	g, ctx := errgroup.WithContext(ctx)
-	// Normalize thread count: 0 would deadlock errgroup.SetLimit (no goroutine
-	// can ever run) and a negative value means unbounded. Clamp to a safe
-	// positive default of 1 (serial execution).
-	if threads <= 0 {
-		threads = 1
-	}
-	g.SetLimit(threads)
-
-	var limiter *rate.Limiter
-	if rateLimit > 0 {
-		limiter = rate.NewLimiter(rate.Limit(rateLimit), 1)
-	}
-
-	results := make([]EnumResult, len(emails))
-	var mu sync.Mutex
-
-	// record stores a completed result and, under the same lock, invokes the
-	// caller's callback so streamed output is serialized and slice-safe.
-	record := func(i int, res EnumResult) {
-		mu.Lock()
-		defer mu.Unlock()
-		results[i] = res
-		if onResult != nil {
-			onResult(res)
-		}
-	}
-
-	for i, email := range emails {
-		i, email := i, email
-		g.Go(func() error {
-			defer func() {
-				if r := recover(); r != nil {
-					fmt.Fprintf(os.Stderr, "teams enum: panic checking %s: %v\n%s\n", email, r, debug.Stack())
-					record(i, EnumResult{
-						Email:  email,
-						Exists: ExistenceUnknown,
-						Error:  fmt.Errorf("teams enum: panicked: %v", r),
-					})
-				}
-			}()
-
-			select {
-			case <-ctx.Done():
-				return nil
-			default:
-			}
-
-			if limiter != nil {
-				if err := limiter.Wait(ctx); err != nil {
-					return nil
-				}
-				if jitter > 0 {
-					delay := time.Duration(rand.Int63n(int64(jitter)))
-					select {
-					case <-time.After(delay):
-					case <-ctx.Done():
-						return nil
-					}
-				}
-			}
-
-			record(i, e.EnumerateOne(ctx, email))
-			return nil
-		})
-	}
-
-	// Discarding g.Wait()'s error is deliberate: worker goroutines never return
-	// a non-nil error (per-email failures are encoded in each EnumResult), so the
-	// returned error is always nil.
-	_ = g.Wait()
-	return results
+//
+// The pool itself is enum.TargetWorker; see its doc comment for the full contract.
+func (e *Enumerator) EnumerateTargetsWith(ctx context.Context, targets []enum.Target, threads int, rateLimit float64, jitter time.Duration, onResult func(EnumResult)) []EnumResult {
+	return e.worker().Run(ctx, targets, threads, rateLimit, jitter, onResult)
 }
 
 // AccountType classifies a Teams MRI: "corporate" (8:orgid:), "consumer"

--- a/pkg/enum/teams/teams_hooks_test.go
+++ b/pkg/enum/teams/teams_hooks_test.go
@@ -1,0 +1,121 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Per-package hook-wiring tests for teams' enum.TargetWorker[EnumResult]
+// configuration (PLAN.md Part 3.3). These are wiring assertions, not a
+// re-test of the pool: TargetWorker's generic behavior (ordering, panic
+// isolation, concurrency bounds, callback serialization, etc.) is covered
+// exactly once in pkg/enum/targetworker_test.go. What cannot be proven there
+// is that THIS package wired its four hooks up correctly -- that Label is
+// the exact string the pre-migration code used (panic diagnostics stay
+// byte-identical), that NewError builds teams' real failure shape (Email,
+// Exists: ExistenceUnknown, Error -- Exists is the field a naive generic
+// construction would leave as the invalid empty string), and that StampName
+// copies only First/Last. worker() exists precisely so these are testable
+// directly, without driving a live pool (PLAN.md Part 2.4, Part 3.3).
+//
+// worker() is not yet defined on *Enumerator; this file is expected to fail
+// to compile until it, newError and the pkg/enum import are added to enum.go
+// (PLAN.md Part 2.4).
+package teams
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/brutus/pkg/enum"
+)
+
+// ---------------------------------------------------------------------------
+// TestWorker_Label
+// teams' pre-migration panic diagnostics were prefixed "teams enum"
+// (enum.go:227,231), yielding "teams enum: panic checking %s: %v" on stderr
+// and "teams enum: panicked: %v" on the EnumResult. The shared worker
+// reproduces that prefix verbatim via Label, so this exact string must never
+// drift -- changing it is a log-format change for anything that greps stderr
+// or an EnumResult's Error text, not a cosmetic rename.
+// ---------------------------------------------------------------------------
+
+func TestWorker_Label(t *testing.T) {
+	t.Parallel()
+
+	e, err := NewEnumerator("tok", "", "", time.Second, false)
+	require.NoError(t, err)
+
+	assert.Equal(t, "teams enum", e.worker().Label)
+}
+
+// ---------------------------------------------------------------------------
+// TestWorker_NewErrorShape
+//
+// teams' failure results carry Email, Exists AND Error -- Exists is the one
+// field a naive generic construction ("R{} + error field") would silently
+// leave at its zero value: the empty string, which is NOT a valid member of
+// the Existence tri-state-plus-unknown set that DerivePosture reads (PLAN.md
+// Part 0.4, Part 2.4). Comparing the full struct -- not just Email/Error
+// individually -- is deliberate and load-bearing here: an assertion that
+// checked only Email and Error would pass even if Exists were left empty,
+// defeating the entire point of this test.
+// ---------------------------------------------------------------------------
+
+func TestWorker_NewErrorShape(t *testing.T) {
+	t.Parallel()
+
+	e, err := NewEnumerator("tok", "", "", time.Second, false)
+	require.NoError(t, err)
+
+	sentinel := errors.New("sentinel")
+	got := e.worker().NewError("a@b.com", sentinel)
+
+	assert.Equal(t, EnumResult{Email: "a@b.com", Exists: ExistenceUnknown, Error: sentinel}, got)
+}
+
+// ---------------------------------------------------------------------------
+// TestWorker_StampNameCopiesFirstLastOnly
+// StampName's documented contract (targetworker.go) is a one-line copy of
+// First/Last from the originating Target. This asserts both halves of that
+// contract: First/Last land correctly, and every other field on an
+// already-populated EnumResult -- including Exists, teams' own tri-state
+// field -- is left untouched.
+// ---------------------------------------------------------------------------
+
+func TestWorker_StampNameCopiesFirstLastOnly(t *testing.T) {
+	t.Parallel()
+
+	e, err := NewEnumerator("tok", "", "", time.Second, false)
+	require.NoError(t, err)
+
+	res := EnumResult{
+		Email:       "a@b.com",
+		Exists:      ExistenceYes,
+		DisplayName: "Existing Name",
+		MRI:         "8:orgid:abc",
+		Error:       errors.New("unchanged-error"),
+	}
+	before := res
+
+	e.worker().StampName(&res, enum.Target{Email: "a@b.com", First: "Jane", Last: "Doe"})
+
+	assert.Equal(t, "Jane", res.First)
+	assert.Equal(t, "Doe", res.Last)
+	assert.Equal(t, before.Email, res.Email, "StampName must not touch Email")
+	assert.Equal(t, before.Exists, res.Exists, "StampName must not touch Exists")
+	assert.Equal(t, before.DisplayName, res.DisplayName, "StampName must not touch DisplayName")
+	assert.Equal(t, before.MRI, res.MRI, "StampName must not touch MRI")
+	assert.Equal(t, before.Error, res.Error, "StampName must not touch Error")
+}

--- a/pkg/enum/teams/teams_targets_test.go
+++ b/pkg/enum/teams/teams_targets_test.go
@@ -1,0 +1,416 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// RED-phase tests for EnumerateTargetsWith, the Target-accepting sibling of
+// EnumerateWith. These tests assert that names travel with their originating
+// enum.Target all the way through to the EnumResult that address produced,
+// correlated by email (never by index/order, since the worker pool is
+// concurrent) -- mirroring pkg/enum/gravatar/gravatar_targets_test.go.
+//
+// Unlike github (which gates the whole batch behind establishSession before
+// the pool ever runs -- see github_targets_test.go), teams has no pre-pool
+// gate: every email goes straight into the worker pool. That means an
+// already-canceled top-level context reaches the pool's own per-email
+// `<-ctx.Done()` guard directly, which is exactly the guard that used to
+// silently drop the result (see TestTeamsEnumerateWith_
+// CanceledContextNowRecordsEverySlot below -- the one genuinely NEW behavior
+// this file pins).
+//
+// EnumerateTargetsWith, worker() and newError do not exist yet on
+// *Enumerator; this file is expected to fail to compile until they are added
+// to enum.go (PLAN.md Part 2.4).
+package teams
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/brutus/pkg/enum"
+)
+
+// registeredEmail is the email the target-test mock server answers with a
+// corporate (8:orgid:) match; failingEmail gets a genuine unexpected-status
+// error from EnumerateOne (mirrors TestEnumerateOne_ServerError500's shape);
+// every other email gets an empty-array "not found" response.
+const (
+	registeredEmail = "exists@contoso.com"
+	failingEmail    = "failing-target@contoso.com"
+)
+
+// newTargetsSearchServer builds an httptest.Server keyed by the escaped email
+// in the URL path, in the same style as searchServerPerEmail
+// (enum_test.go:1042 -- the package's existing HTTP-stubbing seam):
+// registeredEmail answers with a corporate user (existence "yes"),
+// failingEmail answers 500 (a genuine EnumerateOne error, same shape as
+// TestEnumerateOne_ServerError500), and every other email answers an empty
+// array (existence "no", no error). This is the minimal extension of the
+// existing seam needed for the target tests below; no fake/injected probe is
+// used and no real network call is made.
+func newTargetsSearchServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		parts := strings.Split(r.URL.Path, "/")
+		email := parts[len(parts)-1]
+
+		if email == failingEmail {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if email == registeredEmail {
+			_, _ = w.Write([]byte(`[{"displayName":"Existing User","mri":"8:orgid:abc123"}]`))
+			return
+		}
+		_, _ = w.Write([]byte(`[]`))
+	}))
+}
+
+// newTargetsTestEnumerator builds an Enumerator wired to srv, mirroring
+// newTestEnumerator (enum_test.go:35) but for the target-test mock server's
+// URL-path (not query-param) keying.
+func newTargetsTestEnumerator(t *testing.T, srv *httptest.Server) *Enumerator {
+	t.Helper()
+	e, err := NewEnumerator("test-access-token", "", "", 5*time.Second, false)
+	require.NoError(t, err)
+	e.searchBaseURL = srv.URL + "/%s"
+	return e
+}
+
+// ---------------------------------------------------------------------------
+// TestTeamsEnumerateTargetsWith_NamesRideOnResult
+// Core test: 3 targets with distinct names against a stub that reports
+// existence for all of them. Each returned EnumResult must carry the name of
+// the target that produced it, correlated by email. An implementation that
+// stamps every EnumResult with the first target's name fails this test.
+// ---------------------------------------------------------------------------
+
+func TestTeamsEnumerateTargetsWith_NamesRideOnResult(t *testing.T) {
+	t.Parallel()
+	srv := newTargetsSearchServer(t)
+	t.Cleanup(srv.Close)
+
+	e := newTargetsTestEnumerator(t, srv)
+
+	targets := []enum.Target{
+		{Email: registeredEmail, First: "john", Last: "smith"},
+		{Email: "notfound1@contoso.com", First: "david", Last: "smith"},
+		{Email: "notfound2@contoso.com", First: "michael", Last: "smith"},
+	}
+
+	results := e.EnumerateTargetsWith(context.Background(), targets, 4, 0, 0, nil)
+	require.Len(t, results, len(targets), "one EnumResult per Target")
+
+	byEmail := make(map[string]EnumResult, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	for _, tgt := range targets {
+		r, ok := byEmail[tgt.Email]
+		require.True(t, ok, "result for %q must be present", tgt.Email)
+		assert.NoError(t, r.Error, "%q must succeed against the stub", tgt.Email)
+		assert.Equal(t, tgt.First, r.First, "First for %q must match its own Target, not another target's", tgt.Email)
+		assert.Equal(t, tgt.Last, r.Last, "Last for %q must match its own Target, not another target's", tgt.Email)
+	}
+	assert.Equal(t, ExistenceYes, byEmail[registeredEmail].Exists, "registeredEmail must be reported as existing by the stub")
+}
+
+// ---------------------------------------------------------------------------
+// TestTeamsEnumerateTargetsWith_NamelessTargetStaysNameless
+// A Target with no name (address supplied by the operator, not generated)
+// must yield First=="" && Last=="". The library must never invent a name.
+// ---------------------------------------------------------------------------
+
+func TestTeamsEnumerateTargetsWith_NamelessTargetStaysNameless(t *testing.T) {
+	t.Parallel()
+	srv := newTargetsSearchServer(t)
+	t.Cleanup(srv.Close)
+
+	e := newTargetsTestEnumerator(t, srv)
+
+	targets := []enum.Target{{Email: "supplied@contoso.com"}}
+
+	results := e.EnumerateTargetsWith(context.Background(), targets, 1, 0, 0, nil)
+	require.Len(t, results, 1)
+	assert.Empty(t, results[0].First, "First must stay empty for a nameless Target")
+	assert.Empty(t, results[0].Last, "Last must stay empty for a nameless Target")
+}
+
+// ---------------------------------------------------------------------------
+// TestTeamsEnumerateWith_StillWorksAndYieldsEmptyNames
+// Pins that the existing EnumerateWith([]string) entry point is unaffected by
+// the refactor: it still returns correct results, and since bare addresses
+// carry no name, First/Last must be empty.
+// ---------------------------------------------------------------------------
+
+func TestTeamsEnumerateWith_StillWorksAndYieldsEmptyNames(t *testing.T) {
+	t.Parallel()
+	srv := newTargetsSearchServer(t)
+	t.Cleanup(srv.Close)
+
+	e := newTargetsTestEnumerator(t, srv)
+
+	emails := []string{registeredEmail, "notfound1@contoso.com", "notfound2@contoso.com"}
+	results := e.EnumerateWith(context.Background(), emails, 3, 0, 0, nil)
+	require.Len(t, results, len(emails))
+
+	byEmail := make(map[string]EnumResult, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	for _, email := range emails {
+		r, ok := byEmail[email]
+		require.True(t, ok, "result for %q must be present", email)
+		assert.NoError(t, r.Error, "%q must succeed against the stub", email)
+		assert.Empty(t, r.First, "EnumerateWith must never invent a name")
+		assert.Empty(t, r.Last, "EnumerateWith must never invent a name")
+	}
+	assert.Equal(t, ExistenceYes, byEmail[registeredEmail].Exists, "registeredEmail must be reported as existing by the stub")
+}
+
+// ---------------------------------------------------------------------------
+// TestTeamsEnumerateTargetsWith_NamesSurviveErrorPath
+// A name is a property of the address, not of the check outcome. Drive an
+// EnumResult whose Error is non-nil (the mock server's 500 for failingEmail)
+// and assert the name is still stamped.
+// ---------------------------------------------------------------------------
+
+func TestTeamsEnumerateTargetsWith_NamesSurviveErrorPath(t *testing.T) {
+	t.Parallel()
+	srv := newTargetsSearchServer(t)
+	t.Cleanup(srv.Close)
+
+	e := newTargetsTestEnumerator(t, srv)
+
+	targets := []enum.Target{
+		{Email: failingEmail, First: "erin", Last: "fail"},
+	}
+
+	results := e.EnumerateTargetsWith(context.Background(), targets, 1, 0, 0, nil)
+	require.Len(t, results, 1)
+
+	r := results[0]
+	assert.Equal(t, failingEmail, r.Email)
+	require.Error(t, r.Error, "the 500 response must surface as a genuine EnumerateOne error")
+	assert.Equal(t, ExistenceUnknown, r.Exists, "a failed probe must report Exists as Unknown, not the invalid empty string")
+	assert.Equal(t, "erin", r.First, "name must survive even when the probe errors")
+	assert.Equal(t, "fail", r.Last, "name must survive even when the probe errors")
+}
+
+// ---------------------------------------------------------------------------
+// TestTeamsEnumerateTargetsWith_MixedNamedAndUnnamed
+// A single batch containing both named and unnamed targets: each EnumResult
+// must get exactly its own target's name, or empty for the unnamed ones.
+// ---------------------------------------------------------------------------
+
+func TestTeamsEnumerateTargetsWith_MixedNamedAndUnnamed(t *testing.T) {
+	t.Parallel()
+	srv := newTargetsSearchServer(t)
+	t.Cleanup(srv.Close)
+
+	e := newTargetsTestEnumerator(t, srv)
+
+	targets := []enum.Target{
+		{Email: "named1@contoso.com", First: "anna", Last: "lee"},
+		{Email: "unnamed1@contoso.com"},
+		{Email: "named2@contoso.com", First: "bob", Last: "wu"},
+		{Email: "unnamed2@contoso.com"},
+	}
+
+	results := e.EnumerateTargetsWith(context.Background(), targets, 4, 0, 0, nil)
+	require.Len(t, results, len(targets))
+
+	byEmail := make(map[string]EnumResult, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	for _, tgt := range targets {
+		r, ok := byEmail[tgt.Email]
+		require.True(t, ok, "result for %q must be present", tgt.Email)
+		assert.Equal(t, tgt.First, r.First, "First for %q", tgt.Email)
+		assert.Equal(t, tgt.Last, r.Last, "Last for %q", tgt.Email)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestTeamsEnumerateTargetsWith_EveryTargetSlotFilled
+// len(results) == len(targets) and every target is present even when some
+// probes fail. Completion order is not asserted (the worker pool is
+// concurrent); correlation is by email only.
+// ---------------------------------------------------------------------------
+
+func TestTeamsEnumerateTargetsWith_EveryTargetSlotFilled(t *testing.T) {
+	t.Parallel()
+	srv := newTargetsSearchServer(t)
+	t.Cleanup(srv.Close)
+
+	e := newTargetsTestEnumerator(t, srv)
+
+	targets := []enum.Target{
+		{Email: registeredEmail, First: "carl", Last: "one"},
+		{Email: failingEmail, First: "dana", Last: "two"},
+		{Email: "notfound@contoso.com", First: "ella", Last: "three"},
+	}
+
+	results := e.EnumerateTargetsWith(context.Background(), targets, 4, 0, 0, nil)
+	require.Len(t, results, len(targets), "one result per target regardless of probe failures")
+
+	byEmail := make(map[string]EnumResult, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	for _, tgt := range targets {
+		r, ok := byEmail[tgt.Email]
+		require.True(t, ok, "no dropped slot for %q", tgt.Email)
+		assert.Equal(t, tgt.First, r.First)
+		assert.Equal(t, tgt.Last, r.Last)
+	}
+
+	// Confirm the engineered failure actually failed and the others didn't,
+	// proving this test exercises a genuinely mixed batch.
+	assert.Error(t, byEmail[failingEmail].Error)
+	assert.NoError(t, byEmail[registeredEmail].Error)
+	assert.NoError(t, byEmail["notfound@contoso.com"].Error)
+}
+
+// ---------------------------------------------------------------------------
+// TestTeamsEnumerateTargetsWith_NamesSurviveCancelledContext
+//
+// Chokepoint test: with the context already canceled before the call, every
+// goroutine takes the <-ctx.Done() early-return branch and records via
+// newError WITHOUT ever calling EnumerateOne. Unlike github (which gates the
+// whole batch behind establishSession first -- see github_targets_test.go),
+// teams has no pre-pool gate, so this reaches the pool's own guard directly.
+// If the name stamp lived only at the EnumerateOne call site rather than at
+// the single funnel every outcome passes through, these Results would come
+// back nameless.
+//
+// This is also the RED-phase pin for the abort-path behavior change itself
+// (PLAN.md Part 0.1, 2.4, 4.5): today, this early-return is a bare `return
+// nil` with no record call at all, so results[i] stays the zero EnumResult
+// (Email=="") and onResult never fires. See
+// TestTeamsEnumerateWith_CanceledContextNowRecordsEverySlot below for the
+// same behavior change asserted through the unchanged EnumerateWith(
+// []string) entry point that cmd/brutus actually calls.
+// ---------------------------------------------------------------------------
+
+func TestTeamsEnumerateTargetsWith_NamesSurviveCancelledContext(t *testing.T) {
+	t.Parallel()
+	srv := newTargetsSearchServer(t)
+	t.Cleanup(srv.Close)
+
+	e := newTargetsTestEnumerator(t, srv)
+
+	targets := []enum.Target{
+		{Email: "one@contoso.com", First: "gwen", Last: "alpha"},
+		{Email: "two@contoso.com", First: "hank", Last: "beta"},
+		{Email: "three@contoso.com", First: "iris", Last: "gamma"},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // canceled BEFORE the call
+
+	results := e.EnumerateTargetsWith(ctx, targets, 1, 0, 0, nil)
+	require.Len(t, results, len(targets), "every slot must be filled, not left as a dropped zero-value EnumResult")
+
+	byEmail := make(map[string]EnumResult, len(results))
+	for _, r := range results {
+		byEmail[r.Email] = r
+	}
+
+	for _, tgt := range targets {
+		r, ok := byEmail[tgt.Email]
+		require.True(t, ok, "result for %q must be present", tgt.Email)
+		require.Error(t, r.Error, "an already-canceled context must surface as a non-nil Error for %q", tgt.Email)
+		assert.Equal(t, ExistenceUnknown, r.Exists, "an aborted result must report Exists as Unknown, not the invalid empty string, for %q", tgt.Email)
+		assert.Equal(t, tgt.First, r.First, "First for %q must survive the ctx.Done() early return", tgt.Email)
+		assert.Equal(t, tgt.Last, r.Last, "Last for %q must survive the ctx.Done() early return", tgt.Email)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestTeamsEnumerateWith_CanceledContextNowRecordsEverySlot
+//
+// THE explicit before/after test for teams' abort-path behavior change
+// (PLAN.md Part 0.1, 2.4, 4.5), asserted through the unchanged
+// EnumerateWith([]string) entry point -- the one cmd/brutus actually calls
+// (cmd_enum_teams.go:471) and therefore where the change is observable.
+//
+// Before this PR: EnumerateWith's per-email goroutine took the
+// `<-ctx.Done(): return nil` branch with NO record call at all, so an
+// already-canceled context left every results[i] the zero EnumResult
+// (Email=="", Exists=="" -- an invalid tri-state DerivePosture reads) and
+// onResult never fired. After the migration onto enum.TargetWorker, the same
+// path records via NewError (Email, Exists: ExistenceUnknown, the
+// cancellation error) and fires onResult exactly once per target -- matching
+// what google, microsoft365 and gravatar already did.
+//
+// Unlike github, teams has no pre-pool session gate, so an already-canceled
+// top-level context reaches this exact guard directly and deterministically;
+// no mid-run cancellation trick is needed here (contrast
+// TestGithubEnumerateWith_CanceledContextNowRecordsEverySlot in
+// github_targets_test.go, where establishSession's own error handling
+// intercepts an already-canceled context before the pool ever runs).
+// ---------------------------------------------------------------------------
+
+func TestTeamsEnumerateWith_CanceledContextNowRecordsEverySlot(t *testing.T) {
+	t.Parallel()
+
+	srv := newTargetsSearchServer(t)
+	t.Cleanup(srv.Close)
+
+	e := newTargetsTestEnumerator(t, srv)
+
+	emails := []string{registeredEmail, "notfound@contoso.com", "nobody@contoso.com"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var mu sync.Mutex
+	var cbResults []EnumResult
+
+	results := e.EnumerateWith(ctx, emails, 4, 0, 0, func(r EnumResult) {
+		mu.Lock()
+		cbResults = append(cbResults, r)
+		mu.Unlock()
+	})
+
+	require.Len(t, results, len(emails), "every slot must be filled even when ctx is already canceled")
+
+	for i := range emails {
+		assert.Equal(t, emails[i], results[i].Email,
+			"results[%d].Email must be set (input order preserved), not left as a dropped zero-value", i)
+		assert.Equal(t, ExistenceUnknown, results[i].Exists,
+			"results[%d].Exists must be the valid ExistenceUnknown tri-state, not the zero-value empty string", i)
+		require.Error(t, results[i].Error, "results[%d] must carry the ctx.Done() error, not be silently dropped", i)
+		assert.True(t, errors.Is(results[i].Error, context.Canceled),
+			"results[%d].Error must be context.Canceled from the <-ctx.Done() guard", i)
+	}
+
+	assert.Len(t, cbResults, len(emails), "onResult callback must fire exactly once per email, even on the canceled-context path")
+}


### PR DESCRIPTION
**PR 3 of 3**, and the only one in the series that **changes observable behavior**. That's why it's isolated.

Branched fresh from `main` after #319; nothing stacked. Completes the set — all five existence oracles now carry the generated name on each `Result`.

## The behavior change

github and teams did **not** record a result on abort paths:

```go
select {
case <-ctx.Done():
    return nil        // results[i] stays the zero value; onResult never fires
default:
}
```

So on interrupt, `results[i]` was left with an empty `Email` and nil `Error`, and the callback was skipped entirely. google, microsoft365 and gravatar all recorded. After this change github and teams match them: the slot gets `newError(email, ctx.Err())` and `onResult` fires.

**This is user-visible.** Both `cmd/brutus` commands stream JSONL from `onResult` (`cmd_enum_github.go:163`, `cmd_enum_teams.go:429`), so interrupting a run now emits an error line per un-probed address instead of dropping it silently.

I think that's the right direction — a zero-value result with no email and no error is strictly less useful than one saying "canceled", and the inconsistency between packages was itself a bug. But it *is* an output change on the interrupt path, and it deserved its own review rather than hiding inside a refactor.

**No existing test asserted the old drop behavior** (verified by grepping both packages for context cancellation), so nothing had to be rewritten to accommodate this.

## teams has gravatar's hazard, in its own currency

teams' result type is `EnumResult`, and its failure results set `Exists: ExistenceUnknown`. A generic zero value yields `""` — not a member of the `Existence` set, and `DerivePosture` reads that field. So:

```go
func newError(email string, err error) EnumResult {
	return EnumResult{Email: email, Exists: ExistenceUnknown, Error: err}
}
```

Copying gravatar's or google's `newError` would compile cleanly and quietly emit invalid tri-states. Pinned by full-struct equality.

## github's session gate is untouched, and that shaped the tests

`establishSession` runs before the pool and its failure branch already fills every slot. That creates a testing trap: **an already-canceled context is intercepted by the session gate, not by the pool** — so the obvious "cancel up front and assert every slot is filled" test would pass without ever exercising the code this PR changes.

The real abort-path test instead forces a 429 with `threads=1`, so the errgroup semaphore serializes execution and later emails deterministically land past a canceled context. The session-failure path keeps a separate test so the two aren't conflated.

## Panic diagnostics are byte-identical

| package | `Label` |
|---|---|
| github | `"github enum"` |
| teams | `"teams enum"` |

The shared worker parameterizes the same literals each package had baked in (`"%s: panic checking %s: %v\n%s\n"` and `"%s: panicked: %v"`). Rendering with each `Label` reproduces the base strings exactly — diffed, both `IDENTICAL`. Anything grepping those stderr lines keeps working.

Both `EnumerateWith` signatures are byte-identical to base `699589f`, so `cmd/brutus` and all other callers are unaffected.

## Mutations

| Mutation | Result |
|---|---|
| drop `Exists: ExistenceUnknown` from teams' `newError` | `TestWorker_NewErrorShape` fails with exactly the predicted invalid tri-state: `Exists: ""` |
| restore drop-on-abort | **11 test functions fail across 6 packages** |
| stamp `targets[0]` not `targets[i]` | both packages' `NamesRideOnResult` fail, names leaking across slots |

On the second one, an honest caveat: it **could not be scoped to github**, because after the migration github contains no drop-on-abort code at all — that path now exists solely in `targetworker.go`. Which is precisely the point of the refactor, but it means the mutation's blast radius is all five packages. The 11 failures are the real result rather than a tidy single-test kill.

All three reverted by editing, verified by SHA-256 against pre-mutation baselines.

## Verification

```
golangci-lint run ./...              0 issues.   (cold cache)
go test ./pkg/enum/... -count=1      13 packages ok, 0 FAIL
go test ./... -count=1               0 FAIL
go test -race github, teams          ok
go build ./...                       exit 0
go vet ./pkg/enum/... ./cmd/...      exit 0
gofmt -l                             clean
grep -c errgroup (both)              0, 0   — pools gone
```

## Where the series lands

| PR | production Δ |
|---|---|
| #318 worker + google/m365 | **+100** (worker was new: +242, of which 81 code) |
| #319 gravatar | **−23** |
| this one | **+8** (github −? / teams −?, net roughly flat) |

The series was never really about line count — it was about five copies of a bounded worker pool becoming one, and about `Result.First`/`Last` stopping being fields that lie. Both done.

## Follow-ups, not here

- **`cmd/brutus`'s stamping is now redundant** for all five packages — the library populates the fields. Removing it is a separate, mechanical PR.
- **10T-739**: on lossy formats the carried name is the most-frequent expansion, not a fact. 55.2% of `flast` usernames have multiple possible first names (worst: 264); `firstl` is 51.4% ambiguous on the *surname* (worst: 604). Representing that uncertainty is filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
