### PR TITLE
fix(enum/apollo): stop requesting personal emails on people/match

### DIFF
--- a/pkg/enum/apollo/apollo.go
+++ b/pkg/enum/apollo/apollo.go
@@ -328,7 +328,16 @@ func (c *Client) searchPage(ctx context.Context, domain string, titles []string,
 // people/match. Consumes credits. Returns the mapped Person (search + reveal
 // fields), which the caller merges onto the discovered person.
 func (c *Client) matchPerson(ctx context.Context, id string) (Person, error) {
-	reqBody := apolloMatchRequest{ID: id, RevealPersonalEmails: true}
+	// Personal email addresses are OUT OF SCOPE: Praetorian's rules of engagement
+	// forbid ever targeting a person's personal address, so this client must never
+	// ask Apollo for one — it would collect personal PII we are forbidden to use, on
+	// a credit we spend either way. The false is DELIBERATE, not a default: the field
+	// carries no omitempty, so it serializes as "reveal_personal_emails":false and
+	// affirmatively tells Apollo to withhold them rather than trusting an
+	// undocumented vendor default. Do NOT flip this to true, and do NOT add
+	// omitempty (which would silently drop the explicit "no").
+	// Enforced by TestEnrichByIDs_DoesNotRequestPersonalEmails.
+	reqBody := apolloMatchRequest{ID: id, RevealPersonalEmails: false}
 	body, err := c.do(ctx, http.MethodPost, matchPath, reqBody)
 	if err != nil {
 		return Person{}, err

--- a/pkg/enum/apollo/apollo_test.go
+++ b/pkg/enum/apollo/apollo_test.go
@@ -628,7 +628,7 @@ func TestEnrichByIDs_DoesNotRequestPersonalEmails(t *testing.T) {
 	var capturedBody []byte
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, matchPath, r.URL.Path, "EnrichByIDs must call /people/match")
+		assert.Equal(t, matchPath, r.URL.Path, "EnrichByIDs must call /people/match")
 		capturedBody, _ = io.ReadAll(r.Body)
 		var req apolloMatchRequest
 		_ = json.Unmarshal(capturedBody, &req)

--- a/pkg/enum/apollo/apollo_test.go
+++ b/pkg/enum/apollo/apollo_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -614,6 +615,47 @@ func TestEnrichByIDs_ReturnsEnrichedPersons(t *testing.T) {
 		assert.Equal(t, "https://linkedin.com/in/"+id, enriched[i].LinkedinURL)
 		assert.True(t, enriched[i].Revealed, "person[%d] Revealed must be true after EnrichByIDs", i)
 	}
+}
+
+// TestEnrichByIDs_DoesNotRequestPersonalEmails is a compliance guard, not a style
+// preference. Praetorian's rules of engagement forbid ever targeting a person's
+// personal email address, so this client must never ask Apollo for one: doing so
+// would pull out-of-scope personal PII on every paid match credit. Both
+// assertions matter. The decoded value proves we do not opt in; the raw body
+// proves the flag is still transmitted as an explicit "no" rather than dropped,
+// which is what would break if someone later added `omitempty`.
+func TestEnrichByIDs_DoesNotRequestPersonalEmails(t *testing.T) {
+	var capturedBody []byte
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, matchPath, r.URL.Path, "EnrichByIDs must call /people/match")
+		capturedBody, _ = io.ReadAll(r.Body)
+		var req apolloMatchRequest
+		_ = json.Unmarshal(capturedBody, &req)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(makeMatchResponseForID(req.ID))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	_, err := c.EnrichByIDs(context.Background(), []string{"p1"})
+	require.NoError(t, err)
+	require.NotEmpty(t, capturedBody, "the people/match request body must have been captured")
+
+	// The decoded request must not opt in to personal emails.
+	var req apolloMatchRequest
+	require.NoError(t, json.Unmarshal(capturedBody, &req))
+	assert.False(t, req.RevealPersonalEmails,
+		"people/match must not request personal emails — out of scope by rules of engagement")
+
+	// The raw body must still carry the key, set to false: an affirmative "no" to
+	// Apollo rather than reliance on an undocumented vendor default.
+	assert.Contains(t, string(capturedBody), `"reveal_personal_emails"`,
+		"reveal_personal_emails must be transmitted explicitly, not omitted")
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(capturedBody, &raw))
+	assert.Equal(t, false, raw["reveal_personal_emails"],
+		"reveal_personal_emails must be transmitted as false")
 }
 
 func TestEnrichByIDs_SkipsEmptyIDs(t *testing.T) {


### PR DESCRIPTION
## Problem

Praetorian's rules of engagement mean we **never** target a person's personal email address in a phishing engagement. But `matchPerson` hardcoded the opposite:

```go
reqBody := apolloMatchRequest{ID: id, RevealPersonalEmails: true}
```

So every `people/match` call — **one paid Apollo credit each** — asked Apollo to return out-of-scope personal addresses.

**Nothing ever consumed them.** `apolloPerson` maps no `personal_emails` field; `grep -rn "personal" pkg/enum/apollo/` returns only the request flag and its struct tag. The personal PII was requested, paid for, transmitted over the wire, and dropped unparsed. There was no code path that could have used it — which also means no existing test depended on it.

The flag was hardcoded with no way for a caller to opt out.

## Fix

`RevealPersonalEmails: false`, plus a comment stating the invariant so a future reader doesn't "helpfully" flip it back.

The flag is **still sent**, now as an explicit `false`. `apolloMatchRequest` carries no `omitempty`, so it serializes as `"reveal_personal_emails":false` and affirmatively tells Apollo to withhold personal addresses, rather than relying on an undocumented vendor default. For an ROE-relevant control, "we told them no" is a materially better position than "we assume their default is no."

**No opt-out knob was added.** Under ROE there is no legitimate caller, so a configurable toggle would only be a foot-gun.

Business email reveal is unaffected — that is what `email` / `email_status` carry, and it's the only thing the client parses.

## Testing

TDD. `TestEnrichByIDs_DoesNotRequestPersonalEmails` written first, failing against the unmodified client for the right reason:

```
Error:      	Not equal:
            	expected: false
            	actual  : true
Messages:   	reveal_personal_emails must be transmitted as false
--- FAIL: TestEnrichByIDs_DoesNotRequestPersonalEmails (0.01s)
```

It asserts **both** the decoded `apolloMatchRequest.RevealPersonalEmails` and the **raw** request body. The second assertion is the load-bearing one: it means a later `omitempty` — which would silently drop the explicit "no" and fall back to Apollo's default — fails the build instead of quietly regressing. That guard was verified by construction rather than assumed (key present + `false` → passes; key absent → fails).

Reuses the file's existing httptest idiom and helpers (`newTestClient`, `makeMatchResponseForID`), placed alongside `TestEnrichByIDs_ReturnsEnrichedPersons`.

| Command | Result |
|---|---|
| `go test ./pkg/enum/apollo/ -count=1` | ok |
| `go test ./pkg/enum/apollo/ -run TestEnrichByIDs -v` | 4/4 PASS |
| `go test -race -count=1 ./pkg/enum/apollo/` | ok |
| `go build ./...` | exit 0 |
| `go vet ./pkg/enum/apollo/` | exit 0 |
| `gofmt -l pkg/enum/apollo/` | clean |

No existing test required adjustment.

## Downstream note

Guard pins `brutus v1.13.0`, so this has no effect on the platform until that pin is bumped — a follow-up once this merges.

This is one of two independent vectors that put off-domain addresses on Guard's Target OSINT roster. The other is Apollo's `q_organization_domains_list` **fuzzy** org matching, which returns people at separate companies (a run against `praetorian.com` yielding `praetorian-pk.com` contacts). That one is filtered consumer-side in Guard (praetorian-inc/guard#7849). Neither fix subsumes the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
