### PR TITLE
feat: distinguish unauthenticated access from credential authentication (ENG-6689, partial)

### DIFF
--- a/pkg/brutus/brutus.go
+++ b/pkg/brutus/brutus.go
@@ -118,6 +118,34 @@ type Config struct {
 	ProxyURL        string        // SOCKS5 proxy URL for all connections (e.g., "socks5://127.0.0.1:1080")
 }
 
+// ResultKind identifies what a Result is evidence of. It is derived at the
+// package boundary from the interface the Result came back through
+// (Plugin.Test / KeyPlugin.TestKey vs. CheckUnauth), so it cannot drift the
+// way per-plugin self-reporting would.
+//
+// Only those two boundaries stamp Kind. Producers that build a Result
+// directly, pkg/brutus/logon among them, leave it KindUnspecified even when
+// they set Success, so an unspecified kind does not mean the attempt failed.
+// A consumer must therefore test Kind == KindCredential positively, and must
+// never infer a credential authentication from Success alone or from
+// Kind != KindUnauthenticated.
+type ResultKind string
+
+const (
+	// KindUnspecified is the zero value: this Result has not been classified.
+	KindUnspecified ResultKind = ""
+	// KindCredential means the tested credentials authenticated successfully.
+	KindCredential ResultKind = "credential_authentication"
+	// KindUnauthenticated means the service granted access with no credentials
+	// at all. It is NOT a credential authentication and must never be reported
+	// as weak or default credentials.
+	KindUnauthenticated ResultKind = "unauthenticated_access"
+	// KindFailed means the attempt did not authenticate.
+	KindFailed ResultKind = "failed_attempt"
+	// KindInconclusive means the attempt could not produce a clean verdict.
+	KindInconclusive ResultKind = "inconclusive_attempt"
+)
+
 // Result contains the outcome of testing a single credential.
 type Result struct {
 	Protocol      string        // protocol used
@@ -137,6 +165,11 @@ type Result struct {
 
 	// Scan metadata (optional, used in --scan mode for backdoor detection)
 	ScanType string // scan type identifier (e.g., "sticky_keys", "utilman")
+
+	// Kind classifies what this Result is evidence of. It is stamped at the
+	// pkg/brutus boundary (classifyCredentialResult / markUnauthenticated).
+	// Purely additive: a consumer that ignores Kind behaves exactly as before.
+	Kind ResultKind
 }
 
 // NewResult creates a Result pre-filled with common fields and Success=false.
@@ -149,6 +182,29 @@ func NewResult(protocol, target, username, password string) *Result {
 		Password: password,
 		Success:  false,
 	}
+}
+
+// classifyCredentialResult returns the kind for a Result produced by a
+// credential attempt (Plugin.Test / KeyPlugin.TestKey). Indeterminate takes
+// precedence over Success: a check that could not reach a verdict is
+// inconclusive, not a credential authentication.
+func classifyCredentialResult(r Result) ResultKind { //nolint:gocritic // hugeParam: signature fixed by the ENG-6689 Result-kind API contract
+	switch {
+	case r.Indeterminate:
+		return KindInconclusive
+	case r.Success:
+		return KindCredential
+	default:
+		return KindFailed
+	}
+}
+
+// markUnauthenticated stamps a Result produced by a CheckUnauth probe as
+// unauthenticated access. It sets Kind and nothing else: Success, Banner,
+// Username, Password and every other field keep their exact values, so the
+// stamp cannot change behavior for any existing consumer of this package.
+func markUnauthenticated(r *Result) {
+	r.Kind = KindUnauthenticated
 }
 
 // LLMConfig enables optional LLM-based banner analysis
