### PR TITLE
feat(enum): reduce generated names to what the address proves (10T-739)

### DIFF
--- a/pkg/enum/fidelity.go
+++ b/pkg/enum/fidelity.go
@@ -1,0 +1,167 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enum
+
+import "unicode/utf8"
+
+// FieldFidelity describes how much of one part of a person's name a generated
+// username actually proves.
+//
+// GenerateCandidates carries the full "first.last" pair each username was built
+// from, which is what a consumer needs in order to avoid reverse-deriving a name
+// from the local part. But carrying the pair does not make the pair a fact: a
+// lossy format discards part of it, and dedup on the username silently drops
+// every colliding pair, so the surviving First/Last is merely the
+// highest-ranked expansion. "jsmith" proves that the given name starts with J
+// and nothing more, whether our wordlist holds one candidate for it or 264.
+//
+// The decisive point is that ambiguity within the wordlist is the wrong test.
+// The wordlist is a frequency-ranked sample (248k pairs), not the universe of
+// names, so a username with exactly one expansion in it still has no proven
+// given name -- the real owner may hold a name the list does not contain.
+// Uniqueness in the sample cannot be evidence. What the address does prove is
+// determined entirely by the format, which is why fidelity is a function of the
+// format string and needs no data source at all.
+type FieldFidelity int
+
+const (
+	// FieldAbsent means the format does not encode this part of the name in any
+	// form. Whatever value the Candidate carries for it came from the wordlist
+	// pair, not from the address, and must not be presented as the person's
+	// name.
+	FieldAbsent FieldFidelity = iota
+
+	// FieldInitial means only the part's first letter is recoverable. The
+	// initial itself is definitionally correct -- formatUsername built the
+	// username from that letter -- but the rest is unknowable.
+	FieldInitial
+
+	// FieldExact means the format encodes the part in full.
+	FieldExact
+)
+
+// String renders a FieldFidelity for logs and test failure messages.
+func (f FieldFidelity) String() string {
+	switch f {
+	case FieldAbsent:
+		return "absent"
+	case FieldInitial:
+		return "initial"
+	case FieldExact:
+		return "exact"
+	default:
+		return "unknown"
+	}
+}
+
+// FormatFidelity reports how much of the given name and surname the usernames
+// produced by format actually prove.
+//
+// This mirrors formatUsername case for case, and the two must be changed
+// together: adding a format there without answering the fidelity question here
+// makes the new format report FieldAbsent for the given name, which
+// TestFormatFidelity_EveryFormatMapped fails on deliberately.
+//
+// An unrecognized format reports FieldAbsent for both parts, matching
+// GenerateCandidates, which yields no candidates at all for a format
+// formatUsername does not know.
+func FormatFidelity(format string) (first, last FieldFidelity) {
+	switch format {
+	// Both parts present and separator-delimited, so the split is unambiguous.
+	case FormatFirstDotLast, FormatLastDotFirst, FormatFirstUnderLast:
+		return FieldExact, FieldExact
+
+	// Both parts present in full but run together, so the boundary is not
+	// recoverable from the string alone ("limandy" is Andy Lim or Mandy Li).
+	// Measured against the shipped wordlist this affects 6 of 248,093 generated
+	// usernames (0.00%), which is too rare to justify a distinct fidelity state
+	// and far rarer than initial truncation, where a majority of usernames are
+	// affected.
+	case FormatLastFirst:
+		return FieldExact, FieldExact
+
+	// The given name is reduced to its initial; the surname survives in full.
+	case FormatFLast, FormatFDotLast, FormatLastF:
+		return FieldInitial, FieldExact
+
+	// The inverse: the given name survives in full, the surname is reduced to
+	// its initial.
+	case FormatFirstL:
+		return FieldExact, FieldInitial
+
+	// "john@example.com" carries no surname whatsoever. The Candidate still
+	// holds one, because every "john.*" pair collapses to the same username and
+	// the highest-ranked pair's surname survives dedup, but that surname has no
+	// basis in the address at all -- it is the one case where the carried value
+	// is not even a truncation of something the username contains.
+	case FormatFirst:
+		return FieldExact, FieldAbsent
+
+	default:
+		return FieldAbsent, FieldAbsent
+	}
+}
+
+// KnownName reduces a generated name to only the parts the address demonstrates,
+// given the format it was generated in.
+//
+// Callers labeling a confirmed hit with a person's name should use this rather
+// than a Candidate's or Result's raw First/Last, so that a lossy format yields
+// an initial instead of a specific name nobody can justify:
+//
+//	KnownName(FormatFLast, "John", "Smith")       // "J", "Smith"
+//	KnownName(FormatFirstL, "John", "Smith")      // "John", "S"
+//	KnownName(FormatFirst, "John", "Smith")       // "John", ""
+//	KnownName(FormatFirstDotLast, "John", "Smith") // "John", "Smith"
+//
+// It exists as a helper, rather than leaving each consumer to switch on
+// FormatFidelity itself, so that the reduction is written and tested once. Two
+// consumers implementing it independently would be two chances to reintroduce
+// the guess.
+//
+// The returned strings are projections of the inputs: no title-casing, no
+// trimming, no normalization. Presentation is the caller's concern, and
+// silently transforming here would make the output disagree with the Candidate
+// fields it derives from.
+func KnownName(format, first, last string) (knownFirst, knownLast string) {
+	firstFidelity, lastFidelity := FormatFidelity(format)
+	return reduceToFidelity(first, firstFidelity), reduceToFidelity(last, lastFidelity)
+}
+
+// reduceToFidelity projects a single name part down to its proven form.
+//
+// The initial is taken by rune rather than by byte. formatUsername slices bytes
+// (first[:1]), which is equivalent for every pair in the shipped wordlist since
+// all 248,231 are ASCII, but KnownName is exported and may be handed a name from
+// elsewhere, where byte-slicing a multi-byte rune would emit an invalid UTF-8
+// fragment.
+func reduceToFidelity(value string, fidelity FieldFidelity) string {
+	switch fidelity {
+	case FieldExact:
+		return value
+	case FieldInitial:
+		// DecodeRuneInString returns (RuneError, 0) for the empty string and
+		// (RuneError, 1) for an undecodable byte, so this single check covers
+		// both: no initial is better than a broken one, and an explicit
+		// empty-string guard above would be unreachable.
+		r, size := utf8.DecodeRuneInString(value)
+		if r == utf8.RuneError && size <= 1 {
+			return ""
+		}
+		return value[:size]
+	default:
+		return ""
+	}
+}

