### PR TITLE
feat(clisurface): walk the cobra tree into a comparable CLI surface (ENG-6871, 1/6)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/redis/go-redis/v9 v9.22.0
 	github.com/sijms/go-ora/v2 v2.9.0
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.9
 	github.com/stretchr/testify v1.11.1
 	github.com/tetratelabs/wazero v1.12.0
 	go.mongodb.org/mongo-driver v1.17.9
@@ -72,7 +73,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/projectdiscovery/wappalyzergo v0.2.17 // indirect
 	github.com/quic-go/quic-go v0.60.0 // indirect
-	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/tidwall/transform v0.0.0-20201103190739-32f242e2dbde // indirect
 	github.com/twmb/murmur3 v1.1.8 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect

--- a/internal/clisurface/paths.go
+++ b/internal/clisurface/paths.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clisurface
+
+// Repo-relative paths of the generated artifacts and of the documents the linter
+// reads, plus the one command that refreshes them. They live in their own file
+// because both the linter and the artifact plumbing need them, and the gate
+// test, the Makefile target and the CI workflow all have to name the same files.
+const (
+	JSONPath     = "docs/cli-surface.json"
+	MarkdownPath = "docs/CLI.md"
+	READMEPath   = "README.md"
+)
+
+// RegenerateCommand is the single documented way to refresh every artifact.
+const RegenerateCommand = "make cli-docs"
+
+// GeneratedPaths lists the generated artifacts in a stable order, for failure messages.
+func GeneratedPaths() []string {
+	return []string{JSONPath, MarkdownPath, READMEPath}
+}