@@ -366,14 +422,25 @@ func CheckUnauthAccess(ctx context.Context, target, protocol string, timeout tim
 	// Try the standard plugin registry first
 	if plug, err := GetPlugin(protocol); err == nil {
 		if checker, ok := plug.(UnauthChecker); ok {
-			return checker.CheckUnauth(ctx, target, timeout, pluginCfg)
+			r := checker.CheckUnauth(ctx, target, timeout, pluginCfg)
+			// A confirmed finding from a CheckUnauth probe is unauthenticated
+			// access by construction. A probe that found the service enforces
+			// authentication is left unclassified rather than mislabeled.
+			if r != nil && r.Success {
+				markUnauthenticated(r)
+			}
+			return r
 		}
 		return nil
 	}
 
 	// Try the unauth-only registry
 	if checker, err := GetUnauthChecker(protocol); err == nil {
-		return checker.CheckUnauth(ctx, target, timeout, pluginCfg)
+		r := checker.CheckUnauth(ctx, target, timeout, pluginCfg)
+		if r != nil && r.Success {
+			markUnauthenticated(r)
+		}
+		return r
 	}
 
 	return nil

--- a/pkg/brutus/kind_test.go
+++ b/pkg/brutus/kind_test.go
@@ -1,0 +1,296 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package brutus
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestClassifyCredentialResult pins the precedence rules for deriving a
+// ResultKind from a Result produced by a credential attempt (Plugin.Test /
+// TestKey): Indeterminate always wins over Success, regardless of Success's
+// value, and only then does Success decide credential vs failed.
+func TestClassifyCredentialResult(t *testing.T) {
+	tests := []struct {
+		name   string
+		result Result
+		want   ResultKind
+	}{
+		{
+			name:   "indeterminate with success true still yields inconclusive",
+			result: Result{Indeterminate: true, Success: true},
+			want:   KindInconclusive,
+		},
+		{
+			name:   "indeterminate with success false yields inconclusive",
+			result: Result{Indeterminate: true, Success: false},
+			want:   KindInconclusive,
+		},
+		{
+			name:   "success alone yields credential",
+			result: Result{Indeterminate: false, Success: true},
+			want:   KindCredential,
+		},
+		{
+			name:   "neither success nor indeterminate yields failed",
+			result: Result{Indeterminate: false, Success: false},
+			want:   KindFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, classifyCredentialResult(tt.result))
+		})
+	}
+}
+
+// TestBrute_UnauthCheckSuccess_StampsKindUnauthenticated is the regression pin
+// for the live defect described in ENG-6689: workers.go returned the
+// CheckUnauth result with Success=true and no way to distinguish it from a
+// credential win, so Guard's adapter reported "no authentication at all" as
+// weak credentials. This test drives the real Brute() entry point with a
+// fake plugin whose CheckUnauth reports unauthenticated access, and asserts
+// the single returned Result is stamped KindUnauthenticated and is NOT
+// KindCredential. If the markUnauthenticated stamp in runWorkers is removed,
+// this test must fail.
+func TestBrute_UnauthCheckSuccess_StampsKindUnauthenticated(t *testing.T) {
+	plug := &fakeUnauthPlugin{unauthSuccess: true}
+
+	cfg := &Config{
+		Target:    "test:9999",
+		Protocol:  "fake-unauth",
+		Usernames: []string{"user"},
+		Passwords: []string{"pass"},
+		Timeout:   1 * time.Second,
+		Threads:   1,
+		Plugin:    plug,
+	}
+
+	results, err := Brute(cfg)
+	require.NoError(t, err)
+	require.Len(t, results, 1, "an unauthenticated finding must short-circuit credential testing")
+
+	assert.Equal(t, KindUnauthenticated, results[0].Kind)
+	assert.NotEqual(t, KindCredential, results[0].Kind,
+		"an unauthenticated-access finding must never be reported as a credential authentication")
+}
+
+// TestBrute_UnauthCheckFailure_ProceedsToCredentialTesting is the counterpart
+// to the regression pin above: when CheckUnauth reports the service DOES
+// enforce authentication (Success=false), credential testing must proceed
+// normally and every resulting Result must carry a credential-path kind,
+// never KindUnauthenticated.
+func TestBrute_UnauthCheckFailure_ProceedsToCredentialTesting(t *testing.T) {
+	plug := &fakeUnauthPlugin{unauthSuccess: false}
+
+	// Two distinct usernames, one per password, so the worker pool's
+	// existing per-user early-stop (a cracked user skips its remaining
+	// passwords) cannot collapse this into a single result.
+	cfg := &Config{
+		Target: "test:9999",
+		Credentials: []Credential{
+			{Username: "userA", Password: "correct"},
+			{Username: "userB", Password: "wrong"},
+		},
+		Protocol: "fake-unauth",
+		Timeout:  1 * time.Second,
+		Threads:  1,
+		Plugin:   plug,
+	}
+
+	results, err := Brute(cfg)
+	require.NoError(t, err)
+	require.Len(t, results, 2, "credential testing must run every password when the unauth probe fails")
+
+	for _, r := range results {
+		assert.NotEqual(t, KindUnauthenticated, r.Kind,
+			"a credential-path result must never be stamped KindUnauthenticated")
+		if r.Password == "correct" {
+			assert.Equal(t, KindCredential, r.Kind)
+		} else {
+			assert.Equal(t, KindFailed, r.Kind)
+		}
+	}
+}
+
+// TestBrute_CredentialSuccess_KindCredential pins that a credential success
+// flowing through the worker pool (executeWorkerPool -> runWorkersDefault ->
+// Brute) is classified KindCredential.
+func TestBrute_CredentialSuccess_KindCredential(t *testing.T) {
+	plug := &fakeCredentialPlugin{}
+
+	cfg := &Config{
+		Target:    "test:9999",
+		Protocol:  "fake-credential",
+		Usernames: []string{"user"},
+		Passwords: []string{"success"},
+		Timeout:   1 * time.Second,
+		Threads:   1,
+		Plugin:    plug,
+	}
+
+	results, err := Brute(cfg)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	assert.Equal(t, KindCredential, results[0].Kind)
+}
+
+// TestBrute_CredentialFailureAndIndeterminate_Kinds pins that a credential
+// failure flowing through the worker pool is classified KindFailed, and an
+// indeterminate result is classified KindInconclusive.
+func TestBrute_CredentialFailureAndIndeterminate_Kinds(t *testing.T) {
+	plug := &fakeCredentialPlugin{}
+
+	cfg := &Config{
+		Target:    "test:9999",
+		Protocol:  "fake-credential",
+		Usernames: []string{"user"},
+		Passwords: []string{"fail", "indeterminate"},
+		Timeout:   1 * time.Second,
+		Threads:   1,
+		Plugin:    plug,
+	}
+
+	results, err := Brute(cfg)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	for _, r := range results {
+		switch r.Password {
+		case "fail":
+			assert.Equal(t, KindFailed, r.Kind)
+		case "indeterminate":
+			assert.Equal(t, KindInconclusive, r.Kind)
+		default:
+			t.Fatalf("unexpected password in result: %q", r.Password)
+		}
+	}
+}
+
+// TestMarkUnauthenticated_AdditiveOnly pins that markUnauthenticated only
+// ever adds the Kind stamp: Success, Banner, Username and Password must be
+// byte-identical before and after the call. This is what proves the change
+// cannot alter behavior for any existing consumer of this package (Guard's
+// compute build imports pkg/brutus).
+func TestMarkUnauthenticated_AdditiveOnly(t *testing.T) {
+	r := Result{
+		Protocol: "postgresql",
+		Target:   "10.0.0.5:5432",
+		Success:  true,
+		Banner:   "unauthenticated access confirmed",
+		Username: "someuser",
+		Password: "somepass",
+	}
+	before := r
+
+	markUnauthenticated(&r)
+
+	assert.Equal(t, KindUnauthenticated, r.Kind)
+	assert.Equal(t, before.Success, r.Success, "markUnauthenticated must not touch Success")
+	assert.Equal(t, before.Banner, r.Banner, "markUnauthenticated must not touch Banner")
+	assert.Equal(t, before.Username, r.Username, "markUnauthenticated must not touch Username")
+	assert.Equal(t, before.Password, r.Password, "markUnauthenticated must not touch Password")
+}
+
+// TestResultKind_ZeroValueIsUnspecified pins that a Result built by a plain
+// struct literal with no Kind is KindUnspecified, never KindCredential, so an
+// un-migrated producer is not silently reported as a credential
+// authentication.
+func TestResultKind_ZeroValueIsUnspecified(t *testing.T) {
+	r := Result{
+		Protocol: "ssh",
+		Target:   "test:22",
+		Username: "root",
+		Password: "password",
+		Success:  true,
+	}
+
+	assert.Equal(t, KindUnspecified, r.Kind)
+	assert.NotEqual(t, KindCredential, r.Kind)
+}
+
+// fakeUnauthPlugin is a test double implementing both Plugin and
+// UnauthChecker, so the worker pool's `plug.(UnauthChecker)` type assertion
+// in runWorkers succeeds. unauthSuccess controls what CheckUnauth reports;
+// Test() reports a credential success only for the password "correct" so
+// tests can distinguish credential-path outcomes by Password.
+type fakeUnauthPlugin struct {
+	unauthSuccess bool
+}
+
+func (p *fakeUnauthPlugin) Name() string { return "fake-unauth" }
+
+func (p *fakeUnauthPlugin) CheckUnauth(ctx context.Context, target string, timeout time.Duration, pluginCfg PluginConfig) *Result {
+	return &Result{
+		Protocol: "fake-unauth",
+		Target:   target,
+		Success:  p.unauthSuccess,
+		Banner:   "fake unauth probe",
+	}
+}
+
+func (p *fakeUnauthPlugin) Test(ctx context.Context, target, username, password string, timeout time.Duration, pluginCfg PluginConfig) *Result {
+	return &Result{
+		Protocol: "fake-unauth",
+		Target:   target,
+		Username: username,
+		Password: password,
+		Success:  password == "correct",
+	}
+}
+
+// fakeCredentialPlugin is a test double implementing only Plugin (no
+// UnauthChecker), so runWorkers's unauth pre-check is skipped entirely and
+// every attempt flows through credential testing. Test() reports success,
+// indeterminate, or failure based on the password value.
+type fakeCredentialPlugin struct{}
+
+func (p *fakeCredentialPlugin) Name() string { return "fake-credential" }
+
+func (p *fakeCredentialPlugin) Test(ctx context.Context, target, username, password string, timeout time.Duration, pluginCfg PluginConfig) *Result {
+	switch password {
+	case "success":
+		return &Result{
+			Protocol: "fake-credential",
+			Target:   target,
+			Username: username,
+			Password: password,
+			Success:  true,
+		}
+	case "indeterminate":
+		return &Result{
+			Protocol:      "fake-credential",
+			Target:        target,
+			Username:      username,
+			Password:      password,
+			Indeterminate: true,
+		}
+	default:
+		return &Result{
+			Protocol: "fake-credential",
+			Target:   target,
+			Username: username,
+			Password: password,
+			Success:  false,
+		}
+	}
+}