--- a/pkg/enum/fidelity_test.go
+++ b/pkg/enum/fidelity_test.go
@@ -1,0 +1,230 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Tests for per-format field fidelity: how much of a name the generated
+// username actually proves. The generator holds the full "first.last" pair it
+// built each username from, but a lossy format discards part of it -- "jsmith"
+// proves only that the given name starts with J. Consumers that label a
+// confirmed hit with a person's name must reduce the carried pair to what the
+// address demonstrates, and that reduction is a pure function of the format.
+//
+// These tests pin the mapping for EVERY format in ListFormats, so adding a
+// format without deciding its fidelity fails here rather than silently
+// defaulting to a guess.
+package enum
+
+import (
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFormatFidelity_EveryFormatMapped is the guard against a new format
+// slipping in without a fidelity decision. FormatFidelity must not report
+// FieldAbsent for the first name of any real format -- every format in the set
+// encodes at least the given name's initial.
+func TestFormatFidelity_EveryFormatMapped(t *testing.T) {
+	for _, format := range ListFormats() {
+		t.Run(format, func(t *testing.T) {
+			first, last := FormatFidelity(format)
+			assert.NotEqual(t, FieldAbsent, first,
+				"every supported format encodes at least the first initial; %q reports the given name absent, which likely means FormatFidelity was never taught about it", format)
+			assert.Contains(t, []FieldFidelity{FieldAbsent, FieldInitial, FieldExact}, last,
+				"surname fidelity must be one of the three defined states")
+		})
+	}
+}
+
+func TestFormatFidelity_Mapping(t *testing.T) {
+	tests := []struct {
+		format string
+		first  FieldFidelity
+		last   FieldFidelity
+		why    string
+	}{
+		// Separator-delimited, both parts present: unambiguous.
+		{FormatFirstDotLast, FieldExact, FieldExact, "john.smith encodes both parts, dot-delimited"},
+		{FormatLastDotFirst, FieldExact, FieldExact, "smith.john encodes both parts, dot-delimited"},
+		{FormatFirstUnderLast, FieldExact, FieldExact, "john_smith encodes both parts, underscore-delimited"},
+
+		// No separator, but both parts are present in full. The boundary is not
+		// recoverable from the string in principle; measured against the shipped
+		// wordlist only 6 of 248,093 lastfirst usernames have an ambiguous split
+		// (0.00%, worst case "limandy" = Andy Lim or Mandy Li), so this is
+		// treated as exact rather than warranting a fourth fidelity state.
+		{FormatLastFirst, FieldExact, FieldExact, "smithjohn carries both parts in full"},
+
+		// Given name truncated to its initial.
+		{FormatFLast, FieldInitial, FieldExact, "jsmith proves only J"},
+		{FormatFDotLast, FieldInitial, FieldExact, "j.smith proves only J"},
+		{FormatLastF, FieldInitial, FieldExact, "smithj proves only J"},
+
+		// Surname truncated to its initial -- the given name survives intact.
+		{FormatFirstL, FieldExact, FieldInitial, "johns proves John but only S"},
+
+		// No surname in the address at all.
+		{FormatFirst, FieldExact, FieldAbsent, "john encodes no surname whatsoever"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.format, func(t *testing.T) {
+			first, last := FormatFidelity(tt.format)
+			assert.Equal(t, tt.first, first, "first name fidelity: %s", tt.why)
+			assert.Equal(t, tt.last, last, "surname fidelity: %s", tt.why)
+		})
+	}
+}
+
+// TestFormatFidelity_UnknownFormatIsAbsent pairs with GenerateCandidates, which
+// yields nothing for an unrecognized format. Reporting Absent/Absent means a
+// consumer that somehow reaches KnownName with a bogus format emits no name
+// rather than a name it cannot justify.
+func TestFormatFidelity_UnknownFormatIsAbsent(t *testing.T) {
+	first, last := FormatFidelity("totally-unknown-format")
+	assert.Equal(t, FieldAbsent, first)
+	assert.Equal(t, FieldAbsent, last)
+
+	kf, kl := KnownName("totally-unknown-format", "John", "Smith")
+	assert.Empty(t, kf, "an unknown format must not license a name")
+	assert.Empty(t, kl)
+}
+
+func TestKnownName_ReducesToWhatTheAddressProves(t *testing.T) {
+	tests := []struct {
+		name        string
+		format      string
+		first, last string
+		wantFirst   string
+		wantLast    string
+	}{
+		{"first.last keeps both", FormatFirstDotLast, "John", "Smith", "John", "Smith"},
+		{"last.first keeps both", FormatLastDotFirst, "John", "Smith", "John", "Smith"},
+		{"first_last keeps both", FormatFirstUnderLast, "John", "Smith", "John", "Smith"},
+		{"lastfirst keeps both", FormatLastFirst, "John", "Smith", "John", "Smith"},
+
+		// The headline case: jsmith@example.com is "J Smith", never "John Smith".
+		{"flast truncates the given name", FormatFLast, "John", "Smith", "J", "Smith"},
+		{"f.last truncates the given name", FormatFDotLast, "James", "Smith", "J", "Smith"},
+		{"lastf truncates the given name", FormatLastF, "Jason", "Smith", "J", "Smith"},
+
+		{"firstl truncates the surname", FormatFirstL, "John", "Smith", "John", "S"},
+
+		// john@example.com contains no surname, so the wordlist's surname for
+		// the highest-ranked "john.*" pair must not leak out as a fact.
+		{"first drops the surname entirely", FormatFirst, "John", "Smith", "John", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotFirst, gotLast := KnownName(tt.format, tt.first, tt.last)
+			assert.Equal(t, tt.wantFirst, gotFirst)
+			assert.Equal(t, tt.wantLast, gotLast)
+		})
+	}
+}
+
+// TestKnownName_InitialMatchesTheGeneratedUsername is the correctness anchor:
+// the initial KnownName reports must be the same character formatUsername
+// actually put into the address. If those two ever disagree we would be
+// reporting an initial the address does not contain.
+func TestKnownName_InitialMatchesTheGeneratedUsername(t *testing.T) {
+	const first, last = "john", "smith"
+
+	for _, format := range []string{FormatFLast, FormatFDotLast, FormatLastF} {
+		t.Run(format, func(t *testing.T) {
+			username := formatUsername(first, last, format)
+			require.NotEmpty(t, username)
+
+			knownFirst, _ := KnownName(format, first, last)
+			require.Len(t, knownFirst, 1)
+			assert.Contains(t, username, knownFirst,
+				"the reported initial %q must appear in the username %q it came from", knownFirst, username)
+			assert.Equal(t, first[:1], knownFirst,
+				"formatUsername uses first[:1]; KnownName must report that same character")
+		})
+	}
+
+	t.Run(FormatFirstL, func(t *testing.T) {
+		username := formatUsername(first, last, FormatFirstL)
+		require.NotEmpty(t, username)
+
+		_, knownLast := KnownName(FormatFirstL, first, last)
+		require.Len(t, knownLast, 1)
+		assert.Equal(t, last[:1], knownLast,
+			"formatUsername uses lastConcat[:1]; KnownName must report that same character")
+	})
+}
+
+// TestKnownName_EmptyInputDoesNotPanic covers the slicing hazard: reducing a
+// field to its initial means taking the first character of a string that may be
+// empty.
+func TestKnownName_EmptyInputDoesNotPanic(t *testing.T) {
+	for _, format := range ListFormats() {
+		t.Run(format, func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				gotFirst, gotLast := KnownName(format, "", "")
+				assert.Empty(t, gotFirst)
+				assert.Empty(t, gotLast)
+			})
+		})
+	}
+}
+
+// TestKnownName_InitialIsRuneSafe documents a divergence rather than asserting
+// parity. Every pair in the shipped wordlist is ASCII, so formatUsername's
+// byte-slicing first[:1] is safe for generated candidates. KnownName is
+// exported and may be called with arbitrary input, where byte-slicing a
+// multi-byte rune would emit an invalid UTF-8 fragment, so it slices by rune.
+func TestKnownName_InitialIsRuneSafe(t *testing.T) {
+	knownFirst, knownLast := KnownName(FormatFLast, "Ángel", "Ruiz")
+	assert.Equal(t, "Á", knownFirst, "must be a whole rune, not a truncated byte")
+	assert.Equal(t, "Ruiz", knownLast)
+
+	_, surname := KnownName(FormatFirstL, "Ana", "Île")
+	assert.Equal(t, "Î", surname)
+}
+
+// TestKnownName_UndecodableInitialIsDropped is the other half of rune safety.
+// An input that is not valid UTF-8 has no meaningful first character, and
+// returning its leading byte would put an invalid string into a Person record.
+// Dropping it is the only option that cannot produce broken output.
+func TestKnownName_UndecodableInitialIsDropped(t *testing.T) {
+	knownFirst, knownLast := KnownName(FormatFLast, "\xffbroken", "Smith")
+	assert.Empty(t, knownFirst, "an undecodable byte must not be reported as an initial")
+	assert.Equal(t, "Smith", knownLast, "the exact field is passed through untouched, valid or not")
+
+	assert.True(t, utf8.ValidString(knownFirst), "output must always be valid UTF-8")
+}
+
+// TestKnownName_DoesNotTitleCaseOrTrim keeps the reduction a pure projection.
+// Casing is the consumer's presentation concern (guard has personname.TitleCase
+// for it); silently title-casing here would make KnownName's output disagree
+// with the Candidate fields it derives from.
+func TestKnownName_DoesNotTitleCaseOrTrim(t *testing.T) {
+	first, last := KnownName(FormatFirstDotLast, "john", "smith")
+	assert.Equal(t, "john", first, "casing is the consumer's concern")
+	assert.Equal(t, "smith", last)
+
+	initial, _ := KnownName(FormatFLast, "john", "smith")
+	assert.Equal(t, "j", initial, "the initial keeps the case it was given")
+}
+
+func TestFieldFidelity_String(t *testing.T) {
+	assert.Equal(t, "absent", FieldAbsent.String())
+	assert.Equal(t, "initial", FieldInitial.String())
+	assert.Equal(t, "exact", FieldExact.String())
+	assert.Equal(t, "unknown", FieldFidelity(99).String())
+}


