### PR TITLE
feat: derive the documented CLI surface from cobra and fail CI on drift (ENG-6871)

### DIFF
--- a/.github/workflows/cli-surface.yml
+++ b/.github/workflows/cli-surface.yml
@@ -1,0 +1,58 @@
+name: CLI Surface Drift
+
+# Fails CI when the documented brutus CLI surface no longer matches what cobra
+# registers, in either direction: a documented flag or subcommand that no longer
+# exists, or a registered one that is not documented.
+#
+# Deliberately carries NO `paths:` filter. Documentation drift usually arrives as
+# a markdown-only change, and `ci.yml` filters on '**/*.go', go.mod, go.sum,
+# '.golangci*' and 'Makefile' — so a README-only pull request runs no CI at all
+# today. This gate has to fire on every pull request to be worth anything.
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  cli-surface:
+    name: CLI Surface Drift
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
+
+      # The surface is walked out of the live cobra tree, which lives in
+      # `package main`, so the gate is a test in that package rather than a
+      # separate generator binary. `make cli-docs` is the regeneration path the
+      # failure message points contributors at.
+      - name: Check CLI surface and documentation for drift
+        run: go test ./cmd/brutus -run 'TestCLISurface' -count=1 -v
+
+      # Safety net: the gate above compares in memory and must never write. If it
+      # did, a stale golden could be silently "fixed" in CI and pass.
+      - name: Verify the gate did not rewrite the goldens
+        run: |
+          if ! git diff --quiet -- docs/ README.md; then
+            echo "::error::The drift gate modified tracked documentation. It must compare without writing; run 'make cli-docs' locally instead."
+            git --no-pager diff -- docs/ README.md
+            exit 1
+          fi
+
+      - name: Verify library unit tests
+        run: go test ./internal/clisurface/... -race -count=1

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -141,6 +141,11 @@ release:
   draft: false
   prerelease: auto
   name_template: "Brutus {{ .Tag }}"
+  # Attach the machine-readable CLI surface to every release so downstream
+  # consumers (e.g. the guard-skills drift gate) can pin the exact surface a
+  # given brutus version registered, rather than scraping prose.
+  extra_files:
+    - glob: docs/cli-surface.json
   header: |
     ## Installation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Thank you for your interest in contributing to Brutus! This document provides gu
 - [Getting Started](#getting-started)
 - [Development Setup](#development-setup)
 - [Making Changes](#making-changes)
+- [Changing the CLI Surface](#changing-the-cli-surface)
 - [Adding a New Protocol](#adding-a-new-protocol)
 - [Testing](#testing)
 - [Pull Request Process](#pull-request-process)
@@ -117,6 +118,45 @@ test(ftp): add integration tests
 - One logical change per commit
 - Keep commits small and reviewable
 - Squash WIP commits before submitting PR
+
+## Changing the CLI Surface
+
+The documented CLI surface is **generated from the live cobra command tree**, not
+maintained by hand. Three files are generated:
+
+| File | Purpose |
+|------|---------|
+| `docs/cli-surface.json` | Machine-readable surface. Downstream consumers pin this; it is attached to every GitHub release. |
+| `docs/CLI.md` | Full human-readable reference: every command, alias and flag. |
+| `README.md` | Two generated regions in Quick Start, delimited by `<!-- BEGIN generated: ... -->` markers. |
+
+If you add, remove or rename a command or a flag, regenerate them:
+
+```bash
+make cli-docs
+```
+
+Then commit the result alongside your code change.
+
+The `CLI Surface Drift` workflow runs the same walk in check mode on every pull
+request and fails when the committed copies disagree with what cobra registers,
+in either direction:
+
+- a **documented** flag or subcommand that no longer exists, or
+- a **registered** flag or subcommand that is not documented.
+
+It also lints prose. Every `brutus` invocation inside a fenced code block, every
+backticked flag name in prose, and every flag name mentioned in a Go comment
+under `cmd/` and `pkg/` is checked against the real surface. A flag that was
+renamed cannot survive in a comment or an example.
+
+If a document must deliberately name a flag that no longer exists — for example
+when describing a historical rename — add it to `docs/cli-surface-allow.txt`
+with a comment explaining why.
+
+Do not edit the generated files or the generated README regions by hand; the next
+`make cli-docs` will overwrite them, and the gate will reject the difference in
+the meantime.
 
 ## Adding a New Protocol
 
@@ -419,6 +459,12 @@ golangci-lint run
    ```bash
    go test -short ./...
    golangci-lint run
+   ```
+
+   If you touched a command or a flag, also regenerate the CLI documentation
+   (see [Changing the CLI Surface](#changing-the-cli-surface)):
+   ```bash
+   make cli-docs
    ```
 
 3. **Update documentation** if needed

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Modern credential brute-forcing library in pure Go
 
 .PHONY: all build build-packed build-wasm clean test test-integration lint install help \
-	services-up services-down
+	services-up services-down cli-docs
 
 # Build configuration
 BINARY_NAME := brutus
@@ -111,6 +111,15 @@ lint:
 		echo "golangci-lint not installed, running go vet..."; \
 		GOWORK=off go vet ./...; \
 	fi
+
+# Regenerate the documented CLI surface from the live cobra tree.
+#
+# This is the single command to run after a deliberate rename: it rewrites
+# docs/cli-surface.json, docs/CLI.md and the generated regions of README.md from
+# whatever cobra actually registers. The CI gate (.github/workflows/cli-surface.yml)
+# runs the same walk in check mode and fails when the committed copies disagree.
+cli-docs:
+	GOWORK=off go test ./cmd/brutus -run 'TestCLISurface' -count=1 -update
 
 # Install to GOPATH/bin
 install:
@@ -269,6 +278,7 @@ help:
 	@echo "  services-up      Start integration test services (Docker)"
 	@echo "  services-down    Stop integration test services"
 	@echo "  lint             Run linter"
+	@echo "  cli-docs         Regenerate CLI docs from cobra (docs/, README.md)"
 	@echo "  deps             Check build dependencies"
 	@echo "  version          Show version info"
 	@echo ""

--- a/README.md
+++ b/README.md
@@ -156,27 +156,33 @@ go install github.com/praetorian-inc/brutus/cmd/brutus@latest
 
 ### Subcommands
 
-Brutus organizes its functionality into six focused subcommands:
+<!-- BEGIN generated: cli-subcommands -->
+Brutus organizes its functionality into these focused subcommands:
 
 ```bash
-brutus creds    # Non-HTTP credential auditing (SSH, databases, SMB, etc.)
-brutus web      # HTTP/web panel auditing (Basic Auth, form login, AI-powered)
-brutus snmp     # SNMP community string testing
-brutus badkeys  # Known weak/compromised SSH key testing
-brutus logon    # Windows logon-screen backdoor detection (sticky keys, utilman)
-brutus enum     # Account enumeration (account-existence oracles, Kerberos, Teams auth, email generation)
+brutus badkeys    # Test known weak/compromised SSH keys against targets
+brutus creds      # Test default credentials on non-HTTP services (SSH, databases, SMB, etc.)
+brutus enum       # Enumerate accounts against account-existence oracles or Active Directory
+brutus logon      # Detect Windows logon-screen backdoors (runs both sticky keys and utilman)
+brutus snmp       # Test SNMP community strings against targets
+brutus stickykeys # Detect the Windows sticky-keys (sethc.exe) logon backdoor only
+brutus utilman    # Detect the Windows utilman (Ease of Access) logon backdoor only
+brutus web        # Audit HTTP/web panel credentials (AI-powered or credential list)
 ```
+<!-- END generated: cli-subcommands -->
 
-Each subcommand has aliases for discoverability:
+<!-- BEGIN generated: cli-aliases -->
+Some subcommands carry aliases for discoverability:
 
 | Subcommand | Aliases |
-|------------|---------|
-| `creds` | `services`, `defaults`, `credentials` |
-| `web` | `http`, `panels` |
-| `snmp` | `community` |
+| --- | --- |
 | `badkeys` | `keys`, `ssh-keys`, `badkey` |
-| `logon` | `stickykeys`, `sticky-keys`, `utilman`, `sethc`, `winlogon`, `accessibility` |
-| `enum` | *(none)* |
+| `creds` | `services`, `defaults`, `credentials` |
+| `snmp` | `community` |
+| `web` | `http`, `panels` |
+
+The full reference — every subcommand, alias and flag, including the ones hidden from `--help` — is generated into [docs/CLI.md](docs/CLI.md).
+<!-- END generated: cli-aliases -->
 
 ```bash
 # Test SSH credentials

--- a/cmd/brutus/cli_surface_test.go
+++ b/cmd/brutus/cli_surface_test.go
@@ -1,0 +1,176 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/brutus/internal/clisurface"
+)
+
+// updateGoldens rewrites the generated CLI-surface artifacts instead of
+// checking them. "make cli-docs" is the documented way to set it.
+var updateGoldens = flag.Bool("update", false,
+	"rewrite docs/cli-surface.json, docs/CLI.md and the generated README.md regions from the live cobra tree")
+
+// TestCLISurface is the drift gate. It walks the live cobra tree, compares it
+// against the committed surface, and compares the committed generated files
+// against what that surface renders. Without -update it never writes.
+func TestCLISurface(t *testing.T) {
+	root := repoRoot(t)
+	live := clisurface.Walk(rootCmd)
+
+	if *updateGoldens {
+		require.NoError(t, clisurface.Write(root, live))
+		t.Logf("regenerated %s", strings.Join(clisurface.GeneratedPaths(), ", "))
+		return
+	}
+
+	golden, err := os.ReadFile(filepath.Join(root, clisurface.JSONPath))
+	require.NoErrorf(t, err, "%s is missing; create it with %q", clisurface.JSONPath, clisurface.RegenerateCommand)
+	documented, err := clisurface.ParseJSON(golden)
+	require.NoError(t, err)
+
+	// Fail with require.Fail rather than require.Empty: Empty dumps the raw
+	// findings slice on one unwrapped line before printing the formatted
+	// message, so every finding prints twice, once unreadable and once
+	// formatted. Fail only prints the formatted report.
+	if findings := clisurface.Diff(documented, live); len(findings) > 0 {
+		require.Fail(t, "CLI surface drift",
+			clisurface.Report(findings, clisurface.GeneratedPaths(), clisurface.RegenerateCommand))
+	}
+
+	stale, err := clisurface.CheckArtifacts(root, live)
+	require.NoError(t, err)
+	if len(stale) > 0 {
+		assert.Fail(t, "generated CLI documentation is stale", stalenessReport(stale))
+	}
+}
+
+// TestCLISurfaceDocLint fails when a document or a Go comment names a flag or a
+// subcommand the CLI does not accept.
+func TestCLISurfaceDocLint(t *testing.T) {
+	root := repoRoot(t)
+	allow, err := clisurface.LoadAllowlist(root)
+	require.NoError(t, err)
+
+	issues, err := clisurface.LintRepo(root, clisurface.Walk(rootCmd), allow)
+	require.NoError(t, err)
+	if len(issues) > 0 {
+		assert.Fail(t, "documentation names flags the CLI does not accept", clisurface.LintReport(issues))
+	}
+}
+
+// TestCLISurfaceGateDetectsRename proves the gate reddens. A gate only ever
+// observed passing is not known to work, so this renames a real flag on the
+// real tree and asserts the diff reports exactly that rename, then feeds the
+// linter a document naming a removed flag and asserts it is reported with
+// file:line.
+func TestCLISurfaceGateDetectsRename(t *testing.T) {
+	documented := clisurface.Walk(rootCmd)
+
+	t.Run("renaming a registered flag is reported", func(t *testing.T) {
+		flagObj := logonCmd.Flags().Lookup("experimental-ai")
+		require.NotNil(t, flagObj, "the fixture flag must exist for this test to mean anything")
+		t.Cleanup(func() { flagObj.Name = "experimental-ai" })
+		flagObj.Name = "experimental-ay"
+
+		findings := clisurface.Diff(documented, clisurface.Walk(rootCmd))
+
+		require.Len(t, findings, 2, "a rename is exactly one removal and one addition, and nothing else:\n%s",
+			clisurface.Report(findings, clisurface.GeneratedPaths(), clisurface.RegenerateCommand))
+		// Findings are sorted by command then flag name, so the old name
+		// ("experimental-ai") is reported before the new one.
+		assert.Equal(t, clisurface.FlagRemoved, findings[0].Kind)
+		assert.Equal(t, "experimental-ai", findings[0].Flag)
+		assert.Equal(t, "brutus logon", findings[0].Command)
+		assert.Equal(t, clisurface.FlagUndocumented, findings[1].Kind)
+		assert.Equal(t, "experimental-ay", findings[1].Flag)
+		assert.Equal(t, "brutus logon", findings[1].Command)
+		assert.Contains(t, findings[0].String(),
+			`flag --experimental-ai on "brutus logon" is in the generated docs but cobra no longer accepts it`)
+		assert.Contains(t, findings[1].String(),
+			`flag --experimental-ay on "brutus logon" is registered by cobra but missing from the generated docs`)
+	})
+
+	t.Run("the tree is restored", func(t *testing.T) {
+		assert.Empty(t, clisurface.Diff(documented, clisurface.Walk(rootCmd)),
+			"the rename above must not leak into the rest of the suite")
+	})
+
+	t.Run("a document naming a removed flag is reported", func(t *testing.T) {
+		empty, err := clisurface.ParseAllowlist("")
+		require.NoError(t, err)
+
+		doc := "Historic note.\n\n```bash\nbrutus logon --target host:3389 --sticky-keys-exec \"whoami\"\n```\n"
+		issues := clisurface.LintMarkdown(documented, "docs/example.md", doc, empty)
+
+		require.Len(t, issues, 1)
+		assert.Equal(t, "--sticky-keys-exec", issues[0].Token)
+		assert.Equal(t, "brutus logon", issues[0].Command)
+		assert.Contains(t, issues[0].String(),
+			`docs/example.md:4: --sticky-keys-exec is not a flag of "brutus logon"`)
+		assert.Contains(t, issues[0].String(), clisurface.AllowlistPath,
+			"the message says how to allow a deliberate mention")
+	})
+
+	t.Run("the allowlist suppresses a deliberate mention", func(t *testing.T) {
+		allow, err := clisurface.ParseAllowlist("--sticky-keys-exec # renamed to --exec; the rename note names the old flag\n")
+		require.NoError(t, err)
+
+		doc := "```bash\nbrutus logon --sticky-keys-exec \"whoami\"\n```\n"
+		assert.Empty(t, clisurface.LintMarkdown(documented, "docs/example.md", doc, allow))
+	})
+
+	t.Run("the logon family rejects the inherited --timeout", func(t *testing.T) {
+		empty, err := clisurface.ParseAllowlist("")
+		require.NoError(t, err)
+
+		doc := "```bash\nbrutus logon --target host:3389 --timeout 30s\n```\n"
+		issues := clisurface.LintMarkdown(documented, "docs/example.md", doc, empty)
+
+		require.Len(t, issues, 1,
+			"--timeout is inherited from the root but guardLogonTimeoutFlag refuses it, so documenting it is drift")
+		assert.Equal(t, "--timeout", issues[0].Token)
+		assert.Contains(t, issues[0].Reason, "use --scan-timeout")
+	})
+}
+
+// repoRoot locates the repository root; a test's working directory is its own
+// package directory, and the generated artifacts are repo-relative.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	root, err := clisurface.FindRepoRoot(wd)
+	require.NoError(t, err)
+	return root
+}
+
+// stalenessReport renders stale artifacts one per line.
+func stalenessReport(stale []clisurface.Staleness) string {
+	lines := make([]string, 0, len(stale))
+	for i := range stale {
+		lines = append(lines, stale[i].String())
+	}
+	return strings.Join(lines, "\n")
+}

--- a/cmd/brutus/runner.go
+++ b/cmd/brutus/runner.go
@@ -36,7 +36,7 @@ import (
 // runs the configured brute force against each one. Order matches the file;
 // a per-target failure does not abort the whole run.
 //
-// Output behavior mirrors --nerva (multi-target) mode: in human output we
+// Output behavior mirrors Nerva-fingerprinted multi-target mode: in human output we
 // stream "valid only" findings per target as soon as they're produced, and
 // in JSON mode the caller flushes the full JSONL after the loop returns.
 //
@@ -421,8 +421,9 @@ func detectTLS(baseTLSMode string, tlsDetected, verbose bool) string {
 	return baseTLSMode
 }
 
-// runStickyKeysInteractive handles the --sticky-keys-exec and --sticky-keys-web modes.
-// These bypass normal brute force and instead exploit the sticky keys backdoor interactively.
+// runStickyKeysInteractive handles the --exec and --web interactive modes of the
+// logon family. These bypass normal brute force and instead exploit the sticky
+// keys backdoor interactively.
 func runStickyKeysInteractive(target string, base *runConfig) ([]brutus.Result, bool) {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,1858 @@
+<!-- Generated from the live cobra command tree by 'make cli-docs'. Do not edit by hand. -->
+
+# brutus CLI reference
+
+Every command, alias and flag below is derived from the cobra command tree, not from prose.
+Schema version 1, surface hash `sha256:1d4cc140290018ebec0060e5db81bb43f05ff38068f9deacee1592ed70cadfa2`.
+
+Regenerate with `make cli-docs` after adding, removing or renaming a command or a flag.
+
+## Command index
+
+| Command | Aliases | Description |
+| --- | --- | --- |
+| [`brutus`](#brutus) | *(none)* | Brutus - Et tu, Brute? |
+| [`brutus badkeys`](#brutus-badkeys) | `keys`, `ssh-keys`, `badkey` | Test known weak/compromised SSH keys against targets |
+| [`brutus creds`](#brutus-creds) | `services`, `defaults`, `credentials` | Test default credentials on non-HTTP services (SSH, databases, SMB, etc.) |
+| [`brutus enum`](#brutus-enum) | *(none)* | Enumerate accounts against account-existence oracles or Active Directory |
+| [`brutus enum active`](#brutus-enum-active) | *(none)* | Active account-existence enumeration against live oracles & directories |
+| [`brutus enum active custom`](#brutus-enum-active-custom) | *(none)* | Run a declaratively-described enumeration oracle from a spec file |
+| [`brutus enum active github`](#brutus-enum-active-github) | *(none)* | Enumerate GitHub accounts by email (existence + username reveal) |
+| [`brutus enum active github map`](#brutus-enum-active-github-map) | *(none)* | Correlate known emails to GitHub usernames (reveal-only, skips existence checks) |
+| [`brutus enum active google`](#brutus-enum-active-google) | *(none)* | Enumerate Google Workspace accounts (existence + SSO/IdP) |
+| [`brutus enum active gravatar`](#brutus-enum-active-gravatar) | *(none)* | Enumerate accounts with a registered Gravatar (by email) |
+| [`brutus enum active kerberos`](#brutus-enum-active-kerberos) | *(none)* | Enumerate Active Directory users via Kerberos AS-REQ |
+| [`brutus enum active microsoft365`](#brutus-enum-active-microsoft365) | *(none)* | Enumerate Microsoft 365 accounts (existence + federation/tenant) |
+| [`brutus enum active oracles`](#brutus-enum-active-oracles) | *(none)* | Enumerate which account-existence oracles work for an organization |
+| [`brutus enum active oracles discover`](#brutus-enum-active-oracles-discover) | *(none)* | Discover working oracles by testing a known-valid email |
+| [`brutus enum active teams`](#brutus-enum-active-teams) | *(none)* | Microsoft Teams: device-code auth, user enumeration, and tenant posture audit |
+| [`brutus enum active teams audit`](#brutus-enum-active-teams-audit) | *(none)* | Audit a Microsoft Teams tenant's external posture into graded findings |
+| [`brutus enum active teams auth`](#brutus-enum-active-teams-auth) | *(none)* | Obtain Microsoft access token and refresh token via device code flow |
+| [`brutus enum active teams users`](#brutus-enum-active-teams-users) | *(none)* | Enumerate corporate Microsoft Teams users by email address |
+| [`brutus enum apollo`](#brutus-enum-apollo) | *(none)* | Discover people for a domain via Apollo.io (free; --enrich reveals emails) (deprecated: use "brutus enum passive apollo" instead) |
+| [`brutus enum dehashed`](#brutus-enum-dehashed) | *(none)* | Collect breach-exposed identity data for a domain via DeHashed (deprecated: use "brutus enum passive dehashed" instead) |
+| [`brutus enum generate`](#brutus-enum-generate) | *(none)* | Generate email addresses or usernames from embedded name lists |
+| [`brutus enum hunter`](#brutus-enum-hunter) | *(none)* | Discover people and emails for a domain via Hunter.io Domain Search (deprecated: use "brutus enum passive hunter" instead) |
+| [`brutus enum lusha`](#brutus-enum-lusha) | *(none)* | Enrich a single person identity to emails and phones via Lusha v3 (deprecated: use "brutus enum passive lusha" instead) |
+| [`brutus enum passive`](#brutus-enum-passive) | *(none)* | API-key OSINT/HUMINT sources — employee email/contact discovery & enrichment |
+| [`brutus enum passive apollo`](#brutus-enum-passive-apollo) | *(none)* | Discover people for a domain via Apollo.io (free; --enrich reveals emails) |
+| [`brutus enum passive dehashed`](#brutus-enum-passive-dehashed) | *(none)* | Collect breach-exposed identity data for a domain via DeHashed |
+| [`brutus enum passive hunter`](#brutus-enum-passive-hunter) | *(none)* | Discover people and emails for a domain via Hunter.io Domain Search |
+| [`brutus enum passive linkedin`](#brutus-enum-passive-linkedin) | *(none)* | Scrape LinkedIn Sales Navigator profiles via PhantomBuster |
+| [`brutus enum passive lusha`](#brutus-enum-passive-lusha) | *(none)* | Enrich a single person identity to emails and phones via Lusha v3 |
+| [`brutus logon`](#brutus-logon) | *(none)* | Detect Windows logon-screen backdoors (runs both sticky keys and utilman) |
+| [`brutus snmp`](#brutus-snmp) | `community` | Test SNMP community strings against targets |
+| [`brutus stickykeys`](#brutus-stickykeys) | *(none)* | Detect the Windows sticky-keys (sethc.exe) logon backdoor only |
+| [`brutus utilman`](#brutus-utilman) | *(none)* | Detect the Windows utilman (Ease of Access) logon backdoor only |
+| [`brutus web`](#brutus-web) | `http`, `panels` | Audit HTTP/web panel credentials (AI-powered or credential list) |
+
+## `brutus`
+
+Brutus - Et tu, Brute?
+
+- Usage: `brutus`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+| `--version` |  | bool | `false` | Show version information |
+
+## `brutus badkeys`
+
+Test known weak/compromised SSH keys against targets
+
+- Usage: `brutus badkeys`
+- Aliases: `keys`, `ssh-keys`, `badkey`
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--connect-timeout` |  | duration | `3s` | TCP connect timeout for scan dials (separate from --scan-timeout, which is the per-host settle deadline). A reachable host completes the handshake in ~1 RTT, so the short default only accelerates dead-host rejection; raise it for high-latency target sets. |
+| `--masscan-file` |  | string |  | Masscan JSON file (-oJ output) to import targets from |
+| `--mode` | `-m` | string | `default` | Aggressiveness tier: cautious, default, aggressive |
+| `--nmap-file` |  | string |  | Nmap XML file (-oX output) to import targets from |
+| `--retries` |  | int | `2` | Max retries on connection error (0 = disabled) |
+| `--target` |  | string |  | Target host:port |
+| `--targets-file` |  | string |  | File of targets to test, one host:port per line (fingerprints with Nerva unless --protocol is set) |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Single target
+brutus badkeys --target 192.168.1.10:22
+
+# Targets file (auto-fingerprinted, only SSH services tested)
+brutus badkeys --targets-file targets.txt
+
+# Pipeline mode
+naabu -host 10.0.0.0/24 -p 22 -silent | nerva --json | brutus badkeys
+
+# Pipe plain targets
+echo "192.168.1.10:22" | brutus badkeys
+
+# URI format
+echo "ssh://192.168.1.10:22" | brutus badkeys
+
+# Import targets from nmap XML scan (only SSH services tested)
+brutus badkeys --nmap-file scan.xml
+```
+
+## `brutus creds`
+
+Test default credentials on non-HTTP services (SSH, databases, SMB, etc.)
+
+- Usage: `brutus creds`
+- Aliases: `services`, `defaults`, `credentials`
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--connect-timeout` |  | duration | `3s` | TCP connect timeout for scan dials (separate from --scan-timeout, which is the per-host settle deadline). A reachable host completes the handshake in ~1 RTT, so the short default only accelerates dead-host rejection; raise it for high-latency target sets. |
+| `--credentials` | `-c` | string |  | Comma-separated user:pass pairs (e.g., admin:admin,root:toor) |
+| `--credentials-file` | `-C` | string |  | Credentials file (user:pass per line) |
+| `--key` | `-k` | string |  | SSH private key file |
+| `--masscan-file` |  | string |  | Masscan JSON file (-oJ output) to import targets from |
+| `--max-attempts` |  | int | `0` | Max password attempts per user (0 = unlimited) |
+| `--mode` | `-m` | string | `default` | Aggressiveness tier: cautious, default, aggressive |
+| `--nmap-file` |  | string |  | Nmap XML file (-oX output) to import targets from |
+| `--password-file` | `-P` | string |  | Password file (one per line) |
+| `--passwords` | `-p` | string |  | Comma-separated passwords |
+| `--protocol` |  | string |  | Protocol to use (auto-detected from nerva) |
+| `--retries` |  | int | `2` | Max retries on connection error (0 = disabled) |
+| `--target` |  | string |  | Target host:port |
+| `--targets-file` |  | string |  | File of targets to test, one host:port per line (fingerprints with Nerva unless --protocol is set) |
+| `--username-file` | `-U` | string |  | Username file (one per line) |
+| `--usernames` | `-u` | string | `root,admin` | Comma-separated usernames |
+| `--verify` |  | bool | `false` | Require strict TLS certificate verification |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Single target
+brutus creds --target 192.168.1.10:22 --protocol ssh -p "password,Password1"
+
+# Pre-paired user:pass combos (no Cartesian product)
+brutus creds --target 10.0.0.50:22 -c "admin:admin,root:toor,deploy:deploy123"
+
+# Credentials file (user:pass per line)
+brutus creds --target 10.0.0.50:3306 -C creds.txt
+
+# Targets file (auto-fingerprinted with Nerva)
+brutus creds --targets-file targets.txt -u admin -P passwords.txt
+
+# Pipeline mode with Nerva JSON (HTTP and SNMP services are skipped)
+naabu -host 10.0.0.0/24 -silent | nerva --json | brutus creds -P passwords.txt
+
+# Pipe URI targets (protocol from scheme, no fingerprinting needed)
+echo "ssh://192.168.1.10:22" | brutus creds -p "password,Password1"
+
+# Import targets from nmap XML scan
+brutus creds --nmap-file scan.xml -P passwords.txt
+
+# Import targets from masscan (requires --protocol or auto-fingerprints with Nerva)
+brutus creds --masscan-file scan.json --protocol ssh -P passwords.txt
+```
+
+## `brutus enum`
+
+Enumerate accounts against account-existence oracles or Active Directory
+
+- Usage: `brutus enum`
+- Aliases: *(none)*
+- Requires a subcommand
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Account-existence oracle enumeration
+brutus enum active oracles --domain praetorian.com -e test@praetorian.com --known-valid admin@praetorian.com
+
+# Kerberos user enumeration
+brutus enum active kerberos --dc 10.0.0.1 --domain CORP.LOCAL -u administrator
+
+# Authenticate with Microsoft Entra ID via device code
+brutus enum active teams auth --tenant contoso.com
+
+# GitHub account enumeration by email
+brutus enum active github -e alice@example.com,bob@example.com
+
+# Generate emails for enumeration
+brutus enum generate --domain example.com --format flast
+
+# API-key OSINT/HUMINT sources (employee email/contact discovery)
+brutus enum passive hunter --domain example.com
+brutus enum passive apollo --domain example.com
+brutus enum passive lusha --first-name Jane --last-name Doe --company "Example Inc"
+brutus enum passive dehashed --domain example.com
+```
+
+## `brutus enum active`
+
+Active account-existence enumeration against live oracles & directories
+
+- Usage: `brutus enum active`
+- Aliases: *(none)*
+- Requires a subcommand
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Account-existence oracle enumeration
+brutus enum active oracles --domain example.com --known-valid admin@example.com
+
+# Google Workspace account enumeration
+brutus enum active google -e alice@example.com,bob@example.com
+
+# Microsoft 365 account enumeration
+brutus enum active microsoft365 -e alice@example.com,bob@example.com
+
+# Kerberos user enumeration
+brutus enum active kerberos --dc 10.0.0.1 --domain CORP.LOCAL -u administrator
+
+# Authenticate with Microsoft Entra ID via device code
+brutus enum active teams auth --tenant contoso.com
+
+# GitHub account enumeration by email
+brutus enum active github -e alice@example.com,bob@example.com
+
+# Gravatar account enumeration by email
+brutus enum active gravatar -e alice@example.com,bob@example.com
+
+# Enumerate against a custom oracle definition
+brutus enum active custom -f oracle.json -e jsmith,asmith
+```
+
+## `brutus enum active custom`
+
+Run a declaratively-described enumeration oracle from a spec file
+
+- Usage: `brutus enum active custom`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--domain` | `-d` | string |  | Domain for email generation (with --generate) |
+| `--email-file` | `-E` | string |  | File of subjects to enumerate (one per line, use - for stdin) |
+| `--emails` | `-e` | string |  | Comma-separated subjects (usernames or emails) to enumerate |
+| `--file` | `-f` | string |  | Oracle spec file (JSON or YAML, required) |
+| `--format` |  | string | `first.last` | Username format for generation (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first) |
+| `--generate` |  | bool | `false` | Generate subjects from embedded name lists |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Run an oracle against inline subjects
+brutus enum active custom -f oracle.json -e jsmith,asmith
+
+# Run against a subject file
+brutus enum active custom -f oracle.yaml -E users.txt
+
+# Generate usernames and run
+brutus enum active custom -f oracle.json --generate --format flast
+
+# JSON output to a file
+brutus enum active custom -f oracle.json -e jsmith -o results.jsonl
+```
+
+## `brutus enum active github`
+
+Enumerate GitHub accounts by email (existence + username reveal)
+
+- Usage: `brutus enum active github`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--domain` | `-d` | string |  | Generate candidate emails for this domain (statistically-likely first/last combos) |
+| `--email-file` | `-E` | string |  | File of email addresses, one per line ("-" for stdin) |
+| `--emails` | `-e` | string |  | Comma-separated email addresses to check |
+| `--format` |  | string | `first.last` | Username format for --domain generation (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first) |
+| `--limit` |  | int | `0` | When generating with --domain, cap to the first N (most-likely) candidates (0 = all) |
+| `--no-reveal` |  | bool | `false` | Skip username reveal after existence enumeration (existence-only; no token used, no temp repo created) |
+| `--rotating-proxy` |  | bool | `false` | Signal that --proxy rotates exit IPs (e.g. Bright Data): reduces per-IP rate-limit backoff during GitHub existence enumeration (short retry delay, higher retry ceiling). No effect on token-rate-limited reveal. |
+| `--token` |  | string |  | GitHub PAT for username reveal (overrides GITHUB_TOKEN; visible in process list — prefer the env var) |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Existence-only enumeration (unauthenticated)
+brutus enum active github -e alice@example.com,bob@example.com
+
+# Generate candidate emails for a domain and enumerate the 5000 most likely
+brutus enum active github --domain target.com --format first.last --limit 5000
+
+# Enumerate emails from a file
+brutus enum active github -E emails.txt
+
+# Reveal usernames for existing accounts (requires a PAT with repo+delete_repo)
+export GITHUB_TOKEN=ghp_...
+brutus enum active github -E emails.txt
+
+# Pace requests to avoid GitHub's existence-endpoint rate limiting
+brutus enum active github -E emails.txt --threads 2 --rate-limit 1
+```
+
+## `brutus enum active github map`
+
+Correlate known emails to GitHub usernames (reveal-only, skips existence checks)
+
+- Usage: `brutus enum active github map`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--email-file` | `-E` | string |  | File of email addresses, one per line ("-" for stdin) |
+| `--emails` | `-e` | string |  | Comma-separated email addresses to correlate |
+| `--token` |  | string |  | GitHub PAT (overrides GITHUB_TOKEN; visible in process list — prefer the env var) |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--rotating-proxy` |  | bool | `false` | Signal that --proxy rotates exit IPs (e.g. Bright Data): reduces per-IP rate-limit backoff during GitHub existence enumeration (short retry delay, higher retry ceiling). No effect on token-rate-limited reveal. |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Correlate emails from a file (token from the environment)
+export GITHUB_TOKEN=ghp_...
+brutus enum active github map -E emails.txt
+
+# Correlate a couple of emails inline
+brutus enum active github map -e alice@example.com,bob@example.com
+```
+
+## `brutus enum active google`
+
+Enumerate Google Workspace accounts (existence + SSO/IdP)
+
+- Usage: `brutus enum active google`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--domain` | `-d` | string |  | Generate candidate emails for this domain (statistically-likely first/last combos) |
+| `--email-file` | `-E` | string |  | File of email addresses, one per line ("-" for stdin) |
+| `--emails` | `-e` | string |  | Comma-separated email addresses to check |
+| `--format` |  | string | `first.last` | Username format for --domain generation (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first) |
+| `--limit` |  | int | `0` | When generating with --domain, cap to the first N (most-likely) candidates (0 = all) |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Enumerate a couple of emails
+brutus enum active google -e alice@example.com,bob@example.com
+
+# Generate candidate emails for a domain and enumerate the 5000 most likely
+brutus enum active google --domain target.com --format first.last --limit 5000
+
+# Enumerate emails from a file
+brutus enum active google -E emails.txt
+
+# Route through a SOCKS5 proxy and raise concurrency
+brutus enum active google -E emails.txt --proxy socks5://127.0.0.1:1080 --threads 20
+```
+
+## `brutus enum active gravatar`
+
+Enumerate accounts with a registered Gravatar (by email)
+
+- Usage: `brutus enum active gravatar`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--domain` | `-d` | string |  | Generate candidate emails for this domain (statistically-likely first/last combos) |
+| `--email-file` | `-E` | string |  | File of email addresses, one per line ("-" for stdin) |
+| `--emails` | `-e` | string |  | Comma-separated email addresses to check |
+| `--format` |  | string | `first.last` | Username format for --domain generation (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first) |
+| `--limit` |  | int | `0` | When generating with --domain, cap to the first N (most-likely) candidates (0 = all) |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Enumerate a couple of emails
+brutus enum active gravatar -e alice@example.com,bob@example.com
+
+# Generate candidate emails for a domain and enumerate the 5000 most likely
+brutus enum active gravatar --domain target.com --format first.last --limit 5000
+
+# Enumerate emails from a file
+brutus enum active gravatar -E emails.txt
+
+# Route through a SOCKS5 proxy and raise concurrency
+brutus enum active gravatar -E emails.txt --proxy socks5://127.0.0.1:1080 --threads 20
+```
+
+## `brutus enum active kerberos`
+
+Enumerate Active Directory users via Kerberos AS-REQ
+
+- Usage: `brutus enum active kerberos`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--dc` |  | string |  | KDC (Domain Controller) address (host or host:port) |
+| `--domain` | `-d` | string |  | Kerberos realm / AD domain (e.g., CORP.LOCAL) |
+| `--user-file` | `-U` | string |  | File of usernames (one per line, use - for stdin) |
+| `--users` | `-u` | string |  | Comma-separated usernames to enumerate |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Enumerate specific users
+brutus enum active kerberos --dc 10.0.0.1 --domain CORP.LOCAL -u administrator,guest,krbtgt
+
+# Enumerate from file
+brutus enum active kerberos --dc dc01.corp.local --domain CORP.LOCAL -U users.txt
+
+# Generate usernames and enumerate
+brutus enum generate --format flast | brutus enum active kerberos --dc 10.0.0.1 --domain CORP.LOCAL -U -
+
+# JSON output
+brutus enum active kerberos --dc 10.0.0.1 --domain CORP.LOCAL -u administrator --json
+```
+
+## `brutus enum active microsoft365`
+
+Enumerate Microsoft 365 accounts (existence + federation/tenant)
+
+- Usage: `brutus enum active microsoft365`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--domain` | `-d` | string |  | Generate candidate emails for this domain (statistically-likely first/last combos) |
+| `--email-file` | `-E` | string |  | File of email addresses, one per line ("-" for stdin) |
+| `--emails` | `-e` | string |  | Comma-separated email addresses to check |
+| `--format` |  | string | `first.last` | Username format for --domain generation (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first) |
+| `--limit` |  | int | `0` | When generating with --domain, cap to the first N (most-likely) candidates (0 = all) |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Enumerate a couple of emails
+brutus enum active microsoft365 -e alice@example.com,bob@example.com
+
+# Generate candidate emails for a domain and enumerate the 5000 most likely
+brutus enum active microsoft365 --domain target.com --format first.last --limit 5000
+
+# Enumerate emails from a file
+brutus enum active microsoft365 -E emails.txt
+
+# Route through a SOCKS5 proxy and raise concurrency
+brutus enum active microsoft365 -E emails.txt --proxy socks5://127.0.0.1:1080 --threads 20
+```
+
+## `brutus enum active oracles`
+
+Enumerate which account-existence oracles work for an organization
+
+- Usage: `brutus enum active oracles`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--domain` | `-d` | string |  | Domain to enumerate for DNS recon and email generation (defaults to the --known-valid email's domain) |
+| `--email-file` | `-E` | string |  | File of emails to enumerate (one per line, use - for stdin) |
+| `--emails` | `-e` | string |  | Comma-separated emails to enumerate |
+| `--format` |  | string | `first.last` | Username format for generation (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first) |
+| `--generate` |  | bool | `false` | Generate emails from embedded name lists |
+| `--known-valid` |  | string |  | Known-valid email to validate oracles before enumeration (required) |
+| `--services` | `-s` | string |  | Comma-separated oracles to check (default: all discovered/registered) |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Discover candidate oracles via DNS and report which ones work
+# (domain defaults to the --known-valid email's domain)
+brutus enum active oracles --known-valid admin@praetorian.com
+
+# Enumerate specific emails against the working oracles
+brutus enum active oracles --domain praetorian.com -e test@praetorian.com,admin@praetorian.com --known-valid admin@praetorian.com
+
+# Enumerate emails from file
+brutus enum active oracles --domain praetorian.com -E emails.txt --known-valid admin@praetorian.com
+
+# Generate emails and enumerate against working oracles
+brutus enum active oracles --domain target.com --generate --format first.last --known-valid admin@target.com
+
+# Check / enumerate against specific oracles only
+brutus enum active oracles -e user@example.com -s microsoft365,google --known-valid admin@example.com
+
+# JSON output
+brutus enum active oracles --domain praetorian.com -e test@praetorian.com --known-valid admin@praetorian.com --json
+```
+
+## `brutus enum active oracles discover`
+
+Discover working oracles by testing a known-valid email
+
+- Usage: `brutus enum active oracles discover`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--domain` | `-d` | string |  | Domain to discover candidate oracles from DNS TXT records |
+| `--known-valid` |  | string |  | Known-valid email to test against oracles (required) |
+| `--services` | `-s` | string |  | Comma-separated oracles to test (default: all registered) |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Test oracles for a domain (auto-discovers candidate oracles from DNS)
+brutus enum active oracles discover --domain praetorian.com --known-valid admin@praetorian.com
+
+# Test specific oracles only
+brutus enum active oracles discover --known-valid admin@example.com -s microsoft365,google
+```
+
+## `brutus enum active teams`
+
+Microsoft Teams: device-code auth, user enumeration, and tenant posture audit
+
+- Usage: `brutus enum active teams`
+- Aliases: *(none)*
+- Requires a subcommand
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+## `brutus enum active teams audit`
+
+Audit a Microsoft Teams tenant's external posture into graded findings
+
+- Usage: `brutus enum active teams audit`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--access-token` |  | string |  | Access token to use (instead of device-code or --token-file) |
+| `--client-id` |  | string | `1fec8e78-bce4-4aaf-ab1b-5451cc387264` | Azure app (client) ID (device-code path) |
+| `--email` |  | string |  | Single known-valid seed email address to audit (required) |
+| `--include-consumer` |  | bool | `false` | Count consumer/personal (8:live:) Teams accounts as hits (default: only corporate 8:orgid: accounts) |
+| `--no-browser` |  | bool | `false` | Don't automatically open the verification URL in a browser |
+| `--no-presence` |  | bool | `false` | Skip Teams presence / out-of-office lookups (fewer requests; presence is gathered by default) |
+| `--refresh-token` |  | string |  | Refresh token used to renew an expired access token |
+| `--scope` |  | string | `offline_access https://api.spaces.skype.com/.default` | Space-separated OAuth2 scopes (device-code path) |
+| `--tenant` |  | string | `organizations` | Tenant ID, domain, or "organizations"/"common" (device-code path) |
+| `--token-file` |  | string |  | JSONL token file from "enum active teams auth -o" to reuse |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Audit a tenant via a single known-valid seed address (device-code auth inline)
+brutus enum active teams audit --email alice@contoso.com
+
+# Skip presence/out-of-office lookups (presence/OOO findings not evaluated)
+brutus enum active teams audit --email alice@contoso.com --no-presence
+
+# Reuse a token captured earlier with "enum active teams auth -o"
+brutus enum active teams auth -o token.jsonl
+brutus enum active teams audit --email alice@contoso.com --token-file token.jsonl
+
+# Emit findings as JSONL
+brutus enum active teams audit --email alice@contoso.com --json
+```
+
+## `brutus enum active teams auth`
+
+Obtain Microsoft access token and refresh token via device code flow
+
+- Usage: `brutus enum active teams auth`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--client-id` |  | string | `1fec8e78-bce4-4aaf-ab1b-5451cc387264` | Azure app (client) ID |
+| `--no-browser` |  | bool | `false` | Don't automatically open the verification URL in a browser |
+| `--scope` | `-s` | string | `offline_access https://api.spaces.skype.com/.default` | Space-separated OAuth2 scopes |
+| `--tenant` |  | string | `organizations` | Tenant ID, domain, or "organizations"/"common" |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Authenticate against the default (organizations / work-school) tenant (interactive)
+brutus enum active teams auth
+
+# Headless / SSH: print the URL and code, don't open a browser
+brutus enum active teams auth --no-browser
+
+# Authenticate against a specific tenant by domain
+brutus enum active teams auth --tenant contoso.com
+
+# Use a custom app registration and scopes
+brutus enum active teams auth --client-id 00000000-0000-0000-0000-000000000000 \
+  --scope "offline_access https://api.spaces.skype.com/.default"
+
+# Capture the full token set as JSON
+brutus enum active teams auth -o token.jsonl
+```
+
+## `brutus enum active teams users`
+
+Enumerate corporate Microsoft Teams users by email address
+
+- Usage: `brutus enum active teams users`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--access-token` |  | string |  | Access token to use (instead of device-code or --token-file) |
+| `--client-id` |  | string | `1fec8e78-bce4-4aaf-ab1b-5451cc387264` | Azure app (client) ID (device-code path) |
+| `--domain` | `-d` | string |  | Generate candidate emails for this domain (statistically-likely first/last combos) |
+| `--email-file` | `-E` | string |  | File of email addresses, one per line ("-" for stdin) |
+| `--emails` | `-e` | string |  | Comma-separated email addresses to check |
+| `--format` |  | string | `first.last` | Username format for --domain generation (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first) |
+| `--include-consumer` |  | bool | `false` | Count consumer/personal (8:live:) Teams accounts as hits (default: only corporate 8:orgid: accounts) |
+| `--limit` |  | int | `0` | When generating with --domain, cap to the first N (most-likely) candidates (0 = all) |
+| `--no-browser` |  | bool | `false` | Don't automatically open the verification URL in a browser |
+| `--no-presence` |  | bool | `false` | Skip Teams presence / out-of-office lookups (fewer requests; presence is gathered by default) |
+| `--refresh-token` |  | string |  | Refresh token used to renew an expired access token |
+| `--scope` |  | string | `offline_access https://api.spaces.skype.com/.default` | Space-separated OAuth2 scopes (device-code path) |
+| `--tenant` |  | string | `organizations` | Tenant ID, domain, or "organizations"/"common" (device-code path) |
+| `--token-file` |  | string |  | JSONL token file from "enum active teams auth -o" to reuse |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Device-code auth inline, then enumerate a few emails
+brutus enum active teams users -e alice@contoso.com,bob@contoso.com
+
+# Generate candidate emails for a domain and enumerate the 5000 most likely
+brutus enum active teams users --domain target.com --format first.last --limit 5000
+
+# Generate first_last candidates (presence is fetched by default for hits)
+brutus enum active teams users --domain target.com --format first_last
+
+# Enumerate emails from a file, skipping presence lookups
+brutus enum active teams users -E emails.txt --no-presence
+
+# Reuse a token captured earlier with "enum active teams auth -o"
+brutus enum active teams auth -o token.jsonl
+brutus enum active teams users -E emails.txt --token-file token.jsonl
+
+# Provide an access token directly
+brutus enum active teams users -e alice@contoso.com --access-token "$TOKEN"
+
+# Route through a SOCKS5 proxy and raise concurrency
+brutus enum active teams users -E emails.txt --proxy socks5://127.0.0.1:1080 --threads 20
+```
+
+## `brutus enum apollo`
+
+Discover people for a domain via Apollo.io (free; --enrich reveals emails)
+
+- Usage: `brutus enum apollo`
+- Aliases: *(none)*
+- Hidden: not shown in `--help` output
+- Deprecated: use "brutus enum passive apollo" instead
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--api-key` |  | string |  | Apollo.io API key (overrides APOLLO_API_KEY; WARNING: visible in process list and shell history — prefer APOLLO_API_KEY) |
+| `--domain` | `-d` | string |  | Company domain to discover people for (required) |
+| `--enrich` |  | bool | `false` | Reveal emails for all discovered people via people/match (CONSUMES CREDITS; bounded by --limit) |
+| `--limit` |  | int | `0` | Max people to discover AND (with --enrich) to reveal (bounds credit spend; 0 = no cap) |
+| `--titles` |  | stringSlice | `[]` | Optional job-title filter (repeatable or comma-separated) |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Discover people (DEFAULT — FREE, no credits; shows email/phone availability)
+brutus enum passive apollo --domain example.com
+
+# Filter by job titles
+brutus enum passive apollo -d example.com --titles "VP Engineering" --titles "CTO"
+
+# Enrich all discovered people (CONSUMES CREDITS, bounded by --limit)
+brutus enum passive apollo -d example.com --enrich --limit 50
+
+# Provide the key explicitly (note: visible in process list / shell history)
+brutus enum passive apollo -d example.com --api-key abc123
+```
+
+## `brutus enum dehashed`
+
+Collect breach-exposed identity data for a domain via DeHashed
+
+- Usage: `brutus enum dehashed`
+- Aliases: *(none)*
+- Hidden: not shown in `--help` output
+- Deprecated: use "brutus enum passive dehashed" instead
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--all-emails` |  | bool | `false` | Keep all emails, not just those @<domain> (disables corporate-only filtering) |
+| `--api-key` |  | string |  | DeHashed API key (overrides DEHASHED_API_KEY; WARNING: visible in process list and shell history — prefer DEHASHED_API_KEY) |
+| `--detailed` |  | bool | `false` | Emit a single structured JSON document with full per-contact detail (ip addresses, addresses, dobs, obtained dates) and run metadata |
+| `--domain` | `-d` | string |  | Domain to search (required) |
+| `--exclude-combolists` |  | bool | `false` | Drop records from known aggregator/combolist source databases (combolists are included by default) |
+| `--limit` |  | int | `100` | Maximum number of records to collect (bounds credit spend) |
+| `--no-credentials` |  | bool | `false` | Suppress breach-exposed plaintext passwords from the output |
+| `--no-dedup` |  | bool | `false` | Do not merge records that share an email |
+| `--sources` |  | stringSlice | `[]` | Restrict results to these DeHashed source databases (comma-separated, exact names) |
+| `--with-credentials` |  | bool | `false` | Include breach-exposed plaintext passwords in --detailed output (off by default; hashes are never included) |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Collect refined breach contacts for a domain (key from DEHASHED_API_KEY)
+brutus enum passive dehashed --domain example.com
+
+# Same, but suppress the breach-exposed plaintext passwords from output
+brutus enum passive dehashed --domain example.com --no-credentials
+
+# Keep every email (not just @example.com), unmerged; drop combolist DBs for clean identity-only enumeration
+brutus enum passive dehashed -d example.com --all-emails --no-dedup --exclude-combolists
+
+# Restrict to specific source databases (exact names, comma-separated)
+brutus enum passive dehashed -d example.com --sources "Adobe,LinkedIn"
+
+# Emit one structured JSON document with full per-contact detail + run metadata
+brutus enum passive dehashed -d example.com --detailed -o breaches.json
+
+# Same detailed export, including breach-exposed plaintext passwords
+brutus enum passive dehashed -d example.com --detailed --with-credentials -o breaches.json
+
+# Provide the key explicitly (note: visible in process list / shell history)
+brutus enum passive dehashed -d example.com --api-key abc123
+
+# Cap results (and credit spend) and write JSONL to a file
+brutus enum passive dehashed -d example.com --limit 50 -o breaches.jsonl
+```
+
+## `brutus enum generate`
+
+Generate email addresses or usernames from embedded name lists
+
+- Usage: `brutus enum generate`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--domain` | `-d` | string |  | Domain to append to generated usernames (omit to generate usernames only) |
+| `--format` |  | string | `first.last` | Username format (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first) |
+| `--limit` |  | int | `0` | Emit only the first N (most-likely) results (0 = no limit, emit all) |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Generate emails: jsmith@example.com
+brutus enum generate --domain example.com --format flast
+
+# Generate usernames only: jsmith
+brutus enum generate --format flast
+
+# Generate john.smith@example.com (default format)
+brutus enum generate --domain example.com
+
+# Emit only the 1000 most-likely emails
+brutus enum generate --domain example.com --limit 1000
+
+# Pipe the 500 most-likely usernames to Kerberos enum
+brutus enum generate --format flast --limit 500 | brutus enum active kerberos --dc 10.0.0.1 --domain CORP.LOCAL -U -
+```
+
+## `brutus enum hunter`
+
+Discover people and emails for a domain via Hunter.io Domain Search
+
+- Usage: `brutus enum hunter`
+- Aliases: *(none)*
+- Hidden: not shown in `--help` output
+- Deprecated: use "brutus enum passive hunter" instead
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--api-key` |  | string |  | Hunter.io API key (overrides HUNTER_API_KEY; WARNING: visible in process list and shell history — prefer HUNTER_API_KEY) |
+| `--domain` | `-d` | string |  | Domain to search (required) |
+| `--limit` |  | int | `0` | Maximum number of people to return (0 = no cap, return all) |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Discover people for a domain (key from HUNTER_API_KEY)
+brutus enum passive hunter --domain example.com
+
+# Provide the key explicitly (note: visible in process list / shell history)
+brutus enum passive hunter -d example.com --api-key abc123
+
+# JSONL output to a file
+brutus enum passive hunter -d example.com -o people.jsonl
+```
+
+## `brutus enum lusha`
+
+Enrich a single person identity to emails and phones via Lusha v3
+
+- Usage: `brutus enum lusha`
+- Aliases: *(none)*
+- Hidden: not shown in `--help` output
+- Deprecated: use "brutus enum passive lusha" instead
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--api-key` |  | string |  | Lusha API key (overrides LUSHA_API_KEY; WARNING: visible in process list and shell history — prefer LUSHA_API_KEY) |
+| `--company` |  | string |  | Company name (with the name pair) |
+| `--domain` |  | string |  | Company domain (alternative to --company) |
+| `--email` |  | string |  | Enrich by email address (mutually exclusive identity) |
+| `--email-only` |  | bool | `false` | Request only email datapoints (mutually exclusive with --phone) |
+| `--first-name` |  | string |  | First name (with --last-name and --company or --domain) |
+| `--last-name` |  | string |  | Last name (with --first-name) |
+| `--limit` |  | int | `0` | Roster mode (--domain only): max contacts to search + enrich; 0 = collect all (consumes ~1 credit/contact) |
+| `--linkedin` |  | string |  | Enrich by LinkedIn profile URL (mutually exclusive identity) |
+| `--phone` |  | bool | `false` | Request phone datapoints in addition to email |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Enrich by name + company (key from LUSHA_API_KEY)
+brutus enum passive lusha --first-name Ada --last-name Lovelace --company Analytical
+
+# Enrich by name + company domain
+brutus enum passive lusha --first-name Ada --last-name Lovelace --domain example.com
+
+# Enrich by email
+brutus enum passive lusha --email ada@example.com
+
+# Enrich by LinkedIn URL, also request phone numbers
+brutus enum passive lusha --linkedin https://linkedin.com/in/ada --phone
+
+# Roster: enumerate an entire company by domain (collect all — consumes credits)
+brutus enum passive lusha --domain example.com
+
+# Roster: cap the roster (and credit spend) at 25 contacts
+brutus enum passive lusha --domain example.com --limit 25
+
+# Provide the key explicitly (note: visible in process list / shell history)
+brutus enum passive lusha --email ada@example.com --api-key abc123
+```
+
+## `brutus enum passive`
+
+API-key OSINT/HUMINT sources — employee email/contact discovery & enrichment
+
+- Usage: `brutus enum passive`
+- Aliases: *(none)*
+- Requires a subcommand
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Discover people via Hunter.io
+brutus enum passive hunter --domain example.com
+
+# Discover and enrich people via Apollo.io
+brutus enum passive apollo --domain example.com
+
+# Enrich a contact via Lusha
+brutus enum passive lusha --first-name Jane --last-name Doe --company "Example Inc"
+
+# Collect breach-exposed identity data via DeHashed
+brutus enum passive dehashed --domain example.com
+
+# Scrape LinkedIn Sales Navigator profiles via PhantomBuster
+brutus enum passive linkedin --agent-id 1234567890
+```
+
+## `brutus enum passive apollo`
+
+Discover people for a domain via Apollo.io (free; --enrich reveals emails)
+
+- Usage: `brutus enum passive apollo`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--api-key` |  | string |  | Apollo.io API key (overrides APOLLO_API_KEY; WARNING: visible in process list and shell history — prefer APOLLO_API_KEY) |
+| `--domain` | `-d` | string |  | Company domain to discover people for (required) |
+| `--enrich` |  | bool | `false` | Reveal emails for all discovered people via people/match (CONSUMES CREDITS; bounded by --limit) |
+| `--limit` |  | int | `0` | Max people to discover AND (with --enrich) to reveal (bounds credit spend; 0 = no cap) |
+| `--titles` |  | stringSlice | `[]` | Optional job-title filter (repeatable or comma-separated) |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Discover people (DEFAULT — FREE, no credits; shows email/phone availability)
+brutus enum passive apollo --domain example.com
+
+# Filter by job titles
+brutus enum passive apollo -d example.com --titles "VP Engineering" --titles "CTO"
+
+# Enrich all discovered people (CONSUMES CREDITS, bounded by --limit)
+brutus enum passive apollo -d example.com --enrich --limit 50
+
+# Provide the key explicitly (note: visible in process list / shell history)
+brutus enum passive apollo -d example.com --api-key abc123
+```
+
+## `brutus enum passive dehashed`
+
+Collect breach-exposed identity data for a domain via DeHashed
+
+- Usage: `brutus enum passive dehashed`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--all-emails` |  | bool | `false` | Keep all emails, not just those @<domain> (disables corporate-only filtering) |
+| `--api-key` |  | string |  | DeHashed API key (overrides DEHASHED_API_KEY; WARNING: visible in process list and shell history — prefer DEHASHED_API_KEY) |
+| `--detailed` |  | bool | `false` | Emit a single structured JSON document with full per-contact detail (ip addresses, addresses, dobs, obtained dates) and run metadata |
+| `--domain` | `-d` | string |  | Domain to search (required) |
+| `--exclude-combolists` |  | bool | `false` | Drop records from known aggregator/combolist source databases (combolists are included by default) |
+| `--limit` |  | int | `100` | Maximum number of records to collect (bounds credit spend) |
+| `--no-credentials` |  | bool | `false` | Suppress breach-exposed plaintext passwords from the output |
+| `--no-dedup` |  | bool | `false` | Do not merge records that share an email |
+| `--sources` |  | stringSlice | `[]` | Restrict results to these DeHashed source databases (comma-separated, exact names) |
+| `--with-credentials` |  | bool | `false` | Include breach-exposed plaintext passwords in --detailed output (off by default; hashes are never included) |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Collect refined breach contacts for a domain (key from DEHASHED_API_KEY)
+brutus enum passive dehashed --domain example.com
+
+# Same, but suppress the breach-exposed plaintext passwords from output
+brutus enum passive dehashed --domain example.com --no-credentials
+
+# Keep every email (not just @example.com), unmerged; drop combolist DBs for clean identity-only enumeration
+brutus enum passive dehashed -d example.com --all-emails --no-dedup --exclude-combolists
+
+# Restrict to specific source databases (exact names, comma-separated)
+brutus enum passive dehashed -d example.com --sources "Adobe,LinkedIn"
+
+# Emit one structured JSON document with full per-contact detail + run metadata
+brutus enum passive dehashed -d example.com --detailed -o breaches.json
+
+# Same detailed export, including breach-exposed plaintext passwords
+brutus enum passive dehashed -d example.com --detailed --with-credentials -o breaches.json
+
+# Provide the key explicitly (note: visible in process list / shell history)
+brutus enum passive dehashed -d example.com --api-key abc123
+
+# Cap results (and credit spend) and write JSONL to a file
+brutus enum passive dehashed -d example.com --limit 50 -o breaches.jsonl
+```
+
+## `brutus enum passive hunter`
+
+Discover people and emails for a domain via Hunter.io Domain Search
+
+- Usage: `brutus enum passive hunter`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--api-key` |  | string |  | Hunter.io API key (overrides HUNTER_API_KEY; WARNING: visible in process list and shell history — prefer HUNTER_API_KEY) |
+| `--domain` | `-d` | string |  | Domain to search (required) |
+| `--limit` |  | int | `0` | Maximum number of people to return (0 = no cap, return all) |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Discover people for a domain (key from HUNTER_API_KEY)
+brutus enum passive hunter --domain example.com
+
+# Provide the key explicitly (note: visible in process list / shell history)
+brutus enum passive hunter -d example.com --api-key abc123
+
+# JSONL output to a file
+brutus enum passive hunter -d example.com -o people.jsonl
+```
+
+## `brutus enum passive linkedin`
+
+Scrape LinkedIn Sales Navigator profiles via PhantomBuster
+
+- Usage: `brutus enum passive linkedin`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--agent-id` |  | string |  | PhantomBuster agent ID for the Sales Navigator scraper (required) |
+| `--api-key` |  | string |  | PhantomBuster API key (overrides PHANTOMBUSTER_KEY; WARNING: visible in process list and shell history — prefer PHANTOMBUSTER_KEY) |
+| `--result-file` |  | string | `result.csv` | Result filename to download from S3 (default: result.csv) |
+| `--skip-launch` |  | bool | `false` | Skip launching the agent — fetch results from the most recent run instead |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Launch a Sales Nav scraper and fetch results
+brutus enum passive linkedin --agent-id 1234567890
+
+# Fetch results from a previous run (skip launching a new one)
+brutus enum passive linkedin --agent-id 1234567890 --skip-launch
+
+# Specify a custom result filename
+brutus enum passive linkedin --agent-id 1234567890 --result-file result.json
+
+# Provide the key explicitly (note: visible in process list / shell history)
+brutus enum passive linkedin --agent-id 1234567890 --api-key abc123
+```
+
+## `brutus enum passive lusha`
+
+Enrich a single person identity to emails and phones via Lusha v3
+
+- Usage: `brutus enum passive lusha`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--api-key` |  | string |  | Lusha API key (overrides LUSHA_API_KEY; WARNING: visible in process list and shell history — prefer LUSHA_API_KEY) |
+| `--company` |  | string |  | Company name (with the name pair) |
+| `--domain` |  | string |  | Company domain (alternative to --company) |
+| `--email` |  | string |  | Enrich by email address (mutually exclusive identity) |
+| `--email-only` |  | bool | `false` | Request only email datapoints (mutually exclusive with --phone) |
+| `--first-name` |  | string |  | First name (with --last-name and --company or --domain) |
+| `--last-name` |  | string |  | Last name (with --first-name) |
+| `--limit` |  | int | `0` | Roster mode (--domain only): max contacts to search + enrich; 0 = collect all (consumes ~1 credit/contact) |
+| `--linkedin` |  | string |  | Enrich by LinkedIn profile URL (mutually exclusive identity) |
+| `--phone` |  | bool | `false` | Request phone datapoints in addition to email |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Enrich by name + company (key from LUSHA_API_KEY)
+brutus enum passive lusha --first-name Ada --last-name Lovelace --company Analytical
+
+# Enrich by name + company domain
+brutus enum passive lusha --first-name Ada --last-name Lovelace --domain example.com
+
+# Enrich by email
+brutus enum passive lusha --email ada@example.com
+
+# Enrich by LinkedIn URL, also request phone numbers
+brutus enum passive lusha --linkedin https://linkedin.com/in/ada --phone
+
+# Roster: enumerate an entire company by domain (collect all — consumes credits)
+brutus enum passive lusha --domain example.com
+
+# Roster: cap the roster (and credit spend) at 25 contacts
+brutus enum passive lusha --domain example.com --limit 25
+
+# Provide the key explicitly (note: visible in process list / shell history)
+brutus enum passive lusha --email ada@example.com --api-key abc123
+```
+
+## `brutus logon`
+
+Detect Windows logon-screen backdoors (runs both sticky keys and utilman)
+
+- Usage: `brutus logon`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--connect-timeout` |  | duration | `3s` | TCP connect timeout for scan dials (separate from --scan-timeout, which is the per-host settle deadline). A reachable host completes the handshake in ~1 RTT, so the short default only accelerates dead-host rejection; raise it for high-latency target sets. |
+| `--exec` |  | string |  | Execute command via detected backdoor |
+| `--experimental-ai` |  | bool | `false` | Enable Vision API for backdoor confirmation |
+| `--fast` |  | bool | `false` | fast triage: shorter settle budget for internet-scale sweeps; reports HIGH/CRITICAL or indeterminate, never clean (rerun indeterminates without --fast for a careful verdict) |
+| `--masscan-file` |  | string |  | Masscan JSON file (-oJ output) to import targets from |
+| `--mode` | `-m` | string | `default` | Aggressiveness tier: cautious, default, aggressive |
+| `--nmap-file` |  | string |  | Nmap XML file (-oX output) to import targets from |
+| `--no-nla-probe` |  | bool | `false` | Disable the pre-WASM RDP negotiation probe (always run the full WASM session) |
+| `--open` |  | bool | `false` | Auto-open browser when web terminal starts |
+| `--retries` |  | int | `2` | Max retries on connection error (0 = disabled) |
+| `--scan-timeout` |  | duration | `10s` | Per-host settle/scan deadline (post-connect): how long to watch the logon screen after the trigger before deciding. Distinct from --connect-timeout (the TCP dial timeout). |
+| `--target` |  | string |  | Target host:port |
+| `--targets-file` |  | string |  | File of targets to test, one host:port per line (fingerprints with Nerva unless --protocol is set) |
+| `--web` |  | bool | `false` | Start interactive web terminal via detected backdoor |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Rejected flags
+
+These flags reach `brutus logon` through inheritance, but the command refuses them:
+
+| Flag | Why |
+| --- | --- |
+| `--timeout` | --timeout is not valid here; use --scan-timeout (settle deadline) and/or --connect-timeout (TCP connect) |
+
+### Examples
+
+```bash
+# Detect sticky keys and utilman backdoors (heuristic)
+brutus logon --target 10.0.0.50:3389
+
+# Vision API confirmation (more accurate)
+brutus logon --target 10.0.0.50:3389 --experimental-ai
+
+# Execute a command via detected backdoor
+brutus logon --target 10.0.0.50:3389 --exec "whoami"
+
+# Interactive web terminal via backdoor
+brutus logon --target 10.0.0.50:3389 --web --open
+
+# Pipeline mode with Nerva JSON (only RDP targets are tested)
+naabu -host 10.0.0.0/24 -p 3389 -silent | nerva --json | brutus logon
+
+# Pipe plain targets (auto-fingerprinted, only RDP services scanned)
+echo "10.0.0.50:3389" | brutus logon
+
+# Pipe URI targets
+echo "rdp://10.0.0.50:3389" | brutus logon
+
+# Import targets from nmap XML scan (only RDP services tested)
+brutus logon --nmap-file scan.xml
+```
+
+## `brutus snmp`
+
+Test SNMP community strings against targets
+
+- Usage: `brutus snmp`
+- Aliases: `community`
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--community` | `-c` | string |  | Custom community strings (comma-separated) |
+| `--community-file` | `-C` | string |  | Community string file (one per line) |
+| `--connect-timeout` |  | duration | `3s` | TCP connect timeout for scan dials (separate from --scan-timeout, which is the per-host settle deadline). A reachable host completes the handshake in ~1 RTT, so the short default only accelerates dead-host rejection; raise it for high-latency target sets. |
+| `--masscan-file` |  | string |  | Masscan JSON file (-oJ output) to import targets from |
+| `--mode` | `-m` | string | `default` | Aggressiveness tier: cautious, default, aggressive |
+| `--nmap-file` |  | string |  | Nmap XML file (-oX output) to import targets from |
+| `--retries` |  | int | `2` | Max retries on connection error (0 = disabled) |
+| `--target` |  | string |  | Target host:port |
+| `--targets-file` |  | string |  | File of targets to test, one host:port per line (fingerprints with Nerva unless --protocol is set) |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Test with default community strings
+brutus snmp --target 192.168.1.1:161
+
+# Aggressive mode for comprehensive testing (~200+ strings)
+brutus snmp --target 10.0.0.1:161 --mode aggressive
+
+# Custom community strings
+brutus snmp --target 192.168.1.1:161 -c "mycommunity,secretstring"
+
+# Pipeline mode
+naabu -host 10.0.0.0/24 -p 161 -silent | nerva --json | brutus snmp
+
+# Targets file
+brutus snmp --targets-file snmp-hosts.txt --mode aggressive
+
+# Import targets from nmap XML scan (only SNMP services tested)
+brutus snmp --nmap-file scan.xml --mode aggressive
+```
+
+## `brutus stickykeys`
+
+Detect the Windows sticky-keys (sethc.exe) logon backdoor only
+
+- Usage: `brutus stickykeys`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--connect-timeout` |  | duration | `3s` | TCP connect timeout for scan dials (separate from --scan-timeout, which is the per-host settle deadline). A reachable host completes the handshake in ~1 RTT, so the short default only accelerates dead-host rejection; raise it for high-latency target sets. |
+| `--exec` |  | string |  | Execute command via detected backdoor |
+| `--experimental-ai` |  | bool | `false` | Enable Vision API for backdoor confirmation |
+| `--fast` |  | bool | `false` | fast triage: shorter settle budget for internet-scale sweeps; reports HIGH/CRITICAL or indeterminate, never clean (rerun indeterminates without --fast for a careful verdict) |
+| `--masscan-file` |  | string |  | Masscan JSON file (-oJ output) to import targets from |
+| `--mode` | `-m` | string | `default` | Aggressiveness tier: cautious, default, aggressive |
+| `--nmap-file` |  | string |  | Nmap XML file (-oX output) to import targets from |
+| `--no-nla-probe` |  | bool | `false` | Disable the pre-WASM RDP negotiation probe (always run the full WASM session) |
+| `--open` |  | bool | `false` | Auto-open browser when web terminal starts |
+| `--retries` |  | int | `2` | Max retries on connection error (0 = disabled) |
+| `--scan-timeout` |  | duration | `10s` | Per-host settle/scan deadline (post-connect): how long to watch the logon screen after the trigger before deciding. Distinct from --connect-timeout (the TCP dial timeout). |
+| `--target` |  | string |  | Target host:port |
+| `--targets-file` |  | string |  | File of targets to test, one host:port per line (fingerprints with Nerva unless --protocol is set) |
+| `--web` |  | bool | `false` | Start interactive web terminal via detected backdoor |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Rejected flags
+
+These flags reach `brutus stickykeys` through inheritance, but the command refuses them:
+
+| Flag | Why |
+| --- | --- |
+| `--timeout` | --timeout is not valid here; use --scan-timeout (settle deadline) and/or --connect-timeout (TCP connect) |
+
+### Examples
+
+```bash
+# Detect the sticky-keys backdoor only
+brutus stickykeys --target 10.0.0.50:3389
+
+# Vision API confirmation (more accurate)
+brutus stickykeys --target 10.0.0.50:3389 --experimental-ai
+```
+
+## `brutus utilman`
+
+Detect the Windows utilman (Ease of Access) logon backdoor only
+
+- Usage: `brutus utilman`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--connect-timeout` |  | duration | `3s` | TCP connect timeout for scan dials (separate from --scan-timeout, which is the per-host settle deadline). A reachable host completes the handshake in ~1 RTT, so the short default only accelerates dead-host rejection; raise it for high-latency target sets. |
+| `--exec` |  | string |  | Execute command via detected backdoor |
+| `--experimental-ai` |  | bool | `false` | Enable Vision API for backdoor confirmation |
+| `--fast` |  | bool | `false` | fast triage: shorter settle budget for internet-scale sweeps; reports HIGH/CRITICAL or indeterminate, never clean (rerun indeterminates without --fast for a careful verdict) |
+| `--masscan-file` |  | string |  | Masscan JSON file (-oJ output) to import targets from |
+| `--mode` | `-m` | string | `default` | Aggressiveness tier: cautious, default, aggressive |
+| `--nmap-file` |  | string |  | Nmap XML file (-oX output) to import targets from |
+| `--no-nla-probe` |  | bool | `false` | Disable the pre-WASM RDP negotiation probe (always run the full WASM session) |
+| `--open` |  | bool | `false` | Auto-open browser when web terminal starts |
+| `--retries` |  | int | `2` | Max retries on connection error (0 = disabled) |
+| `--scan-timeout` |  | duration | `10s` | Per-host settle/scan deadline (post-connect): how long to watch the logon screen after the trigger before deciding. Distinct from --connect-timeout (the TCP dial timeout). |
+| `--target` |  | string |  | Target host:port |
+| `--targets-file` |  | string |  | File of targets to test, one host:port per line (fingerprints with Nerva unless --protocol is set) |
+| `--web` |  | bool | `false` | Start interactive web terminal via detected backdoor |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Rejected flags
+
+These flags reach `brutus utilman` through inheritance, but the command refuses them:
+
+| Flag | Why |
+| --- | --- |
+| `--timeout` | --timeout is not valid here; use --scan-timeout (settle deadline) and/or --connect-timeout (TCP connect) |
+
+### Examples
+
+```bash
+# Detect the utilman backdoor only
+brutus utilman --target 10.0.0.50:3389
+
+# Vision API confirmation (more accurate)
+brutus utilman --target 10.0.0.50:3389 --experimental-ai
+```
+
+## `brutus web`
+
+Audit HTTP/web panel credentials (AI-powered or credential list)
+
+- Usage: `brutus web`
+- Aliases: `http`, `panels`
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--browser-tabs` |  | int | `3` | Number of concurrent browser tabs |
+| `--browser-timeout` |  | duration | `1m0s` | Total timeout for browser operations |
+| `--browser-visible` |  | bool | `false` | Show browser window (demo mode) |
+| `--connect-timeout` |  | duration | `3s` | TCP connect timeout for scan dials (separate from --scan-timeout, which is the per-host settle deadline). A reachable host completes the handshake in ~1 RTT, so the short default only accelerates dead-host rejection; raise it for high-latency target sets. |
+| `--credentials` | `-c` | string |  | Comma-separated user:pass pairs (e.g., admin:admin,root:toor) |
+| `--credentials-file` | `-C` | string |  | Credentials file (user:pass per line) |
+| `--experimental-ai` |  | bool | `false` | Enable AI-powered credential detection and Vision verification |
+| `--https` |  | bool | `false` | Use HTTPS for browser connections |
+| `--masscan-file` |  | string |  | Masscan JSON file (-oJ output) to import targets from |
+| `--mode` | `-m` | string | `default` | Aggressiveness tier: cautious, default, aggressive |
+| `--nmap-file` |  | string |  | Nmap XML file (-oX output) to import targets from |
+| `--protocol` |  | string |  | Protocol override (http or https) |
+| `--retries` |  | int | `2` | Max retries on connection error (0 = disabled) |
+| `--target` |  | string |  | Target host:port |
+| `--targets-file` |  | string |  | File of targets to test, one host:port per line (fingerprints with Nerva unless --protocol is set) |
+| `--verify` |  | bool | `false` | Require strict TLS certificate verification |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# AI-powered credential detection (recommended)
+brutus web --target 192.168.1.1:80 --experimental-ai
+
+# Pipeline mode with Nerva JSON
+naabu -host 192.168.1.0/24 -p 80,443,8080 -silent | nerva --json | brutus web --experimental-ai
+
+# Manual credential list
+brutus web --target 192.168.1.1:80 -c "admin:admin,root:toor"
+brutus web --target 192.168.1.1:80 -C creds.txt
+
+# HTTPS target
+brutus web --target 192.168.1.1:443 --https --experimental-ai
+
+# Browser with visible window (demo mode)
+brutus web --target 192.168.1.1:8080 --experimental-ai --browser-visible
+
+# Import targets from nmap XML scan
+brutus web --nmap-file scan.xml --experimental-ai
+```

--- a/docs/cli-surface-allow.txt
+++ b/docs/cli-surface-allow.txt
@@ -1,0 +1,14 @@
+# Flag names documentation may mention even though the CLI does not accept them.
+#
+# The CLI-surface doc lint (see CONTRIBUTING.md) checks every brutus invocation in
+# a fenced code block, every backticked flag name in prose, and every flag name in
+# a Go comment under cmd/ and pkg/ against the flags cobra actually registers.
+# This file is the escape hatch for deliberate mentions. Every entry MUST carry a
+# '#' reason: the gate rejects an entry without one, because an unexplained
+# exception is how a stale flag reference survives forever.
+#
+# Keep this list as short as possible. If a mention is not deliberate, fix the
+# document instead of allowing it.
+
+--reveal            # Apollo's old reveal flag, renamed to --enrich by the discover/enrich split. The apollo command test deliberately names the removed flag to pin the new behavior: "Discovery note must mention --enrich (not --reveal)".
+--domain-generated  # Not a flag: a prose compound. The enum-source comments say "--domain-generated candidates", meaning the candidates generated from --domain.

--- a/docs/cli-surface.json
+++ b/docs/cli-surface.json
@@ -1,0 +1,4305 @@
+{
+  "schemaVersion": 1,
+  "surfaceHash": "sha256:1d4cc140290018ebec0060e5db81bb43f05ff38068f9deacee1592ed70cadfa2",
+  "commands": [
+    {
+      "path": "brutus",
+      "use": "brutus",
+      "short": "Brutus - Et tu, Brute?",
+      "runnable": true,
+      "flags": [
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting"
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output"
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)"
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080"
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history."
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials"
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)"
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads"
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout"
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr"
+        },
+        {
+          "name": "version",
+          "type": "bool",
+          "default": "false",
+          "usage": "Show version information"
+        }
+      ]
+    },
+    {
+      "path": "brutus badkeys",
+      "use": "badkeys",
+      "short": "Test known weak/compromised SSH keys against targets",
+      "aliases": [
+        "keys",
+        "ssh-keys",
+        "badkey"
+      ],
+      "runnable": true,
+      "example": "  # Single target\n  brutus badkeys --target 192.168.1.10:22\n\n  # Targets file (auto-fingerprinted, only SSH services tested)\n  brutus badkeys --targets-file targets.txt\n\n  # Pipeline mode\n  naabu -host 10.0.0.0/24 -p 22 -silent | nerva --json | brutus badkeys\n\n  # Pipe plain targets\n  echo \"192.168.1.10:22\" | brutus badkeys\n\n  # URI format\n  echo \"ssh://192.168.1.10:22\" | brutus badkeys\n\n  # Import targets from nmap XML scan (only SSH services tested)\n  brutus badkeys --nmap-file scan.xml",
+      "flags": [
+        {
+          "name": "connect-timeout",
+          "type": "duration",
+          "default": "3s",
+          "usage": "TCP connect timeout for scan dials (separate from --scan-timeout, which is the per-host settle deadline). A reachable host completes the handshake in ~1 RTT, so the short default only accelerates dead-host rejection; raise it for high-latency target sets."
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "masscan-file",
+          "type": "string",
+          "usage": "Masscan JSON file (-oJ output) to import targets from"
+        },
+        {
+          "name": "mode",
+          "shorthand": "m",
+          "type": "string",
+          "default": "default",
+          "usage": "Aggressiveness tier: cautious, default, aggressive"
+        },
+        {
+          "name": "nmap-file",
+          "type": "string",
+          "usage": "Nmap XML file (-oX output) to import targets from"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "retries",
+          "type": "int",
+          "default": "2",
+          "usage": "Max retries on connection error (0 = disabled)"
+        },
+        {
+          "name": "target",
+          "type": "string",
+          "usage": "Target host:port"
+        },
+        {
+          "name": "targets-file",
+          "type": "string",
+          "usage": "File of targets to test, one host:port per line (fingerprints with Nerva unless --protocol is set)"
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus creds",
+      "use": "creds",
+      "short": "Test default credentials on non-HTTP services (SSH, databases, SMB, etc.)",
+      "aliases": [
+        "services",
+        "defaults",
+        "credentials"
+      ],
+      "runnable": true,
+      "example": "  # Single target\n  brutus creds --target 192.168.1.10:22 --protocol ssh -p \"password,Password1\"\n\n  # Pre-paired user:pass combos (no Cartesian product)\n  brutus creds --target 10.0.0.50:22 -c \"admin:admin,root:toor,deploy:deploy123\"\n\n  # Credentials file (user:pass per line)\n  brutus creds --target 10.0.0.50:3306 -C creds.txt\n\n  # Targets file (auto-fingerprinted with Nerva)\n  brutus creds --targets-file targets.txt -u admin -P passwords.txt\n\n  # Pipeline mode with Nerva JSON (HTTP and SNMP services are skipped)\n  naabu -host 10.0.0.0/24 -silent | nerva --json | brutus creds -P passwords.txt\n\n  # Pipe URI targets (protocol from scheme, no fingerprinting needed)\n  echo \"ssh://192.168.1.10:22\" | brutus creds -p \"password,Password1\"\n\n  # Import targets from nmap XML scan\n  brutus creds --nmap-file scan.xml -P passwords.txt\n\n  # Import targets from masscan (requires --protocol or auto-fingerprints with Nerva)\n  brutus creds --masscan-file scan.json --protocol ssh -P passwords.txt",
+      "flags": [
+        {
+          "name": "connect-timeout",
+          "type": "duration",
+          "default": "3s",
+          "usage": "TCP connect timeout for scan dials (separate from --scan-timeout, which is the per-host settle deadline). A reachable host completes the handshake in ~1 RTT, so the short default only accelerates dead-host rejection; raise it for high-latency target sets."
+        },
+        {
+          "name": "credentials",
+          "shorthand": "c",
+          "type": "string",
+          "usage": "Comma-separated user:pass pairs (e.g., admin:admin,root:toor)"
+        },
+        {
+          "name": "credentials-file",
+          "shorthand": "C",
+          "type": "string",
+          "usage": "Credentials file (user:pass per line)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "key",
+          "shorthand": "k",
+          "type": "string",
+          "usage": "SSH private key file"
+        },
+        {
+          "name": "masscan-file",
+          "type": "string",
+          "usage": "Masscan JSON file (-oJ output) to import targets from"
+        },
+        {
+          "name": "max-attempts",
+          "type": "int",
+          "default": "0",
+          "usage": "Max password attempts per user (0 = unlimited)"
+        },
+        {
+          "name": "mode",
+          "shorthand": "m",
+          "type": "string",
+          "default": "default",
+          "usage": "Aggressiveness tier: cautious, default, aggressive"
+        },
+        {
+          "name": "nmap-file",
+          "type": "string",
+          "usage": "Nmap XML file (-oX output) to import targets from"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "password-file",
+          "shorthand": "P",
+          "type": "string",
+          "usage": "Password file (one per line)"
+        },
+        {
+          "name": "passwords",
+          "shorthand": "p",
+          "type": "string",
+          "usage": "Comma-separated passwords"
+        },
+        {
+          "name": "protocol",
+          "type": "string",
+          "usage": "Protocol to use (auto-detected from nerva)"
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "retries",
+          "type": "int",
+          "default": "2",
+          "usage": "Max retries on connection error (0 = disabled)"
+        },
+        {
+          "name": "target",
+          "type": "string",
+          "usage": "Target host:port"
+        },
+        {
+          "name": "targets-file",
+          "type": "string",
+          "usage": "File of targets to test, one host:port per line (fingerprints with Nerva unless --protocol is set)"
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "username-file",
+          "shorthand": "U",
+          "type": "string",
+          "usage": "Username file (one per line)"
+        },
+        {
+          "name": "usernames",
+          "shorthand": "u",
+          "type": "string",
+          "default": "root,admin",
+          "usage": "Comma-separated usernames"
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        },
+        {
+          "name": "verify",
+          "type": "bool",
+          "default": "false",
+          "usage": "Require strict TLS certificate verification"
+        }
+      ]
+    },
+    {
+      "path": "brutus enum",
+      "use": "enum",
+      "short": "Enumerate accounts against account-existence oracles or Active Directory",
+      "runnable": false,
+      "example": "  # Account-existence oracle enumeration\n  brutus enum active oracles --domain praetorian.com -e test@praetorian.com --known-valid admin@praetorian.com\n\n  # Kerberos user enumeration\n  brutus enum active kerberos --dc 10.0.0.1 --domain CORP.LOCAL -u administrator\n\n  # Authenticate with Microsoft Entra ID via device code\n  brutus enum active teams auth --tenant contoso.com\n\n  # GitHub account enumeration by email\n  brutus enum active github -e alice@example.com,bob@example.com\n\n  # Generate emails for enumeration\n  brutus enum generate --domain example.com --format flast\n\n  # API-key OSINT/HUMINT sources (employee email/contact discovery)\n  brutus enum passive hunter --domain example.com\n  brutus enum passive apollo --domain example.com\n  brutus enum passive lusha --first-name Jane --last-name Doe --company \"Example Inc\"\n  brutus enum passive dehashed --domain example.com",
+      "flags": [
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum active",
+      "use": "active",
+      "short": "Active account-existence enumeration against live oracles & directories",
+      "runnable": false,
+      "example": "  # Account-existence oracle enumeration\n  brutus enum active oracles --domain example.com --known-valid admin@example.com\n\n  # Google Workspace account enumeration\n  brutus enum active google -e alice@example.com,bob@example.com\n\n  # Microsoft 365 account enumeration\n  brutus enum active microsoft365 -e alice@example.com,bob@example.com\n\n  # Kerberos user enumeration\n  brutus enum active kerberos --dc 10.0.0.1 --domain CORP.LOCAL -u administrator\n\n  # Authenticate with Microsoft Entra ID via device code\n  brutus enum active teams auth --tenant contoso.com\n\n  # GitHub account enumeration by email\n  brutus enum active github -e alice@example.com,bob@example.com\n\n  # Gravatar account enumeration by email\n  brutus enum active gravatar -e alice@example.com,bob@example.com\n\n  # Enumerate against a custom oracle definition\n  brutus enum active custom -f oracle.json -e jsmith,asmith",
+      "flags": [
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum active custom",
+      "use": "custom",
+      "short": "Run a declaratively-described enumeration oracle from a spec file",
+      "runnable": true,
+      "example": "  # Run an oracle against inline subjects\n  brutus enum active custom -f oracle.json -e jsmith,asmith\n\n  # Run against a subject file\n  brutus enum active custom -f oracle.yaml -E users.txt\n\n  # Generate usernames and run\n  brutus enum active custom -f oracle.json --generate --format flast\n\n  # JSON output to a file\n  brutus enum active custom -f oracle.json -e jsmith -o results.jsonl",
+      "flags": [
+        {
+          "name": "domain",
+          "shorthand": "d",
+          "type": "string",
+          "usage": "Domain for email generation (with --generate)"
+        },
+        {
+          "name": "email-file",
+          "shorthand": "E",
+          "type": "string",
+          "usage": "File of subjects to enumerate (one per line, use - for stdin)"
+        },
+        {
+          "name": "emails",
+          "shorthand": "e",
+          "type": "string",
+          "usage": "Comma-separated subjects (usernames or emails) to enumerate"
+        },
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "usage": "Oracle spec file (JSON or YAML, required)"
+        },
+        {
+          "name": "format",
+          "type": "string",
+          "default": "first.last",
+          "usage": "Username format for generation (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first)"
+        },
+        {
+          "name": "generate",
+          "type": "bool",
+          "default": "false",
+          "usage": "Generate subjects from embedded name lists"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum active github",
+      "use": "github",
+      "short": "Enumerate GitHub accounts by email (existence + username reveal)",
+      "runnable": true,
+      "example": "  # Existence-only enumeration (unauthenticated)\n  brutus enum active github -e alice@example.com,bob@example.com\n\n  # Generate candidate emails for a domain and enumerate the 5000 most likely\n  brutus enum active github --domain target.com --format first.last --limit 5000\n\n  # Enumerate emails from a file\n  brutus enum active github -E emails.txt\n\n  # Reveal usernames for existing accounts (requires a PAT with repo+delete_repo)\n  export GITHUB_TOKEN=ghp_...\n  brutus enum active github -E emails.txt\n\n  # Pace requests to avoid GitHub's existence-endpoint rate limiting\n  brutus enum active github -E emails.txt --threads 2 --rate-limit 1",
+      "flags": [
+        {
+          "name": "domain",
+          "shorthand": "d",
+          "type": "string",
+          "usage": "Generate candidate emails for this domain (statistically-likely first/last combos)"
+        },
+        {
+          "name": "email-file",
+          "shorthand": "E",
+          "type": "string",
+          "usage": "File of email addresses, one per line (\"-\" for stdin)"
+        },
+        {
+          "name": "emails",
+          "shorthand": "e",
+          "type": "string",
+          "usage": "Comma-separated email addresses to check"
+        },
+        {
+          "name": "format",
+          "type": "string",
+          "default": "first.last",
+          "usage": "Username format for --domain generation (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "limit",
+          "type": "int",
+          "default": "0",
+          "usage": "When generating with --domain, cap to the first N (most-likely) candidates (0 = all)"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "no-reveal",
+          "type": "bool",
+          "default": "false",
+          "usage": "Skip username reveal after existence enumeration (existence-only; no token used, no temp repo created)"
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "rotating-proxy",
+          "type": "bool",
+          "default": "false",
+          "usage": "Signal that --proxy rotates exit IPs (e.g. Bright Data): reduces per-IP rate-limit backoff during GitHub existence enumeration (short retry delay, higher retry ceiling). No effect on token-rate-limited reveal."
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "token",
+          "type": "string",
+          "usage": "GitHub PAT for username reveal (overrides GITHUB_TOKEN; visible in process list — prefer the env var)"
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum active github map",
+      "use": "map",
+      "short": "Correlate known emails to GitHub usernames (reveal-only, skips existence checks)",
+      "runnable": true,
+      "example": "  # Correlate emails from a file (token from the environment)\n  export GITHUB_TOKEN=ghp_...\n  brutus enum active github map -E emails.txt\n\n  # Correlate a couple of emails inline\n  brutus enum active github map -e alice@example.com,bob@example.com",
+      "flags": [
+        {
+          "name": "email-file",
+          "shorthand": "E",
+          "type": "string",
+          "usage": "File of email addresses, one per line (\"-\" for stdin)"
+        },
+        {
+          "name": "emails",
+          "shorthand": "e",
+          "type": "string",
+          "usage": "Comma-separated email addresses to correlate"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "rotating-proxy",
+          "type": "bool",
+          "default": "false",
+          "usage": "Signal that --proxy rotates exit IPs (e.g. Bright Data): reduces per-IP rate-limit backoff during GitHub existence enumeration (short retry delay, higher retry ceiling). No effect on token-rate-limited reveal.",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "token",
+          "type": "string",
+          "usage": "GitHub PAT (overrides GITHUB_TOKEN; visible in process list — prefer the env var)"
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum active google",
+      "use": "google",
+      "short": "Enumerate Google Workspace accounts (existence + SSO/IdP)",
+      "runnable": true,
+      "example": "  # Enumerate a couple of emails\n  brutus enum active google -e alice@example.com,bob@example.com\n\n  # Generate candidate emails for a domain and enumerate the 5000 most likely\n  brutus enum active google --domain target.com --format first.last --limit 5000\n\n  # Enumerate emails from a file\n  brutus enum active google -E emails.txt\n\n  # Route through a SOCKS5 proxy and raise concurrency\n  brutus enum active google -E emails.txt --proxy socks5://127.0.0.1:1080 --threads 20",
+      "flags": [
+        {
+          "name": "domain",
+          "shorthand": "d",
+          "type": "string",
+          "usage": "Generate candidate emails for this domain (statistically-likely first/last combos)"
+        },
+        {
+          "name": "email-file",
+          "shorthand": "E",
+          "type": "string",
+          "usage": "File of email addresses, one per line (\"-\" for stdin)"
+        },
+        {
+          "name": "emails",
+          "shorthand": "e",
+          "type": "string",
+          "usage": "Comma-separated email addresses to check"
+        },
+        {
+          "name": "format",
+          "type": "string",
+          "default": "first.last",
+          "usage": "Username format for --domain generation (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "limit",
+          "type": "int",
+          "default": "0",
+          "usage": "When generating with --domain, cap to the first N (most-likely) candidates (0 = all)"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum active gravatar",
+      "use": "gravatar",
+      "short": "Enumerate accounts with a registered Gravatar (by email)",
+      "runnable": true,
+      "example": "  # Enumerate a couple of emails\n  brutus enum active gravatar -e alice@example.com,bob@example.com\n\n  # Generate candidate emails for a domain and enumerate the 5000 most likely\n  brutus enum active gravatar --domain target.com --format first.last --limit 5000\n\n  # Enumerate emails from a file\n  brutus enum active gravatar -E emails.txt\n\n  # Route through a SOCKS5 proxy and raise concurrency\n  brutus enum active gravatar -E emails.txt --proxy socks5://127.0.0.1:1080 --threads 20",
+      "flags": [
+        {
+          "name": "domain",
+          "shorthand": "d",
+          "type": "string",
+          "usage": "Generate candidate emails for this domain (statistically-likely first/last combos)"
+        },
+        {
+          "name": "email-file",
+          "shorthand": "E",
+          "type": "string",
+          "usage": "File of email addresses, one per line (\"-\" for stdin)"
+        },
+        {
+          "name": "emails",
+          "shorthand": "e",
+          "type": "string",
+          "usage": "Comma-separated email addresses to check"
+        },
+        {
+          "name": "format",
+          "type": "string",
+          "default": "first.last",
+          "usage": "Username format for --domain generation (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "limit",
+          "type": "int",
+          "default": "0",
+          "usage": "When generating with --domain, cap to the first N (most-likely) candidates (0 = all)"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum active kerberos",
+      "use": "kerberos",
+      "short": "Enumerate Active Directory users via Kerberos AS-REQ",
+      "runnable": true,
+      "example": "  # Enumerate specific users\n  brutus enum active kerberos --dc 10.0.0.1 --domain CORP.LOCAL -u administrator,guest,krbtgt\n\n  # Enumerate from file\n  brutus enum active kerberos --dc dc01.corp.local --domain CORP.LOCAL -U users.txt\n\n  # Generate usernames and enumerate\n  brutus enum generate --format flast | brutus enum active kerberos --dc 10.0.0.1 --domain CORP.LOCAL -U -\n\n  # JSON output\n  brutus enum active kerberos --dc 10.0.0.1 --domain CORP.LOCAL -u administrator --json",
+      "flags": [
+        {
+          "name": "dc",
+          "type": "string",
+          "usage": "KDC (Domain Controller) address (host or host:port)"
+        },
+        {
+          "name": "domain",
+          "shorthand": "d",
+          "type": "string",
+          "usage": "Kerberos realm / AD domain (e.g., CORP.LOCAL)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "user-file",
+          "shorthand": "U",
+          "type": "string",
+          "usage": "File of usernames (one per line, use - for stdin)"
+        },
+        {
+          "name": "users",
+          "shorthand": "u",
+          "type": "string",
+          "usage": "Comma-separated usernames to enumerate"
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum active microsoft365",
+      "use": "microsoft365",
+      "short": "Enumerate Microsoft 365 accounts (existence + federation/tenant)",
+      "runnable": true,
+      "example": "  # Enumerate a couple of emails\n  brutus enum active microsoft365 -e alice@example.com,bob@example.com\n\n  # Generate candidate emails for a domain and enumerate the 5000 most likely\n  brutus enum active microsoft365 --domain target.com --format first.last --limit 5000\n\n  # Enumerate emails from a file\n  brutus enum active microsoft365 -E emails.txt\n\n  # Route through a SOCKS5 proxy and raise concurrency\n  brutus enum active microsoft365 -E emails.txt --proxy socks5://127.0.0.1:1080 --threads 20",
+      "flags": [
+        {
+          "name": "domain",
+          "shorthand": "d",
+          "type": "string",
+          "usage": "Generate candidate emails for this domain (statistically-likely first/last combos)"
+        },
+        {
+          "name": "email-file",
+          "shorthand": "E",
+          "type": "string",
+          "usage": "File of email addresses, one per line (\"-\" for stdin)"
+        },
+        {
+          "name": "emails",
+          "shorthand": "e",
+          "type": "string",
+          "usage": "Comma-separated email addresses to check"
+        },
+        {
+          "name": "format",
+          "type": "string",
+          "default": "first.last",
+          "usage": "Username format for --domain generation (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "limit",
+          "type": "int",
+          "default": "0",
+          "usage": "When generating with --domain, cap to the first N (most-likely) candidates (0 = all)"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum active oracles",
+      "use": "oracles",
+      "short": "Enumerate which account-existence oracles work for an organization",
+      "runnable": true,
+      "example": "  # Discover candidate oracles via DNS and report which ones work\n  # (domain defaults to the --known-valid email's domain)\n  brutus enum active oracles --known-valid admin@praetorian.com\n\n  # Enumerate specific emails against the working oracles\n  brutus enum active oracles --domain praetorian.com -e test@praetorian.com,admin@praetorian.com --known-valid admin@praetorian.com\n\n  # Enumerate emails from file\n  brutus enum active oracles --domain praetorian.com -E emails.txt --known-valid admin@praetorian.com\n\n  # Generate emails and enumerate against working oracles\n  brutus enum active oracles --domain target.com --generate --format first.last --known-valid admin@target.com\n\n  # Check / enumerate against specific oracles only\n  brutus enum active oracles -e user@example.com -s microsoft365,google --known-valid admin@example.com\n\n  # JSON output\n  brutus enum active oracles --domain praetorian.com -e test@praetorian.com --known-valid admin@praetorian.com --json",
+      "flags": [
+        {
+          "name": "domain",
+          "shorthand": "d",
+          "type": "string",
+          "usage": "Domain to enumerate for DNS recon and email generation (defaults to the --known-valid email's domain)"
+        },
+        {
+          "name": "email-file",
+          "shorthand": "E",
+          "type": "string",
+          "usage": "File of emails to enumerate (one per line, use - for stdin)"
+        },
+        {
+          "name": "emails",
+          "shorthand": "e",
+          "type": "string",
+          "usage": "Comma-separated emails to enumerate"
+        },
+        {
+          "name": "format",
+          "type": "string",
+          "default": "first.last",
+          "usage": "Username format for generation (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first)"
+        },
+        {
+          "name": "generate",
+          "type": "bool",
+          "default": "false",
+          "usage": "Generate emails from embedded name lists"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "known-valid",
+          "type": "string",
+          "usage": "Known-valid email to validate oracles before enumeration (required)"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "services",
+          "shorthand": "s",
+          "type": "string",
+          "usage": "Comma-separated oracles to check (default: all discovered/registered)"
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum active oracles discover",
+      "use": "discover",
+      "short": "Discover working oracles by testing a known-valid email",
+      "runnable": true,
+      "example": "  # Test oracles for a domain (auto-discovers candidate oracles from DNS)\n  brutus enum active oracles discover --domain praetorian.com --known-valid admin@praetorian.com\n\n  # Test specific oracles only\n  brutus enum active oracles discover --known-valid admin@example.com -s microsoft365,google",
+      "flags": [
+        {
+          "name": "domain",
+          "shorthand": "d",
+          "type": "string",
+          "usage": "Domain to discover candidate oracles from DNS TXT records"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "known-valid",
+          "type": "string",
+          "usage": "Known-valid email to test against oracles (required)"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "services",
+          "shorthand": "s",
+          "type": "string",
+          "usage": "Comma-separated oracles to test (default: all registered)"
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum active teams",
+      "use": "teams",
+      "short": "Microsoft Teams: device-code auth, user enumeration, and tenant posture audit",
+      "runnable": false,
+      "flags": [
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum active teams audit",
+      "use": "audit",
+      "short": "Audit a Microsoft Teams tenant's external posture into graded findings",
+      "runnable": true,
+      "example": "  # Audit a tenant via a single known-valid seed address (device-code auth inline)\n  brutus enum active teams audit --email alice@contoso.com\n\n  # Skip presence/out-of-office lookups (presence/OOO findings not evaluated)\n  brutus enum active teams audit --email alice@contoso.com --no-presence\n\n  # Reuse a token captured earlier with \"enum active teams auth -o\"\n  brutus enum active teams auth -o token.jsonl\n  brutus enum active teams audit --email alice@contoso.com --token-file token.jsonl\n\n  # Emit findings as JSONL\n  brutus enum active teams audit --email alice@contoso.com --json",
+      "flags": [
+        {
+          "name": "access-token",
+          "type": "string",
+          "usage": "Access token to use (instead of device-code or --token-file)"
+        },
+        {
+          "name": "client-id",
+          "type": "string",
+          "default": "1fec8e78-bce4-4aaf-ab1b-5451cc387264",
+          "usage": "Azure app (client) ID (device-code path)"
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "usage": "Single known-valid seed email address to audit (required)"
+        },
+        {
+          "name": "include-consumer",
+          "type": "bool",
+          "default": "false",
+          "usage": "Count consumer/personal (8:live:) Teams accounts as hits (default: only corporate 8:orgid: accounts)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "no-browser",
+          "type": "bool",
+          "default": "false",
+          "usage": "Don't automatically open the verification URL in a browser"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "no-presence",
+          "type": "bool",
+          "default": "false",
+          "usage": "Skip Teams presence / out-of-office lookups (fewer requests; presence is gathered by default)"
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "refresh-token",
+          "type": "string",
+          "usage": "Refresh token used to renew an expired access token"
+        },
+        {
+          "name": "scope",
+          "type": "string",
+          "default": "offline_access https://api.spaces.skype.com/.default",
+          "usage": "Space-separated OAuth2 scopes (device-code path)"
+        },
+        {
+          "name": "tenant",
+          "type": "string",
+          "default": "organizations",
+          "usage": "Tenant ID, domain, or \"organizations\"/\"common\" (device-code path)"
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "token-file",
+          "type": "string",
+          "usage": "JSONL token file from \"enum active teams auth -o\" to reuse"
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum active teams auth",
+      "use": "auth",
+      "short": "Obtain Microsoft access token and refresh token via device code flow",
+      "runnable": true,
+      "example": "  # Authenticate against the default (organizations / work-school) tenant (interactive)\n  brutus enum active teams auth\n\n  # Headless / SSH: print the URL and code, don't open a browser\n  brutus enum active teams auth --no-browser\n\n  # Authenticate against a specific tenant by domain\n  brutus enum active teams auth --tenant contoso.com\n\n  # Use a custom app registration and scopes\n  brutus enum active teams auth --client-id 00000000-0000-0000-0000-000000000000 \\\n    --scope \"offline_access https://api.spaces.skype.com/.default\"\n\n  # Capture the full token set as JSON\n  brutus enum active teams auth -o token.jsonl",
+      "flags": [
+        {
+          "name": "client-id",
+          "type": "string",
+          "default": "1fec8e78-bce4-4aaf-ab1b-5451cc387264",
+          "usage": "Azure app (client) ID"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "no-browser",
+          "type": "bool",
+          "default": "false",
+          "usage": "Don't automatically open the verification URL in a browser"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "scope",
+          "shorthand": "s",
+          "type": "string",
+          "default": "offline_access https://api.spaces.skype.com/.default",
+          "usage": "Space-separated OAuth2 scopes"
+        },
+        {
+          "name": "tenant",
+          "type": "string",
+          "default": "organizations",
+          "usage": "Tenant ID, domain, or \"organizations\"/\"common\""
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum active teams users",
+      "use": "users",
+      "short": "Enumerate corporate Microsoft Teams users by email address",
+      "runnable": true,
+      "example": "  # Device-code auth inline, then enumerate a few emails\n  brutus enum active teams users -e alice@contoso.com,bob@contoso.com\n\n  # Generate candidate emails for a domain and enumerate the 5000 most likely\n  brutus enum active teams users --domain target.com --format first.last --limit 5000\n\n  # Generate first_last candidates (presence is fetched by default for hits)\n  brutus enum active teams users --domain target.com --format first_last\n\n  # Enumerate emails from a file, skipping presence lookups\n  brutus enum active teams users -E emails.txt --no-presence\n\n  # Reuse a token captured earlier with \"enum active teams auth -o\"\n  brutus enum active teams auth -o token.jsonl\n  brutus enum active teams users -E emails.txt --token-file token.jsonl\n\n  # Provide an access token directly\n  brutus enum active teams users -e alice@contoso.com --access-token \"$TOKEN\"\n\n  # Route through a SOCKS5 proxy and raise concurrency\n  brutus enum active teams users -E emails.txt --proxy socks5://127.0.0.1:1080 --threads 20",
+      "flags": [
+        {
+          "name": "access-token",
+          "type": "string",
+          "usage": "Access token to use (instead of device-code or --token-file)"
+        },
+        {
+          "name": "client-id",
+          "type": "string",
+          "default": "1fec8e78-bce4-4aaf-ab1b-5451cc387264",
+          "usage": "Azure app (client) ID (device-code path)"
+        },
+        {
+          "name": "domain",
+          "shorthand": "d",
+          "type": "string",
+          "usage": "Generate candidate emails for this domain (statistically-likely first/last combos)"
+        },
+        {
+          "name": "email-file",
+          "shorthand": "E",
+          "type": "string",
+          "usage": "File of email addresses, one per line (\"-\" for stdin)"
+        },
+        {
+          "name": "emails",
+          "shorthand": "e",
+          "type": "string",
+          "usage": "Comma-separated email addresses to check"
+        },
+        {
+          "name": "format",
+          "type": "string",
+          "default": "first.last",
+          "usage": "Username format for --domain generation (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first)"
+        },
+        {
+          "name": "include-consumer",
+          "type": "bool",
+          "default": "false",
+          "usage": "Count consumer/personal (8:live:) Teams accounts as hits (default: only corporate 8:orgid: accounts)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "limit",
+          "type": "int",
+          "default": "0",
+          "usage": "When generating with --domain, cap to the first N (most-likely) candidates (0 = all)"
+        },
+        {
+          "name": "no-browser",
+          "type": "bool",
+          "default": "false",
+          "usage": "Don't automatically open the verification URL in a browser"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "no-presence",
+          "type": "bool",
+          "default": "false",
+          "usage": "Skip Teams presence / out-of-office lookups (fewer requests; presence is gathered by default)"
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "refresh-token",
+          "type": "string",
+          "usage": "Refresh token used to renew an expired access token"
+        },
+        {
+          "name": "scope",
+          "type": "string",
+          "default": "offline_access https://api.spaces.skype.com/.default",
+          "usage": "Space-separated OAuth2 scopes (device-code path)"
+        },
+        {
+          "name": "tenant",
+          "type": "string",
+          "default": "organizations",
+          "usage": "Tenant ID, domain, or \"organizations\"/\"common\" (device-code path)"
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "token-file",
+          "type": "string",
+          "usage": "JSONL token file from \"enum active teams auth -o\" to reuse"
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum apollo",
+      "use": "apollo",
+      "short": "Discover people for a domain via Apollo.io (free; --enrich reveals emails)",
+      "hidden": true,
+      "deprecated": "use \"brutus enum passive apollo\" instead",
+      "runnable": true,
+      "example": "  # Discover people (DEFAULT — FREE, no credits; shows email/phone availability)\n  brutus enum passive apollo --domain example.com\n\n  # Filter by job titles\n  brutus enum passive apollo -d example.com --titles \"VP Engineering\" --titles \"CTO\"\n\n  # Enrich all discovered people (CONSUMES CREDITS, bounded by --limit)\n  brutus enum passive apollo -d example.com --enrich --limit 50\n\n  # Provide the key explicitly (note: visible in process list / shell history)\n  brutus enum passive apollo -d example.com --api-key abc123",
+      "flags": [
+        {
+          "name": "api-key",
+          "type": "string",
+          "usage": "Apollo.io API key (overrides APOLLO_API_KEY; WARNING: visible in process list and shell history — prefer APOLLO_API_KEY)"
+        },
+        {
+          "name": "domain",
+          "shorthand": "d",
+          "type": "string",
+          "usage": "Company domain to discover people for (required)"
+        },
+        {
+          "name": "enrich",
+          "type": "bool",
+          "default": "false",
+          "usage": "Reveal emails for all discovered people via people/match (CONSUMES CREDITS; bounded by --limit)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "limit",
+          "type": "int",
+          "default": "0",
+          "usage": "Max people to discover AND (with --enrich) to reveal (bounds credit spend; 0 = no cap)"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "titles",
+          "type": "stringSlice",
+          "default": "[]",
+          "usage": "Optional job-title filter (repeatable or comma-separated)"
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum dehashed",
+      "use": "dehashed",
+      "short": "Collect breach-exposed identity data for a domain via DeHashed",
+      "hidden": true,
+      "deprecated": "use \"brutus enum passive dehashed\" instead",
+      "runnable": true,
+      "example": "  # Collect refined breach contacts for a domain (key from DEHASHED_API_KEY)\n  brutus enum passive dehashed --domain example.com\n\n  # Same, but suppress the breach-exposed plaintext passwords from output\n  brutus enum passive dehashed --domain example.com --no-credentials\n\n  # Keep every email (not just @example.com), unmerged; drop combolist DBs for clean identity-only enumeration\n  brutus enum passive dehashed -d example.com --all-emails --no-dedup --exclude-combolists\n\n  # Restrict to specific source databases (exact names, comma-separated)\n  brutus enum passive dehashed -d example.com --sources \"Adobe,LinkedIn\"\n\n  # Emit one structured JSON document with full per-contact detail + run metadata\n  brutus enum passive dehashed -d example.com --detailed -o breaches.json\n\n  # Same detailed export, including breach-exposed plaintext passwords\n  brutus enum passive dehashed -d example.com --detailed --with-credentials -o breaches.json\n\n  # Provide the key explicitly (note: visible in process list / shell history)\n  brutus enum passive dehashed -d example.com --api-key abc123\n\n  # Cap results (and credit spend) and write JSONL to a file\n  brutus enum passive dehashed -d example.com --limit 50 -o breaches.jsonl",
+      "flags": [
+        {
+          "name": "all-emails",
+          "type": "bool",
+          "default": "false",
+          "usage": "Keep all emails, not just those @<domain> (disables corporate-only filtering)"
+        },
+        {
+          "name": "api-key",
+          "type": "string",
+          "usage": "DeHashed API key (overrides DEHASHED_API_KEY; WARNING: visible in process list and shell history — prefer DEHASHED_API_KEY)"
+        },
+        {
+          "name": "detailed",
+          "type": "bool",
+          "default": "false",
+          "usage": "Emit a single structured JSON document with full per-contact detail (ip addresses, addresses, dobs, obtained dates) and run metadata"
+        },
+        {
+          "name": "domain",
+          "shorthand": "d",
+          "type": "string",
+          "usage": "Domain to search (required)"
+        },
+        {
+          "name": "exclude-combolists",
+          "type": "bool",
+          "default": "false",
+          "usage": "Drop records from known aggregator/combolist source databases (combolists are included by default)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "limit",
+          "type": "int",
+          "default": "100",
+          "usage": "Maximum number of records to collect (bounds credit spend)"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "no-credentials",
+          "type": "bool",
+          "default": "false",
+          "usage": "Suppress breach-exposed plaintext passwords from the output"
+        },
+        {
+          "name": "no-dedup",
+          "type": "bool",
+          "default": "false",
+          "usage": "Do not merge records that share an email"
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "sources",
+          "type": "stringSlice",
+          "default": "[]",
+          "usage": "Restrict results to these DeHashed source databases (comma-separated, exact names)"
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        },
+        {
+          "name": "with-credentials",
+          "type": "bool",
+          "default": "false",
+          "usage": "Include breach-exposed plaintext passwords in --detailed output (off by default; hashes are never included)"
+        }
+      ]
+    },
+    {
+      "path": "brutus enum generate",
+      "use": "generate",
+      "short": "Generate email addresses or usernames from embedded name lists",
+      "runnable": true,
+      "example": "  # Generate emails: jsmith@example.com\n  brutus enum generate --domain example.com --format flast\n\n  # Generate usernames only: jsmith\n  brutus enum generate --format flast\n\n  # Generate john.smith@example.com (default format)\n  brutus enum generate --domain example.com\n\n  # Emit only the 1000 most-likely emails\n  brutus enum generate --domain example.com --limit 1000\n\n  # Pipe the 500 most-likely usernames to Kerberos enum\n  brutus enum generate --format flast --limit 500 | brutus enum active kerberos --dc 10.0.0.1 --domain CORP.LOCAL -U -",
+      "flags": [
+        {
+          "name": "domain",
+          "shorthand": "d",
+          "type": "string",
+          "usage": "Domain to append to generated usernames (omit to generate usernames only)"
+        },
+        {
+          "name": "format",
+          "type": "string",
+          "default": "first.last",
+          "usage": "Username format (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "limit",
+          "type": "int",
+          "default": "0",
+          "usage": "Emit only the first N (most-likely) results (0 = no limit, emit all)"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum hunter",
+      "use": "hunter",
+      "short": "Discover people and emails for a domain via Hunter.io Domain Search",
+      "hidden": true,
+      "deprecated": "use \"brutus enum passive hunter\" instead",
+      "runnable": true,
+      "example": "  # Discover people for a domain (key from HUNTER_API_KEY)\n  brutus enum passive hunter --domain example.com\n\n  # Provide the key explicitly (note: visible in process list / shell history)\n  brutus enum passive hunter -d example.com --api-key abc123\n\n  # JSONL output to a file\n  brutus enum passive hunter -d example.com -o people.jsonl",
+      "flags": [
+        {
+          "name": "api-key",
+          "type": "string",
+          "usage": "Hunter.io API key (overrides HUNTER_API_KEY; WARNING: visible in process list and shell history — prefer HUNTER_API_KEY)"
+        },
+        {
+          "name": "domain",
+          "shorthand": "d",
+          "type": "string",
+          "usage": "Domain to search (required)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "limit",
+          "type": "int",
+          "default": "0",
+          "usage": "Maximum number of people to return (0 = no cap, return all)"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum lusha",
+      "use": "lusha",
+      "short": "Enrich a single person identity to emails and phones via Lusha v3",
+      "hidden": true,
+      "deprecated": "use \"brutus enum passive lusha\" instead",
+      "runnable": true,
+      "example": "  # Enrich by name + company (key from LUSHA_API_KEY)\n  brutus enum passive lusha --first-name Ada --last-name Lovelace --company Analytical\n\n  # Enrich by name + company domain\n  brutus enum passive lusha --first-name Ada --last-name Lovelace --domain example.com\n\n  # Enrich by email\n  brutus enum passive lusha --email ada@example.com\n\n  # Enrich by LinkedIn URL, also request phone numbers\n  brutus enum passive lusha --linkedin https://linkedin.com/in/ada --phone\n\n  # Roster: enumerate an entire company by domain (collect all — consumes credits)\n  brutus enum passive lusha --domain example.com\n\n  # Roster: cap the roster (and credit spend) at 25 contacts\n  brutus enum passive lusha --domain example.com --limit 25\n\n  # Provide the key explicitly (note: visible in process list / shell history)\n  brutus enum passive lusha --email ada@example.com --api-key abc123",
+      "flags": [
+        {
+          "name": "api-key",
+          "type": "string",
+          "usage": "Lusha API key (overrides LUSHA_API_KEY; WARNING: visible in process list and shell history — prefer LUSHA_API_KEY)"
+        },
+        {
+          "name": "company",
+          "type": "string",
+          "usage": "Company name (with the name pair)"
+        },
+        {
+          "name": "domain",
+          "type": "string",
+          "usage": "Company domain (alternative to --company)"
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "usage": "Enrich by email address (mutually exclusive identity)"
+        },
+        {
+          "name": "email-only",
+          "type": "bool",
+          "default": "false",
+          "usage": "Request only email datapoints (mutually exclusive with --phone)"
+        },
+        {
+          "name": "first-name",
+          "type": "string",
+          "usage": "First name (with --last-name and --company or --domain)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "last-name",
+          "type": "string",
+          "usage": "Last name (with --first-name)"
+        },
+        {
+          "name": "limit",
+          "type": "int",
+          "default": "0",
+          "usage": "Roster mode (--domain only): max contacts to search + enrich; 0 = collect all (consumes ~1 credit/contact)"
+        },
+        {
+          "name": "linkedin",
+          "type": "string",
+          "usage": "Enrich by LinkedIn profile URL (mutually exclusive identity)"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "phone",
+          "type": "bool",
+          "default": "false",
+          "usage": "Request phone datapoints in addition to email"
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum passive",
+      "use": "passive",
+      "short": "API-key OSINT/HUMINT sources — employee email/contact discovery & enrichment",
+      "runnable": false,
+      "example": "  # Discover people via Hunter.io\n  brutus enum passive hunter --domain example.com\n\n  # Discover and enrich people via Apollo.io\n  brutus enum passive apollo --domain example.com\n\n  # Enrich a contact via Lusha\n  brutus enum passive lusha --first-name Jane --last-name Doe --company \"Example Inc\"\n\n  # Collect breach-exposed identity data via DeHashed\n  brutus enum passive dehashed --domain example.com\n\n  # Scrape LinkedIn Sales Navigator profiles via PhantomBuster\n  brutus enum passive linkedin --agent-id 1234567890",
+      "flags": [
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum passive apollo",
+      "use": "apollo",
+      "short": "Discover people for a domain via Apollo.io (free; --enrich reveals emails)",
+      "runnable": true,
+      "example": "  # Discover people (DEFAULT — FREE, no credits; shows email/phone availability)\n  brutus enum passive apollo --domain example.com\n\n  # Filter by job titles\n  brutus enum passive apollo -d example.com --titles \"VP Engineering\" --titles \"CTO\"\n\n  # Enrich all discovered people (CONSUMES CREDITS, bounded by --limit)\n  brutus enum passive apollo -d example.com --enrich --limit 50\n\n  # Provide the key explicitly (note: visible in process list / shell history)\n  brutus enum passive apollo -d example.com --api-key abc123",
+      "flags": [
+        {
+          "name": "api-key",
+          "type": "string",
+          "usage": "Apollo.io API key (overrides APOLLO_API_KEY; WARNING: visible in process list and shell history — prefer APOLLO_API_KEY)"
+        },
+        {
+          "name": "domain",
+          "shorthand": "d",
+          "type": "string",
+          "usage": "Company domain to discover people for (required)"
+        },
+        {
+          "name": "enrich",
+          "type": "bool",
+          "default": "false",
+          "usage": "Reveal emails for all discovered people via people/match (CONSUMES CREDITS; bounded by --limit)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "limit",
+          "type": "int",
+          "default": "0",
+          "usage": "Max people to discover AND (with --enrich) to reveal (bounds credit spend; 0 = no cap)"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "titles",
+          "type": "stringSlice",
+          "default": "[]",
+          "usage": "Optional job-title filter (repeatable or comma-separated)"
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum passive dehashed",
+      "use": "dehashed",
+      "short": "Collect breach-exposed identity data for a domain via DeHashed",
+      "runnable": true,
+      "example": "  # Collect refined breach contacts for a domain (key from DEHASHED_API_KEY)\n  brutus enum passive dehashed --domain example.com\n\n  # Same, but suppress the breach-exposed plaintext passwords from output\n  brutus enum passive dehashed --domain example.com --no-credentials\n\n  # Keep every email (not just @example.com), unmerged; drop combolist DBs for clean identity-only enumeration\n  brutus enum passive dehashed -d example.com --all-emails --no-dedup --exclude-combolists\n\n  # Restrict to specific source databases (exact names, comma-separated)\n  brutus enum passive dehashed -d example.com --sources \"Adobe,LinkedIn\"\n\n  # Emit one structured JSON document with full per-contact detail + run metadata\n  brutus enum passive dehashed -d example.com --detailed -o breaches.json\n\n  # Same detailed export, including breach-exposed plaintext passwords\n  brutus enum passive dehashed -d example.com --detailed --with-credentials -o breaches.json\n\n  # Provide the key explicitly (note: visible in process list / shell history)\n  brutus enum passive dehashed -d example.com --api-key abc123\n\n  # Cap results (and credit spend) and write JSONL to a file\n  brutus enum passive dehashed -d example.com --limit 50 -o breaches.jsonl",
+      "flags": [
+        {
+          "name": "all-emails",
+          "type": "bool",
+          "default": "false",
+          "usage": "Keep all emails, not just those @<domain> (disables corporate-only filtering)"
+        },
+        {
+          "name": "api-key",
+          "type": "string",
+          "usage": "DeHashed API key (overrides DEHASHED_API_KEY; WARNING: visible in process list and shell history — prefer DEHASHED_API_KEY)"
+        },
+        {
+          "name": "detailed",
+          "type": "bool",
+          "default": "false",
+          "usage": "Emit a single structured JSON document with full per-contact detail (ip addresses, addresses, dobs, obtained dates) and run metadata"
+        },
+        {
+          "name": "domain",
+          "shorthand": "d",
+          "type": "string",
+          "usage": "Domain to search (required)"
+        },
+        {
+          "name": "exclude-combolists",
+          "type": "bool",
+          "default": "false",
+          "usage": "Drop records from known aggregator/combolist source databases (combolists are included by default)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "limit",
+          "type": "int",
+          "default": "100",
+          "usage": "Maximum number of records to collect (bounds credit spend)"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "no-credentials",
+          "type": "bool",
+          "default": "false",
+          "usage": "Suppress breach-exposed plaintext passwords from the output"
+        },
+        {
+          "name": "no-dedup",
+          "type": "bool",
+          "default": "false",
+          "usage": "Do not merge records that share an email"
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "sources",
+          "type": "stringSlice",
+          "default": "[]",
+          "usage": "Restrict results to these DeHashed source databases (comma-separated, exact names)"
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        },
+        {
+          "name": "with-credentials",
+          "type": "bool",
+          "default": "false",
+          "usage": "Include breach-exposed plaintext passwords in --detailed output (off by default; hashes are never included)"
+        }
+      ]
+    },
+    {
+      "path": "brutus enum passive hunter",
+      "use": "hunter",
+      "short": "Discover people and emails for a domain via Hunter.io Domain Search",
+      "runnable": true,
+      "example": "  # Discover people for a domain (key from HUNTER_API_KEY)\n  brutus enum passive hunter --domain example.com\n\n  # Provide the key explicitly (note: visible in process list / shell history)\n  brutus enum passive hunter -d example.com --api-key abc123\n\n  # JSONL output to a file\n  brutus enum passive hunter -d example.com -o people.jsonl",
+      "flags": [
+        {
+          "name": "api-key",
+          "type": "string",
+          "usage": "Hunter.io API key (overrides HUNTER_API_KEY; WARNING: visible in process list and shell history — prefer HUNTER_API_KEY)"
+        },
+        {
+          "name": "domain",
+          "shorthand": "d",
+          "type": "string",
+          "usage": "Domain to search (required)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "limit",
+          "type": "int",
+          "default": "0",
+          "usage": "Maximum number of people to return (0 = no cap, return all)"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum passive linkedin",
+      "use": "linkedin",
+      "short": "Scrape LinkedIn Sales Navigator profiles via PhantomBuster",
+      "runnable": true,
+      "example": "  # Launch a Sales Nav scraper and fetch results\n  brutus enum passive linkedin --agent-id 1234567890\n\n  # Fetch results from a previous run (skip launching a new one)\n  brutus enum passive linkedin --agent-id 1234567890 --skip-launch\n\n  # Specify a custom result filename\n  brutus enum passive linkedin --agent-id 1234567890 --result-file result.json\n\n  # Provide the key explicitly (note: visible in process list / shell history)\n  brutus enum passive linkedin --agent-id 1234567890 --api-key abc123",
+      "flags": [
+        {
+          "name": "agent-id",
+          "type": "string",
+          "usage": "PhantomBuster agent ID for the Sales Navigator scraper (required)"
+        },
+        {
+          "name": "api-key",
+          "type": "string",
+          "usage": "PhantomBuster API key (overrides PHANTOMBUSTER_KEY; WARNING: visible in process list and shell history — prefer PHANTOMBUSTER_KEY)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "result-file",
+          "type": "string",
+          "default": "result.csv",
+          "usage": "Result filename to download from S3 (default: result.csv)"
+        },
+        {
+          "name": "skip-launch",
+          "type": "bool",
+          "default": "false",
+          "usage": "Skip launching the agent — fetch results from the most recent run instead"
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum passive lusha",
+      "use": "lusha",
+      "short": "Enrich a single person identity to emails and phones via Lusha v3",
+      "runnable": true,
+      "example": "  # Enrich by name + company (key from LUSHA_API_KEY)\n  brutus enum passive lusha --first-name Ada --last-name Lovelace --company Analytical\n\n  # Enrich by name + company domain\n  brutus enum passive lusha --first-name Ada --last-name Lovelace --domain example.com\n\n  # Enrich by email\n  brutus enum passive lusha --email ada@example.com\n\n  # Enrich by LinkedIn URL, also request phone numbers\n  brutus enum passive lusha --linkedin https://linkedin.com/in/ada --phone\n\n  # Roster: enumerate an entire company by domain (collect all — consumes credits)\n  brutus enum passive lusha --domain example.com\n\n  # Roster: cap the roster (and credit spend) at 25 contacts\n  brutus enum passive lusha --domain example.com --limit 25\n\n  # Provide the key explicitly (note: visible in process list / shell history)\n  brutus enum passive lusha --email ada@example.com --api-key abc123",
+      "flags": [
+        {
+          "name": "api-key",
+          "type": "string",
+          "usage": "Lusha API key (overrides LUSHA_API_KEY; WARNING: visible in process list and shell history — prefer LUSHA_API_KEY)"
+        },
+        {
+          "name": "company",
+          "type": "string",
+          "usage": "Company name (with the name pair)"
+        },
+        {
+          "name": "domain",
+          "type": "string",
+          "usage": "Company domain (alternative to --company)"
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "usage": "Enrich by email address (mutually exclusive identity)"
+        },
+        {
+          "name": "email-only",
+          "type": "bool",
+          "default": "false",
+          "usage": "Request only email datapoints (mutually exclusive with --phone)"
+        },
+        {
+          "name": "first-name",
+          "type": "string",
+          "usage": "First name (with --last-name and --company or --domain)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "last-name",
+          "type": "string",
+          "usage": "Last name (with --first-name)"
+        },
+        {
+          "name": "limit",
+          "type": "int",
+          "default": "0",
+          "usage": "Roster mode (--domain only): max contacts to search + enrich; 0 = collect all (consumes ~1 credit/contact)"
+        },
+        {
+          "name": "linkedin",
+          "type": "string",
+          "usage": "Enrich by LinkedIn profile URL (mutually exclusive identity)"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "phone",
+          "type": "bool",
+          "default": "false",
+          "usage": "Request phone datapoints in addition to email"
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus logon",
+      "use": "logon",
+      "short": "Detect Windows logon-screen backdoors (runs both sticky keys and utilman)",
+      "runnable": true,
+      "example": "  # Detect sticky keys and utilman backdoors (heuristic)\n  brutus logon --target 10.0.0.50:3389\n\n  # Vision API confirmation (more accurate)\n  brutus logon --target 10.0.0.50:3389 --experimental-ai\n\n  # Execute a command via detected backdoor\n  brutus logon --target 10.0.0.50:3389 --exec \"whoami\"\n\n  # Interactive web terminal via backdoor\n  brutus logon --target 10.0.0.50:3389 --web --open\n\n  # Pipeline mode with Nerva JSON (only RDP targets are tested)\n  naabu -host 10.0.0.0/24 -p 3389 -silent | nerva --json | brutus logon\n\n  # Pipe plain targets (auto-fingerprinted, only RDP services scanned)\n  echo \"10.0.0.50:3389\" | brutus logon\n\n  # Pipe URI targets\n  echo \"rdp://10.0.0.50:3389\" | brutus logon\n\n  # Import targets from nmap XML scan (only RDP services tested)\n  brutus logon --nmap-file scan.xml",
+      "flags": [
+        {
+          "name": "connect-timeout",
+          "type": "duration",
+          "default": "3s",
+          "usage": "TCP connect timeout for scan dials (separate from --scan-timeout, which is the per-host settle deadline). A reachable host completes the handshake in ~1 RTT, so the short default only accelerates dead-host rejection; raise it for high-latency target sets."
+        },
+        {
+          "name": "exec",
+          "type": "string",
+          "usage": "Execute command via detected backdoor"
+        },
+        {
+          "name": "experimental-ai",
+          "type": "bool",
+          "default": "false",
+          "usage": "Enable Vision API for backdoor confirmation"
+        },
+        {
+          "name": "fast",
+          "type": "bool",
+          "default": "false",
+          "usage": "fast triage: shorter settle budget for internet-scale sweeps; reports HIGH/CRITICAL or indeterminate, never clean (rerun indeterminates without --fast for a careful verdict)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "masscan-file",
+          "type": "string",
+          "usage": "Masscan JSON file (-oJ output) to import targets from"
+        },
+        {
+          "name": "mode",
+          "shorthand": "m",
+          "type": "string",
+          "default": "default",
+          "usage": "Aggressiveness tier: cautious, default, aggressive"
+        },
+        {
+          "name": "nmap-file",
+          "type": "string",
+          "usage": "Nmap XML file (-oX output) to import targets from"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "no-nla-probe",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable the pre-WASM RDP negotiation probe (always run the full WASM session)"
+        },
+        {
+          "name": "open",
+          "type": "bool",
+          "default": "false",
+          "usage": "Auto-open browser when web terminal starts"
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "retries",
+          "type": "int",
+          "default": "2",
+          "usage": "Max retries on connection error (0 = disabled)"
+        },
+        {
+          "name": "scan-timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-host settle/scan deadline (post-connect): how long to watch the logon screen after the trigger before deciding. Distinct from --connect-timeout (the TCP dial timeout)."
+        },
+        {
+          "name": "target",
+          "type": "string",
+          "usage": "Target host:port"
+        },
+        {
+          "name": "targets-file",
+          "type": "string",
+          "usage": "File of targets to test, one host:port per line (fingerprints with Nerva unless --protocol is set)"
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true,
+          "rejected": true,
+          "rejectedReason": "--timeout is not valid here; use --scan-timeout (settle deadline) and/or --connect-timeout (TCP connect)"
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        },
+        {
+          "name": "web",
+          "type": "bool",
+          "default": "false",
+          "usage": "Start interactive web terminal via detected backdoor"
+        }
+      ]
+    },
+    {
+      "path": "brutus snmp",
+      "use": "snmp",
+      "short": "Test SNMP community strings against targets",
+      "aliases": [
+        "community"
+      ],
+      "runnable": true,
+      "example": "  # Test with default community strings\n  brutus snmp --target 192.168.1.1:161\n\n  # Aggressive mode for comprehensive testing (~200+ strings)\n  brutus snmp --target 10.0.0.1:161 --mode aggressive\n\n  # Custom community strings\n  brutus snmp --target 192.168.1.1:161 -c \"mycommunity,secretstring\"\n\n  # Pipeline mode\n  naabu -host 10.0.0.0/24 -p 161 -silent | nerva --json | brutus snmp\n\n  # Targets file\n  brutus snmp --targets-file snmp-hosts.txt --mode aggressive\n\n  # Import targets from nmap XML scan (only SNMP services tested)\n  brutus snmp --nmap-file scan.xml --mode aggressive",
+      "flags": [
+        {
+          "name": "community",
+          "shorthand": "c",
+          "type": "string",
+          "usage": "Custom community strings (comma-separated)"
+        },
+        {
+          "name": "community-file",
+          "shorthand": "C",
+          "type": "string",
+          "usage": "Community string file (one per line)"
+        },
+        {
+          "name": "connect-timeout",
+          "type": "duration",
+          "default": "3s",
+          "usage": "TCP connect timeout for scan dials (separate from --scan-timeout, which is the per-host settle deadline). A reachable host completes the handshake in ~1 RTT, so the short default only accelerates dead-host rejection; raise it for high-latency target sets."
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "masscan-file",
+          "type": "string",
+          "usage": "Masscan JSON file (-oJ output) to import targets from"
+        },
+        {
+          "name": "mode",
+          "shorthand": "m",
+          "type": "string",
+          "default": "default",
+          "usage": "Aggressiveness tier: cautious, default, aggressive"
+        },
+        {
+          "name": "nmap-file",
+          "type": "string",
+          "usage": "Nmap XML file (-oX output) to import targets from"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "retries",
+          "type": "int",
+          "default": "2",
+          "usage": "Max retries on connection error (0 = disabled)"
+        },
+        {
+          "name": "target",
+          "type": "string",
+          "usage": "Target host:port"
+        },
+        {
+          "name": "targets-file",
+          "type": "string",
+          "usage": "File of targets to test, one host:port per line (fingerprints with Nerva unless --protocol is set)"
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus stickykeys",
+      "use": "stickykeys",
+      "short": "Detect the Windows sticky-keys (sethc.exe) logon backdoor only",
+      "runnable": true,
+      "example": "  # Detect the sticky-keys backdoor only\n  brutus stickykeys --target 10.0.0.50:3389\n\n  # Vision API confirmation (more accurate)\n  brutus stickykeys --target 10.0.0.50:3389 --experimental-ai",
+      "flags": [
+        {
+          "name": "connect-timeout",
+          "type": "duration",
+          "default": "3s",
+          "usage": "TCP connect timeout for scan dials (separate from --scan-timeout, which is the per-host settle deadline). A reachable host completes the handshake in ~1 RTT, so the short default only accelerates dead-host rejection; raise it for high-latency target sets."
+        },
+        {
+          "name": "exec",
+          "type": "string",
+          "usage": "Execute command via detected backdoor"
+        },
+        {
+          "name": "experimental-ai",
+          "type": "bool",
+          "default": "false",
+          "usage": "Enable Vision API for backdoor confirmation"
+        },
+        {
+          "name": "fast",
+          "type": "bool",
+          "default": "false",
+          "usage": "fast triage: shorter settle budget for internet-scale sweeps; reports HIGH/CRITICAL or indeterminate, never clean (rerun indeterminates without --fast for a careful verdict)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "masscan-file",
+          "type": "string",
+          "usage": "Masscan JSON file (-oJ output) to import targets from"
+        },
+        {
+          "name": "mode",
+          "shorthand": "m",
+          "type": "string",
+          "default": "default",
+          "usage": "Aggressiveness tier: cautious, default, aggressive"
+        },
+        {
+          "name": "nmap-file",
+          "type": "string",
+          "usage": "Nmap XML file (-oX output) to import targets from"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "no-nla-probe",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable the pre-WASM RDP negotiation probe (always run the full WASM session)"
+        },
+        {
+          "name": "open",
+          "type": "bool",
+          "default": "false",
+          "usage": "Auto-open browser when web terminal starts"
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "retries",
+          "type": "int",
+          "default": "2",
+          "usage": "Max retries on connection error (0 = disabled)"
+        },
+        {
+          "name": "scan-timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-host settle/scan deadline (post-connect): how long to watch the logon screen after the trigger before deciding. Distinct from --connect-timeout (the TCP dial timeout)."
+        },
+        {
+          "name": "target",
+          "type": "string",
+          "usage": "Target host:port"
+        },
+        {
+          "name": "targets-file",
+          "type": "string",
+          "usage": "File of targets to test, one host:port per line (fingerprints with Nerva unless --protocol is set)"
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true,
+          "rejected": true,
+          "rejectedReason": "--timeout is not valid here; use --scan-timeout (settle deadline) and/or --connect-timeout (TCP connect)"
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        },
+        {
+          "name": "web",
+          "type": "bool",
+          "default": "false",
+          "usage": "Start interactive web terminal via detected backdoor"
+        }
+      ]
+    },
+    {
+      "path": "brutus utilman",
+      "use": "utilman",
+      "short": "Detect the Windows utilman (Ease of Access) logon backdoor only",
+      "runnable": true,
+      "example": "  # Detect the utilman backdoor only\n  brutus utilman --target 10.0.0.50:3389\n\n  # Vision API confirmation (more accurate)\n  brutus utilman --target 10.0.0.50:3389 --experimental-ai",
+      "flags": [
+        {
+          "name": "connect-timeout",
+          "type": "duration",
+          "default": "3s",
+          "usage": "TCP connect timeout for scan dials (separate from --scan-timeout, which is the per-host settle deadline). A reachable host completes the handshake in ~1 RTT, so the short default only accelerates dead-host rejection; raise it for high-latency target sets."
+        },
+        {
+          "name": "exec",
+          "type": "string",
+          "usage": "Execute command via detected backdoor"
+        },
+        {
+          "name": "experimental-ai",
+          "type": "bool",
+          "default": "false",
+          "usage": "Enable Vision API for backdoor confirmation"
+        },
+        {
+          "name": "fast",
+          "type": "bool",
+          "default": "false",
+          "usage": "fast triage: shorter settle budget for internet-scale sweeps; reports HIGH/CRITICAL or indeterminate, never clean (rerun indeterminates without --fast for a careful verdict)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "masscan-file",
+          "type": "string",
+          "usage": "Masscan JSON file (-oJ output) to import targets from"
+        },
+        {
+          "name": "mode",
+          "shorthand": "m",
+          "type": "string",
+          "default": "default",
+          "usage": "Aggressiveness tier: cautious, default, aggressive"
+        },
+        {
+          "name": "nmap-file",
+          "type": "string",
+          "usage": "Nmap XML file (-oX output) to import targets from"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "no-nla-probe",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable the pre-WASM RDP negotiation probe (always run the full WASM session)"
+        },
+        {
+          "name": "open",
+          "type": "bool",
+          "default": "false",
+          "usage": "Auto-open browser when web terminal starts"
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "retries",
+          "type": "int",
+          "default": "2",
+          "usage": "Max retries on connection error (0 = disabled)"
+        },
+        {
+          "name": "scan-timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-host settle/scan deadline (post-connect): how long to watch the logon screen after the trigger before deciding. Distinct from --connect-timeout (the TCP dial timeout)."
+        },
+        {
+          "name": "target",
+          "type": "string",
+          "usage": "Target host:port"
+        },
+        {
+          "name": "targets-file",
+          "type": "string",
+          "usage": "File of targets to test, one host:port per line (fingerprints with Nerva unless --protocol is set)"
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true,
+          "rejected": true,
+          "rejectedReason": "--timeout is not valid here; use --scan-timeout (settle deadline) and/or --connect-timeout (TCP connect)"
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        },
+        {
+          "name": "web",
+          "type": "bool",
+          "default": "false",
+          "usage": "Start interactive web terminal via detected backdoor"
+        }
+      ]
+    },
+    {
+      "path": "brutus web",
+      "use": "web",
+      "short": "Audit HTTP/web panel credentials (AI-powered or credential list)",
+      "aliases": [
+        "http",
+        "panels"
+      ],
+      "runnable": true,
+      "example": "  # AI-powered credential detection (recommended)\n  brutus web --target 192.168.1.1:80 --experimental-ai\n\n  # Pipeline mode with Nerva JSON\n  naabu -host 192.168.1.0/24 -p 80,443,8080 -silent | nerva --json | brutus web --experimental-ai\n\n  # Manual credential list\n  brutus web --target 192.168.1.1:80 -c \"admin:admin,root:toor\"\n  brutus web --target 192.168.1.1:80 -C creds.txt\n\n  # HTTPS target\n  brutus web --target 192.168.1.1:443 --https --experimental-ai\n\n  # Browser with visible window (demo mode)\n  brutus web --target 192.168.1.1:8080 --experimental-ai --browser-visible\n\n  # Import targets from nmap XML scan\n  brutus web --nmap-file scan.xml --experimental-ai",
+      "flags": [
+        {
+          "name": "browser-tabs",
+          "type": "int",
+          "default": "3",
+          "usage": "Number of concurrent browser tabs"
+        },
+        {
+          "name": "browser-timeout",
+          "type": "duration",
+          "default": "1m0s",
+          "usage": "Total timeout for browser operations"
+        },
+        {
+          "name": "browser-visible",
+          "type": "bool",
+          "default": "false",
+          "usage": "Show browser window (demo mode)"
+        },
+        {
+          "name": "connect-timeout",
+          "type": "duration",
+          "default": "3s",
+          "usage": "TCP connect timeout for scan dials (separate from --scan-timeout, which is the per-host settle deadline). A reachable host completes the handshake in ~1 RTT, so the short default only accelerates dead-host rejection; raise it for high-latency target sets."
+        },
+        {
+          "name": "credentials",
+          "shorthand": "c",
+          "type": "string",
+          "usage": "Comma-separated user:pass pairs (e.g., admin:admin,root:toor)"
+        },
+        {
+          "name": "credentials-file",
+          "shorthand": "C",
+          "type": "string",
+          "usage": "Credentials file (user:pass per line)"
+        },
+        {
+          "name": "experimental-ai",
+          "type": "bool",
+          "default": "false",
+          "usage": "Enable AI-powered credential detection and Vision verification"
+        },
+        {
+          "name": "https",
+          "type": "bool",
+          "default": "false",
+          "usage": "Use HTTPS for browser connections"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "masscan-file",
+          "type": "string",
+          "usage": "Masscan JSON file (-oJ output) to import targets from"
+        },
+        {
+          "name": "mode",
+          "shorthand": "m",
+          "type": "string",
+          "default": "default",
+          "usage": "Aggressiveness tier: cautious, default, aggressive"
+        },
+        {
+          "name": "nmap-file",
+          "type": "string",
+          "usage": "Nmap XML file (-oX output) to import targets from"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "protocol",
+          "type": "string",
+          "usage": "Protocol override (http or https)"
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "retries",
+          "type": "int",
+          "default": "2",
+          "usage": "Max retries on connection error (0 = disabled)"
+        },
+        {
+          "name": "target",
+          "type": "string",
+          "usage": "Target host:port"
+        },
+        {
+          "name": "targets-file",
+          "type": "string",
+          "usage": "File of targets to test, one host:port per line (fingerprints with Nerva unless --protocol is set)"
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        },
+        {
+          "name": "verify",
+          "type": "bool",
+          "default": "false",
+          "usage": "Require strict TLS certificate verification"
+        }
+      ]
+    }
+  ]
+}

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/redis/go-redis/v9 v9.22.0
 	github.com/sijms/go-ora/v2 v2.9.0
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.9
 	github.com/stretchr/testify v1.11.1
 	github.com/tetratelabs/wazero v1.12.0
 	go.mongodb.org/mongo-driver v1.17.9
@@ -72,7 +73,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/projectdiscovery/wappalyzergo v0.2.17 // indirect
 	github.com/quic-go/quic-go v0.60.0 // indirect
-	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/tidwall/transform v0.0.0-20201103190739-32f242e2dbde // indirect
 	github.com/twmb/murmur3 v1.1.8 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect

--- a/internal/clisurface/artifacts.go
+++ b/internal/clisurface/artifacts.go
@@ -42,7 +42,19 @@ const RegenerateCommand = "make cli-docs"
 var LintedMarkdown = []string{READMEPath, "CONTRIBUTING.md"}
 
 // LintedGoDirs are the trees whose Go comments are checked against the surface.
-var LintedGoDirs = []string{"cmd", "pkg"}
+//
+// internal/ is included: a comment naming a flag that no longer exists is the
+// drift this gate was built for, and it does not become harmless by living
+// outside cmd/ and pkg/. Adding it found two RDP comments still describing
+// Vision confirmation as something a removed opt-out flag disabled, when it had
+// become opt-in.
+//
+// A package whose subject is flag syntax has to write its placeholders in
+// angle brackets rather than as bare dashed words, or its own documentation
+// reads as a reference to a flag that does not exist. See this package's
+// comments -- and note that this very comment had to be reworded, because the
+// gate caught it naming the flags above.
+var LintedGoDirs = []string{"cmd", "internal", "pkg"}
 
 // FindRepoRoot walks up from start until it finds the directory holding go.mod.
 // The gate runs as a test, whose working directory is the package directory, so

--- a/internal/clisurface/artifacts.go
+++ b/internal/clisurface/artifacts.go
@@ -16,6 +16,7 @@ package clisurface
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -140,6 +141,12 @@ func (s Staleness) String() string {
 
 // CheckArtifacts compares the committed artifacts against what the surface
 // renders, without writing anything.
+//
+// Line endings are normalized before comparing. The repository carries no
+// .gitattributes, so a contributor with core.autocrlf=true has CRLF on disk
+// while the renderers emit LF — comparing raw bytes would report every
+// generated file as stale on Windows, which is exactly the unexplained friction
+// that gets a gate disabled.
 func CheckArtifacts(repoRoot string, s Surface) ([]Staleness, error) {
 	artifacts, err := Artifacts(repoRoot, s)
 	if err != nil {
@@ -154,7 +161,7 @@ func CheckArtifacts(repoRoot string, s Surface) ([]Staleness, error) {
 			stale = append(stale, Staleness{Path: artifacts[i].Path, Detail: "cannot be read (" + readErr.Error() + ")"})
 			continue
 		}
-		if bytes.Equal(onDisk, artifacts[i].Content) {
+		if bytes.Equal(normalizeNewlines(onDisk), normalizeNewlines(artifacts[i].Content)) {
 			continue
 		}
 		stale = append(stale, Staleness{
@@ -165,11 +172,18 @@ func CheckArtifacts(repoRoot string, s Surface) ([]Staleness, error) {
 	return stale, nil
 }
 
+// normalizeNewlines rewrites CRLF to LF so that a checkout's line-ending
+// convention cannot look like documentation drift.
+func normalizeNewlines(b []byte) []byte {
+	return bytes.ReplaceAll(b, []byte("\r\n"), []byte("\n"))
+}
+
 // firstDifference describes the first line where committed and generated
-// content diverge.
+// content diverge. Both sides are normalized first, so the line it names is a
+// real difference rather than an invisible carriage return.
 func firstDifference(committed, generated []byte) string {
-	got := strings.Split(string(committed), "\n")
-	want := strings.Split(string(generated), "\n")
+	got := strings.Split(string(normalizeNewlines(committed)), "\n")
+	want := strings.Split(string(normalizeNewlines(generated)), "\n")
 	for i := 0; i < len(got) && i < len(want); i++ {
 		if got[i] == want[i] {
 			continue
@@ -239,20 +253,30 @@ func LintRepo(repoRoot string, s Surface, allow Allowlist) ([]Issue, error) {
 }
 
 // lintedMarkdownFiles lists the markdown documents to check, sorted.
+//
+// The docs/ tree is walked recursively: a document that names a removed flag
+// escapes the gate just as thoroughly from docs/guides/ as from docs/, and a
+// check with a silent blind spot is worse than one whose reach is obvious.
 func lintedMarkdownFiles(repoRoot string) ([]string, error) {
 	files := append([]string(nil), LintedMarkdown...)
 
-	entries, err := os.ReadDir(filepath.Join(repoRoot, "docs"))
-	switch {
-	case os.IsNotExist(err):
-	case err != nil:
-		return nil, fmt.Errorf("reading docs/: %w", err)
-	default:
-		for _, e := range entries {
-			if !e.IsDir() && strings.HasSuffix(e.Name(), ".md") {
-				files = append(files, "docs/"+e.Name())
-			}
+	docsRoot := filepath.Join(repoRoot, "docs")
+	err := filepath.WalkDir(docsRoot, func(path string, d fs.DirEntry, walkErr error) error {
+		switch {
+		case walkErr != nil:
+			return walkErr
+		case d.IsDir(), !strings.HasSuffix(d.Name(), ".md"):
+			return nil
 		}
+		rel, relErr := filepath.Rel(repoRoot, path)
+		if relErr != nil {
+			return relErr
+		}
+		files = append(files, filepath.ToSlash(rel))
+		return nil
+	})
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return nil, fmt.Errorf("walking docs/: %w", err)
 	}
 
 	sort.Strings(files)

--- a/internal/clisurface/artifacts.go
+++ b/internal/clisurface/artifacts.go
@@ -1,0 +1,300 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clisurface
+
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Repo-relative paths of the generated artifacts and of the documents the
+// linter reads. Keeping them here means the gate test, the Makefile target and
+// the CI workflow all talk about the same files.
+const (
+	JSONPath     = "docs/cli-surface.json"
+	MarkdownPath = "docs/CLI.md"
+	READMEPath   = "README.md"
+)
+
+// RegenerateCommand is the single documented way to refresh every artifact.
+const RegenerateCommand = "make cli-docs"
+
+// LintedMarkdown are the hand-written documents whose examples and prose are
+// checked against the surface, in addition to every file under docs/.
+var LintedMarkdown = []string{READMEPath, "CONTRIBUTING.md"}
+
+// LintedGoDirs are the trees whose Go comments are checked against the surface.
+var LintedGoDirs = []string{"cmd", "pkg"}
+
+// FindRepoRoot walks up from start until it finds the directory holding go.mod.
+// The gate runs as a test, whose working directory is the package directory, so
+// it needs the repository root to read and write repo-relative artifacts.
+func FindRepoRoot(start string) (string, error) {
+	dir, err := filepath.Abs(start)
+	if err != nil {
+		return "", fmt.Errorf("resolving %s: %w", start, err)
+	}
+	for {
+		if _, statErr := os.Stat(filepath.Join(dir, "go.mod")); statErr == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("no go.mod found in %s or any parent directory", start)
+		}
+		dir = parent
+	}
+}
+
+// Artifact is one generated file and the content it must have.
+type Artifact struct {
+	// Path is repo-relative.
+	Path string
+	// Content is the full file content the surface renders to. For README.md
+	// it is the on-disk file with the generated regions replaced.
+	Content []byte
+}
+
+// GeneratedPaths lists the artifacts in a stable order, for failure messages.
+func GeneratedPaths() []string {
+	return []string{JSONPath, MarkdownPath, READMEPath}
+}
+
+// Artifacts renders every generated artifact for s. README.md is spliced from
+// its current on-disk content, so the hand-written parts of it are preserved.
+func Artifacts(repoRoot string, s Surface) ([]Artifact, error) {
+	jsonBytes, err := RenderJSON(s)
+	if err != nil {
+		return nil, err
+	}
+
+	readmePath := filepath.Join(repoRoot, READMEPath)
+	readme, err := os.ReadFile(readmePath)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", READMEPath, err)
+	}
+	spliced := string(readme)
+	for _, region := range RenderRegions(s) {
+		spliced, err = Splice(spliced, region.Name, region.Body)
+		if err != nil {
+			return nil, fmt.Errorf("splicing region %q into %s: %w", region.Name, READMEPath, err)
+		}
+	}
+
+	return []Artifact{
+		{Path: JSONPath, Content: jsonBytes},
+		{Path: MarkdownPath, Content: RenderMarkdown(s)},
+		{Path: READMEPath, Content: []byte(spliced)},
+	}, nil
+}
+
+// Write writes every generated artifact. This is the -update path; the drift
+// gate itself must never call it.
+func Write(repoRoot string, s Surface) error {
+	artifacts, err := Artifacts(repoRoot, s)
+	if err != nil {
+		return err
+	}
+	for i := range artifacts {
+		path := filepath.Join(repoRoot, artifacts[i].Path)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return fmt.Errorf("creating directory for %s: %w", artifacts[i].Path, err)
+		}
+		if err := os.WriteFile(path, artifacts[i].Content, 0o644); err != nil {
+			return fmt.Errorf("writing %s: %w", artifacts[i].Path, err)
+		}
+	}
+	return nil
+}
+
+// Staleness is a generated artifact whose committed content no longer matches
+// what the surface renders.
+type Staleness struct {
+	// Path is the repo-relative artifact.
+	Path string
+	// Detail says how it differs, naming the first differing line.
+	Detail string
+}
+
+// String renders the staleness as one actionable line.
+func (s Staleness) String() string {
+	return fmt.Sprintf("%s is stale: %s. Regenerate it with '%s'", s.Path, s.Detail, RegenerateCommand)
+}
+
+// CheckArtifacts compares the committed artifacts against what the surface
+// renders, without writing anything.
+func CheckArtifacts(repoRoot string, s Surface) ([]Staleness, error) {
+	artifacts, err := Artifacts(repoRoot, s)
+	if err != nil {
+		return nil, err
+	}
+
+	var stale []Staleness
+	for i := range artifacts {
+		path := filepath.Join(repoRoot, artifacts[i].Path)
+		onDisk, readErr := os.ReadFile(path)
+		if readErr != nil {
+			stale = append(stale, Staleness{Path: artifacts[i].Path, Detail: "cannot be read (" + readErr.Error() + ")"})
+			continue
+		}
+		if bytes.Equal(onDisk, artifacts[i].Content) {
+			continue
+		}
+		stale = append(stale, Staleness{
+			Path:   artifacts[i].Path,
+			Detail: firstDifference(onDisk, artifacts[i].Content),
+		})
+	}
+	return stale, nil
+}
+
+// firstDifference describes the first line where committed and generated
+// content diverge.
+func firstDifference(committed, generated []byte) string {
+	got := strings.Split(string(committed), "\n")
+	want := strings.Split(string(generated), "\n")
+	for i := 0; i < len(got) && i < len(want); i++ {
+		if got[i] == want[i] {
+			continue
+		}
+		return fmt.Sprintf("line %d is %q, generated content has %q", i+1, got[i], want[i])
+	}
+	return fmt.Sprintf("committed content has %d lines, generated content has %d", len(got), len(want))
+}
+
+// LoadAllowlist reads the deliberate-mention allowlist. A missing file is an
+// empty allowlist, not an error.
+func LoadAllowlist(repoRoot string) (Allowlist, error) {
+	content, err := os.ReadFile(filepath.Join(repoRoot, AllowlistPath))
+	switch {
+	case os.IsNotExist(err):
+		return ParseAllowlist("")
+	case err != nil:
+		return Allowlist{}, fmt.Errorf("reading %s: %w", AllowlistPath, err)
+	}
+	return ParseAllowlist(string(content))
+}
+
+// LintRepo checks every documented CLI reference in the repository against the
+// surface: shell examples and prose in the markdown documents, and flag names
+// in Go comments under cmd/ and pkg/. Issues come back sorted by file and line.
+func LintRepo(repoRoot string, s Surface, allow Allowlist) ([]Issue, error) {
+	var issues []Issue
+
+	docs, err := lintedMarkdownFiles(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	for _, rel := range docs {
+		content, readErr := os.ReadFile(filepath.Join(repoRoot, rel))
+		if readErr != nil {
+			return nil, fmt.Errorf("reading %s: %w", rel, readErr)
+		}
+		issues = append(issues, LintMarkdown(s, rel, string(content), allow)...)
+	}
+
+	goFiles, err := lintedGoFiles(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	for _, rel := range goFiles {
+		src, readErr := os.ReadFile(filepath.Join(repoRoot, rel))
+		if readErr != nil {
+			return nil, fmt.Errorf("reading %s: %w", rel, readErr)
+		}
+		found, lintErr := LintGoComments(s, rel, src, allow)
+		if lintErr != nil {
+			return nil, lintErr
+		}
+		issues = append(issues, found...)
+	}
+
+	sort.SliceStable(issues, func(i, j int) bool {
+		if issues[i].File != issues[j].File {
+			return issues[i].File < issues[j].File
+		}
+		if issues[i].Line != issues[j].Line {
+			return issues[i].Line < issues[j].Line
+		}
+		return issues[i].Token < issues[j].Token
+	})
+	return issues, nil
+}
+
+// lintedMarkdownFiles lists the markdown documents to check, sorted.
+func lintedMarkdownFiles(repoRoot string) ([]string, error) {
+	files := append([]string(nil), LintedMarkdown...)
+
+	entries, err := os.ReadDir(filepath.Join(repoRoot, "docs"))
+	switch {
+	case os.IsNotExist(err):
+	case err != nil:
+		return nil, fmt.Errorf("reading docs/: %w", err)
+	default:
+		for _, e := range entries {
+			if !e.IsDir() && strings.HasSuffix(e.Name(), ".md") {
+				files = append(files, "docs/"+e.Name())
+			}
+		}
+	}
+
+	sort.Strings(files)
+	return files, nil
+}
+
+// lintedGoFiles lists the Go files whose comments to check, sorted.
+func lintedGoFiles(repoRoot string) ([]string, error) {
+	var files []string
+	for _, dir := range LintedGoDirs {
+		root := filepath.Join(repoRoot, dir)
+		if _, statErr := os.Stat(root); os.IsNotExist(statErr) {
+			continue
+		}
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			switch {
+			case err != nil:
+				return err
+			case d.IsDir(), !strings.HasSuffix(d.Name(), ".go"):
+				return nil
+			}
+			rel, relErr := filepath.Rel(repoRoot, path)
+			if relErr != nil {
+				return relErr
+			}
+			files = append(files, filepath.ToSlash(rel))
+			return nil
+		})
+		if err != nil {
+			return nil, fmt.Errorf("walking %s: %w", dir, err)
+		}
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+// LintReport renders lint issues as a failure message.
+func LintReport(issues []Issue) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "documentation references %d CLI flag(s) or subcommand(s) that do not exist:\n\n", len(issues))
+	for i := range issues {
+		fmt.Fprintf(&b, "  %d. %s\n", i+1, issues[i].String())
+	}
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/internal/clisurface/artifacts_test.go
+++ b/internal/clisurface/artifacts_test.go
@@ -269,3 +269,73 @@ func readAll(t *testing.T, root string) map[string]string {
 	}
 	return out
 }
+
+// TestLintRepoWalksNestedDocsDirectories pins the recursive docs/ walk. A
+// document in docs/guides/ names removed flags exactly as effectively as one in
+// docs/, and a check with a silent blind spot is worse than one whose reach is
+// obvious.
+func TestLintRepoWalksNestedDocsDirectories(t *testing.T) {
+	root := newFakeRepo(t)
+	s := Walk(newTestTree())
+	require.NoError(t, Write(root, s))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "CONTRIBUTING.md"), []byte("hi\n"), 0o644))
+
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "docs", "guides", "deep"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "docs", "guides", "nested.md"),
+		[]byte("```bash\ntool scan --nested-gone\n```\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "docs", "guides", "deep", "deeper.md"),
+		[]byte("```bash\ntool scan --deeper-gone\n```\n"), 0o644))
+
+	issues, err := LintRepo(root, s, emptyAllowlist(t))
+	require.NoError(t, err)
+
+	require.Len(t, issues, 2, "both nested documents must be reached")
+	assert.Equal(t, "docs/guides/deep/deeper.md", issues[0].File)
+	assert.Equal(t, "--deeper-gone", issues[0].Token)
+	assert.Equal(t, "docs/guides/nested.md", issues[1].File)
+	assert.Equal(t, "--nested-gone", issues[1].Token)
+}
+
+// TestCheckArtifactsToleratesCRLF checks that a checkout's line-ending
+// convention cannot look like documentation drift. The repository carries no
+// .gitattributes, so a contributor with core.autocrlf=true has CRLF on disk
+// while the renderers emit LF.
+func TestCheckArtifactsToleratesCRLF(t *testing.T) {
+	root := newFakeRepo(t)
+	s := Walk(newTestTree())
+	require.NoError(t, Write(root, s))
+
+	for _, rel := range GeneratedPaths() {
+		path := filepath.Join(root, rel)
+		content, err := os.ReadFile(path)
+		require.NoError(t, err)
+		crlf := strings.ReplaceAll(strings.ReplaceAll(string(content), "\r\n", "\n"), "\n", "\r\n")
+		require.NoError(t, os.WriteFile(path, []byte(crlf), 0o644))
+	}
+
+	stale, err := CheckArtifacts(root, s)
+	require.NoError(t, err)
+	assert.Empty(t, stale, "CRLF line endings are not drift")
+}
+
+// TestCheckArtifactsStillCatchesRealDriftInACRLFCheckout guards the tolerance
+// above from swallowing a genuine difference.
+func TestCheckArtifactsStillCatchesRealDriftInACRLFCheckout(t *testing.T) {
+	root := newFakeRepo(t)
+	s := Walk(newTestTree())
+	require.NoError(t, Write(root, s))
+
+	path := filepath.Join(root, MarkdownPath)
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	edited := strings.ReplaceAll(string(content), "--timeout", "--timeuot")
+	require.NotEqual(t, string(content), edited, "the fixture must actually change")
+	require.NoError(t, os.WriteFile(path, []byte(strings.ReplaceAll(edited, "\n", "\r\n")), 0o644))
+
+	stale, err := CheckArtifacts(root, s)
+	require.NoError(t, err)
+
+	require.Len(t, stale, 1)
+	assert.Equal(t, MarkdownPath, stale[0].Path)
+	assert.NotContains(t, stale[0].Detail, `\r`, "the reported line must not be noisy with carriage returns")
+}

--- a/internal/clisurface/artifacts_test.go
+++ b/internal/clisurface/artifacts_test.go
@@ -1,0 +1,271 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clisurface
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newFakeRepo lays out a temporary repository with a README carrying both
+// generated regions, and returns its root.
+func newFakeRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "docs"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, READMEPath), []byte(strings.Join([]string{
+		"# tool",
+		"",
+		"## Quick Start",
+		"",
+		BeginMarker(RegionSubcommands),
+		"stale listing",
+		EndMarker(RegionSubcommands),
+		"",
+		BeginMarker(RegionAliases),
+		"stale aliases",
+		EndMarker(RegionAliases),
+		"",
+		"hand-written tail",
+		"",
+	}, "\n")), 0o644))
+	return root
+}
+
+func TestArtifactsRendersEveryGeneratedFile(t *testing.T) {
+	root := newFakeRepo(t)
+	s := Walk(newTestTree())
+
+	artifacts, err := Artifacts(root, s)
+	require.NoError(t, err)
+
+	require.Len(t, artifacts, 3)
+	assert.Equal(t, []string{JSONPath, MarkdownPath, READMEPath}, []string{
+		artifacts[0].Path, artifacts[1].Path, artifacts[2].Path,
+	}, "artifacts come back in a stable order")
+	assert.Equal(t, GeneratedPaths(), []string{artifacts[0].Path, artifacts[1].Path, artifacts[2].Path})
+
+	readme := string(artifacts[2].Content)
+	assert.Contains(t, readme, "hand-written tail", "the hand-written parts of README.md survive")
+	assert.NotContains(t, readme, "stale listing", "the generated region is replaced")
+	assert.Contains(t, readme, "into these focused subcommands")
+	assert.Contains(t, readme, "| `scan` | `sc`, `scanner` |")
+}
+
+func TestArtifactsFailsLoudlyWhenTheREADMEHasNoRegionMarkers(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, READMEPath), []byte("# tool\n"), 0o644))
+
+	_, err := Artifacts(root, Walk(newTestTree()))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "splicing region \"cli-subcommands\" into README.md")
+}
+
+func TestArtifactsFailsWhenTheREADMEIsMissing(t *testing.T) {
+	_, err := Artifacts(t.TempDir(), Walk(newTestTree()))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading README.md")
+}
+
+func TestWriteThenCheckIsClean(t *testing.T) {
+	root := newFakeRepo(t)
+	s := Walk(newTestTree())
+
+	require.NoError(t, Write(root, s))
+
+	stale, err := CheckArtifacts(root, s)
+	require.NoError(t, err)
+	assert.Empty(t, stale, "freshly written artifacts are not stale")
+
+	for _, rel := range GeneratedPaths() {
+		_, statErr := os.Stat(filepath.Join(root, rel))
+		require.NoError(t, statErr, "%s must exist on disk", rel)
+	}
+}
+
+func TestWriteIsIdempotent(t *testing.T) {
+	root := newFakeRepo(t)
+	s := Walk(newTestTree())
+
+	require.NoError(t, Write(root, s))
+	first := readAll(t, root)
+	require.NoError(t, Write(root, s))
+	second := readAll(t, root)
+
+	assert.Equal(t, first, second, "regenerating twice must produce byte-identical files")
+}
+
+func TestCheckArtifactsNamesTheStaleFileAndTheFirstDifference(t *testing.T) {
+	root := newFakeRepo(t)
+	s := Walk(newTestTree())
+	require.NoError(t, Write(root, s))
+
+	// Hand-edit the generated reference, the way a well-meaning contributor would.
+	mdPath := filepath.Join(root, MarkdownPath)
+	content, err := os.ReadFile(mdPath)
+	require.NoError(t, err)
+	edited := strings.Replace(string(content), "# tool CLI reference", "# Tool CLI Reference", 1)
+	require.NoError(t, os.WriteFile(mdPath, []byte(edited), 0o644))
+
+	stale, err := CheckArtifacts(root, s)
+	require.NoError(t, err)
+
+	require.Len(t, stale, 1)
+	assert.Equal(t, MarkdownPath, stale[0].Path)
+	assert.Contains(t, stale[0].Detail, `line 3 is "# Tool CLI Reference", generated content has "# tool CLI reference"`)
+	assert.Contains(t, stale[0].String(), "docs/CLI.md is stale")
+	assert.Contains(t, stale[0].String(), "Regenerate it with 'make cli-docs'")
+}
+
+func TestCheckArtifactsReportsMissingFiles(t *testing.T) {
+	root := newFakeRepo(t)
+	s := Walk(newTestTree())
+
+	stale, err := CheckArtifacts(root, s)
+	require.NoError(t, err)
+
+	require.Len(t, stale, 3, "nothing has been generated yet: the JSON and markdown are missing and the README is stale")
+	assert.Equal(t, JSONPath, stale[0].Path)
+	assert.Contains(t, stale[0].Detail, "cannot be read")
+}
+
+func TestCheckArtifactsReportsATruncatedFile(t *testing.T) {
+	root := newFakeRepo(t)
+	s := Walk(newTestTree())
+	require.NoError(t, Write(root, s))
+
+	// A truncation that keeps every surviving line identical can only be
+	// described by the line counts.
+	full, err := os.ReadFile(filepath.Join(root, JSONPath))
+	require.NoError(t, err)
+	truncated := strings.Join(strings.Split(string(full), "\n")[:3], "\n")
+	require.NoError(t, os.WriteFile(filepath.Join(root, JSONPath), []byte(truncated), 0o644))
+
+	stale, err := CheckArtifacts(root, s)
+	require.NoError(t, err)
+
+	require.Len(t, stale, 1)
+	assert.Equal(t, JSONPath, stale[0].Path)
+	assert.Contains(t, stale[0].Detail, "committed content has 3 lines, generated content has")
+}
+
+func TestLintRepoChecksMarkdownAndGoComments(t *testing.T) {
+	root := newFakeRepo(t)
+	s := Walk(newTestTree())
+	require.NoError(t, Write(root, s))
+
+	require.NoError(t, os.WriteFile(filepath.Join(root, "CONTRIBUTING.md"),
+		[]byte("Run `tool scan --target host`.\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "docs", "guide.md"),
+		[]byte("```bash\ntool scan --removed-flag\n```\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "cmd", "tool"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "cmd", "tool", "main.go"),
+		[]byte("package main\n\n// handles the --gone-from-comments mode.\nfunc main() {}\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "pkg", "lib"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "pkg", "lib", "lib.go"),
+		[]byte("package lib\n\n// Uses --timeout, which still exists.\nconst A = 1\n"), 0o644))
+
+	issues, err := LintRepo(root, s, emptyAllowlist(t))
+	require.NoError(t, err)
+
+	require.Len(t, issues, 2)
+	assert.Equal(t, "cmd/tool/main.go", issues[0].File, "issues are sorted by file then line")
+	assert.Equal(t, "--gone-from-comments", issues[0].Token)
+	assert.Equal(t, "docs/guide.md", issues[1].File)
+	assert.Equal(t, "--removed-flag", issues[1].Token)
+}
+
+func TestLintRepoAcceptsTheDocumentsItJustGenerated(t *testing.T) {
+	root := newFakeRepo(t)
+	s := Walk(newTestTree())
+	require.NoError(t, Write(root, s))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "CONTRIBUTING.md"), []byte("Run `make cli-docs`.\n"), 0o644))
+
+	issues, err := LintRepo(root, s, emptyAllowlist(t))
+	require.NoError(t, err)
+	assert.Empty(t, issues,
+		"the generated reference and README regions must lint clean against the surface they came from")
+}
+
+func TestLintRepoSurvivesAMissingDocsDirectory(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, READMEPath), []byte("# tool\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "CONTRIBUTING.md"), []byte("hi\n"), 0o644))
+
+	issues, err := LintRepo(root, Walk(newTestTree()), emptyAllowlist(t))
+	require.NoError(t, err)
+	assert.Empty(t, issues)
+}
+
+func TestLintRepoFailsWhenAConfiguredDocumentIsMissing(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, READMEPath), []byte("# tool\n"), 0o644))
+
+	_, err := LintRepo(root, Walk(newTestTree()), emptyAllowlist(t))
+	require.Error(t, err, "a document the linter is configured to read must not be skipped silently")
+	assert.Contains(t, err.Error(), "reading CONTRIBUTING.md")
+}
+
+func TestLoadAllowlist(t *testing.T) {
+	root := t.TempDir()
+
+	allow, err := LoadAllowlist(root)
+	require.NoError(t, err, "a missing allowlist is an empty allowlist, not an error")
+	assert.Empty(t, allow.Entries())
+
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "docs"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, AllowlistPath),
+		[]byte("--old-name # renamed in v1.9, the migration note has to name it\n"), 0o644))
+
+	allow, err = LoadAllowlist(root)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"--old-name"}, allow.Entries())
+
+	require.NoError(t, os.WriteFile(filepath.Join(root, AllowlistPath), []byte("--no-reason\n"), 0o644))
+	_, err = LoadAllowlist(root)
+	require.Error(t, err, "an entry without a reason is a hard error")
+}
+
+func TestFindRepoRoot(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/tool\n"), 0o644))
+	nested := filepath.Join(root, "cmd", "tool")
+	require.NoError(t, os.MkdirAll(nested, 0o755))
+
+	found, err := FindRepoRoot(nested)
+	require.NoError(t, err)
+	assert.Equal(t, root, found, "the root is the nearest ancestor holding go.mod")
+
+	_, err = FindRepoRoot(filepath.Join(t.TempDir(), "nowhere"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no go.mod found")
+}
+
+// readAll reads every generated artifact into a map keyed by repo-relative path.
+func readAll(t *testing.T, root string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	for _, rel := range GeneratedPaths() {
+		content, err := os.ReadFile(filepath.Join(root, rel))
+		require.NoError(t, err)
+		out[rel] = string(content)
+	}
+	return out
+}

--- a/internal/clisurface/diff.go
+++ b/internal/clisurface/diff.go
@@ -1,0 +1,187 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clisurface
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// FindingKind classifies a single disagreement between the documented surface
+// and the surface cobra actually registers.
+type FindingKind string
+
+const (
+	// CommandUndocumented: cobra registers a command the docs do not describe.
+	CommandUndocumented FindingKind = "command-undocumented"
+	// CommandRemoved: the docs describe a command cobra no longer registers.
+	CommandRemoved FindingKind = "command-removed"
+	// CommandChanged: a documented command's metadata drifted.
+	CommandChanged FindingKind = "command-changed"
+	// FlagUndocumented: cobra registers a flag the docs do not describe.
+	FlagUndocumented FindingKind = "flag-undocumented"
+	// FlagRemoved: the docs describe a flag cobra no longer accepts.
+	FlagRemoved FindingKind = "flag-removed"
+	// FlagChanged: a documented flag's metadata drifted.
+	FlagChanged FindingKind = "flag-changed"
+)
+
+// Finding is one actionable disagreement. It always names the command, names
+// the flag when the disagreement is about a flag, and says what changed.
+type Finding struct {
+	Kind FindingKind
+	// Command is the full command path, e.g. "brutus logon".
+	Command string
+	// Flag is the long flag name without dashes, empty for command findings.
+	Flag string
+	// Field is the metadata field that drifted, empty for add/remove findings.
+	Field string
+	// Documented is the value in the committed docs.
+	Documented string
+	// Registered is the value cobra registers.
+	Registered string
+}
+
+// String renders the finding as one actionable line.
+func (f Finding) String() string {
+	subject := strconv.Quote(f.Command)
+	if f.Flag != "" {
+		subject = "flag --" + f.Flag + " on " + strconv.Quote(f.Command)
+	}
+	switch f.Kind {
+	case CommandUndocumented:
+		return "command " + subject + " is registered by cobra but missing from the generated docs"
+	case CommandRemoved:
+		return "command " + subject + " is in the generated docs but cobra no longer registers it"
+	case FlagUndocumented:
+		return subject + " is registered by cobra but missing from the generated docs"
+	case FlagRemoved:
+		return subject + " is in the generated docs but cobra no longer accepts it"
+	case CommandChanged, FlagChanged:
+		return subject + ": " + f.Field + " changed from " + strconv.Quote(f.Documented) +
+			" (docs) to " + strconv.Quote(f.Registered) + " (cobra)"
+	default:
+		return string(f.Kind) + ": " + subject
+	}
+}
+
+// Diff compares the documented surface against the surface cobra registers and
+// returns one finding per disagreement, ordered by command path then flag name.
+// It is deliberately not a text diff: every finding names what changed so the
+// failure explains itself without the reader diffing two files by eye.
+func Diff(documented, registered Surface) []Finding {
+	var findings []Finding
+
+	for i := range registered.Commands {
+		live := &registered.Commands[i]
+		doc, ok := documented.Command(live.Path)
+		if !ok {
+			findings = append(findings, Finding{Kind: CommandUndocumented, Command: live.Path})
+			continue
+		}
+		findings = append(findings, diffCommand(doc, live)...)
+	}
+
+	for i := range documented.Commands {
+		doc := &documented.Commands[i]
+		if _, ok := registered.Command(doc.Path); !ok {
+			findings = append(findings, Finding{Kind: CommandRemoved, Command: doc.Path})
+		}
+	}
+
+	sort.SliceStable(findings, func(i, j int) bool {
+		if findings[i].Command != findings[j].Command {
+			return findings[i].Command < findings[j].Command
+		}
+		return findings[i].Flag < findings[j].Flag
+	})
+	return findings
+}
+
+// diffCommand compares one command's metadata and flag set.
+func diffCommand(doc, live *Command) []Finding {
+	var findings []Finding
+
+	changed := func(field, documented, registered string) {
+		if documented != registered {
+			findings = append(findings, Finding{
+				Kind: CommandChanged, Command: live.Path, Field: field,
+				Documented: documented, Registered: registered,
+			})
+		}
+	}
+	changed("use", doc.Use, live.Use)
+	changed("short description", doc.Short, live.Short)
+	changed("aliases", strings.Join(doc.Aliases, ","), strings.Join(live.Aliases, ","))
+	changed("hidden", strconv.FormatBool(doc.Hidden), strconv.FormatBool(live.Hidden))
+	changed("deprecation notice", doc.Deprecated, live.Deprecated)
+	changed("runnable", strconv.FormatBool(doc.Runnable), strconv.FormatBool(live.Runnable))
+	changed("example", doc.Example, live.Example)
+
+	for i := range live.Flags {
+		lf := &live.Flags[i]
+		df, ok := doc.Flag(lf.Name)
+		if !ok {
+			findings = append(findings, Finding{Kind: FlagUndocumented, Command: live.Path, Flag: lf.Name})
+			continue
+		}
+		findings = append(findings, diffFlag(live.Path, df, lf)...)
+	}
+	for i := range doc.Flags {
+		df := &doc.Flags[i]
+		if _, ok := live.Flag(df.Name); !ok {
+			findings = append(findings, Finding{Kind: FlagRemoved, Command: live.Path, Flag: df.Name})
+		}
+	}
+	return findings
+}
+
+// diffFlag compares one flag's metadata on one command.
+func diffFlag(path string, doc, live *Flag) []Finding {
+	var findings []Finding
+	changed := func(field, documented, registered string) {
+		if documented != registered {
+			findings = append(findings, Finding{
+				Kind: FlagChanged, Command: path, Flag: live.Name, Field: field,
+				Documented: documented, Registered: registered,
+			})
+		}
+	}
+	changed("shorthand", doc.Shorthand, live.Shorthand)
+	changed("type", doc.Type, live.Type)
+	changed("default", doc.Default, live.Default)
+	changed("usage", doc.Usage, live.Usage)
+	changed("deprecation notice", doc.Deprecated, live.Deprecated)
+	changed("inherited", strconv.FormatBool(doc.Inherited), strconv.FormatBool(live.Inherited))
+	changed("hidden", strconv.FormatBool(doc.Hidden), strconv.FormatBool(live.Hidden))
+	changed("rejected by the command", strconv.FormatBool(doc.Rejected), strconv.FormatBool(live.Rejected))
+	changed("rejection reason", doc.RejectedReason, live.RejectedReason)
+	return findings
+}
+
+// Report renders findings as a failure message that says what drifted, which
+// files carry the stale copy, and the one command that fixes them.
+func Report(findings []Finding, artifacts []string, regenerate string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "CLI surface drift: %d disagreement(s) between the generated documentation and the cobra command tree.\n\n",
+		len(findings))
+	for i := range findings {
+		fmt.Fprintf(&b, "  %d. %s\n", i+1, findings[i].String())
+		fmt.Fprintf(&b, "     fix: regenerate %s with '%s'\n", strings.Join(artifacts, ", "), regenerate)
+	}
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/internal/clisurface/diff_test.go
+++ b/internal/clisurface/diff_test.go
@@ -1,0 +1,195 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clisurface
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiffOfIdenticalSurfacesIsEmpty(t *testing.T) {
+	assert.Empty(t, Diff(Walk(newTestTree()), Walk(newTestTree())))
+}
+
+func TestDiffReportsARenamedFlagAsOneRemovalAndOneAddition(t *testing.T) {
+	documented := Walk(newTestTree())
+
+	tree := newTestTree()
+	scan, _, err := tree.Find([]string{"scan"})
+	require.NoError(t, err)
+	// What a deliberate rename looks like in source: the old flag is gone and
+	// an otherwise identical flag is registered under the new name.
+	scan.ResetFlags()
+	scan.Flags().StringP("host", "t", "", "target host:port")
+	registered := Walk(tree)
+
+	findings := Diff(documented, registered)
+
+	require.Len(t, findings, 2, "a rename is exactly one undocumented flag and one removed flag")
+	assert.Equal(t, FlagUndocumented, findings[0].Kind)
+	assert.Equal(t, "host", findings[0].Flag)
+	assert.Equal(t, "tool scan", findings[0].Command)
+	assert.Equal(t, FlagRemoved, findings[1].Kind)
+	assert.Equal(t, "target", findings[1].Flag)
+	assert.Contains(t, findings[0].String(), `flag --host on "tool scan" is registered by cobra but missing from the generated docs`)
+	assert.Contains(t, findings[1].String(), `flag --target on "tool scan" is in the generated docs but cobra no longer accepts it`)
+}
+
+func TestDiffReportsAddedAndRemovedCommands(t *testing.T) {
+	documented := Walk(newTestTree())
+
+	tree := newTestTree()
+	tree.AddCommand(&cobra.Command{Use: "brand-new", Short: "new thing", RunE: func(*cobra.Command, []string) error { return nil }})
+	scan, _, err := tree.Find([]string{"scan"})
+	require.NoError(t, err)
+	tree.RemoveCommand(scan)
+
+	findings := Diff(documented, Walk(tree))
+
+	require.Len(t, findings, 2)
+	assert.Equal(t, CommandUndocumented, findings[0].Kind)
+	assert.Equal(t, "tool brand-new", findings[0].Command)
+	assert.Equal(t, CommandRemoved, findings[1].Kind)
+	assert.Equal(t, "tool scan", findings[1].Command)
+	assert.Contains(t, findings[1].String(), `command "tool scan" is in the generated docs but cobra no longer registers it`)
+}
+
+func TestDiffReportsEveryDriftedField(t *testing.T) {
+	tests := []struct {
+		name       string
+		mutate     func(c *Command)
+		wantField  string
+		wantKind   FindingKind
+		wantDetail string
+	}{
+		{
+			name:      "short description",
+			mutate:    func(c *Command) { c.Short = "reworded" },
+			wantField: "short description",
+			wantKind:  CommandChanged,
+		},
+		{
+			name:      "aliases",
+			mutate:    func(c *Command) { c.Aliases = []string{"sc"} },
+			wantField: "aliases",
+			wantKind:  CommandChanged,
+		},
+		{
+			name:      "hidden",
+			mutate:    func(c *Command) { c.Hidden = true },
+			wantField: "hidden",
+			wantKind:  CommandChanged,
+		},
+		{
+			name:      "example",
+			mutate:    func(c *Command) { c.Example = "different" },
+			wantField: "example",
+			wantKind:  CommandChanged,
+		},
+		{
+			name:      "flag shorthand",
+			mutate:    func(c *Command) { c.Flags[1].Shorthand = "T" },
+			wantField: "shorthand",
+			wantKind:  FlagChanged,
+		},
+		{
+			name:      "flag default",
+			mutate:    func(c *Command) { c.Flags[1].Default = "changed" },
+			wantField: "default",
+			wantKind:  FlagChanged,
+		},
+		{
+			name:      "flag usability",
+			mutate:    func(c *Command) { c.Flags[1].Rejected = true },
+			wantField: "rejected by the command",
+			wantKind:  FlagChanged,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			documented := Walk(newTestTree())
+			registered := Walk(newTestTree())
+			cmd, ok := registered.Command("tool scan")
+			require.True(t, ok)
+			require.Equal(t, "target", cmd.Flags[1].Name, "the fixture's second flag is --target")
+			tt.mutate(cmd)
+
+			findings := Diff(documented, registered)
+
+			require.Len(t, findings, 1)
+			assert.Equal(t, tt.wantKind, findings[0].Kind)
+			assert.Equal(t, tt.wantField, findings[0].Field)
+			assert.Equal(t, "tool scan", findings[0].Command)
+			assert.Contains(t, findings[0].String(), tt.wantField+" changed from")
+		})
+	}
+}
+
+func TestDiffDetectsARejectionGuardBeingRemoved(t *testing.T) {
+	documented := Walk(newTestTree())
+
+	tree := newTestTree()
+	guarded, _, err := tree.Find([]string{"guarded"})
+	require.NoError(t, err)
+	guarded.PreRunE = nil // the guard is deleted
+
+	findings := Diff(documented, Walk(tree))
+
+	require.NotEmpty(t, findings, "dropping the guard changes what the CLI accepts, so it must redden the gate")
+	assert.Equal(t, "timeout", findings[0].Flag)
+	assert.Equal(t, "tool guarded", findings[0].Command)
+	assert.Contains(t, findings[0].String(), "rejected by the command changed from \"true\" (docs) to \"false\" (cobra)")
+}
+
+func TestDiffOrdersFindingsByCommandThenFlag(t *testing.T) {
+	documented := Walk(newTestTree())
+	registered := Walk(newTestTree())
+
+	scan, ok := registered.Command("tool scan")
+	require.True(t, ok)
+	scan.Flags[2].Default = "changed"
+	scan.Flags[0].Default = "changed"
+	guarded, ok := registered.Command("tool guarded")
+	require.True(t, ok)
+	guarded.Flags[0].Default = "changed"
+
+	findings := Diff(documented, registered)
+
+	require.Len(t, findings, 3)
+	assert.Equal(t, "tool guarded", findings[0].Command)
+	assert.Equal(t, "tool scan", findings[1].Command)
+	assert.Equal(t, "json", findings[1].Flag)
+	assert.Equal(t, "timeout", findings[2].Flag)
+}
+
+func TestReportNamesTheFilesAndTheRegenerationCommand(t *testing.T) {
+	findings := []Finding{
+		{Kind: FlagRemoved, Command: "brutus logon", Flag: "sticky-keys-exec"},
+	}
+
+	report := Report(findings, GeneratedPaths(), RegenerateCommand)
+
+	assert.Contains(t, report, "CLI surface drift: 1 disagreement(s)")
+	assert.Contains(t, report, "1. flag --sticky-keys-exec on \"brutus logon\"")
+	assert.Contains(t, report, "fix: regenerate docs/cli-surface.json, docs/CLI.md, README.md with 'make cli-docs'")
+}
+
+func TestFindingStringForAnUnknownKind(t *testing.T) {
+	assert.Equal(t, `something-else: "brutus"`, Finding{Kind: "something-else", Command: "brutus"}.String())
+}

--- a/internal/clisurface/lint.go
+++ b/internal/clisurface/lint.go
@@ -44,7 +44,10 @@ type Issue struct {
 	File string
 	// Line is the 1-based line the reference appears on.
 	Line int
-	// Token is the offending token exactly as written, e.g. "--sticky-keys-exec".
+	// Token is the offending token exactly as written, dashes included. No
+	// example of a removed flag is given here: this package's own comments are
+	// linted, and allowlisting a real removed flag to quote it would suppress
+	// that name everywhere, including in the README the gate exists to police.
 	Token string
 	// Command is the command the token was checked against, empty when the
 	// token was checked against the whole surface (prose and Go comments).
@@ -107,7 +110,7 @@ type Allowlist struct {
 }
 
 // ParseAllowlist reads an allowlist file. Every entry is one token
-// ("--flag" or "-x") followed by a '#' comment giving the reason; blank lines
+// ("--<flag>" or "-<x>") followed by a '#' comment giving the reason; blank lines
 // and whole-line comments are ignored. The reason is mandatory: an entry
 // without one is an error, because an unexplained exception is how a stale
 // reference survives forever.
@@ -344,7 +347,8 @@ func lintInvocation(s Surface, file string, line int, argv []string, allow Allow
 	return issues
 }
 
-// checkLongFlag validates a "--name" or "--name=value" token against cmd. The
+// checkLongFlag validates a "--<name>" or "--<name>=<value>" token against cmd.
+// The
 // second return reports whether next is this flag's value and so must not be
 // read as a flag or a subcommand.
 func checkLongFlag(s Surface, cmd *Command, file string, line int, arg, next string, allow Allowlist) ([]Issue, bool) {
@@ -361,7 +365,7 @@ func checkLongFlag(s Surface, cmd *Command, file string, line int, arg, next str
 	}
 
 	flag, known := cmd.Flag(name)
-	// A "--name=value" token carries its own value. Otherwise any non-boolean
+	// A "--<name>=<value>" token carries its own value. Otherwise any non-boolean
 	// flag takes the next argument. An unknown flag is reported below, and its
 	// value is guessed from shape — anything that does not itself look like a
 	// flag — so that one unknown flag does not also get its value reported as a
@@ -623,7 +627,7 @@ func contains(list []string, want string) bool {
 	return false
 }
 
-// nearest returns the closest candidate to name as a "--flag" string, or "" if
+// nearest returns the closest candidate to name as a "--<flag>" string, or "" if
 // nothing is close enough to be a useful suggestion.
 func nearest(name string, candidates []string) string {
 	best, bestDistance := "", 0

--- a/internal/clisurface/lint.go
+++ b/internal/clisurface/lint.go
@@ -1,0 +1,585 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clisurface
+
+import (
+	"fmt"
+	"go/parser"
+	"go/token"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// AllowlistPath is the repo-relative file listing flag names documentation may
+// mention even though the CLI does not (or no longer does) accept them.
+const AllowlistPath = "docs/cli-surface-allow.txt"
+
+// longFlagPattern matches a long flag token in prose or in a Go comment.
+// Group 2 is the token. The leading group requires the dashes to start a word,
+// so neither "// -----" rule comments, nor "--" used as a dash-dash separator,
+// nor "dash--dash" inside a word can look like a flag.
+var longFlagPattern = regexp.MustCompile(`(^|[^A-Za-z0-9_])(--[a-zA-Z0-9][a-zA-Z0-9._-]*)`)
+
+// backtickPattern matches an inline code span on a single line.
+var backtickPattern = regexp.MustCompile("`[^`\n]+`")
+
+// Issue is one documentation reference to a flag or subcommand that the CLI
+// does not accept.
+type Issue struct {
+	// File is the repo-relative file the reference appears in.
+	File string
+	// Line is the 1-based line the reference appears on.
+	Line int
+	// Token is the offending token exactly as written, e.g. "--sticky-keys-exec".
+	Token string
+	// Command is the command the token was checked against, empty when the
+	// token was checked against the whole surface (prose and Go comments).
+	Command string
+	// Reason says what is wrong.
+	Reason string
+	// Suggestion is the nearest real flag, empty when nothing is close.
+	Suggestion string
+}
+
+// String renders the issue as one actionable line.
+func (i Issue) String() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s:%d: %s %s", i.File, i.Line, i.Token, i.Reason)
+	if i.Command != "" {
+		// Every command-scoped reason ends in a preposition, so the command
+		// reads as part of the sentence: `--exec is not a flag of "brutus logon"`.
+		fmt.Fprintf(&b, " %s", strconv.Quote(i.Command))
+	}
+	if i.Suggestion != "" {
+		fmt.Fprintf(&b, "; nearest real flag: %s", i.Suggestion)
+	}
+	// An issue inside a generated file is a symptom of a stale artifact, not
+	// something to hand-edit or allowlist: say so, or the reader "fixes" a file
+	// the next regeneration overwrites.
+	if whollyGenerated(i.File) {
+		fmt.Fprintf(&b, ". %s is generated: regenerate it with '%s' rather than editing it",
+			i.File, RegenerateCommand)
+		return b.String()
+	}
+	fmt.Fprintf(&b, ". Fix the documentation, or add %s to %s with a '#' reason if the mention is deliberate",
+		i.Token, AllowlistPath)
+	return b.String()
+}
+
+// whollyGenerated reports whether every line of path is generated, and so must
+// never be hand-edited. README.md is deliberately excluded: only two regions of
+// it are generated, so a lint hit there is normally in hand-written prose.
+func whollyGenerated(path string) bool {
+	return path == JSONPath || path == MarkdownPath
+}
+
+// Allowlist holds deliberately documented tokens and why each is allowed.
+type Allowlist struct {
+	reasons map[string]string
+}
+
+// ParseAllowlist reads an allowlist file. Every entry is one token
+// ("--flag" or "-x") followed by a '#' comment giving the reason; blank lines
+// and whole-line comments are ignored. The reason is mandatory: an entry
+// without one is an error, because an unexplained exception is how a stale
+// reference survives forever.
+func ParseAllowlist(content string) (Allowlist, error) {
+	out := Allowlist{reasons: map[string]string{}}
+	for i, raw := range strings.Split(content, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		entry, reason, found := strings.Cut(line, "#")
+		entry = strings.TrimSpace(entry)
+		reason = strings.TrimSpace(reason)
+		switch {
+		case !strings.HasPrefix(entry, "-"):
+			return Allowlist{}, fmt.Errorf("%s:%d: entry %q must start with '-'", AllowlistPath, i+1, entry)
+		case !found || reason == "":
+			return Allowlist{}, fmt.Errorf("%s:%d: entry %q needs a '# reason' explaining why it is allowed", AllowlistPath, i+1, entry)
+		}
+		out.reasons[entry] = reason
+	}
+	return out, nil
+}
+
+// Allows reports whether the token is allowlisted.
+func (a Allowlist) Allows(entry string) bool {
+	_, ok := a.reasons[entry]
+	return ok
+}
+
+// Entries returns the allowlisted tokens in sorted order.
+func (a Allowlist) Entries() []string {
+	out := make([]string, 0, len(a.reasons))
+	for entry := range a.reasons {
+		out = append(out, entry)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// LintMarkdown checks one markdown document against the surface.
+//
+// Fenced code blocks are parsed as shell: line continuations are joined,
+// pipelines are split, and only segments whose argv[0] is the CLI binary are
+// checked — every flag of every other tool in an example pipeline is ignored,
+// which is what keeps the false-positive rate at zero. Prose outside fences is
+// checked more loosely: only backticked long-flag tokens, and only against the
+// union of every flag in the tree, because prose rarely says which command it
+// means.
+func LintMarkdown(s Surface, file, content string, allow Allowlist) []Issue {
+	var issues []Issue
+
+	var (
+		inFence    bool
+		fence      string
+		pending    string
+		pendingAt  int
+		flushFence = func() {
+			if pending == "" {
+				return
+			}
+			issues = append(issues, lintShellLine(s, file, pendingAt, pending, allow)...)
+			pending = ""
+		}
+	)
+
+	for i, raw := range strings.Split(content, "\n") {
+		lineNo := i + 1
+		trimmed := strings.TrimSpace(raw)
+
+		if !inFence {
+			if delim := fenceDelimiter(trimmed); delim != "" {
+				inFence, fence = true, delim
+				continue
+			}
+			issues = append(issues, lintProseLine(s, file, lineNo, raw, allow)...)
+			continue
+		}
+
+		if isFenceClose(trimmed, fence) {
+			flushFence()
+			inFence, fence = false, ""
+			continue
+		}
+
+		body := strings.TrimRight(raw, " \t")
+		if pending == "" {
+			pendingAt = lineNo
+		}
+		if strings.HasSuffix(body, `\`) {
+			pending += strings.TrimSuffix(body, `\`) + " "
+			continue
+		}
+		pending += body
+		flushFence()
+	}
+	flushFence()
+
+	return issues
+}
+
+// fenceDelimiter returns the fence delimiter a line opens a code block with, or
+// "" when the line does not open one.
+func fenceDelimiter(trimmed string) string {
+	for _, delim := range []string{"```", "~~~"} {
+		if strings.HasPrefix(trimmed, delim) {
+			return delim
+		}
+	}
+	return ""
+}
+
+// isFenceClose reports whether the line closes the open fence.
+func isFenceClose(trimmed, fence string) bool {
+	return strings.HasPrefix(trimmed, fence) && strings.TrimRight(strings.TrimPrefix(trimmed, fence), fence) == ""
+}
+
+// lintProseLine checks the backticked long-flag tokens of one prose line
+// against the union of every flag in the tree.
+func lintProseLine(s Surface, file string, line int, raw string, allow Allowlist) []Issue {
+	var issues []Issue
+	known := vocabulary(s)
+	for _, span := range backtickPattern.FindAllString(raw, -1) {
+		for _, tok := range longFlagTokens(span) {
+			name := strings.TrimPrefix(tok, "--")
+			if allow.Allows(tok) || contains(known, name) {
+				continue
+			}
+			issues = append(issues, Issue{
+				File:       file,
+				Line:       line,
+				Token:      tok,
+				Reason:     "is not a flag of any command in the CLI",
+				Suggestion: nearest(name, known),
+			})
+		}
+	}
+	return issues
+}
+
+// lintShellLine checks one logical shell line from a fenced code block.
+func lintShellLine(s Surface, file string, line int, text string, allow Allowlist) []Issue {
+	var issues []Issue
+	root := s.Root()
+	for _, argv := range shellSegments(text) {
+		if len(argv) == 0 || baseName(argv[0]) != root {
+			continue
+		}
+		issues = append(issues, lintInvocation(s, file, line, argv, allow)...)
+	}
+	return issues
+}
+
+// lintInvocation checks one "brutus ..." invocation: it resolves the
+// subcommand path first, then validates every flag against that command's real
+// flag set (local plus inherited, minus the flags the command rejects).
+func lintInvocation(s Surface, file string, line int, argv []string, allow Allowlist) []Issue {
+	var issues []Issue
+
+	cmd, ok := s.Command(s.Root())
+	if !ok {
+		return nil
+	}
+
+	resolving := true
+	for _, arg := range argv[1:] {
+		switch {
+		case arg == "-" || arg == "--":
+			resolving = false
+		case strings.HasPrefix(arg, "--"):
+			resolving = false
+			issues = append(issues, checkLongFlag(s, cmd, file, line, arg, allow)...)
+		case strings.HasPrefix(arg, "-") && len(arg) > 1:
+			resolving = false
+			issues = append(issues, checkShortFlags(cmd, file, line, arg, allow)...)
+		case resolving:
+			child := resolveChild(s, cmd.Path, arg)
+			switch {
+			case child != nil:
+				cmd = child
+			case len(s.Children(cmd.Path)) > 0:
+				issues = append(issues, Issue{
+					File: file, Line: line, Token: arg, Command: cmd.Path,
+					Reason:     "is not a subcommand of",
+					Suggestion: nearestCommand(s, cmd.Path, arg),
+				})
+				resolving = false
+			default:
+				resolving = false
+			}
+		}
+	}
+	return issues
+}
+
+// checkLongFlag validates a "--name" or "--name=value" token against cmd.
+func checkLongFlag(s Surface, cmd *Command, file string, line int, arg string, allow Allowlist) []Issue {
+	name, _, _ := strings.Cut(strings.TrimPrefix(arg, "--"), "=")
+	written := "--" + name
+	if name == "" || name == HelpFlag || allow.Allows(written) {
+		return nil
+	}
+
+	flag, ok := cmd.Flag(name)
+	switch {
+	case ok && flag.Rejected:
+		// No edit-distance suggestion here: the command's own rejection
+		// message already names the flag to use instead.
+		return []Issue{{
+			File: file, Line: line, Token: written, Command: cmd.Path,
+			Reason: "is rejected by this command: " + flag.RejectedReason + ", so it is not usable on",
+		}}
+	case ok:
+		return nil
+	}
+
+	reason := "is not a flag of"
+	if contains(s.FlagNames(), name) {
+		reason = "exists on other commands but not on"
+	}
+	return []Issue{{
+		File: file, Line: line, Token: written, Command: cmd.Path,
+		Reason:     reason,
+		Suggestion: nearest(name, usableFlagNames(cmd)),
+	}}
+}
+
+// checkShortFlags validates a "-x" token (or a "-xyz" cluster) against cmd.
+func checkShortFlags(cmd *Command, file string, line int, arg string, allow Allowlist) []Issue {
+	var issues []Issue
+	cluster, _, _ := strings.Cut(strings.TrimPrefix(arg, "-"), "=")
+	for _, r := range cluster {
+		if !isShorthandRune(r) {
+			break
+		}
+		written := "-" + string(r)
+		if r == 'h' || allow.Allows(written) {
+			// -h is cobra's help shorthand, present on every command.
+			continue
+		}
+		flag, ok := cmd.FlagByShorthand(string(r))
+		switch {
+		case ok && flag.Rejected:
+			issues = append(issues, Issue{
+				File: file, Line: line, Token: written, Command: cmd.Path,
+				Reason: "is rejected by this command: " + flag.RejectedReason + ", so it is not usable on",
+			})
+		case ok:
+		default:
+			issues = append(issues, Issue{
+				File: file, Line: line, Token: written, Command: cmd.Path,
+				Reason: "is not a shorthand flag of",
+			})
+		}
+	}
+	return issues
+}
+
+// isShorthandRune reports whether r can be a pflag shorthand. Anything else
+// (a digit sign, a slash, a dot) means the token is a value, not a flag
+// cluster, and the rest of it must not be validated.
+func isShorthandRune(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
+}
+
+// resolveChild resolves one path segment to a direct subcommand of path, by
+// name or by alias.
+func resolveChild(s Surface, path, segment string) *Command {
+	if c, ok := s.Command(path + " " + segment); ok {
+		return c
+	}
+	for _, c := range s.Children(path) {
+		if contains(c.Aliases, segment) {
+			return c
+		}
+	}
+	return nil
+}
+
+// vocabulary is every flag name documentation may name without saying which
+// command it means: the union of the tree's flags plus cobra's help flag.
+func vocabulary(s Surface) []string {
+	return append(s.FlagNames(), HelpFlag)
+}
+
+// usableFlagNames lists the flags actually usable on cmd.
+func usableFlagNames(cmd *Command) []string {
+	out := make([]string, 0, len(cmd.Flags))
+	for i := range cmd.Flags {
+		if !cmd.Flags[i].Rejected {
+			out = append(out, cmd.Flags[i].Name)
+		}
+	}
+	return out
+}
+
+// LintGoComments checks every long-flag token in the comments of one Go file.
+// This is the check that keeps a renamed flag from surviving in a comment that
+// no compiler and no test would ever read.
+func LintGoComments(s Surface, file string, src []byte, allow Allowlist) ([]Issue, error) {
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, file, src, parser.ParseComments|parser.SkipObjectResolution)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", file, err)
+	}
+
+	known := vocabulary(s)
+	var issues []Issue
+	for _, group := range parsed.Comments {
+		for _, comment := range group.List {
+			line := fset.Position(comment.Slash).Line
+			for _, tok := range longFlagTokens(comment.Text) {
+				name := strings.TrimRight(strings.TrimPrefix(tok, "--"), ".,;:)")
+				if name == "" || allow.Allows("--"+name) || contains(known, name) {
+					continue
+				}
+				issues = append(issues, Issue{
+					File:       file,
+					Line:       line,
+					Token:      "--" + name,
+					Reason:     "is named in a comment but is not a flag of any command in the CLI",
+					Suggestion: nearest(name, known),
+				})
+			}
+		}
+	}
+	return issues, nil
+}
+
+// --- shell tokenising -------------------------------------------------------
+
+// shellSegments splits one logical shell line into pipeline segments of argv
+// tokens. It is quote-aware (so a flag value containing '&&', '|' or '#' stays
+// one token), honors backslash escapes outside quotes, drops a leading "$"
+// prompt, and stops at an unquoted '#' comment.
+func shellSegments(line string) [][]string {
+	var (
+		segments [][]string
+		argv     []string
+		cur      strings.Builder
+		quote    rune
+	)
+
+	endToken := func() {
+		if cur.Len() > 0 {
+			argv = append(argv, cur.String())
+			cur.Reset()
+		}
+	}
+	endSegment := func() {
+		endToken()
+		if len(argv) > 0 {
+			segments = append(segments, argv)
+			argv = nil
+		}
+	}
+
+	runes := []rune(line)
+	for i := 0; i < len(runes); i++ {
+		c := runes[i]
+		switch {
+		case quote != 0:
+			if c == quote {
+				quote = 0
+				continue
+			}
+			if c == '\\' && quote == '"' && i+1 < len(runes) {
+				i++
+				cur.WriteRune(runes[i])
+				continue
+			}
+			cur.WriteRune(c)
+		case c == '\'' || c == '"':
+			quote = c
+		case c == '\\' && i+1 < len(runes):
+			i++
+			cur.WriteRune(runes[i])
+		case c == ' ' || c == '\t':
+			endToken()
+		case c == '#' && cur.Len() == 0:
+			endSegment()
+			return segments
+		case c == '|' || c == ';' || c == '&' || c == '>' || c == '<' || c == '(' || c == ')':
+			endSegment()
+		default:
+			cur.WriteRune(c)
+		}
+	}
+	endSegment()
+
+	for i := range segments {
+		if len(segments[i]) > 1 && segments[i][0] == "$" {
+			segments[i] = segments[i][1:]
+		}
+	}
+	return segments
+}
+
+// longFlagTokens returns the long-flag tokens in text, in order.
+func longFlagTokens(text string) []string {
+	matches := longFlagPattern.FindAllStringSubmatch(text, -1)
+	out := make([]string, 0, len(matches))
+	for _, m := range matches {
+		out = append(out, m[2])
+	}
+	return out
+}
+
+// baseName is the last path element of an argv[0], so "./brutus" and
+// "/usr/local/bin/brutus" both name the binary.
+func baseName(arg string) string {
+	if i := strings.LastIndexAny(arg, `/\`); i >= 0 {
+		return arg[i+1:]
+	}
+	return arg
+}
+
+// --- suggestions ------------------------------------------------------------
+
+// contains reports whether want is in list.
+func contains(list []string, want string) bool {
+	for _, v := range list {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}
+
+// nearest returns the closest candidate to name as a "--flag" string, or "" if
+// nothing is close enough to be a useful suggestion.
+func nearest(name string, candidates []string) string {
+	best, bestDistance := "", 0
+	for _, c := range candidates {
+		d := editDistance(name, c)
+		if best == "" || d < bestDistance {
+			best, bestDistance = c, d
+		}
+	}
+	limit := len(name) / 2
+	if limit < 2 {
+		limit = 2
+	}
+	if best == "" || bestDistance > limit {
+		return ""
+	}
+	return "--" + best
+}
+
+// nearestCommand returns the closest subcommand name of path to token.
+func nearestCommand(s Surface, path, segment string) string {
+	var names []string
+	for _, c := range s.Children(path) {
+		names = append(names, name(c.Path))
+		names = append(names, c.Aliases...)
+	}
+	best, bestDistance := "", 0
+	for _, n := range names {
+		d := editDistance(segment, n)
+		if best == "" || d < bestDistance {
+			best, bestDistance = n, d
+		}
+	}
+	if best == "" || bestDistance > 3 {
+		return ""
+	}
+	return best
+}
+
+// editDistance is the Levenshtein distance between a and b.
+func editDistance(a, b string) int {
+	prev := make([]int, len(b)+1)
+	curr := make([]int, len(b)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(a); i++ {
+		curr[0] = i
+		for j := 1; j <= len(b); j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			curr[j] = min(prev[j]+1, min(curr[j-1]+1, prev[j-1]+cost))
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(b)]
+}

--- a/internal/clisurface/lint.go
+++ b/internal/clisurface/lint.go
@@ -51,8 +51,14 @@ type Issue struct {
 	Command string
 	// Reason says what is wrong.
 	Reason string
-	// Suggestion is the nearest real flag, empty when nothing is close.
+	// Suggestion is the nearest real flag or subcommand, empty when nothing is
+	// close.
 	Suggestion string
+	// Subcommand reports whether Token is a subcommand name rather than a flag.
+	// The two get different advice: the allowlist only holds flag tokens (see
+	// ParseAllowlist), so offering it for a misspelled subcommand would send the
+	// reader to write an entry the allowlist parser rejects.
+	Subcommand bool
 }
 
 // String renders the issue as one actionable line.
@@ -65,7 +71,11 @@ func (i Issue) String() string {
 		fmt.Fprintf(&b, " %s", strconv.Quote(i.Command))
 	}
 	if i.Suggestion != "" {
-		fmt.Fprintf(&b, "; nearest real flag: %s", i.Suggestion)
+		label := "nearest real flag"
+		if i.Subcommand {
+			label = "nearest subcommand"
+		}
+		fmt.Fprintf(&b, "; %s: %s", label, i.Suggestion)
 	}
 	// An issue inside a generated file is a symptom of a stale artifact, not
 	// something to hand-edit or allowlist: say so, or the reader "fixes" a file
@@ -73,6 +83,10 @@ func (i Issue) String() string {
 	if whollyGenerated(i.File) {
 		fmt.Fprintf(&b, ". %s is generated: regenerate it with '%s' rather than editing it",
 			i.File, RegenerateCommand)
+		return b.String()
+	}
+	if i.Subcommand {
+		fmt.Fprintf(&b, ". Fix the documentation: %s holds flag tokens only", AllowlistPath)
 		return b.String()
 	}
 	fmt.Fprintf(&b, ". Fix the documentation, or add %s to %s with a '#' reason if the mention is deliberate",
@@ -143,6 +157,13 @@ func (a Allowlist) Entries() []string {
 // checked more loosely: only backticked long-flag tokens, and only against the
 // union of every flag in the tree, because prose rarely says which command it
 // means.
+//
+// The argv[0] rule is what buys the zero false-positive rate, and it costs
+// reach: an invocation the binary does not lead — "sudo brutus …", "time brutus
+// …", "FOO=bar brutus …" — is skipped rather than checked. Recognizing prefixes
+// one at a time would trade a guarantee for a list that is never finished, so
+// examples are written with the binary first. There are none of the other shape
+// in this repository.
 func LintMarkdown(s Surface, file, content string, allow Allowlist) []Issue {
 	var issues []Issue
 
@@ -247,9 +268,21 @@ func lintShellLine(s Surface, file string, line int, text string, allow Allowlis
 	return issues
 }
 
-// lintInvocation checks one "brutus ..." invocation: it resolves the
-// subcommand path first, then validates every flag against that command's real
-// flag set (local plus inherited, minus the flags the command rejects).
+// lintInvocation checks one "brutus ..." invocation.
+//
+// It walks argv the way cobra does: flags and the values they consume are
+// stepped over while the subcommand path keeps resolving, so a global flag
+// written before the subcommand still resolves the command it belongs to.
+// Both halves of that matter, because getting either wrong invents findings on
+// valid examples — and a gate that reddens on correct documentation is the one
+// that gets switched off:
+//
+//   - Stopping resolution at the first flag validates every later flag against
+//     the root. `brutus --json enum apollo --domain example.com` is a legal
+//     invocation, but --domain would be reported as not existing on "brutus".
+//   - Reading a flag's value as another flag reports its characters as
+//     nonexistent shorthands. `-oresults.json` is one pflag token, not -o
+//     followed by -r, -e, -s, -u, -l and -t.
 func lintInvocation(s Surface, file string, line int, argv []string, allow Allowlist) []Issue {
 	var issues []Issue
 
@@ -258,17 +291,38 @@ func lintInvocation(s Surface, file string, line int, argv []string, allow Allow
 		return nil
 	}
 
+	// resolving stays true across flags and goes false at the first positional
+	// that is not a subcommand: from there on argv holds this command's
+	// arguments, and an argument that happens to spell a subcommand name is not
+	// one.
 	resolving := true
-	for _, arg := range argv[1:] {
+	for i := 1; i < len(argv); i++ {
+		arg := argv[i]
+		next := ""
+		if i+1 < len(argv) {
+			next = argv[i+1]
+		}
+
 		switch {
-		case arg == "-" || arg == "--":
+		case arg == "--":
+			// pflag stops parsing at a bare "--": everything after it is a
+			// positional argument, however much it looks like a flag.
+			return issues
+		case arg == "-":
+			// A bare "-" is a positional, conventionally stdin.
 			resolving = false
 		case strings.HasPrefix(arg, "--"):
-			resolving = false
-			issues = append(issues, checkLongFlag(s, cmd, file, line, arg, allow)...)
+			found, consumed := checkLongFlag(s, cmd, file, line, arg, next, allow)
+			issues = append(issues, found...)
+			if consumed {
+				i++
+			}
 		case strings.HasPrefix(arg, "-") && len(arg) > 1:
-			resolving = false
-			issues = append(issues, checkShortFlags(cmd, file, line, arg, allow)...)
+			found, consumed := checkShortFlags(cmd, file, line, arg, next, allow)
+			issues = append(issues, found...)
+			if consumed {
+				i++
+			}
 		case resolving:
 			child := resolveChild(s, cmd.Path, arg)
 			switch {
@@ -279,6 +333,7 @@ func lintInvocation(s Surface, file string, line int, argv []string, allow Allow
 					File: file, Line: line, Token: arg, Command: cmd.Path,
 					Reason:     "is not a subcommand of",
 					Suggestion: nearestCommand(s, cmd.Path, arg),
+					Subcommand: true,
 				})
 				resolving = false
 			default:
@@ -289,25 +344,50 @@ func lintInvocation(s Surface, file string, line int, argv []string, allow Allow
 	return issues
 }
 
-// checkLongFlag validates a "--name" or "--name=value" token against cmd.
-func checkLongFlag(s Surface, cmd *Command, file string, line int, arg string, allow Allowlist) []Issue {
-	name, _, _ := strings.Cut(strings.TrimPrefix(arg, "--"), "=")
+// checkLongFlag validates a "--name" or "--name=value" token against cmd. The
+// second return reports whether next is this flag's value and so must not be
+// read as a flag or a subcommand.
+func checkLongFlag(s Surface, cmd *Command, file string, line int, arg, next string, allow Allowlist) ([]Issue, bool) {
+	name, _, carriesValue := strings.Cut(strings.TrimPrefix(arg, "--"), "=")
 	written := "--" + name
-	if name == "" || name == HelpFlag || allow.Allows(written) {
-		return nil
+	if name == "" {
+		return nil, false
 	}
 
-	flag, ok := cmd.Flag(name)
+	// cobra's --help is boolean and is not part of the surface, so it is
+	// answered here rather than looked up and guessed at below.
+	if name == HelpFlag {
+		return nil, false
+	}
+
+	flag, known := cmd.Flag(name)
+	// A "--name=value" token carries its own value. Otherwise any non-boolean
+	// flag takes the next argument. An unknown flag is reported below, and its
+	// value is guessed from shape — anything that does not itself look like a
+	// flag — so that one unknown flag does not also get its value reported as a
+	// bogus subcommand.
+	consumesNext := next != "" && !carriesValue
 	switch {
-	case ok && flag.Rejected:
+	case known:
+		consumesNext = consumesNext && flag.Type != "bool"
+	default:
+		consumesNext = consumesNext && !strings.HasPrefix(next, "-")
+	}
+
+	if allow.Allows(written) {
+		return nil, consumesNext
+	}
+
+	switch {
+	case known && flag.Rejected:
 		// No edit-distance suggestion here: the command's own rejection
 		// message already names the flag to use instead.
 		return []Issue{{
 			File: file, Line: line, Token: written, Command: cmd.Path,
 			Reason: "is rejected by this command: " + flag.RejectedReason + ", so it is not usable on",
-		}}
-	case ok:
-		return nil
+		}}, consumesNext
+	case known:
+		return nil, consumesNext
 	}
 
 	reason := "is not a flag of"
@@ -318,38 +398,58 @@ func checkLongFlag(s Surface, cmd *Command, file string, line int, arg string, a
 		File: file, Line: line, Token: written, Command: cmd.Path,
 		Reason:     reason,
 		Suggestion: nearest(name, usableFlagNames(cmd)),
-	}}
+	}}, consumesNext
 }
 
-// checkShortFlags validates a "-x" token (or a "-xyz" cluster) against cmd.
-func checkShortFlags(cmd *Command, file string, line int, arg string, allow Allowlist) []Issue {
+// checkShortFlags validates a "-x" token, or a "-xyz" cluster, against cmd the
+// way pflag reads one: booleans cluster freely, and the first flag that takes a
+// value swallows the rest of the token ("-oresults.json", "-o=results.json") or,
+// when the token ends there, the next argument ("-o results.json"). The second
+// return reports whether it took that next argument.
+func checkShortFlags(cmd *Command, file string, line int, arg, next string, allow Allowlist) ([]Issue, bool) {
 	var issues []Issue
-	cluster, _, _ := strings.Cut(strings.TrimPrefix(arg, "-"), "=")
-	for _, r := range cluster {
+
+	cluster := []rune(strings.TrimPrefix(arg, "-"))
+	for i := 0; i < len(cluster); i++ {
+		r := cluster[i]
 		if !isShorthandRune(r) {
-			break
+			// Not a shorthand, so this token is a value rather than a cluster.
+			return issues, false
 		}
+
 		written := "-" + string(r)
+		// -h is cobra's help shorthand, present on every command.
 		if r == 'h' || allow.Allows(written) {
-			// -h is cobra's help shorthand, present on every command.
 			continue
 		}
+
 		flag, ok := cmd.FlagByShorthand(string(r))
-		switch {
-		case ok && flag.Rejected:
-			issues = append(issues, Issue{
-				File: file, Line: line, Token: written, Command: cmd.Path,
-				Reason: "is rejected by this command: " + flag.RejectedReason + ", so it is not usable on",
-			})
-		case ok:
-		default:
+		if !ok {
 			issues = append(issues, Issue{
 				File: file, Line: line, Token: written, Command: cmd.Path,
 				Reason: "is not a shorthand flag of",
 			})
+			// Stop here. Without knowing whether this shorthand takes a value
+			// there is no way to tell whether the rest of the token is more
+			// shorthands or that value, and guessing invents findings.
+			return issues, false
 		}
+		if flag.Rejected {
+			issues = append(issues, Issue{
+				File: file, Line: line, Token: written, Command: cmd.Path,
+				Reason: "is rejected by this command: " + flag.RejectedReason + ", so it is not usable on",
+			})
+		}
+		if flag.Type == "bool" {
+			continue
+		}
+
+		// A value-taking shorthand ends the cluster: it takes the rest of the
+		// token, or the next argument when the token ends here.
+		rest := strings.TrimPrefix(string(cluster[i+1:]), "=")
+		return issues, rest == "" && next != ""
 	}
-	return issues
+	return issues, false
 }
 
 // isShorthandRune reports whether r can be a pflag shorthand. Anything else

--- a/internal/clisurface/lint.go
+++ b/internal/clisurface/lint.go
@@ -273,26 +273,39 @@ func lintShellLine(s Surface, file string, line int, text string, allow Allowlis
 
 // lintInvocation checks one "brutus ..." invocation.
 //
-// It walks argv the way cobra does: flags and the values they consume are
-// stepped over while the subcommand path keeps resolving, so a global flag
-// written before the subcommand still resolves the command it belongs to.
-// Both halves of that matter, because getting either wrong invents findings on
-// valid examples — and a gate that reddens on correct documentation is the one
-// that gets switched off:
+// It works in the two stages cobra works in. First it resolves the command,
+// stepping over flags and the values they consume; then it validates every flag
+// in the invocation against the command that was finally resolved. That order is
+// not incidental — cobra dispatches to the resolved command and parses the whole
+// argv against *that* command's flag set, so where a flag sits relative to the
+// subcommand does not change whether it is accepted.
 //
-//   - Stopping resolution at the first flag validates every later flag against
-//     the root. `brutus --json enum apollo --domain example.com` is a legal
-//     invocation, but --domain would be reported as not existing on "brutus".
-//   - Reading a flag's value as another flag reports its characters as
-//     nonexistent shorthands. `-oresults.json` is one pflag token, not -o
-//     followed by -r, -e, -s, -u, -l and -t.
+// Validating each flag against whichever command happened to be resolved when it
+// was read gets this wrong in both directions:
+//
+//   - Reporting a flag against the root because it was written before the
+//     subcommand. `brutus --json enum apollo --domain example.com` is legal, but
+//     --domain would be reported as not existing on "brutus".
+//   - Missing a flag the resolved command refuses. `brutus --timeout 5s logon`
+//     fails at runtime because the logon family rejects the inherited --timeout,
+//     and `brutus --version logon` fails because --version is local to the root
+//     — neither is excused by being written early.
+//
+// Values are stepped over using the command resolved so far, which is what cobra
+// does too: a non-boolean flag takes the next argument, a value-taking shorthand
+// takes the rest of its token ("-oresults.json") or the next argument, and "--"
+// ends flag parsing. Reading a value as a flag would report its characters as
+// nonexistent shorthands.
 func lintInvocation(s Surface, file string, line int, argv []string, allow Allowlist) []Issue {
-	var issues []Issue
-
 	cmd, ok := s.Command(s.Root())
 	if !ok {
 		return nil
 	}
+
+	var (
+		issues []Issue
+		flags  []string
+	)
 
 	// resolving stays true across flags and goes false at the first positional
 	// that is not a subcommand: from there on argv holds this command's
@@ -308,22 +321,20 @@ func lintInvocation(s Surface, file string, line int, argv []string, allow Allow
 
 		switch {
 		case arg == "--":
-			// pflag stops parsing at a bare "--": everything after it is a
-			// positional argument, however much it looks like a flag.
-			return issues
+			// pflag stops parsing here: everything after is positional,
+			// however much it looks like a flag.
+			i = len(argv)
 		case arg == "-":
 			// A bare "-" is a positional, conventionally stdin.
 			resolving = false
 		case strings.HasPrefix(arg, "--"):
-			found, consumed := checkLongFlag(s, cmd, file, line, arg, next, allow)
-			issues = append(issues, found...)
-			if consumed {
+			flags = append(flags, arg)
+			if longFlagTakesNext(cmd, arg, next) {
 				i++
 			}
 		case strings.HasPrefix(arg, "-") && len(arg) > 1:
-			found, consumed := checkShortFlags(cmd, file, line, arg, next, allow)
-			issues = append(issues, found...)
-			if consumed {
+			flags = append(flags, arg)
+			if shortFlagTakesNext(cmd, arg, next) {
 				i++
 			}
 		case resolving:
@@ -344,54 +355,87 @@ func lintInvocation(s Surface, file string, line int, argv []string, allow Allow
 			}
 		}
 	}
+
+	for _, arg := range flags {
+		if strings.HasPrefix(arg, "--") {
+			issues = append(issues, checkLongFlag(s, cmd, file, line, arg, allow)...)
+			continue
+		}
+		issues = append(issues, checkShortFlags(cmd, file, line, arg, allow)...)
+	}
 	return issues
 }
 
-// checkLongFlag validates a "--<name>" or "--<name>=<value>" token against cmd.
-// The
-// second return reports whether next is this flag's value and so must not be
-// read as a flag or a subcommand.
-func checkLongFlag(s Surface, cmd *Command, file string, line int, arg, next string, allow Allowlist) ([]Issue, bool) {
+// longFlagTakesNext reports whether the argument after a "--<name>" token is
+// that flag's value rather than a token of its own.
+//
+// A "--<name>=<value>" token carries its own value. Otherwise any non-boolean
+// flag takes the next argument. A flag cmd does not declare is guessed from
+// shape — anything that does not itself look like a flag — so that one unknown
+// flag does not also get its value read as a bogus subcommand.
+func longFlagTakesNext(cmd *Command, arg, next string) bool {
 	name, _, carriesValue := strings.Cut(strings.TrimPrefix(arg, "--"), "=")
+	if next == "" || carriesValue || name == "" || name == HelpFlag {
+		return false
+	}
+	if flag, known := cmd.Flag(name); known {
+		return flag.Type != "bool"
+	}
+	return !strings.HasPrefix(next, "-")
+}
+
+// shortFlagTakesNext reports whether the argument after a "-x" token, or a
+// "-xyz" cluster, is a value of that cluster. pflag clusters booleans freely,
+// and the first flag that takes a value swallows the rest of the token
+// ("-oresults.json", "-o=results.json") or, when the token ends there, the next
+// argument ("-o results.json").
+func shortFlagTakesNext(cmd *Command, arg, next string) bool {
+	if next == "" {
+		return false
+	}
+	cluster := []rune(strings.TrimPrefix(arg, "-"))
+	for i := 0; i < len(cluster); i++ {
+		r := cluster[i]
+		if !isShorthandRune(r) {
+			return false
+		}
+		if r == 'h' {
+			continue
+		}
+		flag, ok := cmd.FlagByShorthand(string(r))
+		switch {
+		case !ok:
+			// Unknown, so whether the rest of the token is more shorthands or a
+			// value is unknowable. Reported by checkShortFlags; guessing here
+			// would only move the damage.
+			return false
+		case flag.Type == "bool":
+			continue
+		}
+		return strings.TrimPrefix(string(cluster[i+1:]), "=") == ""
+	}
+	return false
+}
+
+// checkLongFlag validates a "--<name>" or "--<name>=<value>" token against cmd.
+func checkLongFlag(s Surface, cmd *Command, file string, line int, arg string, allow Allowlist) []Issue {
+	name, _, _ := strings.Cut(strings.TrimPrefix(arg, "--"), "=")
 	written := "--" + name
-	if name == "" {
-		return nil, false
+	if name == "" || name == HelpFlag || allow.Allows(written) {
+		return nil
 	}
 
-	// cobra's --help is boolean and is not part of the surface, so it is
-	// answered here rather than looked up and guessed at below.
-	if name == HelpFlag {
-		return nil, false
-	}
-
-	flag, known := cmd.Flag(name)
-	// A "--<name>=<value>" token carries its own value. Otherwise any non-boolean
-	// flag takes the next argument. An unknown flag is reported below, and its
-	// value is guessed from shape — anything that does not itself look like a
-	// flag — so that one unknown flag does not also get its value reported as a
-	// bogus subcommand.
-	consumesNext := next != "" && !carriesValue
+	flag, ok := cmd.Flag(name)
 	switch {
-	case known:
-		consumesNext = consumesNext && flag.Type != "bool"
-	default:
-		consumesNext = consumesNext && !strings.HasPrefix(next, "-")
-	}
-
-	if allow.Allows(written) {
-		return nil, consumesNext
-	}
-
-	switch {
-	case known && flag.Rejected:
+	case ok && flag.Rejected:
 		// No edit-distance suggestion here: the command's own rejection
 		// message already names the flag to use instead.
 		return []Issue{{
 			File: file, Line: line, Token: written, Command: cmd.Path,
 			Reason: "is rejected by this command: " + flag.RejectedReason + ", so it is not usable on",
-		}}, consumesNext
-	case known:
-		return nil, consumesNext
+		}}
+	case ok:
+		return nil
 	}
 
 	reason := "is not a flag of"
@@ -402,15 +446,14 @@ func checkLongFlag(s Surface, cmd *Command, file string, line int, arg, next str
 		File: file, Line: line, Token: written, Command: cmd.Path,
 		Reason:     reason,
 		Suggestion: nearest(name, usableFlagNames(cmd)),
-	}}, consumesNext
+	}}
 }
 
-// checkShortFlags validates a "-x" token, or a "-xyz" cluster, against cmd the
-// way pflag reads one: booleans cluster freely, and the first flag that takes a
-// value swallows the rest of the token ("-oresults.json", "-o=results.json") or,
-// when the token ends there, the next argument ("-o results.json"). The second
-// return reports whether it took that next argument.
-func checkShortFlags(cmd *Command, file string, line int, arg, next string, allow Allowlist) ([]Issue, bool) {
+// checkShortFlags validates a "-x" token, or a "-xyz" cluster, against cmd. It
+// reads the cluster the way pflag does (see shortFlagTakesNext): scanning a
+// flag's value as more shorthands is how "-oresults.json" turns into six
+// invented flags.
+func checkShortFlags(cmd *Command, file string, line int, arg string, allow Allowlist) []Issue {
 	var issues []Issue
 
 	cluster := []rune(strings.TrimPrefix(arg, "-"))
@@ -418,7 +461,7 @@ func checkShortFlags(cmd *Command, file string, line int, arg, next string, allo
 		r := cluster[i]
 		if !isShorthandRune(r) {
 			// Not a shorthand, so this token is a value rather than a cluster.
-			return issues, false
+			return issues
 		}
 
 		written := "-" + string(r)
@@ -436,7 +479,7 @@ func checkShortFlags(cmd *Command, file string, line int, arg, next string, allo
 			// Stop here. Without knowing whether this shorthand takes a value
 			// there is no way to tell whether the rest of the token is more
 			// shorthands or that value, and guessing invents findings.
-			return issues, false
+			return issues
 		}
 		if flag.Rejected {
 			issues = append(issues, Issue{
@@ -444,16 +487,12 @@ func checkShortFlags(cmd *Command, file string, line int, arg, next string, allo
 				Reason: "is rejected by this command: " + flag.RejectedReason + ", so it is not usable on",
 			})
 		}
-		if flag.Type == "bool" {
-			continue
+		if flag.Type != "bool" {
+			// A value-taking shorthand ends the cluster.
+			return issues
 		}
-
-		// A value-taking shorthand ends the cluster: it takes the rest of the
-		// token, or the next argument when the token ends here.
-		rest := strings.TrimPrefix(string(cluster[i+1:]), "=")
-		return issues, rest == "" && next != ""
 	}
-	return issues, false
+	return issues
 }
 
 // isShorthandRune reports whether r can be a pflag shorthand. Anything else

--- a/internal/clisurface/lint_test.go
+++ b/internal/clisurface/lint_test.go
@@ -441,3 +441,47 @@ func TestLintMarkdownTreatsHelpAsBoolean(t *testing.T) {
 		assert.Equal(t, "group", issues[i].Suggestion)
 	}
 }
+
+// TestLintMarkdownJudgesEveryFlagAgainstTheResolvedCommand pins the order of the
+// two stages. cobra dispatches to the resolved command and parses the whole argv
+// against that command's flag set, so writing a flag before the subcommand does
+// not excuse it: a flag the command rejects, and a flag local to the root, both
+// fail at runtime wherever they appear.
+func TestLintMarkdownJudgesEveryFlagAgainstTheResolvedCommand(t *testing.T) {
+	s := Walk(newTestTree())
+
+	t.Run("a rejected inherited flag is caught before the subcommand too", func(t *testing.T) {
+		for _, line := range []string{
+			"tool guarded --timeout 30s",
+			"tool --timeout 30s guarded",
+			"tool --timeout=30s guarded --scan-timeout 5s",
+		} {
+			issues := LintMarkdown(s, "README.md", "```bash\n"+line+"\n```", emptyAllowlist(t))
+			require.Len(t, issues, 1, "%q: guarded refuses --timeout wherever it is written", line)
+			assert.Equal(t, "--timeout", issues[0].Token)
+			assert.Equal(t, "tool guarded", issues[0].Command,
+				"the flag is judged against the command cobra would dispatch to")
+			assert.Contains(t, issues[0].Reason, "use --scan-timeout")
+		}
+	})
+
+	t.Run("a root-local flag is not usable once a subcommand is named", func(t *testing.T) {
+		assert.Empty(t, LintMarkdown(s, "README.md", "```bash\ntool --version\n```", emptyAllowlist(t)),
+			"--version is a flag of the root itself")
+
+		issues := LintMarkdown(s, "README.md", "```bash\ntool --version scan\n```", emptyAllowlist(t))
+		require.Len(t, issues, 1, "--version is local to the root, not persistent, so scan does not accept it")
+		assert.Equal(t, "--version", issues[0].Token)
+		assert.Equal(t, "tool scan", issues[0].Command)
+	})
+
+	t.Run("a persistent flag stays usable everywhere", func(t *testing.T) {
+		for _, line := range []string{
+			"tool --json scan --target host",
+			"tool scan --json --target host",
+			"tool --json group leaf --only-here x",
+		} {
+			assert.Empty(t, LintMarkdown(s, "README.md", "```bash\n"+line+"\n```", emptyAllowlist(t)), "%q", line)
+		}
+	})
+}

--- a/internal/clisurface/lint_test.go
+++ b/internal/clisurface/lint_test.go
@@ -1,0 +1,334 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clisurface
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// emptyAllowlist is the allowlist used by tests that do not exercise it.
+func emptyAllowlist(t *testing.T) Allowlist {
+	t.Helper()
+	allow, err := ParseAllowlist("")
+	require.NoError(t, err)
+	return allow
+}
+
+// tokensOf flattens issues to their offending tokens.
+func tokensOf(issues []Issue) []string {
+	out := make([]string, 0, len(issues))
+	for i := range issues {
+		out = append(out, issues[i].Token)
+	}
+	return out
+}
+
+func TestShellSegmentsSplitsPipelines(t *testing.T) {
+	segments := shellSegments("naabu -host 10.0.0.0/24 -silent | nerva --json | brutus creds -P passwords.txt")
+
+	require.Len(t, segments, 3)
+	assert.Equal(t, []string{"naabu", "-host", "10.0.0.0/24", "-silent"}, segments[0])
+	assert.Equal(t, []string{"nerva", "--json"}, segments[1])
+	assert.Equal(t, []string{"brutus", "creds", "-P", "passwords.txt"}, segments[2])
+}
+
+func TestShellSegmentsKeepsQuotedValuesWhole(t *testing.T) {
+	segments := shellSegments(`brutus logon --target host --exec "net user attacker P@ssw0rd /add && net localgroup administrators attacker /add"`)
+
+	require.Len(t, segments, 1, "the && inside quotes must not split the command")
+	assert.Equal(t, []string{
+		"brutus", "logon", "--target", "host", "--exec",
+		"net user attacker P@ssw0rd /add && net localgroup administrators attacker /add",
+	}, segments[0])
+}
+
+func TestShellSegmentsHandlesPromptsCommentsAndSeparators(t *testing.T) {
+	assert.Equal(t, [][]string{{"brutus", "creds"}}, shellSegments("$ brutus creds"),
+		"a copied shell prompt is not argv[0]")
+	assert.Equal(t, [][]string{{"brutus", "creds"}}, shellSegments("brutus creds    # test SSH, MySQL, ..."),
+		"an unquoted # starts a comment")
+	assert.Empty(t, shellSegments("# only a comment"))
+	assert.Equal(t, [][]string{{"brutus", "creds"}, {"results.json"}}, shellSegments("brutus creds > results.json"),
+		"a redirect target is its own segment, so it is never read as a flag")
+	assert.Equal(t, [][]string{{"jq", "-r", `"\(.target) \(.username)"`, "findings.json"}},
+		shellSegments(`jq -r '"\(.target) \(.username)"' findings.json`),
+		"single quotes are literal")
+}
+
+func TestLintMarkdownOnlyChecksTheCLIsOwnInvocations(t *testing.T) {
+	s := Walk(newTestTree())
+	doc := strings.Join([]string{
+		"```bash",
+		"naabu -host 10.0.0.0/24 -p 3389 -silent | nerva --json | tool scan",
+		"curl -LO https://example.com/tool.tar.gz | tar -xzf -",
+		"go install example.com/cmd/tool@latest",
+		"sudo mv tool /usr/local/bin/",
+		"jq 'select(.finding)' findings.json",
+		"```",
+	}, "\n")
+
+	issues := LintMarkdown(s, "README.md", doc, emptyAllowlist(t))
+
+	assert.Empty(t, issues, "flags belonging to other tools in the pipeline must never be validated")
+}
+
+func TestLintMarkdownReportsFlagsTheCommandDoesNotHave(t *testing.T) {
+	s := Walk(newTestTree())
+	doc := strings.Join([]string{
+		"prose line",
+		"```bash",
+		"tool scan --target host --targt host",
+		"```",
+	}, "\n")
+
+	issues := LintMarkdown(s, "README.md", doc, emptyAllowlist(t))
+
+	require.Len(t, issues, 1)
+	assert.Equal(t, "--targt", issues[0].Token)
+	assert.Equal(t, 3, issues[0].Line, "the issue points at the line inside the fence")
+	assert.Equal(t, "tool scan", issues[0].Command)
+	assert.Equal(t, "--target", issues[0].Suggestion, "the nearest real flag is offered")
+	assert.Contains(t, issues[0].String(), `README.md:3: --targt is not a flag of "tool scan"`,
+		"the message names the file, the line, the token and the command")
+	assert.Contains(t, issues[0].String(), AllowlistPath, "the message says how to allow a deliberate mention")
+}
+
+func TestLintMarkdownReportsFlagsRejectedByTheCommand(t *testing.T) {
+	s := Walk(newTestTree())
+	doc := "```bash\ntool guarded --timeout 30s\n```"
+
+	issues := LintMarkdown(s, "README.md", doc, emptyAllowlist(t))
+
+	require.Len(t, issues, 1, "--timeout is inherited but the command refuses it")
+	assert.Equal(t, "--timeout", issues[0].Token)
+	assert.Equal(t, "tool guarded", issues[0].Command)
+	assert.Contains(t, issues[0].Reason, "use --scan-timeout", "the command's own error explains the rejection")
+	assert.Empty(t, issues[0].Suggestion, "the rejection message is the guidance; an edit-distance guess would add noise")
+}
+
+func TestLintMarkdownAcceptsInheritedAndHiddenFlags(t *testing.T) {
+	s := Walk(newTestTree())
+	doc := "```bash\ntool scan --target host --timeout 5s --json\ntool guarded --scan-timeout 15s --json\n```"
+
+	assert.Empty(t, LintMarkdown(s, "README.md", doc, emptyAllowlist(t)),
+		"a flag inherited from the root is usable unless the command rejects it")
+}
+
+func TestLintMarkdownJoinsLineContinuations(t *testing.T) {
+	s := Walk(newTestTree())
+	doc := strings.Join([]string{
+		"```bash",
+		"naabu -host 10.0.0.0/24 -silent | \\",
+		"  nerva --json | \\",
+		"  tool scan --nope",
+		"```",
+	}, "\n")
+
+	issues := LintMarkdown(s, "README.md", doc, emptyAllowlist(t))
+
+	require.Len(t, issues, 1, "the continued pipeline is one logical command line")
+	assert.Equal(t, "--nope", issues[0].Token)
+	assert.Equal(t, 2, issues[0].Line, "a continued line is reported at the line it starts on")
+}
+
+func TestLintMarkdownChecksShorthandFlags(t *testing.T) {
+	s := Walk(newTestTree())
+
+	assert.Empty(t, LintMarkdown(s, "README.md", "```bash\ntool scan -t host -j\n```", emptyAllowlist(t)))
+
+	issues := LintMarkdown(s, "README.md", "```bash\ntool scan -Z host\n```", emptyAllowlist(t))
+	require.Len(t, issues, 1)
+	assert.Equal(t, "-Z", issues[0].Token)
+	assert.Contains(t, issues[0].Reason, "is not a shorthand flag of")
+}
+
+func TestLintMarkdownIgnoresValuesThatLookLikeFlags(t *testing.T) {
+	s := Walk(newTestTree())
+	doc := "```bash\ntool scan --target - -t -\n```"
+
+	assert.Empty(t, LintMarkdown(s, "README.md", doc, emptyAllowlist(t)),
+		"a bare - is stdin, not a flag")
+}
+
+func TestLintMarkdownResolvesSubcommandsAndAliases(t *testing.T) {
+	s := Walk(newTestTree())
+
+	assert.Empty(t, LintMarkdown(s, "README.md", "```bash\ntool sc --target host\ntool group leaf --only-here x\n```", emptyAllowlist(t)),
+		"aliases and nested paths must resolve")
+
+	issues := LintMarkdown(s, "README.md", "```bash\ntool group leef --only-here x\n```", emptyAllowlist(t))
+	require.Len(t, issues, 2, "the unknown subcommand and the flag it cannot carry are both reported")
+	assert.Equal(t, "leef", issues[0].Token)
+	assert.Contains(t, issues[0].Reason, "is not a subcommand of")
+	assert.Equal(t, "leaf", issues[0].Suggestion)
+}
+
+func TestLintMarkdownTreatsPositionalArgumentsAsValues(t *testing.T) {
+	s := Walk(newTestTree())
+
+	assert.Empty(t, LintMarkdown(s, "README.md", "```bash\ntool scan somehost:22\n```", emptyAllowlist(t)),
+		"a leaf command's positional argument is not a subcommand")
+}
+
+func TestLintMarkdownChecksBacktickedFlagsInProse(t *testing.T) {
+	s := Walk(newTestTree())
+	doc := strings.Join([]string{
+		"Route traffic through `--timeout 5s` or use `--mode cautious|default|aggressive`.",
+		"Unbackticked --alsogone is ignored because prose says things loosely.",
+		"```bash",
+		"tool scan --target host",
+		"```",
+	}, "\n")
+
+	issues := LintMarkdown(s, "README.md", doc, emptyAllowlist(t))
+
+	require.Len(t, issues, 1)
+	assert.Equal(t, "--mode", issues[0].Token)
+	assert.Equal(t, 1, issues[0].Line)
+	assert.Empty(t, issues[0].Command, "prose is checked against the whole surface, not one command")
+	assert.Contains(t, issues[0].Reason, "is not a flag of any command")
+}
+
+func TestLintMarkdownIgnoresProseInsideFencesAndFencesInsideProse(t *testing.T) {
+	s := Walk(newTestTree())
+	doc := strings.Join([]string{
+		"~~~",
+		"tool scan --gone",
+		"~~~",
+		"`--gone` in prose is reported once more",
+	}, "\n")
+
+	issues := LintMarkdown(s, "README.md", doc, emptyAllowlist(t))
+
+	require.Len(t, issues, 2, "a tilde fence is a fence, and prose after it is prose")
+	assert.Equal(t, 2, issues[0].Line)
+	assert.Equal(t, "tool scan", issues[0].Command)
+	assert.Equal(t, 4, issues[1].Line)
+	assert.Empty(t, issues[1].Command)
+}
+
+func TestLintGoCommentsReportsRenamedFlags(t *testing.T) {
+	s := Walk(newTestTree())
+	src := []byte(`package demo
+
+// runInteractive handles the --scan-timeout and --sticky-keys-exec modes.
+func runInteractive() {}
+
+// ---------------------------------------------------------------------------
+// A rule comment and a dash--dash word must not look like flags.
+`)
+
+	issues, err := LintGoComments(s, "cmd/demo/demo.go", src, emptyAllowlist(t))
+	require.NoError(t, err)
+
+	require.Len(t, issues, 1)
+	assert.Equal(t, "--sticky-keys-exec", issues[0].Token)
+	assert.Equal(t, "cmd/demo/demo.go", issues[0].File)
+	assert.Equal(t, 3, issues[0].Line)
+	assert.Contains(t, issues[0].Reason, "is named in a comment")
+}
+
+func TestLintGoCommentsIgnoresStringLiteralsAndCode(t *testing.T) {
+	s := Walk(newTestTree())
+	src := []byte(`package demo
+
+func run() string { return "--not-a-real-flag" }
+`)
+
+	issues, err := LintGoComments(s, "cmd/demo/demo.go", src, emptyAllowlist(t))
+	require.NoError(t, err)
+	assert.Empty(t, issues, "only comments are checked; string literals are out of scope")
+}
+
+func TestLintGoCommentsFailsOnUnparseableSource(t *testing.T) {
+	_, err := LintGoComments(Walk(newTestTree()), "cmd/demo/demo.go", []byte("not go at all"), emptyAllowlist(t))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parsing cmd/demo/demo.go")
+}
+
+func TestAllowlistSuppressesDeliberateMentions(t *testing.T) {
+	s := Walk(newTestTree())
+	allow, err := ParseAllowlist(strings.Join([]string{
+		"# deliberate historical references",
+		"--sticky-keys-exec  # renamed to --exec in v1.9; the rename note has to name the old flag",
+		"",
+		"-Z # nmap's -Z, quoted in a pipeline example",
+	}, "\n"))
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"--sticky-keys-exec", "-Z"}, allow.Entries())
+	assert.True(t, allow.Allows("--sticky-keys-exec"))
+	assert.False(t, allow.Allows("--something-else"))
+
+	doc := "`--sticky-keys-exec` was renamed.\n```bash\ntool scan -Z --sticky-keys-exec\n```"
+	assert.Empty(t, LintMarkdown(s, "README.md", doc, allow))
+	assert.NotEmpty(t, LintMarkdown(s, "README.md", doc, emptyAllowlist(t)),
+		"without the allowlist the same document is reported")
+}
+
+func TestParseAllowlistRequiresAReason(t *testing.T) {
+	_, err := ParseAllowlist("--orphan\n")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "needs a '# reason'")
+
+	_, err = ParseAllowlist("--orphan #   \n")
+	require.Error(t, err)
+
+	_, err = ParseAllowlist("orphan # missing dashes\n")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must start with '-'")
+}
+
+func TestIssueInAGeneratedFilePointsAtRegeneration(t *testing.T) {
+	generated := Issue{File: MarkdownPath, Line: 12, Token: "--gone", Reason: "is not a flag of any command in the CLI"}
+	assert.Equal(t,
+		"docs/CLI.md:12: --gone is not a flag of any command in the CLI. docs/CLI.md is generated: regenerate it with 'make cli-docs' rather than editing it",
+		generated.String(),
+		"a stale generated file must not be advertised as something to hand-edit or allowlist")
+
+	for _, file := range []string{"CONTRIBUTING.md", READMEPath} {
+		handWritten := Issue{File: file, Line: 12, Token: "--gone", Reason: "is not a flag of any command in the CLI"}
+		assert.Contains(t, handWritten.String(), AllowlistPath,
+			"%s still offers the allowlist escape hatch: only two regions of README.md are generated", file)
+		assert.NotContains(t, handWritten.String(), RegenerateCommand, "%s", file)
+	}
+}
+
+func TestLintReportNumbersEveryIssue(t *testing.T) {
+	report := LintReport([]Issue{
+		{File: "README.md", Line: 7, Token: "--gone", Reason: "is not a flag of any command in the CLI"},
+		{File: "docs/CLI.md", Line: 9, Token: "--also-gone", Reason: "is not a flag of any command in the CLI"},
+	})
+
+	assert.Contains(t, report, "references 2 CLI flag(s)")
+	assert.Contains(t, report, "1. README.md:7: --gone")
+	assert.Contains(t, report, "2. docs/CLI.md:9: --also-gone")
+}
+
+func TestNearestOnlySuggestsPlausibleMatches(t *testing.T) {
+	assert.Equal(t, "--target", nearest("targt", []string{"target", "timeout"}))
+	assert.Empty(t, nearest("wildly-different", []string{"target", "timeout"}),
+		"a distant token gets no suggestion rather than a misleading one")
+}
+
+func TestTokensOfIssuesAreStable(t *testing.T) {
+	s := Walk(newTestTree())
+	doc := "```bash\ntool scan --aaa --bbb\n```"
+	assert.Equal(t, []string{"--aaa", "--bbb"}, tokensOf(LintMarkdown(s, "README.md", doc, emptyAllowlist(t))))
+}

--- a/internal/clisurface/lint_test.go
+++ b/internal/clisurface/lint_test.go
@@ -332,3 +332,112 @@ func TestTokensOfIssuesAreStable(t *testing.T) {
 	doc := "```bash\ntool scan --aaa --bbb\n```"
 	assert.Equal(t, []string{"--aaa", "--bbb"}, tokensOf(LintMarkdown(s, "README.md", doc, emptyAllowlist(t))))
 }
+
+// TestLintMarkdownResolvesSubcommandsAcrossGlobalFlags pins the fix for the
+// linter's worst failure mode: a global flag written before the subcommand used
+// to stop subcommand resolution, so every later flag was validated against the
+// root and a perfectly valid example was reported as drift.
+func TestLintMarkdownResolvesSubcommandsAcrossGlobalFlags(t *testing.T) {
+	s := Walk(newTestTree())
+
+	for _, line := range []string{
+		"tool --json scan --target host",             // boolean global first
+		"tool --timeout 5s scan --target host",       // value-taking global first
+		"tool --timeout=5s group leaf --only-here x", // attached value, nested path
+		"tool -j scan --target host",                 // boolean shorthand first
+		"tool -j --timeout 5s sc --target host",      // several globals, then an alias
+	} {
+		assert.Empty(t, LintMarkdown(s, "README.md", "```bash\n"+line+"\n```", emptyAllowlist(t)),
+			"%q is a valid invocation: cobra accepts a global flag before the subcommand", line)
+	}
+}
+
+// TestLintMarkdownCatchesABadSubcommandAfterAGlobalFlag is the other half of the
+// same fix. Resolution used to stop at the first flag, which silently swallowed
+// a misspelled subcommand written after one.
+func TestLintMarkdownCatchesABadSubcommandAfterAGlobalFlag(t *testing.T) {
+	s := Walk(newTestTree())
+
+	issues := LintMarkdown(s, "README.md", "```bash\ntool --json groop leaf\n```", emptyAllowlist(t))
+
+	require.Len(t, issues, 1)
+	assert.Equal(t, "groop", issues[0].Token)
+	assert.Equal(t, "tool", issues[0].Command)
+	assert.Contains(t, issues[0].Reason, "is not a subcommand of")
+	assert.Equal(t, "group", issues[0].Suggestion)
+}
+
+// TestLintMarkdownDoesNotReadFlagValuesAsFlags pins the second false-positive
+// class: a value that pflag reads as one token used to be scanned as a cluster
+// of shorthands, so "-thost" became -t plus five invented flags.
+func TestLintMarkdownDoesNotReadFlagValuesAsFlags(t *testing.T) {
+	s := Walk(newTestTree())
+
+	for _, line := range []string{
+		"tool scan -thost",                  // value attached to the shorthand
+		"tool scan -t=host",                 // value attached with =
+		"tool scan -t host",                 // value as the next argument
+		"tool scan -jt host",                // boolean clustered before a value-taking flag
+		"tool scan --target -weird-looking", // a value that starts with a dash
+	} {
+		assert.Empty(t, LintMarkdown(s, "README.md", "```bash\n"+line+"\n```", emptyAllowlist(t)),
+			"%q: the flag's value must not be scanned as flags", line)
+	}
+}
+
+// TestLintMarkdownStopsAtTheDashDashSeparator checks that a token after "--" is
+// a positional argument, however much it looks like a flag.
+func TestLintMarkdownStopsAtTheDashDashSeparator(t *testing.T) {
+	s := Walk(newTestTree())
+
+	assert.Empty(t, LintMarkdown(s, "README.md", "```bash\ntool scan -- --not-a-flag-here\n```", emptyAllowlist(t)),
+		"pflag stops parsing flags at a bare --")
+}
+
+// TestLintMarkdownStillCatchesFlagsAfterAResolvedSubcommand guards against the
+// resolution fix loosening the check: the flags of a correctly resolved deep
+// command must still be validated against that command.
+func TestLintMarkdownStillCatchesFlagsAfterAResolvedSubcommand(t *testing.T) {
+	s := Walk(newTestTree())
+
+	issues := LintMarkdown(s, "README.md", "```bash\ntool --json group leaf --only-here x --gone y\n```", emptyAllowlist(t))
+
+	require.Len(t, issues, 1)
+	assert.Equal(t, "--gone", issues[0].Token)
+	assert.Equal(t, "tool group leaf", issues[0].Command,
+		"the flag is checked against the command the global flag did not hide")
+}
+
+// TestSubcommandIssueDoesNotOfferTheFlagAllowlist checks the advice matches the
+// token. The allowlist holds flag tokens only, so pointing a misspelled
+// subcommand at it would send the reader to write an entry ParseAllowlist
+// rejects.
+func TestSubcommandIssueDoesNotOfferTheFlagAllowlist(t *testing.T) {
+	issue := Issue{
+		File: "README.md", Line: 3, Token: "groop", Command: "tool",
+		Reason: "is not a subcommand of", Suggestion: "group", Subcommand: true,
+	}
+
+	rendered := issue.String()
+	assert.Contains(t, rendered, `README.md:3: groop is not a subcommand of "tool"`)
+	assert.Contains(t, rendered, "nearest subcommand: group")
+	assert.NotContains(t, rendered, "add groop to", "the allowlist parser rejects an entry that is not a flag")
+
+	_, err := ParseAllowlist("groop # what the old message told the reader to write\n")
+	require.Error(t, err, "the advice the message used to give was not even valid")
+}
+
+// TestLintMarkdownTreatsHelpAsBoolean checks that --help and -h do not swallow
+// the token after them: both are boolean, and cobra registers them on every
+// command without them appearing in the surface.
+func TestLintMarkdownTreatsHelpAsBoolean(t *testing.T) {
+	s := Walk(newTestTree())
+
+	issues := LintMarkdown(s, "README.md", "```bash\ntool --help groop\ntool -h groop\n```", emptyAllowlist(t))
+
+	require.Len(t, issues, 2, "the subcommand after --help/-h is still resolved and still checked")
+	for i := range issues {
+		assert.Equal(t, "groop", issues[i].Token)
+		assert.Equal(t, "group", issues[i].Suggestion)
+	}
+}

--- a/internal/clisurface/region.go
+++ b/internal/clisurface/region.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clisurface
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Generated regions let a hand-written document carry generated blocks. The
+// markers are HTML comments so they are invisible when the markdown renders.
+const (
+	regionBeginFormat = "<!-- BEGIN generated: %s -->"
+	regionEndFormat   = "<!-- END generated: %s -->"
+)
+
+// BeginMarker is the opening marker of the named region.
+func BeginMarker(name string) string { return fmt.Sprintf(regionBeginFormat, name) }
+
+// EndMarker is the closing marker of the named region.
+func EndMarker(name string) string { return fmt.Sprintf(regionEndFormat, name) }
+
+// Splice replaces the body of the named region in doc with body. The markers
+// themselves are preserved. body is normalized to exactly one trailing newline
+// so repeated splices converge.
+func Splice(doc, name, body string) (string, error) {
+	begin, end, err := regionBounds(doc, name)
+	if err != nil {
+		return "", err
+	}
+	normalized := strings.TrimRight(body, "\n") + "\n"
+	return doc[:begin] + normalized + doc[end:], nil
+}
+
+// RegionBody returns the current body of the named region.
+func RegionBody(doc, name string) (string, error) {
+	begin, end, err := regionBounds(doc, name)
+	if err != nil {
+		return "", err
+	}
+	return doc[begin:end], nil
+}
+
+// regionBounds returns the offsets of the region body: begin is just after the
+// newline that ends the opening marker line, end is the start of the closing
+// marker line.
+func regionBounds(doc, name string) (begin, end int, err error) {
+	beginMarker, endMarker := BeginMarker(name), EndMarker(name)
+
+	if n := strings.Count(doc, beginMarker); n != 1 {
+		return 0, 0, fmt.Errorf("expected exactly one %q marker, found %d", beginMarker, n)
+	}
+	if n := strings.Count(doc, endMarker); n != 1 {
+		return 0, 0, fmt.Errorf("expected exactly one %q marker, found %d", endMarker, n)
+	}
+
+	beginIdx := strings.Index(doc, beginMarker)
+	endIdx := strings.Index(doc, endMarker)
+	if endIdx < beginIdx {
+		return 0, 0, fmt.Errorf("%q appears before %q", endMarker, beginMarker)
+	}
+
+	afterBegin := beginIdx + len(beginMarker)
+	nl := strings.IndexByte(doc[afterBegin:], '\n')
+	if nl < 0 {
+		return 0, 0, fmt.Errorf("%q must be followed by a newline", beginMarker)
+	}
+	return afterBegin + nl + 1, endIdx, nil
+}

--- a/internal/clisurface/region_test.go
+++ b/internal/clisurface/region_test.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clisurface
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// docWithRegion builds a small document carrying one generated region.
+func docWithRegion(name, body string) string {
+	return strings.Join([]string{
+		"# Title",
+		"",
+		BeginMarker(name),
+		body,
+		EndMarker(name),
+		"",
+		"hand-written tail",
+		"",
+	}, "\n")
+}
+
+func TestSpliceReplacesOnlyTheRegionBody(t *testing.T) {
+	doc := docWithRegion("cli-subcommands", "stale body")
+
+	out, err := Splice(doc, "cli-subcommands", "fresh body")
+	require.NoError(t, err)
+
+	assert.Equal(t, docWithRegion("cli-subcommands", "fresh body"), out)
+	assert.Contains(t, out, "hand-written tail", "text outside the region is untouched")
+}
+
+func TestSpliceIsIdempotent(t *testing.T) {
+	doc := docWithRegion("cli-aliases", "old")
+
+	once, err := Splice(doc, "cli-aliases", "new\nlines\n")
+	require.NoError(t, err)
+	twice, err := Splice(once, "cli-aliases", "new\nlines\n")
+	require.NoError(t, err)
+
+	assert.Equal(t, once, twice, "splicing the same body twice must converge")
+	assert.NotContains(t, once, "new\n\n</", "the body keeps exactly one trailing newline")
+}
+
+func TestRegionBodyRoundTrips(t *testing.T) {
+	doc := docWithRegion("cli-aliases", "line one\nline two")
+
+	body, err := RegionBody(doc, "cli-aliases")
+	require.NoError(t, err)
+	assert.Equal(t, "line one\nline two\n", body)
+}
+
+func TestSpliceRejectsBrokenMarkers(t *testing.T) {
+	tests := []struct {
+		name    string
+		doc     string
+		wantErr string
+	}{
+		{
+			name:    "missing begin marker",
+			doc:     "text\n" + EndMarker("cli-aliases") + "\n",
+			wantErr: `expected exactly one "<!-- BEGIN generated: cli-aliases -->" marker, found 0`,
+		},
+		{
+			name:    "missing end marker",
+			doc:     BeginMarker("cli-aliases") + "\nbody\n",
+			wantErr: `expected exactly one "<!-- END generated: cli-aliases -->" marker, found 0`,
+		},
+		{
+			name:    "duplicated region",
+			doc:     docWithRegion("cli-aliases", "a") + docWithRegion("cli-aliases", "b"),
+			wantErr: "found 2",
+		},
+		{
+			name:    "markers out of order",
+			doc:     EndMarker("cli-aliases") + "\nbody\n" + BeginMarker("cli-aliases") + "\n",
+			wantErr: "appears before",
+		},
+		{
+			name:    "begin marker not on its own line",
+			doc:     BeginMarker("cli-aliases") + " trailing text without newline" + EndMarker("cli-aliases"),
+			wantErr: "must be followed by a newline",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Splice(tt.doc, "cli-aliases", "body")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestMarkersAreHTMLComments(t *testing.T) {
+	assert.Equal(t, "<!-- BEGIN generated: cli-subcommands -->", BeginMarker(RegionSubcommands))
+	assert.Equal(t, "<!-- END generated: cli-aliases -->", EndMarker(RegionAliases))
+}

--- a/internal/clisurface/render_json.go
+++ b/internal/clisurface/render_json.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clisurface
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// jsonDoc is the on-disk shape of docs/cli-surface.json. Field order here is
+// the key order in the rendered file.
+type jsonDoc struct {
+	SchemaVersion int       `json:"schemaVersion"`
+	SurfaceHash   string    `json:"surfaceHash"`
+	Commands      []Command `json:"commands"`
+}
+
+// RenderJSON renders the machine-readable artifact: two-space indentation, no
+// HTML escaping, one trailing newline. Key order comes from the struct
+// definitions, so the output is byte-stable for a given surface.
+func RenderJSON(s Surface) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(jsonDoc{
+		SchemaVersion: SchemaVersion,
+		SurfaceHash:   s.Hash(),
+		Commands:      s.Commands,
+	}); err != nil {
+		return nil, fmt.Errorf("rendering cli surface json: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// ParseJSON reads a surface back out of the machine-readable artifact.
+func ParseJSON(b []byte) (Surface, error) {
+	var doc jsonDoc
+	if err := json.Unmarshal(b, &doc); err != nil {
+		return Surface{}, fmt.Errorf("parsing cli surface json: %w", err)
+	}
+	if doc.SchemaVersion != SchemaVersion {
+		return Surface{}, fmt.Errorf("cli surface json has schemaVersion %d, this build renders %d: regenerate with 'make cli-docs'",
+			doc.SchemaVersion, SchemaVersion)
+	}
+	return Surface{Commands: doc.Commands}, nil
+}

--- a/internal/clisurface/render_json_test.go
+++ b/internal/clisurface/render_json_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clisurface
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderJSONShape(t *testing.T) {
+	s := Walk(newTestTree())
+
+	out, err := RenderJSON(s)
+	require.NoError(t, err)
+
+	text := string(out)
+	assert.True(t, strings.HasPrefix(text, "{\n  \"schemaVersion\": 1,\n  \"surfaceHash\": \"sha256:"),
+		"schemaVersion and surfaceHash lead the document, two-space indented:\n%s", text[:120])
+	assert.True(t, strings.HasSuffix(text, "}\n"), "the file ends with exactly one newline")
+	assert.NotContains(t, text, "\n\n", "no blank lines")
+	assert.Contains(t, text, `"path": "tool guarded"`)
+	assert.Contains(t, text, `"rejected": true`)
+	assert.Contains(t, text, `"rejectedReason": "--timeout is not valid here; use --scan-timeout"`)
+}
+
+func TestRenderJSONDoesNotEscapeHTML(t *testing.T) {
+	s := Surface{Commands: []Command{{
+		Path: "tool", Use: "tool", Short: "serve on http://127.0.0.1:<port> & wait",
+	}}}
+
+	out, err := RenderJSON(s)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(out), "http://127.0.0.1:<port> & wait",
+		"help text with angle brackets and ampersands must stay readable")
+	assert.NotContains(t, string(out), `\u003c`, "the encoder must not escape angle brackets")
+}
+
+func TestRenderJSONOmitsEmptyOptionalFields(t *testing.T) {
+	s := Surface{Commands: []Command{{Path: "tool", Use: "tool", Short: "a tool", Runnable: true}}}
+
+	out, err := RenderJSON(s)
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(out), "aliases")
+	assert.NotContains(t, string(out), "hidden")
+	assert.Contains(t, string(out), `"runnable": true`)
+}
+
+func TestParseJSONRoundTripsTheSurface(t *testing.T) {
+	s := Walk(newTestTree())
+
+	out, err := RenderJSON(s)
+	require.NoError(t, err)
+	parsed, err := ParseJSON(out)
+	require.NoError(t, err)
+
+	assert.Equal(t, s, parsed, "the JSON artifact is a lossless copy of the surface")
+	assert.Equal(t, s.Hash(), parsed.Hash())
+	assert.Empty(t, Diff(parsed, s), "a round-tripped surface has no drift against itself")
+}
+
+func TestParseJSONRejectsAnUnknownSchemaVersion(t *testing.T) {
+	_, err := ParseJSON([]byte(`{"schemaVersion": 99, "commands": []}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "schemaVersion 99")
+	assert.Contains(t, err.Error(), RegenerateCommand, "the error says how to fix it")
+}
+
+func TestParseJSONRejectsGarbage(t *testing.T) {
+	_, err := ParseJSON([]byte("not json"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parsing cli surface json")
+}

--- a/internal/clisurface/render_md.go
+++ b/internal/clisurface/render_md.go
@@ -1,0 +1,325 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clisurface
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// generatedNotice heads every generated markdown artifact.
+const generatedNotice = "<!-- Generated from the live cobra command tree by 'make cli-docs'. Do not edit by hand. -->"
+
+// Region names spliced into README.md.
+const (
+	RegionSubcommands = "cli-subcommands"
+	RegionAliases     = "cli-aliases"
+)
+
+// Region is one generated block of a hand-written document.
+type Region struct {
+	Name string
+	Body string
+}
+
+// RenderMarkdown renders the full human-readable reference (docs/CLI.md).
+func RenderMarkdown(s Surface) []byte {
+	root := s.Root()
+
+	var b strings.Builder
+	writeLines(&b,
+		generatedNotice,
+		"",
+		"# "+root+" CLI reference",
+		"",
+		"Every command, alias and flag below is derived from the cobra command tree, not from prose.",
+		"Schema version "+strconv.Itoa(SchemaVersion)+", surface hash `"+s.Hash()+"`.",
+		"",
+		"Regenerate with `make cli-docs` after adding, removing or renaming a command or a flag.",
+		"",
+		"## Command index",
+		"",
+		"| Command | Aliases | Description |",
+		"| --- | --- | --- |",
+	)
+	for i := range s.Commands {
+		c := &s.Commands[i]
+		writeLines(&b, "| ["+code(c.Path)+"](#"+anchor(c.Path)+") | "+aliasCell(c)+" | "+cell(indexDescription(c))+" |")
+	}
+
+	for i := range s.Commands {
+		writeCommand(&b, &s.Commands[i])
+	}
+
+	return []byte(b.String())
+}
+
+// writeCommand renders one command section of the reference.
+func writeCommand(b *strings.Builder, c *Command) {
+	writeLines(b, "", "## "+code(c.Path), "")
+	if c.Short != "" {
+		writeLines(b, c.Short, "")
+	}
+
+	writeLines(b, "- Usage: "+code(usage(c)))
+	writeLines(b, "- Aliases: "+aliasCell(c))
+	if c.Hidden {
+		writeLines(b, "- Hidden: not shown in `--help` output")
+	}
+	if c.Deprecated != "" {
+		writeLines(b, "- Deprecated: "+c.Deprecated)
+	}
+	if !c.Runnable {
+		writeLines(b, "- Requires a subcommand")
+	}
+
+	local, inherited, rejected := partitionFlags(c)
+	writeFlagTable(b, "Flags", local)
+	writeFlagTable(b, "Inherited flags", inherited)
+
+	if len(rejected) > 0 {
+		writeLines(b, "", "### Rejected flags", "",
+			"These flags reach "+code(c.Path)+" through inheritance, but the command refuses them:",
+			"", "| Flag | Why |", "| --- | --- |")
+		for _, f := range rejected {
+			writeLines(b, "| "+code("--"+f.Name)+" | "+cell(f.RejectedReason)+" |")
+		}
+	}
+
+	if c.Example != "" {
+		writeLines(b, "", "### Examples", "", "```bash")
+		writeLines(b, strings.Split(strings.TrimRight(dedent(c.Example), "\n"), "\n")...)
+		writeLines(b, "```")
+	}
+}
+
+// writeFlagTable renders a titled flag table, or nothing when there are none.
+func writeFlagTable(b *strings.Builder, title string, flags []*Flag) {
+	if len(flags) == 0 {
+		return
+	}
+	writeLines(b, "", "### "+title, "", "| Flag | Short | Type | Default | Description |", "| --- | --- | --- | --- | --- |")
+	for _, f := range flags {
+		short := ""
+		if f.Shorthand != "" {
+			short = code("-" + f.Shorthand)
+		}
+		def := ""
+		if f.Default != "" {
+			def = code(f.Default)
+		}
+		writeLines(b, "| "+code("--"+f.Name)+" | "+short+" | "+f.Type+" | "+def+" | "+cell(flagDescription(f))+" |")
+	}
+}
+
+// RenderRegions renders the generated regions of README.md, in a fixed order.
+func RenderRegions(s Surface) []Region {
+	return []Region{
+		{Name: RegionSubcommands, Body: renderSubcommandRegion(s)},
+		{Name: RegionAliases, Body: renderAliasRegion(s)},
+	}
+}
+
+// renderSubcommandRegion renders the Quick Start subcommand listing: the
+// visible top-level commands with their cobra Short descriptions. It states no
+// count — the list below it is the count, and a written one would be a second
+// thing that can go stale.
+func renderSubcommandRegion(s Surface) string {
+	root := s.Root()
+	children := visible(s.Children(root))
+
+	width := 0
+	for _, c := range children {
+		if n := len(name(c.Path)); n > width {
+			width = n
+		}
+	}
+
+	var b strings.Builder
+	writeLines(&b,
+		"Brutus organizes its functionality into these focused subcommands:",
+		"",
+		"```bash",
+	)
+	for _, c := range children {
+		writeLines(&b, fmt.Sprintf("%s %-*s # %s", root, width, name(c.Path), c.Short))
+	}
+	writeLines(&b, "```")
+	return b.String()
+}
+
+// renderAliasRegion renders the Quick Start alias table. Only subcommands that
+// actually declare aliases are listed: this is the most-read part of the
+// README, and rows reading "none" contradict the lead-in and add noise.
+// docs/CLI.md remains the complete reference and does list them.
+func renderAliasRegion(s Surface) string {
+	root := s.Root()
+
+	var b strings.Builder
+	writeLines(&b,
+		"Some subcommands carry aliases for discoverability:",
+		"",
+		"| Subcommand | Aliases |",
+		"| --- | --- |",
+	)
+	for _, c := range visible(s.Children(root)) {
+		if len(c.Aliases) == 0 {
+			continue
+		}
+		writeLines(&b, "| "+code(name(c.Path))+" | "+aliasCell(c)+" |")
+	}
+	writeLines(&b,
+		"",
+		"The full reference — every subcommand, alias and flag, including the ones "+
+			"hidden from `--help` — is generated into [docs/CLI.md](docs/CLI.md).",
+	)
+	return b.String()
+}
+
+// --- helpers ---------------------------------------------------------------
+
+// writeLines appends each line plus a newline.
+func writeLines(b *strings.Builder, lines ...string) {
+	for _, l := range lines {
+		b.WriteString(l)
+		b.WriteString("\n")
+	}
+}
+
+// visible drops commands hidden from help output.
+func visible(cmds []*Command) []*Command {
+	out := make([]*Command, 0, len(cmds))
+	for _, c := range cmds {
+		if !c.Hidden {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// partitionFlags splits a command's flags into the ones declared on it, the
+// usable ones it inherits, and the ones it inherits but refuses.
+func partitionFlags(c *Command) (local, inherited, rejected []*Flag) {
+	for i := range c.Flags {
+		f := &c.Flags[i]
+		switch {
+		case f.Rejected:
+			rejected = append(rejected, f)
+		case f.Inherited:
+			inherited = append(inherited, f)
+		default:
+			local = append(local, f)
+		}
+	}
+	return local, inherited, rejected
+}
+
+// name returns the last segment of a command path.
+func name(path string) string {
+	if i := strings.LastIndex(path, " "); i >= 0 {
+		return path[i+1:]
+	}
+	return path
+}
+
+// usage renders the invocation sketch: the full path with the cobra Use
+// string's argument sketch (everything after the command name) appended.
+func usage(c *Command) string {
+	if i := strings.Index(c.Use, " "); i >= 0 {
+		return c.Path + c.Use[i:]
+	}
+	return c.Path
+}
+
+// indexDescription is the command-index description, annotated for commands
+// that are hidden or deprecated.
+func indexDescription(c *Command) string {
+	switch {
+	case c.Deprecated != "":
+		return c.Short + " (deprecated: " + c.Deprecated + ")"
+	case c.Hidden:
+		return c.Short + " (hidden)"
+	default:
+		return c.Short
+	}
+}
+
+// flagDescription is the flag-table description, annotated for flags that are
+// hidden or deprecated.
+func flagDescription(f *Flag) string {
+	switch {
+	case f.Deprecated != "":
+		return f.Usage + " (deprecated: " + f.Deprecated + ")"
+	case f.Hidden:
+		return f.Usage + " (hidden)"
+	default:
+		return f.Usage
+	}
+}
+
+// aliasCell renders a command's aliases for a table cell.
+func aliasCell(c *Command) string {
+	if len(c.Aliases) == 0 {
+		return "*(none)*"
+	}
+	out := make([]string, 0, len(c.Aliases))
+	for _, a := range c.Aliases {
+		out = append(out, code(a))
+	}
+	return strings.Join(out, ", ")
+}
+
+// code wraps s in markdown code ticks.
+func code(s string) string { return "`" + s + "`" }
+
+// cell makes arbitrary help text safe inside a markdown table cell.
+func cell(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "|", "\\|")
+	return strings.TrimSpace(s)
+}
+
+// anchor is the GitHub heading anchor for a "## `path`" heading.
+func anchor(path string) string {
+	return strings.ReplaceAll(path, " ", "-")
+}
+
+// dedent removes the common leading-space indent cobra examples carry so the
+// rendered fence is not indented as a code block twice over.
+func dedent(s string) string {
+	lines := strings.Split(s, "\n")
+	indent := -1
+	for _, l := range lines {
+		trimmed := strings.TrimLeft(l, " ")
+		if trimmed == "" {
+			continue
+		}
+		if n := len(l) - len(trimmed); indent < 0 || n < indent {
+			indent = n
+		}
+	}
+	if indent <= 0 {
+		return s
+	}
+	for i, l := range lines {
+		if len(l) >= indent {
+			lines[i] = l[indent:]
+		} else {
+			lines[i] = strings.TrimLeft(l, " ")
+		}
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/clisurface/render_md_test.go
+++ b/internal/clisurface/render_md_test.go
@@ -1,0 +1,194 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clisurface
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderMarkdownDocumentsEveryCommand(t *testing.T) {
+	s := Walk(newTestTree())
+
+	md := string(RenderMarkdown(s))
+
+	assert.True(t, strings.HasPrefix(md, generatedNotice), "the file warns that it is generated")
+	assert.Contains(t, md, "Do not edit by hand")
+	assert.Contains(t, md, "# tool CLI reference")
+	assert.Contains(t, md, "surface hash `"+s.Hash()+"`")
+	for _, path := range []string{"tool", "tool scan", "tool guarded", "tool group", "tool group leaf", "tool group old"} {
+		assert.Contains(t, md, "## `"+path+"`", "every command gets a section")
+	}
+	assert.Contains(t, md, "| [`tool scan`](#tool-scan) |", "the index links to the sections")
+	assert.True(t, strings.HasSuffix(md, "\n"))
+}
+
+func TestRenderMarkdownSeparatesLocalInheritedAndRejectedFlags(t *testing.T) {
+	s := Walk(newTestTree())
+
+	md := string(RenderMarkdown(s))
+	guarded := section(t, md, "tool guarded")
+
+	assert.Contains(t, guarded, "### Flags")
+	assert.Contains(t, guarded, "| `--scan-timeout` |")
+	assert.Contains(t, guarded, "### Inherited flags")
+	assert.Contains(t, guarded, "| `--json` | `-j` | bool |")
+	assert.Contains(t, guarded, "### Rejected flags")
+	assert.Contains(t, guarded, "| `--timeout` | --timeout is not valid here; use --scan-timeout |")
+
+	timeoutRows := strings.Count(guarded, "`--timeout`")
+	assert.Equal(t, 1, timeoutRows,
+		"a rejected flag appears only in the rejected table, never as a usable option")
+}
+
+func TestRenderMarkdownAnnotatesHiddenAndDeprecatedCommands(t *testing.T) {
+	s := Walk(newTestTree())
+
+	md := string(RenderMarkdown(s))
+	old := section(t, md, "tool group old")
+
+	assert.Contains(t, old, "- Hidden: not shown in `--help` output")
+	assert.Contains(t, old, `- Deprecated: use "tool group leaf" instead`)
+	assert.Contains(t, md, "the old spelling (deprecated:", "the index flags it too")
+	assert.Contains(t, section(t, md, "tool group"), "- Requires a subcommand")
+}
+
+func TestRenderMarkdownIncludesDedentedExamples(t *testing.T) {
+	s := Walk(newTestTree())
+
+	scan := section(t, string(RenderMarkdown(s)), "tool scan")
+
+	assert.Contains(t, scan, "### Examples")
+	assert.Contains(t, scan, "```bash\n# scan one host\ntool scan --target host\n```",
+		"cobra's two-space example indent is removed so the fence is a plain shell block")
+}
+
+func TestRenderMarkdownEscapesTableCells(t *testing.T) {
+	s := Surface{Commands: []Command{{
+		Path: "tool", Use: "tool", Short: "a | b", Runnable: true,
+		Flags: []Flag{{Name: "mode", Type: "string", Usage: "cautious | default | aggressive\nsecond line"}},
+	}}}
+
+	md := string(RenderMarkdown(s))
+
+	assert.Contains(t, md, `cautious \| default \| aggressive second line`,
+		"pipes are escaped and newlines folded so the markdown table survives")
+}
+
+func TestRenderRegionsListsSubcommandsWithoutClaimingACount(t *testing.T) {
+	s := Walk(newTestTree())
+
+	regions := RenderRegions(s)
+	require.Len(t, regions, 2)
+	assert.Equal(t, RegionSubcommands, regions[0].Name, "regions render in a fixed order")
+	assert.Equal(t, RegionAliases, regions[1].Name)
+
+	body := regions[0].Body
+	assert.Contains(t, body, "Brutus organizes its functionality into these focused subcommands:")
+	assert.NotRegexp(t, `into \d+ `, body,
+		"the list below is the count; a written count is a second thing that can be wrong")
+	assert.Contains(t, body, "```bash\ntool group   # a group of things\n")
+	assert.Contains(t, body, "tool guarded # rejects --timeout\n")
+	assert.Contains(t, body, "tool scan    # scan things\n")
+	assert.NotContains(t, body, "tool group leaf", "only top-level subcommands are listed")
+}
+
+func TestRenderRegionsAliasTableOmitsCommandsWithoutAliases(t *testing.T) {
+	s := Walk(newTestTree())
+
+	body := RenderRegions(s)[1].Body
+
+	assert.Contains(t, body, "| `scan` | `sc`, `scanner` |")
+	assert.NotContains(t, body, "*(none)*",
+		"the region says 'some subcommands carry aliases', so rows saying 'none' contradict it")
+	assert.NotContains(t, body, "| `guarded` |", "a command with no aliases is not listed at all")
+	assert.NotContains(t, body, "| `group` |")
+	assert.Contains(t, body, "[docs/CLI.md](docs/CLI.md)", "the region links to the full reference")
+}
+
+func TestRenderRegionsAliasTableFollowsAliasTransitions(t *testing.T) {
+	base := Surface{Commands: []Command{
+		{Path: "tool", Use: "tool"},
+		{Path: "tool scan", Use: "scan", Short: "scan things", Aliases: []string{"sc"}},
+		{Path: "tool plain", Use: "plain", Short: "no aliases yet"},
+	}}
+
+	body := RenderRegions(base)[1].Body
+	require.Contains(t, body, "| `scan` | `sc` |")
+	require.NotContains(t, body, "| `plain` |")
+
+	t.Run("a command gaining its first alias appears", func(t *testing.T) {
+		gained := base
+		gained.Commands = append([]Command(nil), base.Commands...)
+		gained.Commands[2].Aliases = []string{"p"}
+
+		body := RenderRegions(gained)[1].Body
+
+		assert.Contains(t, body, "| `plain` | `p` |",
+			"declaring an alias must add the command to the README table")
+	})
+
+	t.Run("a command losing its last alias disappears", func(t *testing.T) {
+		lost := base
+		lost.Commands = append([]Command(nil), base.Commands...)
+		lost.Commands[1].Aliases = nil
+
+		body := RenderRegions(lost)[1].Body
+
+		assert.NotContains(t, body, "| `scan` |",
+			"dropping the last alias must remove the command from the README table")
+		assert.Contains(t, body, "[docs/CLI.md](docs/CLI.md)",
+			"the rest of the region survives an empty table")
+	})
+}
+
+func TestRenderRegionsSkipsHiddenSubcommands(t *testing.T) {
+	s := Surface{Commands: []Command{
+		{Path: "tool", Use: "tool"},
+		{Path: "tool shown", Use: "shown", Short: "visible"},
+		{Path: "tool secret", Use: "secret", Short: "hidden", Hidden: true},
+	}}
+
+	body := RenderRegions(s)[0].Body
+
+	assert.Contains(t, body, "tool shown # visible")
+	assert.NotContains(t, body, "secret", "hidden commands stay out of the Quick Start listing")
+}
+
+func TestUsageIncludesTheArgumentSketch(t *testing.T) {
+	assert.Equal(t, "tool scan [flags]", usage(&Command{Path: "tool scan", Use: "scan [flags]"}))
+	assert.Equal(t, "tool scan", usage(&Command{Path: "tool scan", Use: "scan"}))
+}
+
+func TestDedentLeavesUnindentedTextAlone(t *testing.T) {
+	assert.Equal(t, "a\nb", dedent("a\nb"))
+	assert.Equal(t, "a\n\nb", dedent("  a\n\n  b"))
+}
+
+// section returns the docs/CLI.md section for one command path.
+func section(t *testing.T, md, path string) string {
+	t.Helper()
+	heading := "## `" + path + "`"
+	start := strings.Index(md, heading)
+	require.GreaterOrEqual(t, start, 0, "section %q must exist", heading)
+	rest := md[start+len(heading):]
+	if next := strings.Index(rest, "\n## "); next >= 0 {
+		return rest[:next]
+	}
+	return rest
+}

--- a/internal/clisurface/surface.go
+++ b/internal/clisurface/surface.go
@@ -1,0 +1,374 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package clisurface derives the documented CLI surface of a cobra command
+// tree — every command, alias and flag — from the live tree rather than from
+// prose, renders it into machine- and human-readable artifacts, and reports
+// structured findings when the committed artifacts disagree with the tree.
+package clisurface
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// SchemaVersion is the version of the JSON artifact layout. Bump it when the
+// shape of the rendered JSON changes in a way consumers must notice.
+const SchemaVersion = 1
+
+// builtinCommands are the commands cobra injects into a tree on the first
+// Execute (InitDefaultHelpCmd / InitDefaultCompletionCmd). They are not part of
+// the surface brutus documents, and whether they are present depends on whether
+// something already executed the tree in this process — so excluding them keeps
+// the walk deterministic regardless of test ordering.
+var builtinCommands = map[string]bool{"help": true, "completion": true}
+
+// HelpFlag is the flag cobra injects into every command on the first Execute
+// (InitDefaultHelpFlag). Like the built-in commands it is excluded from the
+// surface — whether it is registered yet depends on whether something already
+// executed the tree in this process — and the doc linter accepts it everywhere
+// instead (see vocabulary).
+const HelpFlag = "help"
+
+// Surface is the complete CLI surface of a command tree. Commands are sorted by
+// path and each command's flags are sorted by name, so a Surface renders
+// byte-identically across runs.
+type Surface struct {
+	Commands []Command `json:"commands"`
+}
+
+// Command is one node of the command tree.
+type Command struct {
+	// Path is the full invocation path, e.g. "brutus enum active teams auth".
+	Path string `json:"path"`
+	// Use is the cobra Use string (the command name plus any argument sketch).
+	Use string `json:"use"`
+	// Short is the one-line description cobra shows in listings.
+	Short string `json:"short"`
+	// Aliases are the alternative names that resolve to this command.
+	Aliases []string `json:"aliases,omitempty"`
+	// Hidden reports whether the command is omitted from help output.
+	Hidden bool `json:"hidden,omitempty"`
+	// Deprecated is cobra's deprecation notice, empty when not deprecated.
+	Deprecated string `json:"deprecated,omitempty"`
+	// Runnable reports whether the command does work itself (as opposed to
+	// only grouping subcommands).
+	Runnable bool `json:"runnable"`
+	// Example is cobra's example block, used verbatim in the generated
+	// reference. It is part of the surface because it is documentation that
+	// must stay honest about the flags it shows.
+	Example string `json:"example,omitempty"`
+	// Flags are every flag usable on this command: its own, plus the
+	// persistent flags inherited from its ancestors.
+	Flags []Flag `json:"flags,omitempty"`
+}
+
+// Flag is one flag as it appears on one command. The same flag name can appear
+// on many commands with different Inherited/Rejected values.
+type Flag struct {
+	Name       string `json:"name"`
+	Shorthand  string `json:"shorthand,omitempty"`
+	Type       string `json:"type"`
+	Default    string `json:"default,omitempty"`
+	Usage      string `json:"usage,omitempty"`
+	Deprecated string `json:"deprecated,omitempty"`
+	// Inherited reports whether the flag reaches this command as a persistent
+	// flag of an ancestor rather than being declared on the command itself.
+	Inherited bool `json:"inherited,omitempty"`
+	// Hidden reports whether the flag is omitted from help output.
+	Hidden bool `json:"hidden,omitempty"`
+	// Rejected reports whether the command hard-errors when the flag is set,
+	// even though the flag is reachable from the command's flag set. brutus
+	// uses this for the logon family, which inherits the root-persistent
+	// --timeout but refuses it in favor of --scan-timeout. A flag that is
+	// rejected is not usable on the command: the generated reference must not
+	// present it as an option and the doc linter must reject examples using it.
+	Rejected bool `json:"rejected,omitempty"`
+	// RejectedReason is the error the command returns when the flag is set.
+	RejectedReason string `json:"rejectedReason,omitempty"`
+}
+
+// Walk derives the surface of the tree rooted at root.
+//
+// Inherited flags are recorded per command, because inheritance alone does not
+// make a flag usable: a command's PreRunE may reject a flag it inherits. Walk
+// discovers those rejections by probing PreRunE (see probeRejections) rather
+// than from a hand-maintained table, so removing the guard in the command
+// changes the surface and reddens the gate.
+//
+// Walk does not mutate the tree. That is a hard requirement, not a nicety: a
+// cobra tree is usually a package-level variable shared by every test in a
+// binary, so any mutation leaks into whatever runs next. In particular Walk
+// never calls cobra's LocalFlags or InheritedFlags accessors — both call
+// mergePersistentFlags, which permanently folds every ancestor's persistent
+// flags into the command's own FlagSet — and it never flips a Changed bit on a
+// real flag (see resolveFlags and probeRejections).
+//
+// Only PreRunE is probed. A guard implemented in PersistentPreRunE or in RunE
+// is not visible to Walk.
+func Walk(root *cobra.Command) Surface {
+	var s Surface
+	collect(root, &s)
+	sort.Slice(s.Commands, func(i, j int) bool { return s.Commands[i].Path < s.Commands[j].Path })
+	return s
+}
+
+// collect appends cmd and its descendants to s, skipping cobra's built-ins.
+func collect(cmd *cobra.Command, s *Surface) {
+	if builtinCommands[cmd.Name()] {
+		return
+	}
+
+	s.Commands = append(s.Commands, describe(cmd))
+
+	children := cmd.Commands()
+	for i := range children {
+		collect(children[i], s)
+	}
+}
+
+// describe snapshots a single command.
+func describe(cmd *cobra.Command) Command {
+	out := Command{
+		Path:       cmd.CommandPath(),
+		Use:        cmd.Use,
+		Short:      cmd.Short,
+		Aliases:    append([]string(nil), cmd.Aliases...),
+		Hidden:     cmd.Hidden,
+		Deprecated: cmd.Deprecated,
+		Runnable:   cmd.Runnable(),
+		Example:    cmd.Example,
+	}
+
+	resolved := resolveFlags(cmd)
+	out.Flags = make([]Flag, 0, len(resolved))
+	for i := range resolved {
+		f := resolved[i].flag
+		out.Flags = append(out.Flags, Flag{
+			Name:       f.Name,
+			Shorthand:  f.Shorthand,
+			Type:       f.Value.Type(),
+			Default:    f.DefValue,
+			Usage:      f.Usage,
+			Deprecated: f.Deprecated,
+			Inherited:  resolved[i].inherited,
+			Hidden:     f.Hidden,
+		})
+	}
+
+	rejected := probeRejections(cmd, resolved)
+	for i := range out.Flags {
+		if reason, ok := rejected[out.Flags[i].Name]; ok {
+			out.Flags[i].Rejected = true
+			out.Flags[i].RejectedReason = reason
+		}
+	}
+
+	return out
+}
+
+// resolvedFlag is one flag reachable from a command, and whether the command
+// gets it from an ancestor rather than declaring it itself.
+type resolvedFlag struct {
+	flag      *pflag.Flag
+	inherited bool
+}
+
+// resolveFlags returns every flag usable on cmd — the flags it declares itself,
+// its own persistent flags, and its ancestors' persistent flags — sorted by
+// name.
+//
+// It reads only cobra's non-mutating accessors (Flags, PersistentFlags,
+// Parent), so it leaves the tree exactly as it found it. Classification comes
+// from the ancestors' persistent-flag names rather than from what happens to be
+// in cmd.Flags(), which makes the result identical whether or not something
+// else already merged the tree.
+func resolveFlags(cmd *cobra.Command) []resolvedFlag {
+	inherited := map[string]bool{}
+	for parent := cmd.Parent(); parent != nil; parent = parent.Parent() {
+		parent.PersistentFlags().VisitAll(func(f *pflag.Flag) { inherited[f.Name] = true })
+	}
+
+	var out []resolvedFlag
+	seen := map[string]bool{}
+	visit := func(f *pflag.Flag) {
+		if seen[f.Name] || f.Name == HelpFlag {
+			return
+		}
+		seen[f.Name] = true
+		out = append(out, resolvedFlag{flag: f, inherited: inherited[f.Name]})
+	}
+
+	cmd.Flags().VisitAll(visit)
+	cmd.PersistentFlags().VisitAll(visit)
+	for parent := cmd.Parent(); parent != nil; parent = parent.Parent() {
+		parent.PersistentFlags().VisitAll(visit)
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].flag.Name < out[j].flag.Name })
+	return out
+}
+
+// probeRejections reports which of the resolved flags cmd's PreRunE refuses,
+// keyed by flag name with the error text as the value.
+//
+// The probe runs PreRunE against a shadow command holding copies of the flags,
+// one copy marked as set at a time. A guard reads the command it is handed
+// (cobra passes the command being executed), so the shadow is what it inspects
+// — and because the Changed bits being flipped belong to copies, the real tree
+// is never written to at all. Two guards keep the result trustworthy:
+//
+//   - Every copy starts with Changed cleared, so a flag another test left
+//     marked as set cannot make the baseline fail and silently drop the probe.
+//   - The baseline (no flag set) must pass. A PreRunE that fails
+//     unconditionally tells us nothing about individual flags, so nothing is
+//     reported.
+func probeRejections(cmd *cobra.Command, resolved []resolvedFlag) map[string]string {
+	if cmd.PreRunE == nil {
+		return nil
+	}
+
+	shadow := &cobra.Command{Use: cmd.Name()}
+	copies := make([]*pflag.Flag, 0, len(resolved))
+	for i := range resolved {
+		duplicate := *resolved[i].flag
+		duplicate.Changed = false
+		copies = append(copies, &duplicate)
+		shadow.Flags().AddFlag(&duplicate)
+	}
+
+	if err := cmd.PreRunE(shadow, nil); err != nil {
+		return nil
+	}
+
+	var out map[string]string
+	for _, f := range copies {
+		f.Changed = true
+		err := cmd.PreRunE(shadow, nil)
+		f.Changed = false
+		if err == nil {
+			continue
+		}
+		if out == nil {
+			out = map[string]string{}
+		}
+		out[f.Name] = err.Error()
+	}
+	return out
+}
+
+// Hash is a stable fingerprint of the structural surface: command paths, names,
+// aliases, visibility, and each flag's name, shorthand, type, default and
+// usability. Descriptive prose (Short, Usage, Example) is deliberately excluded
+// so that rewording help text does not move a hash downstream consumers pin.
+func (s Surface) Hash() string {
+	lines := make([]string, 0, len(s.Commands)*4)
+	for i := range s.Commands {
+		c := &s.Commands[i]
+		lines = append(lines, strings.Join([]string{
+			"command", c.Path, c.Use, strings.Join(c.Aliases, ","),
+			strconv.FormatBool(c.Hidden), strconv.FormatBool(c.Runnable), c.Deprecated,
+		}, "\t"))
+		for j := range c.Flags {
+			f := &c.Flags[j]
+			lines = append(lines, strings.Join([]string{
+				"flag", c.Path, f.Name, f.Shorthand, f.Type, f.Default,
+				strconv.FormatBool(f.Inherited), strconv.FormatBool(f.Hidden),
+				strconv.FormatBool(f.Rejected), f.Deprecated,
+			}, "\t"))
+		}
+	}
+	sum := sha256.Sum256([]byte(strings.Join(lines, "\n")))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// Command returns the command at the given full path.
+func (s Surface) Command(path string) (*Command, bool) {
+	for i := range s.Commands {
+		if s.Commands[i].Path == path {
+			return &s.Commands[i], true
+		}
+	}
+	return nil, false
+}
+
+// Children returns the direct subcommands of path, in path order.
+func (s Surface) Children(path string) []*Command {
+	prefix := path + " "
+	var out []*Command
+	for i := range s.Commands {
+		p := s.Commands[i].Path
+		if strings.HasPrefix(p, prefix) && !strings.Contains(p[len(prefix):], " ") {
+			out = append(out, &s.Commands[i])
+		}
+	}
+	return out
+}
+
+// Root returns the shortest command path in the surface, i.e. the binary name.
+func (s Surface) Root() string {
+	if len(s.Commands) == 0 {
+		return ""
+	}
+	root := s.Commands[0].Path
+	for i := range s.Commands {
+		if len(s.Commands[i].Path) < len(root) {
+			root = s.Commands[i].Path
+		}
+	}
+	return root
+}
+
+// Flag returns the named flag as it applies to the command at path.
+func (c *Command) Flag(name string) (*Flag, bool) {
+	for i := range c.Flags {
+		if c.Flags[i].Name == name {
+			return &c.Flags[i], true
+		}
+	}
+	return nil, false
+}
+
+// FlagByShorthand returns the flag carrying the single-character shorthand.
+func (c *Command) FlagByShorthand(short string) (*Flag, bool) {
+	for i := range c.Flags {
+		if c.Flags[i].Shorthand != "" && c.Flags[i].Shorthand == short {
+			return &c.Flags[i], true
+		}
+	}
+	return nil, false
+}
+
+// FlagNames returns every long flag name that appears anywhere in the surface.
+func (s Surface) FlagNames() []string {
+	seen := map[string]bool{}
+	var out []string
+	for i := range s.Commands {
+		c := &s.Commands[i]
+		for j := range c.Flags {
+			if name := c.Flags[j].Name; !seen[name] {
+				seen[name] = true
+				out = append(out, name)
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/clisurface/surface.go
+++ b/internal/clisurface/surface.go
@@ -113,13 +113,21 @@ type Flag struct {
 // than from a hand-maintained table, so removing the guard in the command
 // changes the surface and reddens the gate.
 //
-// Walk does not mutate the tree. That is a hard requirement, not a nicety: a
-// cobra tree is usually a package-level variable shared by every test in a
-// binary, so any mutation leaks into whatever runs next. In particular Walk
+// Walk does not mutate the observable tree. That is a hard requirement, not a
+// nicety: a cobra tree is usually a package-level variable shared by every test
+// in a binary, so any mutation leaks into whatever runs next. In particular Walk
 // never calls cobra's LocalFlags or InheritedFlags accessors — both call
 // mergePersistentFlags, which permanently folds every ancestor's persistent
 // flags into the command's own FlagSet — and it never flips a Changed bit on a
 // real flag (see resolveFlags and probeRejections).
+//
+// One cobra-internal write is unavoidable and harmless: cmd.Commands() sorts a
+// command's child slice in place when cobra.EnableCommandSorting is set (the
+// default), which is the only way to enumerate children. It is the same sort
+// cobra performs itself before printing help, it is idempotent, and the slice is
+// unexported — every route to it calls Commands() and therefore sorts first — so
+// no caller can observe the difference. Toggling the package-level
+// EnableCommandSorting to avoid it would be a data race with any parallel test.
 //
 // Only PreRunE is probed. A guard implemented in PersistentPreRunE or in RunE
 // is not visible to Walk.
@@ -240,10 +248,28 @@ func resolveFlags(cmd *cobra.Command) []resolvedFlag {
 //   - The baseline (no flag set) must pass. A PreRunE that fails
 //     unconditionally tells us nothing about individual flags, so nothing is
 //     reported.
-func probeRejections(cmd *cobra.Command, resolved []resolvedFlag) map[string]string {
+//
+// The copies are shallow, so a copy shares the real flag's pflag.Value pointer.
+// Only Changed is written, which lives in the copy — but a future guard that
+// called Set on a flag would write through to the live tree. A guard that reads
+// its inputs is the contract here; see the recover below for the other half.
+//
+// Probing calls PreRunE outside cobra's execution lifecycle, so a guard that
+// assumed cobra had already validated Args and dereferenced args[0] would panic
+// and take the whole gate down. That is recovered rather than propagated: an
+// unprobeable command yields no rejections, which is the same conservative
+// answer as a command with no PreRunE at all, and the deterministic half of the
+// gate still covers it.
+func probeRejections(cmd *cobra.Command, resolved []resolvedFlag) (rejections map[string]string) {
 	if cmd.PreRunE == nil {
 		return nil
 	}
+
+	defer func() {
+		if recover() != nil {
+			rejections = nil
+		}
+	}()
 
 	shadow := &cobra.Command{Use: cmd.Name()}
 	copies := make([]*pflag.Flag, 0, len(resolved))
@@ -258,7 +284,7 @@ func probeRejections(cmd *cobra.Command, resolved []resolvedFlag) map[string]str
 		return nil
 	}
 
-	var out map[string]string
+	out := map[string]string{}
 	for _, f := range copies {
 		f.Changed = true
 		err := cmd.PreRunE(shadow, nil)
@@ -266,10 +292,10 @@ func probeRejections(cmd *cobra.Command, resolved []resolvedFlag) map[string]str
 		if err == nil {
 			continue
 		}
-		if out == nil {
-			out = map[string]string{}
-		}
 		out[f.Name] = err.Error()
+	}
+	if len(out) == 0 {
+		return nil
 	}
 	return out
 }

--- a/internal/clisurface/surface_test.go
+++ b/internal/clisurface/surface_test.go
@@ -16,6 +16,7 @@ package clisurface
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -389,4 +390,38 @@ func forEachCommand(cmd *cobra.Command, fn func(*cobra.Command)) {
 	for _, child := range cmd.Commands() {
 		forEachCommand(child, fn)
 	}
+}
+
+// TestWalkSurvivesAPreRunEThatNeedsArgs pins the probe's recover. Probing calls
+// PreRunE outside cobra's execution lifecycle, where cobra would have validated
+// Args first — so a guard that reasonably assumes args[0] exists panics. The
+// gate must degrade to "no rejections discovered" rather than take the whole
+// build down.
+func TestWalkSurvivesAPreRunEThatNeedsArgs(t *testing.T) {
+	root := &cobra.Command{Use: "tool", RunE: func(*cobra.Command, []string) error { return nil }}
+	root.PersistentFlags().Duration("timeout", time.Second, "timeout")
+
+	needy := &cobra.Command{
+		Use:  "needy",
+		Args: cobra.ExactArgs(1),
+		RunE: func(*cobra.Command, []string) error { return nil },
+	}
+	needy.Flags().String("target", "", "target")
+	needy.PreRunE = func(_ *cobra.Command, args []string) error {
+		// Legitimate under cobra, which validates Args before PreRunE.
+		if strings.HasPrefix(args[0], "-") {
+			return fmt.Errorf("target must not look like a flag")
+		}
+		return nil
+	}
+	root.AddCommand(needy)
+
+	var s Surface
+	require.NotPanics(t, func() { s = Walk(root) }, "a panicking guard must not take the gate down")
+
+	cmd, ok := s.Command("tool needy")
+	require.True(t, ok, "the command is still described")
+	flag, ok := cmd.Flag("timeout")
+	require.True(t, ok, "its inherited flags are still recorded")
+	assert.False(t, flag.Rejected, "an unprobeable command reports no rejections, the conservative answer")
 }

--- a/internal/clisurface/surface_test.go
+++ b/internal/clisurface/surface_test.go
@@ -1,0 +1,392 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clisurface
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestTree builds a synthetic command tree that mirrors the shapes the real
+// brutus tree has: a root with persistent flags, a leaf with local flags, a
+// leaf that rejects an inherited flag from its PreRunE, aliases, a hidden and
+// deprecated command, and a group command that is not runnable.
+func newTestTree() *cobra.Command {
+	root := &cobra.Command{Use: "tool", Short: "a tool", RunE: func(*cobra.Command, []string) error { return nil }}
+	root.PersistentFlags().Duration("timeout", 10*time.Second, "per-target timeout")
+	root.PersistentFlags().BoolP("json", "j", false, "JSON output")
+	root.Flags().Bool("version", false, "show version")
+
+	scan := &cobra.Command{
+		Use:     "scan",
+		Short:   "scan things",
+		Aliases: []string{"sc", "scanner"},
+		Example: "  # scan one host\n  tool scan --target host",
+		RunE:    func(*cobra.Command, []string) error { return nil },
+	}
+	scan.Flags().StringP("target", "t", "", "target host:port")
+
+	// guarded mirrors brutus's logon family: it inherits --timeout from the
+	// root but its PreRunE hard-errors when the flag is set.
+	guarded := &cobra.Command{Use: "guarded", Short: "rejects --timeout", RunE: func(*cobra.Command, []string) error { return nil }}
+	guarded.Flags().Duration("scan-timeout", time.Second, "settle deadline")
+	guarded.PreRunE = func(c *cobra.Command, _ []string) error {
+		if c.Flags().Changed("timeout") {
+			return fmt.Errorf("--timeout is not valid here; use --scan-timeout")
+		}
+		return nil
+	}
+
+	group := &cobra.Command{Use: "group", Short: "a group of things"}
+	leaf := &cobra.Command{Use: "leaf", Short: "a leaf", RunE: func(*cobra.Command, []string) error { return nil }}
+	leaf.Flags().String("only-here", "", "leaf-local flag")
+	hidden := &cobra.Command{
+		Use:        "old",
+		Short:      "the old spelling",
+		Hidden:     true,
+		Deprecated: `use "tool group leaf" instead`,
+		RunE:       func(*cobra.Command, []string) error { return nil },
+	}
+	group.AddCommand(leaf, hidden)
+
+	root.AddCommand(scan, guarded, group)
+	return root
+}
+
+func TestWalkCollectsEveryCommandSortedByPath(t *testing.T) {
+	s := Walk(newTestTree())
+
+	var paths []string
+	for i := range s.Commands {
+		paths = append(paths, s.Commands[i].Path)
+	}
+	assert.Equal(t, []string{
+		"tool",
+		"tool group",
+		"tool group leaf",
+		"tool group old",
+		"tool guarded",
+		"tool scan",
+	}, paths, "commands must be collected recursively and sorted by full path")
+}
+
+func TestWalkRecordsCommandMetadata(t *testing.T) {
+	s := Walk(newTestTree())
+
+	scan, ok := s.Command("tool scan")
+	require.True(t, ok, "tool scan must be in the surface")
+	assert.Equal(t, "scan", scan.Use)
+	assert.Equal(t, "scan things", scan.Short)
+	assert.Equal(t, []string{"sc", "scanner"}, scan.Aliases)
+	assert.True(t, scan.Runnable, "scan has a RunE so it is runnable")
+	assert.False(t, scan.Hidden)
+	assert.Contains(t, scan.Example, "tool scan --target host")
+
+	group, ok := s.Command("tool group")
+	require.True(t, ok)
+	assert.False(t, group.Runnable, "a command with no RunE only groups subcommands")
+
+	old, ok := s.Command("tool group old")
+	require.True(t, ok)
+	assert.True(t, old.Hidden, "hidden commands stay in the surface so the linter accepts them")
+	assert.Equal(t, `use "tool group leaf" instead`, old.Deprecated)
+}
+
+func TestWalkSeparatesLocalFromInheritedFlags(t *testing.T) {
+	s := Walk(newTestTree())
+
+	scan, ok := s.Command("tool scan")
+	require.True(t, ok)
+
+	target, ok := scan.Flag("target")
+	require.True(t, ok, "scan must carry its own --target")
+	assert.False(t, target.Inherited, "--target is declared on scan")
+	assert.Equal(t, "t", target.Shorthand)
+	assert.Equal(t, "string", target.Type)
+
+	timeout, ok := scan.Flag("timeout")
+	require.True(t, ok, "scan must carry the root-persistent --timeout")
+	assert.True(t, timeout.Inherited, "--timeout reaches scan from the root")
+	assert.Equal(t, "duration", timeout.Type)
+	assert.Equal(t, "10s", timeout.Default)
+
+	_, ok = scan.Flag("version")
+	assert.False(t, ok, "--version is local to the root and must not leak into subcommands")
+
+	root, ok := s.Command("tool")
+	require.True(t, ok)
+	version, ok := root.Flag("version")
+	require.True(t, ok)
+	assert.False(t, version.Inherited, "the root's own flags are not inherited")
+}
+
+func TestWalkSortsFlagsByName(t *testing.T) {
+	s := Walk(newTestTree())
+
+	scan, ok := s.Command("tool scan")
+	require.True(t, ok)
+
+	var names []string
+	for i := range scan.Flags {
+		names = append(names, scan.Flags[i].Name)
+	}
+	assert.Equal(t, []string{"json", "target", "timeout"}, names, "flags must be sorted by name")
+}
+
+func TestWalkMarksFlagsTheCommandRejects(t *testing.T) {
+	s := Walk(newTestTree())
+
+	guarded, ok := s.Command("tool guarded")
+	require.True(t, ok)
+
+	timeout, ok := guarded.Flag("timeout")
+	require.True(t, ok, "the rejected flag is still reachable, so it stays in the surface")
+	assert.True(t, timeout.Rejected, "PreRunE hard-errors on --timeout, so it is not usable here")
+	assert.Equal(t, "--timeout is not valid here; use --scan-timeout", timeout.RejectedReason,
+		"the rejection reason is recorded so the generated reference can explain it")
+
+	scanTimeout, ok := guarded.Flag("scan-timeout")
+	require.True(t, ok)
+	assert.False(t, scanTimeout.Rejected, "the replacement flag is usable")
+
+	json, ok := guarded.Flag("json")
+	require.True(t, ok)
+	assert.False(t, json.Rejected, "only the guarded flag is rejected, not every inherited flag")
+
+	sibling, ok := s.Command("tool scan")
+	require.True(t, ok)
+	siblingTimeout, ok := sibling.Flag("timeout")
+	require.True(t, ok)
+	assert.False(t, siblingTimeout.Rejected, "the rejection is per command, not global")
+}
+
+func TestWalkDetectsRejectionEvenWhenAFlagWasAlreadySet(t *testing.T) {
+	root := newTestTree()
+	guarded, _, err := root.Find([]string{"guarded"})
+	require.NoError(t, err)
+
+	// Simulate an earlier test having parsed --timeout on the shared flag.
+	require.NoError(t, root.PersistentFlags().Set("timeout", "30s"))
+	require.True(t, root.PersistentFlags().Lookup("timeout").Changed)
+
+	s := Walk(root)
+
+	cmd, ok := s.Command("tool guarded")
+	require.True(t, ok)
+	timeout, ok := cmd.Flag("timeout")
+	require.True(t, ok)
+	assert.True(t, timeout.Rejected,
+		"a Changed bit left set by another test must not hide the rejection")
+
+	assert.True(t, root.PersistentFlags().Lookup("timeout").Changed,
+		"the probe must not clear a Changed bit that was already set")
+	assert.Equal(t, "30s", root.PersistentFlags().Lookup("timeout").Value.String(),
+		"the probe must never touch flag values")
+	assert.Nil(t, guarded.Flags().Lookup("timeout"),
+		"and it must not merge the ancestor's flag into the command's own FlagSet")
+}
+
+// TestWalkDoesNotMutateTheTree pins the invariant that broke once already: a
+// cobra tree is package-level state shared by every test in a binary, so a Walk
+// that merges persistent flags into a command's own FlagSet makes every later
+// test see flags the command does not declare.
+func TestWalkDoesNotMutateTheTree(t *testing.T) {
+	root := newTestTree()
+	scan, _, err := root.Find([]string{"scan"})
+	require.NoError(t, err)
+	guarded, _, err := root.Find([]string{"guarded"})
+	require.NoError(t, err)
+
+	require.Nil(t, scan.Flags().Lookup("timeout"),
+		"precondition: the child does not declare the root's persistent flag")
+	require.Nil(t, scan.Flags().ShorthandLookup("j"),
+		"precondition: the child does not declare the root's persistent shorthand")
+
+	s := Walk(root)
+
+	timeout, ok := mustFlag(t, s, "tool scan", "timeout")
+	require.True(t, ok)
+	require.True(t, timeout.Inherited, "the surface still records the inherited flag")
+
+	assert.Nil(t, scan.Flags().Lookup("timeout"),
+		"Walk must not fold the root's persistent flags into the child's own FlagSet")
+	assert.Nil(t, scan.Flags().ShorthandLookup("j"),
+		"nor its shorthands, which is what makes a -t collision test start failing")
+	assert.Nil(t, guarded.Flags().Lookup("timeout"),
+		"not even on a command whose PreRunE the probe had to run")
+
+	for _, name := range []string{"timeout", "json"} {
+		assert.False(t, root.PersistentFlags().Lookup(name).Changed,
+			"--%s must not be left marked as set by the probe", name)
+	}
+}
+
+func TestWalkIsIdenticalWhetherTheTreeWasAlreadyMerged(t *testing.T) {
+	pristine := Walk(newTestTree())
+
+	merged := newTestTree()
+	// InheritedFlags is cobra's mutating accessor: calling it folds the
+	// ancestors' persistent flags into each command's own FlagSet, which is the
+	// state Walk finds when another test rendered help or executed the tree
+	// first.
+	forEachCommand(merged, func(c *cobra.Command) { _ = c.InheritedFlags() })
+	require.NotNil(t, mustCommand(t, merged, "scan").Flags().Lookup("timeout"),
+		"precondition: the tree really is merged now")
+
+	assert.Equal(t, pristine, Walk(merged),
+		"flag classification must come from the ancestors' persistent flags, not from whatever is in cmd.Flags()")
+	assert.Equal(t, pristine.Hash(), Walk(merged).Hash())
+}
+
+func TestWalkIgnoresCommandsWithoutAnAttributableRejection(t *testing.T) {
+	root := &cobra.Command{Use: "tool", RunE: func(*cobra.Command, []string) error { return nil }}
+	root.PersistentFlags().Bool("json", false, "JSON output")
+	always := &cobra.Command{Use: "always", Short: "always fails", RunE: func(*cobra.Command, []string) error { return nil }}
+	always.PreRunE = func(*cobra.Command, []string) error { return fmt.Errorf("this command always refuses to run") }
+	root.AddCommand(always)
+
+	s := Walk(root)
+
+	cmd, ok := s.Command("tool always")
+	require.True(t, ok)
+	for i := range cmd.Flags {
+		assert.False(t, cmd.Flags[i].Rejected,
+			"a PreRunE that fails unconditionally attributes nothing to flag %q", cmd.Flags[i].Name)
+	}
+}
+
+func TestWalkExcludesCobrasInjectedCommands(t *testing.T) {
+	root := newTestTree()
+	// Executing a tree is what makes cobra inject help/completion. Whether
+	// that happened must not change the surface.
+	root.InitDefaultHelpCmd()
+	root.InitDefaultCompletionCmd()
+
+	s := Walk(root)
+
+	_, hasHelp := s.Command("tool help")
+	_, hasCompletion := s.Command("tool completion")
+	assert.False(t, hasHelp, "cobra's injected help command is not part of the documented surface")
+	assert.False(t, hasCompletion, "cobra's injected completion command is not part of the documented surface")
+}
+
+func TestWalkIsDeterministic(t *testing.T) {
+	first := Walk(newTestTree())
+	second := Walk(newTestTree())
+
+	assert.Equal(t, first, second, "two walks of identical trees must produce identical surfaces")
+	assert.Equal(t, first.Hash(), second.Hash(), "and identical hashes")
+
+	firstJSON, err := RenderJSON(first)
+	require.NoError(t, err)
+	secondJSON, err := RenderJSON(second)
+	require.NoError(t, err)
+	assert.Equal(t, string(firstJSON), string(secondJSON), "rendering must be byte-identical")
+}
+
+func TestHashTracksStructureNotProse(t *testing.T) {
+	base := Walk(newTestTree())
+
+	renamed := Walk(newTestTree())
+	cmd, ok := renamed.Command("tool scan")
+	require.True(t, ok)
+	flag, ok := cmd.Flag("target")
+	require.True(t, ok)
+	flag.Name = "host"
+	assert.NotEqual(t, base.Hash(), renamed.Hash(), "renaming a flag must move the hash")
+
+	reworded := Walk(newTestTree())
+	cmd, ok = reworded.Command("tool scan")
+	require.True(t, ok)
+	cmd.Short = "scan things, but described differently"
+	flag, ok = cmd.Flag("target")
+	require.True(t, ok)
+	flag.Usage = "reworded usage"
+	assert.Equal(t, base.Hash(), reworded.Hash(),
+		"the hash pins the structural surface, so rewording help text must not move it")
+}
+
+func TestSurfaceLookupHelpers(t *testing.T) {
+	s := Walk(newTestTree())
+
+	assert.Equal(t, "tool", s.Root(), "the root is the shortest command path")
+
+	var childPaths []string
+	for _, c := range s.Children("tool") {
+		childPaths = append(childPaths, c.Path)
+	}
+	assert.Equal(t, []string{"tool group", "tool guarded", "tool scan"}, childPaths,
+		"Children returns direct subcommands only")
+
+	assert.Equal(t, []string{"tool group leaf", "tool group old"},
+		pathsOf(s.Children("tool group")))
+
+	_, ok := s.Command("tool nope")
+	assert.False(t, ok)
+
+	assert.Equal(t, []string{"json", "only-here", "scan-timeout", "target", "timeout", "version"},
+		s.FlagNames(), "FlagNames is the sorted union of every flag in the tree")
+
+	scan, ok := s.Command("tool scan")
+	require.True(t, ok)
+	byShorthand, ok := scan.FlagByShorthand("t")
+	require.True(t, ok)
+	assert.Equal(t, "target", byShorthand.Name)
+	_, ok = scan.FlagByShorthand("z")
+	assert.False(t, ok)
+}
+
+func TestSurfaceRootOfEmptySurface(t *testing.T) {
+	assert.Empty(t, Surface{}.Root())
+}
+
+// pathsOf is a test helper that flattens command pointers to their paths.
+func pathsOf(cmds []*Command) []string {
+	out := make([]string, 0, len(cmds))
+	for _, c := range cmds {
+		out = append(out, c.Path)
+	}
+	return out
+}
+
+// mustFlag looks up one flag of one command in a surface.
+func mustFlag(t *testing.T, s Surface, path, name string) (*Flag, bool) {
+	t.Helper()
+	cmd, ok := s.Command(path)
+	require.True(t, ok, "command %q must be in the surface", path)
+	return cmd.Flag(name)
+}
+
+// mustCommand resolves a command by name from a live cobra tree.
+func mustCommand(t *testing.T, root *cobra.Command, name string) *cobra.Command {
+	t.Helper()
+	cmd, _, err := root.Find([]string{name})
+	require.NoError(t, err)
+	require.NotNil(t, cmd)
+	return cmd
+}
+
+// forEachCommand applies fn to every command in the tree.
+func forEachCommand(cmd *cobra.Command, fn func(*cobra.Command)) {
+	fn(cmd)
+	for _, child := range cmd.Commands() {
+		forEachCommand(child, fn)
+	}
+}

--- a/internal/plugins/rdp/detect.go
+++ b/internal/plugins/rdp/detect.go
@@ -307,8 +307,9 @@ func (p *Plugin) runStickyKeysDetection(ctx context.Context, inst *wasmInstance,
 		dumpFrame(dir, addr, "sticky_keys", "response", response, width, height)
 	}
 
-	// Vision API confirmation is optional: requires ANTHROPIC_API_KEY and
-	// can be disabled with --no-vision flag.
+	// Vision API confirmation is optional: it requires ANTHROPIC_API_KEY and is
+	// opted into with --experimental-ai, which is where noVision comes from
+	// (see workers.go: NoVision is !AIMode).
 	var visionAPIKey string
 	if !noVision {
 		visionAPIKey = os.Getenv("ANTHROPIC_API_KEY")
@@ -371,8 +372,9 @@ func (p *Plugin) runUtilmanDetection(ctx context.Context, inst *wasmInstance, ad
 		dumpFrame(dir, addr, "utilman", "response", response, width, height)
 	}
 
-	// Vision API confirmation is optional: requires ANTHROPIC_API_KEY and
-	// can be disabled with --no-vision flag.
+	// Vision API confirmation is optional: it requires ANTHROPIC_API_KEY and is
+	// opted into with --experimental-ai, which is where noVision comes from
+	// (see workers.go: NoVision is !AIMode).
 	var visionAPIKey string
 	if !noVision {
 		visionAPIKey = os.Getenv("ANTHROPIC_API_KEY")

--- a/pkg/brutus/brutus.go
+++ b/pkg/brutus/brutus.go
@@ -135,7 +135,7 @@ type Result struct {
 	LLMSuggested      bool     // was this credential suggested by LLM?
 	LLMSuggestedCreds []string // all LLM suggestions for this service
 
-	// Scan metadata (optional, used in --scan mode for backdoor detection)
+	// Scan metadata (optional, used by the logon-family scans for backdoor detection)
 	ScanType string // scan type identifier (e.g., "sticky_keys", "utilman")
 }
 


### PR DESCRIPTION
Closes ENG-6871.

## Problem

The documented brutus CLI surface had drifted from the code, with nothing anywhere that would have noticed. The published [blog post](https://www.praetorian.com/blog/rdp-sticky-keys-backdoor-brutus/) documents `--sticky-keys-web`, `--sticky-keys-open` and `--sticky-keys-exec`; none of those flags exist. Comments in the repo still named removed flags too. Nothing in CI compared what the documentation claimed against what cobra registers, so every rename silently invalidated the README, the blog, and anything written from them — soon to include a `using-brutus` skill.

## Approach

Derive the surface from the command tree instead of asserting it in prose.

`internal/clisurface` walks a `*cobra.Command` into a deterministic model, renders it as JSON and Markdown, diffs two surfaces into per-flag findings, and lints documents and Go comments against it.

The gate is a **test**, not a subcommand, because `cmd/brutus` is `package main` and the tree cannot be reached from a separate generator binary. A test in that package reaches `rootCmd` directly and adds no CLI surface — a `brutus docs` subcommand would have had to document itself.

## Generated artifacts

| File | Purpose |
|---|---|
| `docs/cli-surface.json` | Machine-readable surface (`schemaVersion`, `surfaceHash`). Attached to every release by goreleaser, so a downstream consumer pins a version rather than scraping prose. |
| `docs/CLI.md` | Full reference: every command, alias and flag. |
| `README.md` | Two small generated regions in Quick Start. |

`make cli-docs` regenerates all three. That is the single command to run after a deliberate rename, so the gate stays cheap to satisfy rather than becoming friction that gets disabled.

## What the gate catches

Both directions, per command, naming the flag and the file to update:

```
CLI surface drift: 6 disagreement(s) between the generated documentation and the cobra command tree.

  1. flag --no-nla-check on "brutus logon" is registered by cobra but missing from the generated docs
     fix: regenerate docs/cli-surface.json, docs/CLI.md, README.md with 'make cli-docs'
  2. flag --no-nla-probe on "brutus logon" is in the generated docs but cobra no longer accepts it
     fix: regenerate docs/cli-surface.json, docs/CLI.md, README.md with 'make cli-docs'
```

And the prose linter, which is the half that would actually have caught the blog post:

```
CONTRIBUTING.md:592: --sticky-keys-web is not a flag of any command in the CLI.
  Fix the documentation, or add --sticky-keys-web to docs/cli-surface-allow.txt with a '#' reason
CONTRIBUTING.md:595: --sticky-keys-exec is not a flag of "brutus logon". …
```

It checks every `brutus` invocation in a fenced code block, every backticked flag in prose, and every flag named in a Go comment. Only segments whose `argv[0]` is `brutus` are validated, so the many non-brutus examples (`naabu`, `nerva`, `jq`, `curl`) cannot produce false positives. The allowlist came out to two entries, each with a reason.

`TestCLISurfaceGateDetectsRename` proves the gate reddens — a drift gate only ever observed passing is not known to work.

## Two things worth a reviewer's attention

**`Walk` must not mutate the tree.** cobra's `LocalFlags()` and `InheritedFlags()` both call `mergePersistentFlags()`, which *permanently* folds every ancestor's persistent flags into a command's own `FlagSet`. `rootCmd` is a package-level var, so the first implementation broke six pre-existing tests that assert a command declares no local `-t` shorthand. Flags are now classified from ancestors' `PersistentFlags()` directly, and `PreRunE` is probed on a shadow command holding *copies* of the flags, so no real flag object is ever written. Three tests pin it, including one that forces a merge first and asserts an identical surface.

**Inheritance alone overstates the surface.** `--timeout` is root-persistent, so a naive walk would advertise `brutus logon --timeout` — but `guardLogonTimeoutFlag` hard-refuses it. The model represents that, `docs/CLI.md` gives those three commands a **"Rejected flags"** table carrying cobra's own error text, and documenting it as usable is treated as drift.

## Existing drift this fixes

- README claimed "six focused subcommands"; cobra registers eight.
- README gave `logon` six aliases (`stickykeys`, `sticky-keys`, `utilman`, `sethc`, `winlogon`, `accessibility`) when it declares **none** — `logon_subcommand_wiring_test.go:67` already asserts `sticky-keys` resolves to nothing, and `stickykeys`/`utilman` are separate top-level commands.
- Stale flag names in comments: `--sticky-keys-exec`/`--sticky-keys-web` (`runner.go:424`), plus `--nerva` (`runner.go:36`) and `--scan` (`pkg/brutus/brutus.go:138`), which the ticket did not list and the linter found.

## CI

`.github/workflows/cli-surface.yml` runs on every pull request with **no `paths:` filter**, deliberately. Drift usually arrives as a markdown-only change, and `ci.yml` filters on `**/*.go`, `go.mod`, `go.sum`, `.golangci*` and `Makefile` — so a README-only PR runs no CI at all today. A gate a README-only change could skip would not have caught the drift that motivated it, which is why this is not a step in `ci.yml`.

## Verification

| Check | Result |
|---|---|
| `CGO_ENABLED=0 go test -short ./...` | green, 57 packages |
| `go test ./internal/clisurface/... -race` | ok |
| `golangci-lint run --max-same-issues=0 --max-issues-per-linter=0 ./...` | `0 issues.` |
| `gofmt -l` / `go mod tidy -diff` | clean |
| `goreleaser check` / `actionlint` | pass |
| 3× `make cli-docs` | byte-identical output |
| Each of the 4 commits, independently | green |

## Scope

**Out:** the guard-skills side of the pin (sibling ticket — this PR produces the artifact it consumes); the published blog post, which is not in this repo.

**Known limit:** the linter enforces that documented flags *exist*, and the golden diff enforces that registered flags are documented *in `docs/CLI.md`*. It does not require the README's hand-written logon prose to mention every new logon flag — that section stays curated, with `docs/CLI.md` as the complete reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