--- a/pkg/brutus/workers.go
+++ b/pkg/brutus/workers.go
@@ -114,7 +114,9 @@ func runWorkers(ctx context.Context, cfg *Config, plug Plugin) ([]Result, error)
 			if r := checker.CheckUnauth(ctx, cfg.Target, cfg.Timeout, pluginConfigFromConfig(cfg)); r != nil && r.Success {
 				// Service doesn't enforce authentication — credential testing
 				// would produce misleading results (every password "works").
-				// Return only the unauthenticated access finding.
+				// Return only the unauthenticated access finding, stamped so no
+				// consumer can mistake it for a credential authentication.
+				markUnauthenticated(r)
 				return []Result{*r}, nil
 			}
 		}
@@ -335,7 +337,20 @@ func executeWorkerPool(ctx context.Context, cfg *Config, plug Plugin, credential
 	}
 
 	// Wait for all workers to complete
-	if err := g.Wait(); err != nil && err != context.Canceled {
+	err := g.Wait()
+
+	// Classify every Result leaving the credential worker pool. This is the
+	// single exit shared by runWorkersDefault and runWorkersWithLLM, and it also
+	// covers the panic-recovery results appended above. Only an unclassified
+	// Result is stamped, so an explicit kind (e.g. KindUnauthenticated from an
+	// unauth path, or a kind set by a plugin) is never overwritten.
+	for i := range results {
+		if results[i].Kind == KindUnspecified {
+			results[i].Kind = classifyCredentialResult(results[i])
+		}
+	}
+
+	if err != nil && err != context.Canceled {
 		return results, err
 	}
 


### PR DESCRIPTION
Refs ENG-6689. **Partial by design** — see Scope. Does not close the ticket.

## The live defect

`pkg/brutus/workers.go:110-120` returns the unauthenticated-access pre-check finding with `Success: true`, byte-identical in shape to a credential win:

```go
if r := checker.CheckUnauth(...); r != nil && r.Success {
    // Service doesn't enforce authentication ...
    return []Result{*r}, nil
}
```

Guard's adapter keeps every `r.Success`, appends `{r.Username, r.Password}`, and emits `{protocol}-default-service-credentials` / "Weak *X* Credentials" at `model.TriageHigh`. So **a service that enforces no authentication at all is reported to customers as weak credentials.** Unlike the sibling ENG-6865, this is shipping now, not latent.

Reachable for exactly four protocols — the ones registered as credential plugins that *also* implement `CheckUnauth`, so the type assertion in `runWorkers` succeeds:

| plugin | `CheckUnauth` | `Test()` | registered as | reaches Guard |
|---|---|---|---|---|
| postgresql, redis, turn, elasticsearch | yes | yes | `Register` | **yes** |
| docker, kubernetes | yes | no | `RegisterUnauthChecker` | no — `CheckUnauthAccess` is called only from `cmd/brutus` |

## What this PR does and does not do

**It does not stop the mislabeling.** Guard reads `Success` and ignores `Kind`, so behaviour is unchanged — by design. What changes is that the two outcomes become *distinguishable*, which is the prerequisite the Guard-side fix needs. Saying otherwise would oversell a purely additive change.

## Why only criterion #1

ENG-6689's criterion #1 is stated verbatim in the ticket — *"Results distinguish credential authentication, unauthenticated access, failed attempt, and inconclusive attempt"* — so the four kinds are given and no taxonomy is invented here.

The rest is blocked, and inventing it is specifically what the parent epic forbids:

| Criterion | Blocker |
|---|---|
| Credential auth asserts **Verified**; Exploited needs the impact rule | "approved protected-boundary impact rule" — ENG-6667 package-1, unstarted |
| Result kinds declare evidence/occurrence/max stage in the **producer registry** | ENG-6667 work |
| Old records **quarantined** unless decisive evidence | "package-4 manifest" — does not exist |
| **Cross-repository** contract and ingestion tests | needs the Guard-side taxonomy agreed |

ENG-6667's own first acceptance criterion is that those decisions be *recorded before enforcing writers ship*. The Guard-side adapter change is also blocked for a second reason: it collides with ENG-6865, in flight in guard.

## Design: classify at the boundary, not in the plugins

There are ~25 `result.Success = true` sites across `internal/plugins/**`. **None are touched.** The interfaces already carry the distinction — `CheckUnauth` is unauthenticated access by construction, `Test`/`TestKey` is a credential attempt — so one boundary derives the kind and cannot drift the way 25 self-reporting plugins would.

All three `CheckUnauth` return paths are stamped: `runWorkers`, and both `CheckUnauthAccess` branches. `executeWorkerPool` is the sole exit for credential Results — verified exhaustively rather than assumed — and stamps only an unspecified `Kind`, so an explicit stamp is never overwritten.

`CheckUnauthAccess` stamps **only when `r.Success`**. An unconditional stamp would label a *secured* service's probe as `unauthenticated_access` with `Success: false` — the same conflation one level down.

## Purely additive

`Kind` is appended at the end of `Result`; no existing field changes meaning or position; Guard's compute build still compiles unchanged, which matters because it imports this package. No JSON tag: nothing marshals `Result` directly, every other field is untagged, and guessing a serialization contract now would pre-empt the producer registry.

## Known gap — in the type's doc comment, not just this PR

`pkg/brutus/logon` is a **third** producer class on neither boundary, and `DetectBackdoors` can set `Success = true` (`logon.go:147`, `:182`), so `Success: true` with `KindUnspecified` is reachable. It was left unstamped deliberately: deciding whether a sticky-keys backdoor counts as "unauthenticated access" is a semantics call ENG-6667 reserves.

An earlier draft of the doc comment claimed the zero value means a Result "is never silently reported as a credential authentication." **That was false** — brutus cannot enforce it. A consumer applying `Success == true && Kind != KindUnauthenticated ⇒ credential authentication` would read a backdoor positive as weak credentials. The comment now states the real contract: test `Kind == KindCredential` **positively**, never infer from `Success` alone. A doc that promises an unenforceable invariant is worse than none.

## Verified by failure, not by passing

- **The key pin bites.** Remove the `runWorkers` stamp → fails on `Kind == ""`. Note: **not** `KindCredential` — the early return never reaches the pool fallback, so my own prediction there was wrong. Consequence worth knowing: `kind_test.go`'s `assert.NotEqual(t, KindCredential, ...)` is *inert* on that path; only the positive assertion does work. Exactly one of 92 tests moved.
- **Precedence is genuinely pinned.** Inverting the classifier's first two cases fails only the `{Indeterminate: true, Success: true}` case — the one case of four that can discriminate the ordering. The other three pass under both orderings, correctly.
- **Two of three stamps are NOT pinned.** Removing both `CheckUnauthAccess` stamps is invisible: `Brute` never reaches them, and the integration tests that do are behind `//go:build integration` *and* never inspect `Kind`. Recorded rather than papered over.

## Verification

| Check | Result |
|---|---|
| `CGO_ENABLED=0 go test -short ./...` | green |
| `go test ./pkg/brutus/... -race -count=1` | ok, all 6 packages |
| `golangci-lint run --max-same-issues=0 --max-issues-per-linter=0 ./...` | `0 issues.` |
| `gofmt -l ./pkg/brutus` / `go mod tidy -diff` | clean |

## Scope

**Out:** the Guard-side adapter change (blocked + collides with ENG-6865), lifecycle stage mapping, the producer registry, record quarantine, cross-repository contract tests, and the `pkg/brutus/logon` producer class.

**Sibling:** ENG-6865 owns only the failed-attempt banner discard in Guard's adapter; this owns the taxonomy of successful results in brutus. ENG-6865 draws that boundary explicitly, which is why these are separate PRs in separate repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