### PR DESCRIPTION
Adds `FormatFidelity` and `KnownName` so a consumer labeling a confirmed hit emits only the part of a name the address actually proves.

**`jsmith@example.com` becomes "J Smith", never "John Smith".**

Purely additive: two new exported symbols and one new file. No existing behavior changes, no struct fields added, nothing re-plumbed through `TargetWorker`.

## Why the ticket's premise was wrong

10T-739 was filed proposing **wordlist-derived ambiguity flags** — count how many pairs collapse to each username, let consumers set a name only when the count is 1. I wrote that ticket, and the premise is wrong in the dangerous direction.

The wordlist is a frequency-ranked sample of **248,231 pairs, not the universe of names.** A username with exactly one expansion in it still has no proven given name — the real owner may hold a name the list doesn't contain. So an "unambiguous" flag would have said *"safe, use Xavier"* and licensed **precisely the guess it was meant to prevent** — with more confidence in the unique case than the ambiguous one, which is backwards.

> The wordlist can prove ambiguity. It cannot prove uniqueness.

What the address *does* prove is a property of the **format**, decidable with no data source at all:

| format | example | first name | surname |
|---|---|---|---|
| `first.last` `last.first` `first_last` `lastfirst` | `john.smith@` | exact | exact |
| `flast` `f.last` `lastf` | `jsmith@` | **initial** | exact |
| `firstl` | `johns@` | exact | **initial** |
| `first` | `john@` | exact | **absent** |