--- a/internal/clisurface/surface.go
+++ b/internal/clisurface/surface.go
@@ -1,0 +1,438 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package clisurface derives the documented CLI surface of a cobra command
+// tree — every command, alias and flag — from the live tree rather than from
+// prose, renders it into machine- and human-readable artifacts, and reports
+// structured findings when the committed artifacts disagree with the tree.
+package clisurface
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// SchemaVersion is the version of the JSON artifact layout. Bump it when the
+// shape of the rendered JSON changes in a way consumers must notice.
+const SchemaVersion = 1
+
+// builtinCommands are the commands cobra injects into a tree on the first Execute
+// (InitDefaultHelpCmd / InitDefaultCompletionCmd / initCompleteCmd). They are not part
+// of the surface brutus documents, and whether they are present depends on whether
+// something already executed the tree in this process — so excluding them keeps the
+// walk deterministic regardless of test ordering.
+//
+// cobra only ever injects them as direct children of the root, and collect only skips
+// them there: filtering by name at every depth would silently drop a legitimate
+// subcommand called "help" along with its own children.
+var builtinCommands = map[string]bool{
+	"help":                          true,
+	"completion":                    true,
+	cobra.ShellCompRequestCmd:       true,
+	cobra.ShellCompNoDescRequestCmd: true,
+}
+
+// HelpFlag is the flag cobra injects into every command on the first Execute
+// (InitDefaultHelpFlag). Like the built-in commands it is excluded from the
+// surface — whether it is registered yet depends on whether something already
+// executed the tree in this process — and the doc linter accepts it everywhere
+// instead (see vocabulary).
+const HelpFlag = "help"
+
+// Surface is the complete CLI surface of a command tree. Commands are sorted by
+// path and each command's flags are sorted by name, so a Surface renders
+// byte-identically across runs.
+type Surface struct {
+	Commands []Command `json:"commands"`
+}
+
+// Command is one node of the command tree.
+type Command struct {
+	// Path is the full invocation path, e.g. "brutus enum active teams auth".
+	Path string `json:"path"`
+	// Use is the cobra Use string (the command name plus any argument sketch).
+	Use string `json:"use"`
+	// Short is the one-line description cobra shows in listings.
+	Short string `json:"short"`
+	// Aliases are the alternative names that resolve to this command.
+	Aliases []string `json:"aliases,omitempty"`
+	// Hidden reports whether the command is omitted from help output.
+	Hidden bool `json:"hidden,omitempty"`
+	// Deprecated is cobra's deprecation notice, empty when not deprecated.
+	Deprecated string `json:"deprecated,omitempty"`
+	// Runnable reports whether the command does work itself (as opposed to
+	// only grouping subcommands).
+	Runnable bool `json:"runnable"`
+	// Example is cobra's example block, used verbatim in the generated
+	// reference. It is part of the surface because it is documentation that
+	// must stay honest about the flags it shows.
+	Example string `json:"example,omitempty"`
+	// Flags are every flag usable on this command: its own, plus the
+	// persistent flags inherited from its ancestors.
+	Flags []Flag `json:"flags,omitempty"`
+}
+
+// Flag is one flag as it appears on one command. The same flag name can appear
+// on many commands with different Inherited/Rejected values.
+type Flag struct {
+	Name       string `json:"name"`
+	Shorthand  string `json:"shorthand,omitempty"`
+	Type       string `json:"type"`
+	Default    string `json:"default,omitempty"`
+	Usage      string `json:"usage,omitempty"`
+	Deprecated string `json:"deprecated,omitempty"`
+	// Inherited reports whether the flag reaches this command as a persistent
+	// flag of an ancestor rather than being declared on the command itself.
+	Inherited bool `json:"inherited,omitempty"`
+	// Hidden reports whether the flag is omitted from help output.
+	Hidden bool `json:"hidden,omitempty"`
+	// Rejected reports whether the command hard-errors when the flag is set,
+	// even though the flag is reachable from the command's flag set. brutus
+	// uses this for the logon family, which inherits the root-persistent
+	// --timeout but refuses it in favor of --scan-timeout. A flag that is
+	// rejected is not usable on the command: the generated reference must not
+	// present it as an option and the doc linter must reject examples using it.
+	Rejected bool `json:"rejected,omitempty"`
+	// RejectedReason is the error the command returns when the flag is set.
+	RejectedReason string `json:"rejectedReason,omitempty"`
+}
+
+// Walk derives the surface of the tree rooted at root.
+//
+// Inherited flags are recorded per command, because inheritance alone does not
+// make a flag usable: a command's PreRunE may reject a flag it inherits. Walk
+// discovers those rejections by probing PreRunE (see probeRejections) rather
+// than from a hand-maintained table, so removing the guard in the command
+// changes the surface and reddens the gate.
+//
+// Walk does not mutate the observable tree. That is a hard requirement, not a
+// nicety: a cobra tree is usually a package-level variable shared by every test
+// in a binary, so any mutation leaks into whatever runs next. In particular Walk
+// never calls cobra's LocalFlags or InheritedFlags accessors — both call
+// mergePersistentFlags, which permanently folds every ancestor's persistent
+// flags into the command's own FlagSet — and it never flips a Changed bit on a
+// real flag (see resolveFlags and probeRejections).
+//
+// One cobra-internal write is unavoidable and harmless: cmd.Commands() sorts a
+// command's child slice in place when cobra.EnableCommandSorting is set (the
+// default), which is the only way to enumerate children. It is the same sort
+// cobra performs itself before printing help, it is idempotent, and the slice is
+// unexported — every route to it calls Commands() and therefore sorts first — so
+// no caller can observe the difference. Toggling the package-level
+// EnableCommandSorting to avoid it would be a data race with any parallel test.
+//
+// Only PreRunE is probed. A guard implemented in PersistentPreRunE or in RunE
+// is not visible to Walk.
+func Walk(root *cobra.Command) Surface {
+	var s Surface
+	collect(root, root, &s)
+	sort.Slice(s.Commands, func(i, j int) bool { return s.Commands[i].Path < s.Commands[j].Path })
+	return s
+}
+
+// collect appends cmd and its descendants to s, skipping the built-ins cobra injects
+// as direct children of root.
+func collect(cmd, root *cobra.Command, s *Surface) {
+	if cmd.Parent() == root && builtinCommands[cmd.Name()] {
+		return
+	}
+
+	s.Commands = append(s.Commands, describe(cmd))
+
+	children := cmd.Commands()
+	for i := range children {
+		collect(children[i], root, s)
+	}
+}
+
+// describe snapshots a single command.
+func describe(cmd *cobra.Command) Command {
+	out := Command{
+		Path:       cmd.CommandPath(),
+		Use:        cmd.Use,
+		Short:      cmd.Short,
+		Aliases:    append([]string(nil), cmd.Aliases...),
+		Hidden:     cmd.Hidden,
+		Deprecated: cmd.Deprecated,
+		Runnable:   cmd.Runnable(),
+		Example:    cmd.Example,
+	}
+
+	resolved := resolveFlags(cmd)
+	out.Flags = make([]Flag, 0, len(resolved))
+	for i := range resolved {
+		f := resolved[i].flag
+		out.Flags = append(out.Flags, Flag{
+			Name:       f.Name,
+			Shorthand:  f.Shorthand,
+			Type:       f.Value.Type(),
+			Default:    f.DefValue,
+			Usage:      f.Usage,
+			Deprecated: f.Deprecated,
+			Inherited:  resolved[i].inherited,
+			Hidden:     f.Hidden,
+		})
+	}
+
+	rejected := probeRejections(cmd, resolved)
+	for i := range out.Flags {
+		if reason, ok := rejected[out.Flags[i].Name]; ok {
+			out.Flags[i].Rejected = true
+			out.Flags[i].RejectedReason = reason
+		}
+	}
+
+	return out
+}
+
+// resolvedFlag is one flag reachable from a command, and whether the command
+// gets it from an ancestor rather than declaring it itself.
+type resolvedFlag struct {
+	flag      *pflag.Flag
+	inherited bool
+}
+
+// resolveFlags returns every flag usable on cmd — the flags it declares itself,
+// its own persistent flags, and its ancestors' persistent flags — sorted by
+// name.
+//
+// It reads only cobra's non-mutating accessors (Flags, PersistentFlags, Parent), so it
+// leaves the tree exactly as it found it.
+//
+// Inheritance is classified by flag identity rather than by name, which is both correct
+// and merge-independent. A command that shadows an ancestor's persistent flag with a
+// local one of the same name holds a different *pflag.Flag, so it is reported as its
+// own — classifying by name marked it inherited while reporting its local default,
+// which is a surface that contradicts itself. And a genuinely inherited flag is the
+// ancestor's own pointer whether or not cobra has already merged the tree into
+// cmd.Flags().
+func resolveFlags(cmd *cobra.Command) []resolvedFlag {
+	inherited := map[*pflag.Flag]bool{}
+	for parent := cmd.Parent(); parent != nil; parent = parent.Parent() {
+		parent.PersistentFlags().VisitAll(func(f *pflag.Flag) { inherited[f] = true })
+	}
+
+	var out []resolvedFlag
+	seen := map[string]bool{}
+	visit := func(f *pflag.Flag) {
+		if seen[f.Name] || f.Name == HelpFlag {
+			return
+		}
+		seen[f.Name] = true
+		out = append(out, resolvedFlag{flag: f, inherited: inherited[f]})
+	}
+
+	cmd.Flags().VisitAll(visit)
+	cmd.PersistentFlags().VisitAll(visit)
+	for parent := cmd.Parent(); parent != nil; parent = parent.Parent() {
+		parent.PersistentFlags().VisitAll(visit)
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].flag.Name < out[j].flag.Name })
+	return out
+}
+
+// probeRejections reports which of the resolved flags cmd's PreRunE refuses,
+// keyed by flag name with the error text as the value.
+//
+// The probe runs PreRunE against a shadow command holding copies of the flags,
+// one copy marked as set at a time. A guard reads the command it is handed
+// (cobra passes the command being executed), so the shadow is what it inspects
+// — and because the Changed bits being flipped belong to copies, the real tree
+// is never written to at all. Two guards keep the result trustworthy:
+//
+//   - Every copy starts with Changed cleared, so a flag another test left
+//     marked as set cannot make the baseline fail and silently drop the probe.
+//   - The baseline (no flag set) must pass. A PreRunE that fails
+//     unconditionally tells us nothing about individual flags, so nothing is
+//     reported.
+//
+// The copies are shallow, so a copy shares the real flag's pflag.Value pointer.
+// Only Changed is written, which lives in the copy — but a future guard that
+// called Set on a flag would write through to the live tree. A guard that reads
+// its inputs is the contract here; see the recover below for the other half.
+//
+// Probing calls PreRunE outside cobra's execution lifecycle, so a guard that
+// assumed cobra had already validated Args and dereferenced args[0] would panic
+// and take the whole gate down. That is recovered rather than propagated: an
+// unprobeable command yields no rejections, which is the same conservative
+// answer as a command with no PreRunE at all, and the deterministic half of the
+// gate still covers it.
+func probeRejections(cmd *cobra.Command, resolved []resolvedFlag) (rejections map[string]string) {
+	if cmd.PreRunE == nil {
+		return nil
+	}
+
+	defer func() {
+		if recover() != nil {
+			rejections = nil
+		}
+	}()
+
+	shadow := &cobra.Command{Use: cmd.Name()}
+	// A guard that reads the context would otherwise dereference a nil one and panic
+	// into the recover above, silently costing this command its rejections.
+	shadow.SetContext(context.Background())
+	copies := make([]*pflag.Flag, 0, len(resolved))
+	for i := range resolved {
+		duplicate := *resolved[i].flag
+		duplicate.Changed = false
+		// The struct copy shares the real flag's Value, so a guard calling Set would
+		// write straight through to the live tree. frozenValue makes that a no-op
+		// while still reporting the real value to anything that reads it.
+		duplicate.Value = frozenValue{duplicate.Value}
+		// Drop the shorthand. The probe only needs the flag reachable by name, and a
+		// command declaring a local flag whose shorthand matches an inherited one
+		// would otherwise make pflag panic on the duplicate -- silently aborting the
+		// probe via the recover above, and only when the tree had not been merged yet.
+		duplicate.Shorthand = ""
+		copies = append(copies, &duplicate)
+		shadow.Flags().AddFlag(&duplicate)
+	}
+
+	if err := cmd.PreRunE(shadow, nil); err != nil {
+		return nil
+	}
+
+	out := map[string]string{}
+	for _, f := range copies {
+		f.Changed = true
+		err := cmd.PreRunE(shadow, nil)
+		f.Changed = false
+		if err == nil {
+			continue
+		}
+		out[f.Name] = err.Error()
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// frozenValue is a pflag.Value that reports the real value but refuses to change it,
+// so probing a command's PreRunE cannot write to the tree being described.
+type frozenValue struct {
+	pflag.Value
+}
+
+// Set discards the write. A guard that normalises a flag rather than only reading it
+// would otherwise mutate the live tree during a walk.
+func (frozenValue) Set(string) error { return nil }
+
+// Hash is a stable fingerprint of the structural surface: command paths, names,
+// aliases, visibility, and each flag's name, shorthand, type, default and
+// usability. Descriptive prose (Short, Usage, Example) is deliberately excluded
+// so that rewording help text does not move a hash downstream consumers pin.
+func (s Surface) Hash() string {
+	lines := make([]string, 0, len(s.Commands)*4)
+	for i := range s.Commands {
+		c := &s.Commands[i]
+		lines = append(lines, strings.Join([]string{
+			"command", c.Path, c.Use, strings.Join(c.Aliases, ","),
+			strconv.FormatBool(c.Hidden), strconv.FormatBool(c.Runnable), c.Deprecated,
+		}, "\t"))
+		for j := range c.Flags {
+			f := &c.Flags[j]
+			lines = append(lines, strings.Join([]string{
+				"flag", c.Path, f.Name, f.Shorthand, f.Type, f.Default,
+				strconv.FormatBool(f.Inherited), strconv.FormatBool(f.Hidden),
+				strconv.FormatBool(f.Rejected), f.Deprecated,
+			}, "\t"))
+		}
+	}
+	sum := sha256.Sum256([]byte(strings.Join(lines, "\n")))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// Command returns the command at the given full path.
+func (s Surface) Command(path string) (*Command, bool) {
+	for i := range s.Commands {
+		if s.Commands[i].Path == path {
+			return &s.Commands[i], true
+		}
+	}
+	return nil, false
+}
+
+// Children returns the direct subcommands of path, in path order.
+func (s Surface) Children(path string) []*Command {
+	prefix := path + " "
+	var out []*Command
+	for i := range s.Commands {
+		p := s.Commands[i].Path
+		if strings.HasPrefix(p, prefix) && !strings.Contains(p[len(prefix):], " ") {
+			out = append(out, &s.Commands[i])
+		}
+	}
+	return out
+}
+
+// Root returns the shortest command path in the surface, i.e. the binary name.
+func (s Surface) Root() string {
+	if len(s.Commands) == 0 {
+		return ""
+	}
+	root := s.Commands[0].Path
+	for i := range s.Commands {
+		if len(s.Commands[i].Path) < len(root) {
+			root = s.Commands[i].Path
+		}
+	}
+	return root
+}
+
+// Flag returns the named flag as it applies to the command at path.
+func (c *Command) Flag(name string) (*Flag, bool) {
+	for i := range c.Flags {
+		if c.Flags[i].Name == name {
+			return &c.Flags[i], true
+		}
+	}
+	return nil, false
+}
+
+// FlagByShorthand returns the flag carrying the single-character shorthand.
+func (c *Command) FlagByShorthand(short string) (*Flag, bool) {
+	for i := range c.Flags {
+		if c.Flags[i].Shorthand != "" && c.Flags[i].Shorthand == short {
+			return &c.Flags[i], true
+		}
+	}
+	return nil, false
+}
+
+// FlagNames returns every long flag name that appears anywhere in the surface.
+func (s Surface) FlagNames() []string {
+	seen := map[string]bool{}
+	var out []string
+	for i := range s.Commands {
+		c := &s.Commands[i]
+		for j := range c.Flags {
+			if name := c.Flags[j].Name; !seen[name] {
+				seen[name] = true
+				out = append(out, name)
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/clisurface/surface_test.go
+++ b/internal/clisurface/surface_test.go
@@ -1,0 +1,572 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clisurface
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestTree builds a synthetic command tree that mirrors the shapes the real
+// brutus tree has: a root with persistent flags, a leaf with local flags, a
+// leaf that rejects an inherited flag from its PreRunE, aliases, a hidden and
+// deprecated command, and a group command that is not runnable.
+func newTestTree() *cobra.Command {
+	root := &cobra.Command{Use: "tool", Short: "a tool", RunE: func(*cobra.Command, []string) error { return nil }}
+	root.PersistentFlags().Duration("timeout", 10*time.Second, "per-target timeout")
+	root.PersistentFlags().BoolP("json", "j", false, "JSON output")
+	root.Flags().Bool("version", false, "show version")
+
+	scan := &cobra.Command{
+		Use:     "scan",
+		Short:   "scan things",
+		Aliases: []string{"sc", "scanner"},
+		Example: "  # scan one host\n  tool scan --target host",
+		RunE:    func(*cobra.Command, []string) error { return nil },
+	}
+	scan.Flags().StringP("target", "t", "", "target host:port")
+
+	// guarded mirrors brutus's logon family: it inherits --timeout from the
+	// root but its PreRunE hard-errors when the flag is set.
+	guarded := &cobra.Command{Use: "guarded", Short: "rejects --timeout", RunE: func(*cobra.Command, []string) error { return nil }}
+	guarded.Flags().Duration("scan-timeout", time.Second, "settle deadline")
+	guarded.PreRunE = func(c *cobra.Command, _ []string) error {
+		if c.Flags().Changed("timeout") {
+			return fmt.Errorf("--timeout is not valid here; use --scan-timeout")
+		}
+		return nil
+	}
+
+	group := &cobra.Command{Use: "group", Short: "a group of things"}
+	leaf := &cobra.Command{Use: "leaf", Short: "a leaf", RunE: func(*cobra.Command, []string) error { return nil }}
+	leaf.Flags().String("only-here", "", "leaf-local flag")
+	hidden := &cobra.Command{
+		Use:        "old",
+		Short:      "the old spelling",
+		Hidden:     true,
+		Deprecated: `use "tool group leaf" instead`,
+		RunE:       func(*cobra.Command, []string) error { return nil },
+	}
+	group.AddCommand(leaf, hidden)
+
+	root.AddCommand(scan, guarded, group)
+	return root
+}
+
+func TestWalkCollectsEveryCommandSortedByPath(t *testing.T) {
+	s := Walk(newTestTree())
+
+	var paths []string
+	for i := range s.Commands {
+		paths = append(paths, s.Commands[i].Path)
+	}
+	assert.Equal(t, []string{
+		"tool",
+		"tool group",
+		"tool group leaf",
+		"tool group old",
+		"tool guarded",
+		"tool scan",
+	}, paths, "commands must be collected recursively and sorted by full path")
+}
+
+func TestWalkRecordsCommandMetadata(t *testing.T) {
+	s := Walk(newTestTree())
+
+	scan, ok := s.Command("tool scan")
+	require.True(t, ok, "tool scan must be in the surface")
+	assert.Equal(t, "scan", scan.Use)
+	assert.Equal(t, "scan things", scan.Short)
+	assert.Equal(t, []string{"sc", "scanner"}, scan.Aliases)
+	assert.True(t, scan.Runnable, "scan has a RunE so it is runnable")
+	assert.False(t, scan.Hidden)
+	assert.Contains(t, scan.Example, "tool scan --target host")
+
+	group, ok := s.Command("tool group")
+	require.True(t, ok)
+	assert.False(t, group.Runnable, "a command with no RunE only groups subcommands")
+
+	old, ok := s.Command("tool group old")
+	require.True(t, ok)
+	assert.True(t, old.Hidden, "hidden commands stay in the surface so the linter accepts them")
+	assert.Equal(t, `use "tool group leaf" instead`, old.Deprecated)
+}
+
+func TestWalkSeparatesLocalFromInheritedFlags(t *testing.T) {
+	s := Walk(newTestTree())
+
+	scan, ok := s.Command("tool scan")
+	require.True(t, ok)
+
+	target, ok := scan.Flag("target")
+	require.True(t, ok, "scan must carry its own --target")
+	assert.False(t, target.Inherited, "--target is declared on scan")
+	assert.Equal(t, "t", target.Shorthand)
+	assert.Equal(t, "string", target.Type)
+
+	timeout, ok := scan.Flag("timeout")
+	require.True(t, ok, "scan must carry the root-persistent --timeout")
+	assert.True(t, timeout.Inherited, "--timeout reaches scan from the root")
+	assert.Equal(t, "duration", timeout.Type)
+	assert.Equal(t, "10s", timeout.Default)
+
+	_, ok = scan.Flag("version")
+	assert.False(t, ok, "--version is local to the root and must not leak into subcommands")
+
+	root, ok := s.Command("tool")
+	require.True(t, ok)
+	version, ok := root.Flag("version")
+	require.True(t, ok)
+	assert.False(t, version.Inherited, "the root's own flags are not inherited")
+}
+
+func TestWalkSortsFlagsByName(t *testing.T) {
+	s := Walk(newTestTree())
+
+	scan, ok := s.Command("tool scan")
+	require.True(t, ok)
+
+	var names []string
+	for i := range scan.Flags {
+		names = append(names, scan.Flags[i].Name)
+	}
+	assert.Equal(t, []string{"json", "target", "timeout"}, names, "flags must be sorted by name")
+}
+
+func TestWalkMarksFlagsTheCommandRejects(t *testing.T) {
+	s := Walk(newTestTree())
+
+	guarded, ok := s.Command("tool guarded")
+	require.True(t, ok)
+
+	timeout, ok := guarded.Flag("timeout")
+	require.True(t, ok, "the rejected flag is still reachable, so it stays in the surface")
+	assert.True(t, timeout.Rejected, "PreRunE hard-errors on --timeout, so it is not usable here")
+	assert.Equal(t, "--timeout is not valid here; use --scan-timeout", timeout.RejectedReason,
+		"the rejection reason is recorded so the generated reference can explain it")
+
+	scanTimeout, ok := guarded.Flag("scan-timeout")
+	require.True(t, ok)
+	assert.False(t, scanTimeout.Rejected, "the replacement flag is usable")
+
+	json, ok := guarded.Flag("json")
+	require.True(t, ok)
+	assert.False(t, json.Rejected, "only the guarded flag is rejected, not every inherited flag")
+
+	sibling, ok := s.Command("tool scan")
+	require.True(t, ok)
+	siblingTimeout, ok := sibling.Flag("timeout")
+	require.True(t, ok)
+	assert.False(t, siblingTimeout.Rejected, "the rejection is per command, not global")
+}
+
+func TestWalkDetectsRejectionEvenWhenAFlagWasAlreadySet(t *testing.T) {
+	root := newTestTree()
+	guarded, _, err := root.Find([]string{"guarded"})
+	require.NoError(t, err)
+
+	// Simulate an earlier test having parsed --timeout on the shared flag.
+	require.NoError(t, root.PersistentFlags().Set("timeout", "30s"))
+	require.True(t, root.PersistentFlags().Lookup("timeout").Changed)
+
+	s := Walk(root)
+
+	cmd, ok := s.Command("tool guarded")
+	require.True(t, ok)
+	timeout, ok := cmd.Flag("timeout")
+	require.True(t, ok)
+	assert.True(t, timeout.Rejected,
+		"a Changed bit left set by another test must not hide the rejection")
+
+	assert.True(t, root.PersistentFlags().Lookup("timeout").Changed,
+		"the probe must not clear a Changed bit that was already set")
+	assert.Equal(t, "30s", root.PersistentFlags().Lookup("timeout").Value.String(),
+		"the probe must never touch flag values")
+	assert.Nil(t, guarded.Flags().Lookup("timeout"),
+		"and it must not merge the ancestor's flag into the command's own FlagSet")
+}
+
+// TestWalkDoesNotMutateTheTree pins the invariant that broke once already: a
+// cobra tree is package-level state shared by every test in a binary, so a Walk
+// that merges persistent flags into a command's own FlagSet makes every later
+// test see flags the command does not declare.
+func TestWalkDoesNotMutateTheTree(t *testing.T) {
+	root := newTestTree()
+	scan, _, err := root.Find([]string{"scan"})
+	require.NoError(t, err)
+	guarded, _, err := root.Find([]string{"guarded"})
+	require.NoError(t, err)
+
+	require.Nil(t, scan.Flags().Lookup("timeout"),
+		"precondition: the child does not declare the root's persistent flag")
+	require.Nil(t, scan.Flags().ShorthandLookup("j"),
+		"precondition: the child does not declare the root's persistent shorthand")
+
+	s := Walk(root)
+
+	timeout, ok := mustFlag(t, s, "tool scan", "timeout")
+	require.True(t, ok)
+	require.True(t, timeout.Inherited, "the surface still records the inherited flag")
+
+	assert.Nil(t, scan.Flags().Lookup("timeout"),
+		"Walk must not fold the root's persistent flags into the child's own FlagSet")
+	assert.Nil(t, scan.Flags().ShorthandLookup("j"),
+		"nor its shorthands, which is what makes a -t collision test start failing")
+	assert.Nil(t, guarded.Flags().Lookup("timeout"),
+		"not even on a command whose PreRunE the probe had to run")
+
+	for _, name := range []string{"timeout", "json"} {
+		assert.False(t, root.PersistentFlags().Lookup(name).Changed,
+			"--%s must not be left marked as set by the probe", name)
+	}
+}
+
+func TestWalkIsIdenticalWhetherTheTreeWasAlreadyMerged(t *testing.T) {
+	pristine := Walk(newTestTree())
+
+	merged := newTestTree()
+	// InheritedFlags is cobra's mutating accessor: calling it folds the
+	// ancestors' persistent flags into each command's own FlagSet, which is the
+	// state Walk finds when another test rendered help or executed the tree
+	// first.
+	forEachCommand(merged, func(c *cobra.Command) { _ = c.InheritedFlags() })
+	require.NotNil(t, mustCommand(t, merged, "scan").Flags().Lookup("timeout"),
+		"precondition: the tree really is merged now")
+
+	assert.Equal(t, pristine, Walk(merged),
+		"flag classification must come from the ancestors' persistent flags, not from whatever is in cmd.Flags()")
+	assert.Equal(t, pristine.Hash(), Walk(merged).Hash())
+}
+
+func TestWalkIgnoresCommandsWithoutAnAttributableRejection(t *testing.T) {
+	root := &cobra.Command{Use: "tool", RunE: func(*cobra.Command, []string) error { return nil }}
+	root.PersistentFlags().Bool("json", false, "JSON output")
+	always := &cobra.Command{Use: "always", Short: "always fails", RunE: func(*cobra.Command, []string) error { return nil }}
+	always.PreRunE = func(*cobra.Command, []string) error { return fmt.Errorf("this command always refuses to run") }
+	root.AddCommand(always)
+
+	s := Walk(root)
+
+	cmd, ok := s.Command("tool always")
+	require.True(t, ok)
+	for i := range cmd.Flags {
+		assert.False(t, cmd.Flags[i].Rejected,
+			"a PreRunE that fails unconditionally attributes nothing to flag %q", cmd.Flags[i].Name)
+	}
+}
+
+func TestWalkExcludesCobrasInjectedCommands(t *testing.T) {
+	root := newTestTree()
+	// Executing a tree is what makes cobra inject help/completion. Whether
+	// that happened must not change the surface.
+	root.InitDefaultHelpCmd()
+	root.InitDefaultCompletionCmd()
+
+	s := Walk(root)
+
+	_, hasHelp := s.Command("tool help")
+	_, hasCompletion := s.Command("tool completion")
+	assert.False(t, hasHelp, "cobra's injected help command is not part of the documented surface")
+	assert.False(t, hasCompletion, "cobra's injected completion command is not part of the documented surface")
+}
+
+func TestWalkIsDeterministic(t *testing.T) {
+	first := Walk(newTestTree())
+	second := Walk(newTestTree())
+
+	assert.Equal(t, first, second, "two walks of identical trees must produce identical surfaces")
+	assert.Equal(t, first.Hash(), second.Hash(), "and identical hashes")
+}
+
+func TestHashTracksStructureNotProse(t *testing.T) {
+	base := Walk(newTestTree())
+
+	renamed := Walk(newTestTree())
+	cmd, ok := renamed.Command("tool scan")
+	require.True(t, ok)
+	flag, ok := cmd.Flag("target")
+	require.True(t, ok)
+	flag.Name = "host"
+	assert.NotEqual(t, base.Hash(), renamed.Hash(), "renaming a flag must move the hash")
+
+	reworded := Walk(newTestTree())
+	cmd, ok = reworded.Command("tool scan")
+	require.True(t, ok)
+	cmd.Short = "scan things, but described differently"
+	flag, ok = cmd.Flag("target")
+	require.True(t, ok)
+	flag.Usage = "reworded usage"
+	assert.Equal(t, base.Hash(), reworded.Hash(),
+		"the hash pins the structural surface, so rewording help text must not move it")
+}
+
+func TestSurfaceLookupHelpers(t *testing.T) {
+	s := Walk(newTestTree())
+
+	assert.Equal(t, "tool", s.Root(), "the root is the shortest command path")
+
+	var childPaths []string
+	for _, c := range s.Children("tool") {
+		childPaths = append(childPaths, c.Path)
+	}
+	assert.Equal(t, []string{"tool group", "tool guarded", "tool scan"}, childPaths,
+		"Children returns direct subcommands only")
+
+	assert.Equal(t, []string{"tool group leaf", "tool group old"},
+		pathsOf(s.Children("tool group")))
+
+	_, ok := s.Command("tool nope")
+	assert.False(t, ok)
+
+	assert.Equal(t, []string{"json", "only-here", "scan-timeout", "target", "timeout", "version"},
+		s.FlagNames(), "FlagNames is the sorted union of every flag in the tree")
+
+	scan, ok := s.Command("tool scan")
+	require.True(t, ok)
+	byShorthand, ok := scan.FlagByShorthand("t")
+	require.True(t, ok)
+	assert.Equal(t, "target", byShorthand.Name)
+	_, ok = scan.FlagByShorthand("z")
+	assert.False(t, ok)
+}
+
+func TestSurfaceRootOfEmptySurface(t *testing.T) {
+	assert.Empty(t, Surface{}.Root())
+}
+
+// pathsOf is a test helper that flattens command pointers to their paths.
+func pathsOf(cmds []*Command) []string {
+	out := make([]string, 0, len(cmds))
+	for _, c := range cmds {
+		out = append(out, c.Path)
+	}
+	return out
+}
+
+// mustFlag looks up one flag of one command in a surface.
+func mustFlag(t *testing.T, s Surface, path, name string) (*Flag, bool) {
+	t.Helper()
+	cmd, ok := s.Command(path)
+	require.True(t, ok, "command %q must be in the surface", path)
+	return cmd.Flag(name)
+}
+
+// mustCommand resolves a command by name from a live cobra tree.
+func mustCommand(t *testing.T, root *cobra.Command, name string) *cobra.Command {
+	t.Helper()
+	cmd, _, err := root.Find([]string{name})
+	require.NoError(t, err)
+	require.NotNil(t, cmd)
+	return cmd
+}
+
+// forEachCommand applies fn to every command in the tree.
+func forEachCommand(cmd *cobra.Command, fn func(*cobra.Command)) {
+	fn(cmd)
+	for _, child := range cmd.Commands() {
+		forEachCommand(child, fn)
+	}
+}
+
+// TestWalkSurvivesAPreRunEThatNeedsArgs pins the probe's recover. Probing calls
+// PreRunE outside cobra's execution lifecycle, where cobra would have validated
+// Args first — so a guard that reasonably assumes args[0] exists panics. The
+// gate must degrade to "no rejections discovered" rather than take the whole
+// build down.
+func TestWalkSurvivesAPreRunEThatNeedsArgs(t *testing.T) {
+	root := &cobra.Command{Use: "tool", RunE: func(*cobra.Command, []string) error { return nil }}
+	root.PersistentFlags().Duration("timeout", time.Second, "timeout")
+
+	needy := &cobra.Command{
+		Use:  "needy",
+		Args: cobra.ExactArgs(1),
+		RunE: func(*cobra.Command, []string) error { return nil },
+	}
+	needy.Flags().String("target", "", "target")
+	needy.PreRunE = func(_ *cobra.Command, args []string) error {
+		// Legitimate under cobra, which validates Args before PreRunE.
+		if strings.HasPrefix(args[0], "-") {
+			return fmt.Errorf("target must not look like a flag")
+		}
+		return nil
+	}
+	root.AddCommand(needy)
+
+	var s Surface
+	require.NotPanics(t, func() { s = Walk(root) }, "a panicking guard must not take the gate down")
+
+	cmd, ok := s.Command("tool needy")
+	require.True(t, ok, "the command is still described")
+	flag, ok := cmd.Flag("timeout")
+	require.True(t, ok, "its inherited flags are still recorded")
+	assert.False(t, flag.Rejected, "an unprobeable command reports no rejections, the conservative answer")
+}
+
+// TestProbeDoesNotWriteThroughACopiedFlagValue pins the frozen Value. A struct copy of
+// a pflag.Flag shares the original's Value, so a guard that normalises a flag rather
+// than only reading it would mutate the tree being described.
+func TestProbeDoesNotWriteThroughACopiedFlagValue(t *testing.T) {
+	root := &cobra.Command{Use: "tool", RunE: func(*cobra.Command, []string) error { return nil }}
+	root.PersistentFlags().Duration("timeout", 10*time.Second, "per-target timeout")
+	kid := &cobra.Command{Use: "kid", RunE: func(*cobra.Command, []string) error { return nil }}
+	kid.PreRunE = func(c *cobra.Command, _ []string) error {
+		_ = c.Flags().Set("timeout", "99s")
+		return nil
+	}
+	root.AddCommand(kid)
+
+	Walk(root)
+
+	assert.Equal(t, "10s", root.PersistentFlags().Lookup("timeout").Value.String(),
+		"probing must not write to the real flag")
+}
+
+// TestProbeSurvivesAShorthandSharedWithAnInheritedFlag pins the shorthand strip. Adding
+// both a local flag and an inherited one carrying the same shorthand to the shadow
+// command made pflag panic, which the probe's recover then swallowed -- so rejection
+// detection silently vanished for that command, and only when the tree had not already
+// been merged by cobra.
+func TestProbeSurvivesAShorthandSharedWithAnInheritedFlag(t *testing.T) {
+	root := &cobra.Command{Use: "tool", RunE: func(*cobra.Command, []string) error { return nil }}
+	root.PersistentFlags().StringP("target", "t", "", "target host")
+	kid := &cobra.Command{Use: "kid", RunE: func(*cobra.Command, []string) error { return nil }}
+	kid.Flags().IntP("threads", "t", 1, "local flag reusing the shorthand")
+	kid.PreRunE = func(c *cobra.Command, _ []string) error {
+		if c.Flags().Changed("threads") {
+			return fmt.Errorf("--threads is not valid here")
+		}
+		return nil
+	}
+	root.AddCommand(kid)
+
+	cmd, ok := Walk(root).Command("tool kid")
+	require.True(t, ok)
+	flag, ok := cmd.Flag("threads")
+	require.True(t, ok)
+	assert.True(t, flag.Rejected, "the rejection must still be discovered despite the shared shorthand")
+}
+
+// TestWalkExcludesCobrasHiddenCompletionHelpers keeps the surface deterministic: cobra
+// injects __complete and __completeNoDesc on the first Execute, so including them would
+// make the surface depend on whether something already ran the tree.
+func TestWalkExcludesCobrasHiddenCompletionHelpers(t *testing.T) {
+	root := newTestTree()
+	root.AddCommand(&cobra.Command{Use: cobra.ShellCompRequestCmd, Hidden: true, RunE: func(*cobra.Command, []string) error { return nil }})
+	root.AddCommand(&cobra.Command{Use: cobra.ShellCompNoDescRequestCmd, Hidden: true, RunE: func(*cobra.Command, []string) error { return nil }})
+
+	for _, c := range Walk(root).Commands {
+		assert.NotContains(t, c.Path, cobra.ShellCompRequestCmd, "cobra's completion helpers are not part of the surface")
+	}
+}
+
+// TestWalkKeepsALegitimateNestedHelpCommand pins that cobra's injected built-ins are
+// filtered only where cobra injects them. Filtering by name at every depth dropped a
+// real subcommand called "help" and, because collect returns rather than descends, its
+// children with it.
+func TestWalkKeepsALegitimateNestedHelpCommand(t *testing.T) {
+	root := &cobra.Command{Use: "tool", RunE: func(*cobra.Command, []string) error { return nil }}
+	group := &cobra.Command{Use: "group"}
+	handbook := &cobra.Command{Use: "help", Short: "show the operator handbook", RunE: func(*cobra.Command, []string) error { return nil }}
+	handbook.AddCommand(&cobra.Command{Use: "topics", RunE: func(*cobra.Command, []string) error { return nil }})
+	group.AddCommand(handbook)
+	root.AddCommand(group)
+
+	var paths []string
+	for _, c := range Walk(root).Commands {
+		paths = append(paths, c.Path)
+	}
+
+	assert.Equal(t, []string{"tool", "tool group", "tool group help", "tool group help topics"}, paths,
+		"only the root's own injected help/completion are excluded")
+}
+
+// TestWalkStillExcludesCobrasRootBuiltins is the other half: the root-level filter has
+// to keep working, or the surface depends on whether something executed the tree.
+func TestWalkStillExcludesCobrasRootBuiltins(t *testing.T) {
+	root := newTestTree()
+	root.AddCommand(&cobra.Command{Use: "help", RunE: func(*cobra.Command, []string) error { return nil }})
+	root.AddCommand(&cobra.Command{Use: "completion", RunE: func(*cobra.Command, []string) error { return nil }})
+
+	for _, c := range Walk(root).Commands {
+		assert.NotEqual(t, "tool help", c.Path)
+		assert.NotEqual(t, "tool completion", c.Path)
+	}
+}
+
+// TestWalkReportsAShadowingFlagAsTheCommandsOwn pins classification by flag identity.
+// Matching on name alone marked a local flag inherited while reporting its local
+// default, so the surface contradicted itself.
+func TestWalkReportsAShadowingFlagAsTheCommandsOwn(t *testing.T) {
+	root := &cobra.Command{Use: "tool", RunE: func(*cobra.Command, []string) error { return nil }}
+	root.PersistentFlags().String("mode", "root-default", "root mode")
+	kid := &cobra.Command{Use: "kid", RunE: func(*cobra.Command, []string) error { return nil }}
+	kid.Flags().String("mode", "kid-default", "the command's own mode, shadowing the root's")
+	root.AddCommand(kid)
+
+	cmd, ok := Walk(root).Command("tool kid")
+	require.True(t, ok)
+	flag, ok := cmd.Flag("mode")
+	require.True(t, ok)
+
+	assert.False(t, flag.Inherited, "the command declares this flag itself")
+	assert.Equal(t, "kid-default", flag.Default, "and it is the local flag that is described")
+}
+
+// TestWalkStillMarksGenuinelyInheritedFlags is the other half, and it must hold whether
+// or not cobra has already merged the tree.
+func TestWalkStillMarksGenuinelyInheritedFlags(t *testing.T) {
+	for _, merged := range []bool{false, true} {
+		tree := newTestTree()
+		if merged {
+			for _, c := range tree.Commands() {
+				_ = c.InheritedFlags()
+			}
+		}
+
+		cmd, ok := Walk(tree).Command("tool scan")
+		require.True(t, ok)
+		flag, ok := cmd.Flag("timeout")
+		require.True(t, ok)
+		assert.True(t, flag.Inherited, "merged=%v: --timeout comes from the root", merged)
+	}
+}
+
+// TestProbeSurvivesAGuardThatReadsTheContext pins the shadow's context. A guard reading
+// a nil context panicked into the recover, silently costing the command its rejections.
+func TestProbeSurvivesAGuardThatReadsTheContext(t *testing.T) {
+	root := &cobra.Command{Use: "tool", RunE: func(*cobra.Command, []string) error { return nil }}
+	root.PersistentFlags().String("timeout", "", "per-target timeout")
+	kid := &cobra.Command{Use: "kid", RunE: func(*cobra.Command, []string) error { return nil }}
+	kid.PreRunE = func(c *cobra.Command, _ []string) error {
+		_ = c.Context().Value("request-id")
+		if c.Flags().Changed("timeout") {
+			return fmt.Errorf("--timeout is not valid here")
+		}
+		return nil
+	}
+	root.AddCommand(kid)
+
+	cmd, ok := Walk(root).Command("tool kid")
+	require.True(t, ok)
+	flag, ok := cmd.Flag("timeout")
+	require.True(t, ok)
+	assert.True(t, flag.Rejected, "the rejection must survive a guard that touches the context")
+}


### PR DESCRIPTION
Part 1 of 6. Derives the CLI surface from a live cobra command tree instead of from prose.

**Review focus:** the two non-obvious properties. `Walk` must not mutate the observable tree (a cobra tree is a shared package-level var, and `LocalFlags`/`InheritedFlags` permanently fold ancestors' persistent flags into a command's own set). And inheritance alone overstates the surface, so `PreRunE` is probed on a shadow command holding flag *copies* — brutus inherits `--timeout` everywhere but the logon family refuses it.

Nothing consumes this yet.

## Review stack (ENG-6871)

Split out of #331 so each layer can be read on its own. Review **in order**; each targets the one before it.

| # | PR | Scope | Hand-written |
|---|---|---|---|
| 1 | #338 | Walk the cobra tree into a comparable surface | ~855 |
| 2 | #339 | Render a surface, and diff two of them | ~1257 |
| 3 | #340 | Lint documents and Go comments against a surface | ~1225 |
| 4 | #341 | Repo-level artifact and lint plumbing | ~650 |
| 5 | #342 | Turn on the gate, commit the generated artifacts | ~290 + 6.1k generated |
| 6 | #343 | Run it in CI, ship the artifact | ~109 |

PRs 1–4 are the library and touch nothing outside `internal/clisurface`. Nothing is wired up until #342.

Every stage compiles and passes `go test -short ./...`, `golangci-lint run ./...` (`0 issues.`) and `gofmt` **on its own**, so you can stop after any one of them. The tip of the stack is byte-identical to #331 as reviewed.

Three small refactors were needed to make the layers separable, and they are the only content not in #331: the shared path constants and `GeneratedPaths` moved into `paths.go`, `LintReport` moved beside the linter, and one test assertion moved from the walk's tests to the renderer's.