The initial isn't a guess — `formatUsername` built the username from that exact character, so reporting `J` is definitionally correct in the way "John" is not. This is what `emailname.DeriveName` produced before 10T-535 removed it, without reintroducing derivation from the local part (which couldn't know the format, and was wrong for `first.last`).

## Two findings from doing the mapping

**`FormatFirst` is the worst case in the set, and the original analysis missed it** — it only looked at formats using both name parts. `john@example.com` encodes **no surname whatsoever**, yet the surviving candidate carries whichever surname the highest-ranked `john.*` pair supplied. That value isn't a truncation of anything in the username; it has no basis in the address at all. Fidelity `FieldAbsent`, and it must never surface.

**`FormatLastFirst` needed a measurement, not a guess.** `smithjohn` runs both parts together so the boundary is in principle unrecoverable — `limandy` is Andy Lim or Mandy Li. Measured against the shipped wordlist: **6 of 248,093 usernames (0.00%)**, versus a majority for initial truncation. Called exact rather than inventing a fourth state; the measurement is in the code comment so it can be revisited if the wordlist changes.

## Design notes

**`KnownName` is a helper, not just the enum.** Leaving each consumer to switch on `FormatFidelity` themselves would be two implementations and two chances to reintroduce the guess. Written and tested once.

**It's a pure projection** — no title-casing, no trimming. Presentation belongs to the caller (guard has `personname.TitleCase`), and transforming here would make the output disagree with the `Candidate` fields it derives from.

**The initial is taken by rune, not byte.** `formatUsername` slices bytes (`first[:1]`), equivalent for the shipped wordlist since **all 248,231 pairs are ASCII** (verified). But `KnownName` is exported and may be handed a name from elsewhere, where byte-slicing a multi-byte rune would emit invalid UTF-8.

## Mutations

Six, all reverted and verified by SHA-256:

| Mutation | Result |
|---|---|
| `FormatFirst` reports surname exact | `Mapping/first` + `..._first_drops_the_surname_entirely` fail |
| `flast`/`f.last`/`lastf` don't truncate | 8 tests fail, including the headline case |
| `firstl` truncates the given name instead | 6 tests fail |
| byte-slice the initial | `InitialIsRuneSafe` fails |
| drop the `utf8.RuneError` guard | `UndecodableInitialIsDropped` fails |
| add an unmapped format to `ListFormats` | `EveryFormatMapped` fails with its intended diagnostic |

That last one is the future-proofing claim, so it's worth showing the actual output:

```
--- FAIL: TestFormatFidelity_EveryFormatMapped/first-middle-last
    every supported format encodes at least the first initial;
    "first-middle-last" reports the given name absent, which likely
    means FormatFidelity was never taught about it
```

A new format can't be added without answering the fidelity question.

**A seventh mutation found dead code rather than a test gap.** An explicit `if value == ""` guard before the rune decode *survived deletion* — because `utf8.DecodeRuneInString("")` returns `(RuneError, 0)` and the `RuneError` check already covered it. Rather than keep code no test can pin, I removed the guard and added a test for undecodable input so the remaining check is load-bearing. That's the difference between the two rune-safety tests: one asserts a whole rune is returned, the other asserts a broken byte is dropped.

## Verification

```
golangci-lint run ./pkg/enum/...    0 issues.   (cold cache)
go test ./... -count=1              56 ok, 0 FAIL
go vet ./pkg/enum/... ./cmd/...     exit 0
go build ./...                      exit 0
gofmt -l pkg/enum/                  clean
```

Lint caught `labelling` → `labeling` (repo pins `misspell.locale: US`); fixed before commit.

## Consumer follow-up

guard calls `enum.KnownName(task.format, r.First, r.Last)` in `google`, `microsoft365` and `teams_enumeration`. For Teams specifically, a real directory `DisplayName` — present on roughly 1% of hits, since Microsoft withholds directory details by default — is a source-produced fact and should win over the generated name; the reduction applies only to the fallback.

Needs a release tag before guard can pin it; v1.13.0 would carry this plus #318, #319 and #326, which are merged but unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
