### PR TITLE
feat(clisurface): render a surface, and diff two of them (ENG-6871, 2/6)

### DIFF
--- a/internal/clisurface/diff.go
+++ b/internal/clisurface/diff.go
@@ -1,0 +1,189 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clisurface
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// FindingKind classifies a single disagreement between the documented surface
+// and the surface cobra actually registers.
+type FindingKind string
+
+const (
+	// CommandUndocumented: cobra registers a command the docs do not describe.
+	CommandUndocumented FindingKind = "command-undocumented"
+	// CommandRemoved: the docs describe a command cobra no longer registers.
+	CommandRemoved FindingKind = "command-removed"
+	// CommandChanged: a documented command's metadata drifted.
+	CommandChanged FindingKind = "command-changed"
+	// FlagUndocumented: cobra registers a flag the docs do not describe.
+	FlagUndocumented FindingKind = "flag-undocumented"
+	// FlagRemoved: the docs describe a flag cobra no longer accepts.
+	FlagRemoved FindingKind = "flag-removed"
+	// FlagChanged: a documented flag's metadata drifted.
+	FlagChanged FindingKind = "flag-changed"
+)
+
+// Finding is one actionable disagreement. It always names the command, names
+// the flag when the disagreement is about a flag, and says what changed.
+type Finding struct {
+	Kind FindingKind
+	// Command is the full command path, e.g. "brutus logon".
+	Command string
+	// Flag is the long flag name without dashes, empty for command findings.
+	Flag string
+	// Field is the metadata field that drifted, empty for add/remove findings.
+	Field string
+	// Documented is the value in the committed docs.
+	Documented string
+	// Registered is the value cobra registers.
+	Registered string
+}
+
+// String renders the finding as one actionable line.
+func (f Finding) String() string {
+	subject := strconv.Quote(f.Command)
+	if f.Flag != "" {
+		subject = "flag --" + f.Flag + " on " + strconv.Quote(f.Command)
+	}
+	switch f.Kind {
+	case CommandUndocumented:
+		return "command " + subject + " is registered by cobra but missing from the generated docs"
+	case CommandRemoved:
+		return "command " + subject + " is in the generated docs but cobra no longer registers it"
+	case FlagUndocumented:
+		return subject + " is registered by cobra but missing from the generated docs"
+	case FlagRemoved:
+		return subject + " is in the generated docs but cobra no longer accepts it"
+	case CommandChanged, FlagChanged:
+		return subject + ": " + f.Field + " changed from " + strconv.Quote(f.Documented) +
+			" (docs) to " + strconv.Quote(f.Registered) + " (cobra)"
+	default:
+		return string(f.Kind) + ": " + subject
+	}
+}
+
+// Diff compares the documented surface against the surface cobra registers and
+// returns one finding per disagreement, ordered by command path then flag name.
+// It is deliberately not a text diff: every finding names what changed so the
+// failure explains itself without the reader diffing two files by eye.
+func Diff(documented, registered Surface) []Finding {
+	var findings []Finding
+
+	for i := range registered.Commands {
+		live := &registered.Commands[i]
+		doc, ok := documented.Command(live.Path)
+		if !ok {
+			findings = append(findings, Finding{Kind: CommandUndocumented, Command: live.Path})
+			continue
+		}
+		findings = append(findings, diffCommand(doc, live)...)
+	}
+
+	for i := range documented.Commands {
+		doc := &documented.Commands[i]
+		if _, ok := registered.Command(doc.Path); !ok {
+			findings = append(findings, Finding{Kind: CommandRemoved, Command: doc.Path})
+		}
+	}
+
+	sort.SliceStable(findings, func(i, j int) bool {
+		if findings[i].Command != findings[j].Command {
+			return findings[i].Command < findings[j].Command
+		}
+		return findings[i].Flag < findings[j].Flag
+	})
+	return findings
+}
+
+// diffCommand compares one command's metadata and flag set.
+func diffCommand(doc, live *Command) []Finding {
+	var findings []Finding
+
+	changed := func(field, documented, registered string) {
+		if documented != registered {
+			findings = append(findings, Finding{
+				Kind: CommandChanged, Command: live.Path, Field: field,
+				Documented: documented, Registered: registered,
+			})
+		}
+	}
+	changed("use", doc.Use, live.Use)
+	changed("short description", doc.Short, live.Short)
+	changed("aliases", strings.Join(doc.Aliases, ","), strings.Join(live.Aliases, ","))
+	changed("hidden", strconv.FormatBool(doc.Hidden), strconv.FormatBool(live.Hidden))
+	changed("deprecation notice", doc.Deprecated, live.Deprecated)
+	changed("runnable", strconv.FormatBool(doc.Runnable), strconv.FormatBool(live.Runnable))
+	changed("example", doc.Example, live.Example)
+
+	for i := range live.Flags {
+		lf := &live.Flags[i]
+		df, ok := doc.Flag(lf.Name)
+		if !ok {
+			findings = append(findings, Finding{Kind: FlagUndocumented, Command: live.Path, Flag: lf.Name})
+			continue
+		}
+		findings = append(findings, diffFlag(live.Path, df, lf)...)
+	}
+	for i := range doc.Flags {
+		df := &doc.Flags[i]
+		if _, ok := live.Flag(df.Name); !ok {
+			findings = append(findings, Finding{Kind: FlagRemoved, Command: live.Path, Flag: df.Name})
+		}
+	}
+	return findings
+}
+
+// diffFlag compares one flag's metadata on one command.
+func diffFlag(path string, doc, live *Flag) []Finding {
+	var findings []Finding
+	changed := func(field, documented, registered string) {
+		if documented != registered {
+			findings = append(findings, Finding{
+				Kind: FlagChanged, Command: path, Flag: live.Name, Field: field,
+				Documented: documented, Registered: registered,
+			})
+		}
+	}
+	changed("shorthand", doc.Shorthand, live.Shorthand)
+	changed("type", doc.Type, live.Type)
+	changed("default", doc.Default, live.Default)
+	changed("usage", doc.Usage, live.Usage)
+	changed("deprecation notice", doc.Deprecated, live.Deprecated)
+	changed("inherited", strconv.FormatBool(doc.Inherited), strconv.FormatBool(live.Inherited))
+	changed("hidden", strconv.FormatBool(doc.Hidden), strconv.FormatBool(live.Hidden))
+	changed("rejected by the command", strconv.FormatBool(doc.Rejected), strconv.FormatBool(live.Rejected))
+	changed("rejection reason", doc.RejectedReason, live.RejectedReason)
+	return findings
+}
+
+// Report renders findings as a failure message that says what drifted, which
+// files carry the stale copy, and the one command that fixes them.
+func Report(findings []Finding, artifacts []string, regenerate string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "CLI surface drift: %d disagreement(s) between the generated documentation and the cobra command tree.\n\n",
+		len(findings))
+	for i := range findings {
+		fmt.Fprintf(&b, "  %d. %s\n", i+1, findings[i].String())
+	}
+	// One trailer, not one per finding: the remediation is the same for all of them,
+	// and repeating it buries the findings it is meant to explain.
+	fmt.Fprintf(&b, "\nRegenerate %s with '%s'.\n", strings.Join(artifacts, ", "), regenerate)
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/internal/clisurface/diff_test.go
+++ b/internal/clisurface/diff_test.go
@@ -1,0 +1,213 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clisurface
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiffOfIdenticalSurfacesIsEmpty(t *testing.T) {
+	assert.Empty(t, Diff(Walk(newTestTree()), Walk(newTestTree())))
+}
+
+func TestDiffReportsARenamedFlagAsOneRemovalAndOneAddition(t *testing.T) {
+	documented := Walk(newTestTree())
+
+	tree := newTestTree()
+	scan, _, err := tree.Find([]string{"scan"})
+	require.NoError(t, err)
+	// What a deliberate rename looks like in source: the old flag is gone and
+	// an otherwise identical flag is registered under the new name.
+	scan.ResetFlags()
+	scan.Flags().StringP("host", "t", "", "target host:port")
+	registered := Walk(tree)
+
+	findings := Diff(documented, registered)
+
+	require.Len(t, findings, 2, "a rename is exactly one undocumented flag and one removed flag")
+	assert.Equal(t, FlagUndocumented, findings[0].Kind)
+	assert.Equal(t, "host", findings[0].Flag)
+	assert.Equal(t, "tool scan", findings[0].Command)
+	assert.Equal(t, FlagRemoved, findings[1].Kind)
+	assert.Equal(t, "target", findings[1].Flag)
+	assert.Contains(t, findings[0].String(), `flag --host on "tool scan" is registered by cobra but missing from the generated docs`)
+	assert.Contains(t, findings[1].String(), `flag --target on "tool scan" is in the generated docs but cobra no longer accepts it`)
+}
+
+func TestDiffReportsAddedAndRemovedCommands(t *testing.T) {
+	documented := Walk(newTestTree())
+
+	tree := newTestTree()
+	tree.AddCommand(&cobra.Command{Use: "brand-new", Short: "new thing", RunE: func(*cobra.Command, []string) error { return nil }})
+	scan, _, err := tree.Find([]string{"scan"})
+	require.NoError(t, err)
+	tree.RemoveCommand(scan)
+
+	findings := Diff(documented, Walk(tree))
+
+	require.Len(t, findings, 2)
+	assert.Equal(t, CommandUndocumented, findings[0].Kind)
+	assert.Equal(t, "tool brand-new", findings[0].Command)
+	assert.Equal(t, CommandRemoved, findings[1].Kind)
+	assert.Equal(t, "tool scan", findings[1].Command)
+	assert.Contains(t, findings[1].String(), `command "tool scan" is in the generated docs but cobra no longer registers it`)
+}
+
+func TestDiffReportsEveryDriftedField(t *testing.T) {
+	tests := []struct {
+		name       string
+		mutate     func(c *Command)
+		wantField  string
+		wantKind   FindingKind
+		wantDetail string
+	}{
+		{
+			name:      "short description",
+			mutate:    func(c *Command) { c.Short = "reworded" },
+			wantField: "short description",
+			wantKind:  CommandChanged,
+		},
+		{
+			name:      "aliases",
+			mutate:    func(c *Command) { c.Aliases = []string{"sc"} },
+			wantField: "aliases",
+			wantKind:  CommandChanged,
+		},
+		{
+			name:      "hidden",
+			mutate:    func(c *Command) { c.Hidden = true },
+			wantField: "hidden",
+			wantKind:  CommandChanged,
+		},
+		{
+			name:      "example",
+			mutate:    func(c *Command) { c.Example = "different" },
+			wantField: "example",
+			wantKind:  CommandChanged,
+		},
+		{
+			name:      "flag shorthand",
+			mutate:    func(c *Command) { c.Flags[1].Shorthand = "T" },
+			wantField: "shorthand",
+			wantKind:  FlagChanged,
+		},
+		{
+			name:      "flag default",
+			mutate:    func(c *Command) { c.Flags[1].Default = "changed" },
+			wantField: "default",
+			wantKind:  FlagChanged,
+		},
+		{
+			name:      "flag usability",
+			mutate:    func(c *Command) { c.Flags[1].Rejected = true },
+			wantField: "rejected by the command",
+			wantKind:  FlagChanged,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			documented := Walk(newTestTree())
+			registered := Walk(newTestTree())
+			cmd, ok := registered.Command("tool scan")
+			require.True(t, ok)
+			require.Equal(t, "target", cmd.Flags[1].Name, "the fixture's second flag is --target")
+			tt.mutate(cmd)
+
+			findings := Diff(documented, registered)
+
+			require.Len(t, findings, 1)
+			assert.Equal(t, tt.wantKind, findings[0].Kind)
+			assert.Equal(t, tt.wantField, findings[0].Field)
+			assert.Equal(t, "tool scan", findings[0].Command)
+			assert.Contains(t, findings[0].String(), tt.wantField+" changed from")
+		})
+	}
+}
+
+func TestDiffDetectsARejectionGuardBeingRemoved(t *testing.T) {
+	documented := Walk(newTestTree())
+
+	tree := newTestTree()
+	guarded, _, err := tree.Find([]string{"guarded"})
+	require.NoError(t, err)
+	guarded.PreRunE = nil // the guard is deleted
+
+	findings := Diff(documented, Walk(tree))
+
+	require.NotEmpty(t, findings, "dropping the guard changes what the CLI accepts, so it must redden the gate")
+	assert.Equal(t, "timeout", findings[0].Flag)
+	assert.Equal(t, "tool guarded", findings[0].Command)
+	assert.Contains(t, findings[0].String(), "rejected by the command changed from \"true\" (docs) to \"false\" (cobra)")
+}
+
+func TestDiffOrdersFindingsByCommandThenFlag(t *testing.T) {
+	documented := Walk(newTestTree())
+	registered := Walk(newTestTree())
+
+	scan, ok := registered.Command("tool scan")
+	require.True(t, ok)
+	scan.Flags[2].Default = "changed"
+	scan.Flags[0].Default = "changed"
+	guarded, ok := registered.Command("tool guarded")
+	require.True(t, ok)
+	guarded.Flags[0].Default = "changed"
+
+	findings := Diff(documented, registered)
+
+	require.Len(t, findings, 3)
+	assert.Equal(t, "tool guarded", findings[0].Command)
+	assert.Equal(t, "tool scan", findings[1].Command)
+	assert.Equal(t, "json", findings[1].Flag)
+	assert.Equal(t, "timeout", findings[2].Flag)
+}
+
+func TestReportNamesTheFilesAndTheRegenerationCommand(t *testing.T) {
+	findings := []Finding{
+		{Kind: FlagRemoved, Command: "brutus logon", Flag: "sticky-keys-exec"},
+	}
+
+	report := Report(findings, GeneratedPaths(), RegenerateCommand)
+
+	assert.Contains(t, report, "CLI surface drift: 1 disagreement(s)")
+	assert.Contains(t, report, "1. flag --sticky-keys-exec on \"brutus logon\"")
+	assert.Contains(t, report, "Regenerate docs/cli-surface.json, docs/CLI.md, README.md with 'make cli-docs'")
+}
+
+// TestReportStatesTheRemediationOnce keeps the failure message readable: repeating the
+// same fix line under every finding buries the findings it is meant to explain.
+func TestReportStatesTheRemediationOnce(t *testing.T) {
+	findings := []Finding{
+		{Kind: FlagRemoved, Command: "brutus logon", Flag: "one"},
+		{Kind: FlagRemoved, Command: "brutus logon", Flag: "two"},
+		{Kind: FlagUndocumented, Command: "brutus creds", Flag: "three"},
+	}
+
+	report := Report(findings, GeneratedPaths(), RegenerateCommand)
+
+	assert.Equal(t, 1, strings.Count(report, RegenerateCommand), "named once, not once per finding")
+	for _, flag := range []string{"--one", "--two", "--three"} {
+		assert.Contains(t, report, flag)
+	}
+}
+
+func TestFindingStringForAnUnknownKind(t *testing.T) {
+	assert.Equal(t, `something-else: "brutus"`, Finding{Kind: "something-else", Command: "brutus"}.String())
+}

--- a/internal/clisurface/region.go
+++ b/internal/clisurface/region.go
@@ -1,0 +1,101 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clisurface
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Generated regions let a hand-written document carry generated blocks. The
+// markers are HTML comments so they are invisible when the markdown renders.
+const (
+	regionBeginFormat = "<!-- BEGIN generated: %s -->"
+	regionEndFormat   = "<!-- END generated: %s -->"
+)
+
+// BeginMarker is the opening marker of the named region.
+func BeginMarker(name string) string { return fmt.Sprintf(regionBeginFormat, name) }
+
+// EndMarker is the closing marker of the named region.
+func EndMarker(name string) string { return fmt.Sprintf(regionEndFormat, name) }
+
+// Splice replaces the body of the named region in doc with body. The markers
+// themselves are preserved. body is normalized to exactly one trailing newline
+// so repeated splices converge.
+func Splice(doc, name, body string) (string, error) {
+	begin, end, err := regionBounds(doc, name)
+	if err != nil {
+		return "", err
+	}
+	normalized := strings.TrimRight(strings.ReplaceAll(body, "\r\n", "\n"), "\n") + "\n"
+	// Match the document's own line endings. Splicing LF into a CRLF checkout leaves a
+	// file that is mixed, which is worse than either convention and shows up as noise
+	// in every later diff.
+	if dominantNewline(doc) == "\r\n" {
+		normalized = strings.ReplaceAll(normalized, "\n", "\r\n")
+	}
+	return doc[:begin] + normalized + doc[end:], nil
+}
+
+// dominantNewline reports the line ending doc mostly uses.
+func dominantNewline(doc string) string {
+	if strings.Count(doc, "\r\n")*2 > strings.Count(doc, "\n") {
+		return "\r\n"
+	}
+	return "\n"
+}
+
+// RegionBody returns the current body of the named region.
+func RegionBody(doc, name string) (string, error) {
+	begin, end, err := regionBounds(doc, name)
+	if err != nil {
+		return "", err
+	}
+	return doc[begin:end], nil
+}
+
+// regionBounds returns the offsets of the region body: begin is just after the
+// newline that ends the opening marker line, end is the start of the closing
+// marker line.
+func regionBounds(doc, name string) (begin, end int, err error) {
+	beginMarker, endMarker := BeginMarker(name), EndMarker(name)
+
+	if n := strings.Count(doc, beginMarker); n != 1 {
+		return 0, 0, fmt.Errorf("expected exactly one %q marker, found %d", beginMarker, n)
+	}
+	if n := strings.Count(doc, endMarker); n != 1 {
+		return 0, 0, fmt.Errorf("expected exactly one %q marker, found %d", endMarker, n)
+	}
+
+	beginIdx := strings.Index(doc, beginMarker)
+	endIdx := strings.Index(doc, endMarker)
+	if endIdx < beginIdx {
+		return 0, 0, fmt.Errorf("%q appears before %q", endMarker, beginMarker)
+	}
+
+	afterBegin := beginIdx + len(beginMarker)
+	nl := strings.IndexByte(doc[afterBegin:], '\n')
+	if nl < 0 {
+		return 0, 0, fmt.Errorf("%q must be followed by a newline", beginMarker)
+	}
+	begin = afterBegin + nl + 1
+	// Both markers on one line leaves begin past endIdx. Splicing that produced a
+	// document with a duplicated closing marker rather than an error, so say so.
+	if begin > endIdx {
+		return 0, 0, fmt.Errorf("%q and %q must be on separate lines", beginMarker, endMarker)
+	}
+	return begin, endIdx, nil
+}

--- a/internal/clisurface/region_test.go
+++ b/internal/clisurface/region_test.go
@@ -1,0 +1,146 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clisurface
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// docWithRegion builds a small document carrying one generated region.
+func docWithRegion(name, body string) string {
+	return strings.Join([]string{
+		"# Title",
+		"",
+		BeginMarker(name),
+		body,
+		EndMarker(name),
+		"",
+		"hand-written tail",
+		"",
+	}, "\n")
+}
+
+func TestSpliceReplacesOnlyTheRegionBody(t *testing.T) {
+	doc := docWithRegion("cli-subcommands", "stale body")
+
+	out, err := Splice(doc, "cli-subcommands", "fresh body")
+	require.NoError(t, err)
+
+	assert.Equal(t, docWithRegion("cli-subcommands", "fresh body"), out)
+	assert.Contains(t, out, "hand-written tail", "text outside the region is untouched")
+}
+
+func TestSpliceIsIdempotent(t *testing.T) {
+	doc := docWithRegion("cli-aliases", "old")
+
+	once, err := Splice(doc, "cli-aliases", "new\nlines\n")
+	require.NoError(t, err)
+	twice, err := Splice(once, "cli-aliases", "new\nlines\n")
+	require.NoError(t, err)
+
+	assert.Equal(t, once, twice, "splicing the same body twice must converge")
+	assert.NotContains(t, once, "new\n\n</", "the body keeps exactly one trailing newline")
+}
+
+func TestRegionBodyRoundTrips(t *testing.T) {
+	doc := docWithRegion("cli-aliases", "line one\nline two")
+
+	body, err := RegionBody(doc, "cli-aliases")
+	require.NoError(t, err)
+	assert.Equal(t, "line one\nline two\n", body)
+}
+
+func TestSpliceRejectsBrokenMarkers(t *testing.T) {
+	tests := []struct {
+		name    string
+		doc     string
+		wantErr string
+	}{
+		{
+			name:    "missing begin marker",
+			doc:     "text\n" + EndMarker("cli-aliases") + "\n",
+			wantErr: `expected exactly one "<!-- BEGIN generated: cli-aliases -->" marker, found 0`,
+		},
+		{
+			name:    "missing end marker",
+			doc:     BeginMarker("cli-aliases") + "\nbody\n",
+			wantErr: `expected exactly one "<!-- END generated: cli-aliases -->" marker, found 0`,
+		},
+		{
+			name:    "duplicated region",
+			doc:     docWithRegion("cli-aliases", "a") + docWithRegion("cli-aliases", "b"),
+			wantErr: "found 2",
+		},
+		{
+			name:    "markers out of order",
+			doc:     EndMarker("cli-aliases") + "\nbody\n" + BeginMarker("cli-aliases") + "\n",
+			wantErr: "appears before",
+		},
+		{
+			name:    "begin marker not on its own line",
+			doc:     BeginMarker("cli-aliases") + " trailing text without newline" + EndMarker("cli-aliases"),
+			wantErr: "must be followed by a newline",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Splice(tt.doc, "cli-aliases", "body")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestMarkersAreHTMLComments(t *testing.T) {
+	assert.Equal(t, "<!-- BEGIN generated: cli-subcommands -->", BeginMarker(RegionSubcommands))
+	assert.Equal(t, "<!-- END generated: cli-aliases -->", EndMarker(RegionAliases))
+}
+
+// TestSpliceRejectsMarkersOnOneLine pins the bounds guard. Both markers on a single line
+// used to splice into a document carrying a duplicated closing marker instead of failing.
+func TestSpliceRejectsMarkersOnOneLine(t *testing.T) {
+	doc := BeginMarker(RegionSubcommands) + " " + EndMarker(RegionSubcommands) + "\n"
+
+	_, err := Splice(doc, RegionSubcommands, "body")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "separate lines")
+}
+
+// TestSplicePreservesCRLF pins the newline convention. Splicing LF regions into a CRLF
+// checkout produced a mixed file, which is worse than either and shows up as noise in
+// every later diff.
+func TestSplicePreservesCRLF(t *testing.T) {
+	lf := strings.Join([]string{
+		"# tool", "", BeginMarker(RegionSubcommands), "old", EndMarker(RegionSubcommands), "tail", "",
+	}, "\n")
+	crlf := strings.ReplaceAll(lf, "\n", "\r\n")
+
+	out, err := Splice(crlf, RegionSubcommands, "line one\nline two")
+	require.NoError(t, err)
+
+	assert.Contains(t, out, "line one\r\nline two\r\n")
+	assert.Equal(t, strings.Count(out, "\n"), strings.Count(out, "\r\n"), "every newline stays CRLF")
+
+	// And an LF document is left alone.
+	out, err = Splice(lf, RegionSubcommands, "line one\nline two")
+	require.NoError(t, err)
+	assert.NotContains(t, out, "\r")
+}

--- a/internal/clisurface/render_json.go
+++ b/internal/clisurface/render_json.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clisurface
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// jsonDoc is the on-disk shape of docs/cli-surface.json. Field order here is
+// the key order in the rendered file.
+type jsonDoc struct {
+	SchemaVersion int       `json:"schemaVersion"`
+	SurfaceHash   string    `json:"surfaceHash"`
+	Commands      []Command `json:"commands"`
+}
+
+// RenderJSON renders the machine-readable artifact: two-space indentation, no
+// HTML escaping, one trailing newline. Key order comes from the struct
+// definitions, so the output is byte-stable for a given surface.
+func RenderJSON(s Surface) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(jsonDoc{
+		SchemaVersion: SchemaVersion,
+		SurfaceHash:   s.Hash(),
+		Commands:      s.Commands,
+	}); err != nil {
+		return nil, fmt.Errorf("rendering cli surface json: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// ParseJSON reads a surface back out of the machine-readable artifact.
+func ParseJSON(b []byte) (Surface, error) {
+	var doc jsonDoc
+	if err := json.Unmarshal(b, &doc); err != nil {
+		return Surface{}, fmt.Errorf("parsing cli surface json: %w", err)
+	}
+	if doc.SchemaVersion != SchemaVersion {
+		return Surface{}, fmt.Errorf("cli surface json has schemaVersion %d, this build renders %d: regenerate with '%s'",
+			doc.SchemaVersion, SchemaVersion, RegenerateCommand)
+	}
+	// The hash has to describe the commands it ships with, or a hand-edited artifact
+	// passes every later comparison: downstream consumers pin the hash, so one that
+	// does not match its own contents is worse than a missing one.
+	s := Surface{Commands: doc.Commands}
+	if got := s.Hash(); doc.SurfaceHash != got {
+		return Surface{}, fmt.Errorf("cli surface json records surfaceHash %s but its commands hash to %s: it looks hand-edited, regenerate with '%s'",
+			doc.SurfaceHash, got, RegenerateCommand)
+	}
+	return s, nil
+}

--- a/internal/clisurface/render_json_test.go
+++ b/internal/clisurface/render_json_test.go
@@ -1,0 +1,122 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clisurface
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderJSONShape(t *testing.T) {
+	s := Walk(newTestTree())
+
+	out, err := RenderJSON(s)
+	require.NoError(t, err)
+
+	text := string(out)
+	assert.True(t, strings.HasPrefix(text, "{\n  \"schemaVersion\": 1,\n  \"surfaceHash\": \"sha256:"),
+		"schemaVersion and surfaceHash lead the document, two-space indented:\n%s", text[:120])
+	assert.True(t, strings.HasSuffix(text, "}\n"), "the file ends with exactly one newline")
+	assert.NotContains(t, text, "\n\n", "no blank lines")
+	assert.Contains(t, text, `"path": "tool guarded"`)
+	assert.Contains(t, text, `"rejected": true`)
+	assert.Contains(t, text, `"rejectedReason": "--timeout is not valid here; use --scan-timeout"`)
+}
+
+func TestRenderJSONDoesNotEscapeHTML(t *testing.T) {
+	s := Surface{Commands: []Command{{
+		Path: "tool", Use: "tool", Short: "serve on http://127.0.0.1:<port> & wait",
+	}}}
+
+	out, err := RenderJSON(s)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(out), "http://127.0.0.1:<port> & wait",
+		"help text with angle brackets and ampersands must stay readable")
+	assert.NotContains(t, string(out), `\u003c`, "the encoder must not escape angle brackets")
+}
+
+func TestRenderJSONOmitsEmptyOptionalFields(t *testing.T) {
+	s := Surface{Commands: []Command{{Path: "tool", Use: "tool", Short: "a tool", Runnable: true}}}
+
+	out, err := RenderJSON(s)
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(out), "aliases")
+	assert.NotContains(t, string(out), "hidden")
+	assert.Contains(t, string(out), `"runnable": true`)
+}
+
+func TestParseJSONRoundTripsTheSurface(t *testing.T) {
+	s := Walk(newTestTree())
+
+	out, err := RenderJSON(s)
+	require.NoError(t, err)
+	parsed, err := ParseJSON(out)
+	require.NoError(t, err)
+
+	assert.Equal(t, s, parsed, "the JSON artifact is a lossless copy of the surface")
+	assert.Equal(t, s.Hash(), parsed.Hash())
+	assert.Empty(t, Diff(parsed, s), "a round-tripped surface has no drift against itself")
+}
+
+func TestParseJSONRejectsAnUnknownSchemaVersion(t *testing.T) {
+	_, err := ParseJSON([]byte(`{"schemaVersion": 99, "commands": []}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "schemaVersion 99")
+	assert.Contains(t, err.Error(), RegenerateCommand, "the error says how to fix it")
+}
+
+func TestParseJSONRejectsGarbage(t *testing.T) {
+	_, err := ParseJSON([]byte("not json"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parsing cli surface json")
+}
+
+// TestRenderJSONIsByteIdenticalAcrossWalks pairs with TestWalkIsDeterministic: the walk
+// producing equal surfaces is only useful if rendering them is byte-stable, since the
+// committed artifact is compared as bytes.
+func TestRenderJSONIsByteIdenticalAcrossWalks(t *testing.T) {
+	first, err := RenderJSON(Walk(newTestTree()))
+	require.NoError(t, err)
+	second, err := RenderJSON(Walk(newTestTree()))
+	require.NoError(t, err)
+
+	assert.Equal(t, string(first), string(second))
+}
+
+// TestParseJSONRejectsAHashThatDoesNotMatchItsCommands pins the consistency check.
+// Downstream consumers pin surfaceHash, so an artifact whose hash does not describe its
+// own commands is worse than one with no hash at all: it passes every later comparison.
+func TestParseJSONRejectsAHashThatDoesNotMatchItsCommands(t *testing.T) {
+	rendered, err := RenderJSON(Walk(newTestTree()))
+	require.NoError(t, err)
+
+	var lines []string
+	for _, line := range strings.Split(string(rendered), "\n") {
+		if strings.HasPrefix(line, `  "surfaceHash": "`) {
+			line = `  "surfaceHash": "sha256:` + strings.Repeat("0", 64) + `",`
+		}
+		lines = append(lines, line)
+	}
+
+	_, err = ParseJSON([]byte(strings.Join(lines, "\n")))
+	require.Error(t, err, "a hand-edited artifact must not parse")
+	assert.Contains(t, err.Error(), "looks hand-edited")
+	assert.Contains(t, err.Error(), RegenerateCommand)
+}

--- a/internal/clisurface/render_md.go
+++ b/internal/clisurface/render_md.go
@@ -1,0 +1,349 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clisurface
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// generatedNotice heads every generated markdown artifact.
+var generatedNotice = "<!-- Generated from the live cobra command tree by '" + RegenerateCommand + "'. Do not edit by hand. -->"
+
+// Region names spliced into README.md.
+const (
+	RegionSubcommands = "cli-subcommands"
+	RegionAliases     = "cli-aliases"
+)
+
+// Region is one generated block of a hand-written document.
+type Region struct {
+	Name string
+	Body string
+}
+
+// RenderMarkdown renders the full human-readable reference (docs/CLI.md).
+func RenderMarkdown(s Surface) []byte {
+	root := s.Root()
+
+	var b strings.Builder
+	writeLines(&b,
+		generatedNotice,
+		"",
+		"# "+root+" CLI reference",
+		"",
+		"Every command, alias and flag below is derived from the cobra command tree, not from prose.",
+		"Schema version "+strconv.Itoa(SchemaVersion)+", surface hash `"+s.Hash()+"`.",
+		"",
+		"Regenerate with `"+RegenerateCommand+"` after adding, removing or renaming a command or a flag.",
+		"",
+		"## Command index",
+		"",
+		"| Command | Aliases | Description |",
+		"| --- | --- | --- |",
+	)
+	for i := range s.Commands {
+		c := &s.Commands[i]
+		writeLines(&b, "| ["+code(c.Path)+"](#"+anchor(c.Path)+") | "+aliasCell(c)+" | "+cell(indexDescription(c))+" |")
+	}
+
+	for i := range s.Commands {
+		writeCommand(&b, &s.Commands[i])
+	}
+
+	return []byte(b.String())
+}
+
+// writeCommand renders one command section of the reference.
+func writeCommand(b *strings.Builder, c *Command) {
+	writeLines(b, "", "## "+code(c.Path), "")
+	if c.Short != "" {
+		writeLines(b, c.Short, "")
+	}
+
+	writeLines(b, "- Usage: "+code(usage(c)))
+	writeLines(b, "- Aliases: "+aliasCell(c))
+	if c.Hidden {
+		writeLines(b, "- Hidden: not shown in `--help` output")
+	}
+	if c.Deprecated != "" {
+		writeLines(b, "- Deprecated: "+c.Deprecated)
+	}
+	if !c.Runnable {
+		writeLines(b, "- Requires a subcommand")
+	}
+
+	local, inherited, rejected := partitionFlags(c)
+	writeFlagTable(b, "Flags", local)
+	writeFlagTable(b, "Inherited flags", inherited)
+
+	if len(rejected) > 0 {
+		writeLines(b, "", "### Rejected flags", "",
+			"These flags reach "+code(c.Path)+" through inheritance, but the command refuses them:",
+			"", "| Flag | Why |", "| --- | --- |")
+		for _, f := range rejected {
+			writeLines(b, "| "+code("--"+f.Name)+" | "+cell(f.RejectedReason)+" |")
+		}
+	}
+
+	if c.Example != "" {
+		writeLines(b, "", "### Examples", "", "```bash")
+		writeLines(b, strings.Split(strings.TrimRight(dedent(c.Example), "\n"), "\n")...)
+		writeLines(b, "```")
+	}
+}
+
+// writeFlagTable renders a titled flag table, or nothing when there are none.
+func writeFlagTable(b *strings.Builder, title string, flags []*Flag) {
+	if len(flags) == 0 {
+		return
+	}
+	writeLines(b, "", "### "+title, "", "| Flag | Short | Type | Default | Description |", "| --- | --- | --- | --- | --- |")
+	for _, f := range flags {
+		short := ""
+		if f.Shorthand != "" {
+			short = code("-" + f.Shorthand)
+		}
+		def := ""
+		if f.Default != "" {
+			def = codeCell(f.Default)
+		}
+		writeLines(b, "| "+code("--"+f.Name)+" | "+short+" | "+cell(f.Type)+" | "+def+" | "+cell(flagDescription(f))+" |")
+	}
+}
+
+// RenderRegions renders the generated regions of README.md, in a fixed order.
+func RenderRegions(s Surface) []Region {
+	return []Region{
+		{Name: RegionSubcommands, Body: renderSubcommandRegion(s)},
+		{Name: RegionAliases, Body: renderAliasRegion(s)},
+	}
+}
+
+// renderSubcommandRegion renders the Quick Start subcommand listing: the
+// visible top-level commands with their cobra Short descriptions. It states no
+// count — the list below it is the count, and a written one would be a second
+// thing that can go stale.
+func renderSubcommandRegion(s Surface) string {
+	root := s.Root()
+	children := visible(s.Children(root))
+
+	width := 0
+	for _, c := range children {
+		if n := len(name(c.Path)); n > width {
+			width = n
+		}
+	}
+
+	var b strings.Builder
+	writeLines(&b,
+		"Brutus organizes its functionality into these focused subcommands:",
+		"",
+		"```bash",
+	)
+	for _, c := range children {
+		writeLines(&b, fmt.Sprintf("%s %-*s # %s", root, width, name(c.Path), c.Short))
+	}
+	writeLines(&b, "```")
+	return b.String()
+}
+
+// renderAliasRegion renders the Quick Start alias table. Only subcommands that
+// actually declare aliases are listed: this is the most-read part of the
+// README, and rows reading "none" contradict the lead-in and add noise.
+// docs/CLI.md remains the complete reference and does list them.
+func renderAliasRegion(s Surface) string {
+	root := s.Root()
+
+	var b strings.Builder
+	writeLines(&b,
+		"Some subcommands carry aliases for discoverability:",
+		"",
+		"| Subcommand | Aliases |",
+		"| --- | --- |",
+	)
+	for _, c := range visible(s.Children(root)) {
+		if len(c.Aliases) == 0 {
+			continue
+		}
+		writeLines(&b, "| "+code(name(c.Path))+" | "+aliasCell(c)+" |")
+	}
+	writeLines(&b,
+		"",
+		"The full reference — every subcommand, alias and flag, including the ones "+
+			"hidden from `--help` — is generated into [docs/CLI.md](docs/CLI.md).",
+	)
+	return b.String()
+}
+
+// --- helpers ---------------------------------------------------------------
+
+// writeLines appends each line plus a newline.
+func writeLines(b *strings.Builder, lines ...string) {
+	for _, l := range lines {
+		b.WriteString(l)
+		b.WriteString("\n")
+	}
+}
+
+// visible drops commands hidden from help output.
+func visible(cmds []*Command) []*Command {
+	out := make([]*Command, 0, len(cmds))
+	for _, c := range cmds {
+		if !c.Hidden {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// partitionFlags splits a command's flags into the ones declared on it, the
+// usable ones it inherits, and the ones it inherits but refuses.
+func partitionFlags(c *Command) (local, inherited, rejected []*Flag) {
+	for i := range c.Flags {
+		f := &c.Flags[i]
+		switch {
+		case f.Rejected:
+			rejected = append(rejected, f)
+		case f.Inherited:
+			inherited = append(inherited, f)
+		default:
+			local = append(local, f)
+		}
+	}
+	return local, inherited, rejected
+}
+
+// name returns the last segment of a command path.
+func name(path string) string {
+	if i := strings.LastIndex(path, " "); i >= 0 {
+		return path[i+1:]
+	}
+	return path
+}
+
+// usage renders the invocation sketch: the full path with the cobra Use
+// string's argument sketch (everything after the command name) appended.
+func usage(c *Command) string {
+	if i := strings.Index(c.Use, " "); i >= 0 {
+		return c.Path + c.Use[i:]
+	}
+	return c.Path
+}
+
+// indexDescription is the command-index description, annotated for commands
+// that are hidden or deprecated.
+func indexDescription(c *Command) string {
+	switch {
+	case c.Deprecated != "":
+		return c.Short + " (deprecated: " + c.Deprecated + ")"
+	case c.Hidden:
+		return c.Short + " (hidden)"
+	default:
+		return c.Short
+	}
+}
+
+// flagDescription is the flag-table description, annotated for flags that are
+// hidden or deprecated.
+func flagDescription(f *Flag) string {
+	switch {
+	case f.Deprecated != "":
+		return f.Usage + " (deprecated: " + f.Deprecated + ")"
+	case f.Hidden:
+		return f.Usage + " (hidden)"
+	default:
+		return f.Usage
+	}
+}
+
+// aliasCell renders a command's aliases for a table cell.
+func aliasCell(c *Command) string {
+	if len(c.Aliases) == 0 {
+		return "*(none)*"
+	}
+	out := make([]string, 0, len(c.Aliases))
+	for _, a := range c.Aliases {
+		out = append(out, code(a))
+	}
+	return strings.Join(out, ", ")
+}
+
+// code wraps s in markdown code ticks.
+func code(s string) string { return "`" + s + "`" }
+
+// cell makes arbitrary help text safe inside a markdown table cell.
+func cell(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "|", "\\|")
+	return strings.TrimSpace(s)
+}
+
+// codeCell wraps a value in code ticks safely inside a table cell. Defaults and flag
+// types come from cobra, so they can hold a pipe, a newline or a backtick -- any of
+// which breaks the row, and a broken row silently drops a flag from the reference.
+// A value containing a backtick needs a longer delimiter plus padding, which is how
+// markdown nests code spans.
+func codeCell(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "|", "\\|")
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	if !strings.Contains(s, "`") {
+		return code(s)
+	}
+	fence := "``"
+	for strings.Contains(s, fence) {
+		fence += "`"
+	}
+	return fence + " " + s + " " + fence
+}
+
+// anchor is the GitHub heading anchor for a "## `path`" heading.
+func anchor(path string) string {
+	// GitHub lowercases heading anchors, so a path carrying an uppercase letter would
+	// otherwise render a link that goes nowhere.
+	return strings.ToLower(strings.ReplaceAll(path, " ", "-"))
+}
+
+// dedent removes the common leading-space indent cobra examples carry so the
+// rendered fence is not indented as a code block twice over.
+func dedent(s string) string {
+	lines := strings.Split(s, "\n")
+	indent := -1
+	for _, l := range lines {
+		trimmed := strings.TrimLeft(l, " ")
+		if trimmed == "" {
+			continue
+		}
+		if n := len(l) - len(trimmed); indent < 0 || n < indent {
+			indent = n
+		}
+	}
+	if indent <= 0 {
+		return s
+	}
+	for i, l := range lines {
+		if len(l) >= indent {
+			lines[i] = l[indent:]
+		} else {
+			lines[i] = strings.TrimLeft(l, " ")
+		}
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/clisurface/render_md_test.go
+++ b/internal/clisurface/render_md_test.go
@@ -1,0 +1,234 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clisurface
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderMarkdownDocumentsEveryCommand(t *testing.T) {
+	s := Walk(newTestTree())
+
+	md := string(RenderMarkdown(s))
+
+	assert.True(t, strings.HasPrefix(md, generatedNotice), "the file warns that it is generated")
+	assert.Contains(t, md, "Do not edit by hand")
+	assert.Contains(t, md, "# tool CLI reference")
+	assert.Contains(t, md, "surface hash `"+s.Hash()+"`")
+	for _, path := range []string{"tool", "tool scan", "tool guarded", "tool group", "tool group leaf", "tool group old"} {
+		assert.Contains(t, md, "## `"+path+"`", "every command gets a section")
+	}
+	assert.Contains(t, md, "| [`tool scan`](#tool-scan) |", "the index links to the sections")
+	assert.True(t, strings.HasSuffix(md, "\n"))
+}
+
+func TestRenderMarkdownSeparatesLocalInheritedAndRejectedFlags(t *testing.T) {
+	s := Walk(newTestTree())
+
+	md := string(RenderMarkdown(s))
+	guarded := section(t, md, "tool guarded")
+
+	assert.Contains(t, guarded, "### Flags")
+	assert.Contains(t, guarded, "| `--scan-timeout` |")
+	assert.Contains(t, guarded, "### Inherited flags")
+	assert.Contains(t, guarded, "| `--json` | `-j` | bool |")
+	assert.Contains(t, guarded, "### Rejected flags")
+	assert.Contains(t, guarded, "| `--timeout` | --timeout is not valid here; use --scan-timeout |")
+
+	timeoutRows := strings.Count(guarded, "`--timeout`")
+	assert.Equal(t, 1, timeoutRows,
+		"a rejected flag appears only in the rejected table, never as a usable option")
+}
+
+func TestRenderMarkdownAnnotatesHiddenAndDeprecatedCommands(t *testing.T) {
+	s := Walk(newTestTree())
+
+	md := string(RenderMarkdown(s))
+	old := section(t, md, "tool group old")
+
+	assert.Contains(t, old, "- Hidden: not shown in `--help` output")
+	assert.Contains(t, old, `- Deprecated: use "tool group leaf" instead`)
+	assert.Contains(t, md, "the old spelling (deprecated:", "the index flags it too")
+	assert.Contains(t, section(t, md, "tool group"), "- Requires a subcommand")
+}
+
+func TestRenderMarkdownIncludesDedentedExamples(t *testing.T) {
+	s := Walk(newTestTree())
+
+	scan := section(t, string(RenderMarkdown(s)), "tool scan")
+
+	assert.Contains(t, scan, "### Examples")
+	assert.Contains(t, scan, "```bash\n# scan one host\ntool scan --target host\n```",
+		"cobra's two-space example indent is removed so the fence is a plain shell block")
+}
+
+func TestRenderMarkdownEscapesTableCells(t *testing.T) {
+	s := Surface{Commands: []Command{{
+		Path: "tool", Use: "tool", Short: "a | b", Runnable: true,
+		Flags: []Flag{{Name: "mode", Type: "string", Usage: "cautious | default | aggressive\nsecond line"}},
+	}}}
+
+	md := string(RenderMarkdown(s))
+
+	assert.Contains(t, md, `cautious \| default \| aggressive second line`,
+		"pipes are escaped and newlines folded so the markdown table survives")
+}
+
+func TestRenderRegionsListsSubcommandsWithoutClaimingACount(t *testing.T) {
+	s := Walk(newTestTree())
+
+	regions := RenderRegions(s)
+	require.Len(t, regions, 2)
+	assert.Equal(t, RegionSubcommands, regions[0].Name, "regions render in a fixed order")
+	assert.Equal(t, RegionAliases, regions[1].Name)
+
+	body := regions[0].Body
+	assert.Contains(t, body, "Brutus organizes its functionality into these focused subcommands:")
+	assert.NotRegexp(t, `into \d+ `, body,
+		"the list below is the count; a written count is a second thing that can be wrong")
+	assert.Contains(t, body, "```bash\ntool group   # a group of things\n")
+	assert.Contains(t, body, "tool guarded # rejects --timeout\n")
+	assert.Contains(t, body, "tool scan    # scan things\n")
+	assert.NotContains(t, body, "tool group leaf", "only top-level subcommands are listed")
+}
+
+func TestRenderRegionsAliasTableOmitsCommandsWithoutAliases(t *testing.T) {
+	s := Walk(newTestTree())
+
+	body := RenderRegions(s)[1].Body
+
+	assert.Contains(t, body, "| `scan` | `sc`, `scanner` |")
+	assert.NotContains(t, body, "*(none)*",
+		"the region says 'some subcommands carry aliases', so rows saying 'none' contradict it")
+	assert.NotContains(t, body, "| `guarded` |", "a command with no aliases is not listed at all")
+	assert.NotContains(t, body, "| `group` |")
+	assert.Contains(t, body, "[docs/CLI.md](docs/CLI.md)", "the region links to the full reference")
+}
+
+func TestRenderRegionsAliasTableFollowsAliasTransitions(t *testing.T) {
+	base := Surface{Commands: []Command{
+		{Path: "tool", Use: "tool"},
+		{Path: "tool scan", Use: "scan", Short: "scan things", Aliases: []string{"sc"}},
+		{Path: "tool plain", Use: "plain", Short: "no aliases yet"},
+	}}
+
+	body := RenderRegions(base)[1].Body
+	require.Contains(t, body, "| `scan` | `sc` |")
+	require.NotContains(t, body, "| `plain` |")
+
+	t.Run("a command gaining its first alias appears", func(t *testing.T) {
+		gained := base
+		gained.Commands = append([]Command(nil), base.Commands...)
+		gained.Commands[2].Aliases = []string{"p"}
+
+		body := RenderRegions(gained)[1].Body
+
+		assert.Contains(t, body, "| `plain` | `p` |",
+			"declaring an alias must add the command to the README table")
+	})
+
+	t.Run("a command losing its last alias disappears", func(t *testing.T) {
+		lost := base
+		lost.Commands = append([]Command(nil), base.Commands...)
+		lost.Commands[1].Aliases = nil
+
+		body := RenderRegions(lost)[1].Body
+
+		assert.NotContains(t, body, "| `scan` |",
+			"dropping the last alias must remove the command from the README table")
+		assert.Contains(t, body, "[docs/CLI.md](docs/CLI.md)",
+			"the rest of the region survives an empty table")
+	})
+}
+
+func TestRenderRegionsSkipsHiddenSubcommands(t *testing.T) {
+	s := Surface{Commands: []Command{
+		{Path: "tool", Use: "tool"},
+		{Path: "tool shown", Use: "shown", Short: "visible"},
+		{Path: "tool secret", Use: "secret", Short: "hidden", Hidden: true},
+	}}
+
+	body := RenderRegions(s)[0].Body
+
+	assert.Contains(t, body, "tool shown # visible")
+	assert.NotContains(t, body, "secret", "hidden commands stay out of the Quick Start listing")
+}
+
+func TestUsageIncludesTheArgumentSketch(t *testing.T) {
+	assert.Equal(t, "tool scan [flags]", usage(&Command{Path: "tool scan", Use: "scan [flags]"}))
+	assert.Equal(t, "tool scan", usage(&Command{Path: "tool scan", Use: "scan"}))
+}
+
+func TestDedentLeavesUnindentedTextAlone(t *testing.T) {
+	assert.Equal(t, "a\nb", dedent("a\nb"))
+	assert.Equal(t, "a\n\nb", dedent("  a\n\n  b"))
+}
+
+// section returns the docs/CLI.md section for one command path.
+func section(t *testing.T, md, path string) string {
+	t.Helper()
+	heading := "## `" + path + "`"
+	start := strings.Index(md, heading)
+	require.GreaterOrEqual(t, start, 0, "section %q must exist", heading)
+	rest := md[start+len(heading):]
+	if next := strings.Index(rest, "\n## "); next >= 0 {
+		return rest[:next]
+	}
+	return rest
+}
+
+// TestAnchorMatchesGitHubsCasing keeps the command-index links working: GitHub lowercases
+// heading anchors, so a path with an uppercase letter needs the same treatment.
+func TestAnchorMatchesGitHubsCasing(t *testing.T) {
+	assert.Equal(t, "tool-scan", anchor("tool scan"))
+	assert.Equal(t, "tool-enum-microsoft365", anchor("tool enum Microsoft365"))
+}
+
+// TestCodeCellSurvivesTableBreakingValues pins cell escaping for values that come from
+// cobra rather than from us. A raw pipe or newline ends the row early, and a broken row
+// silently drops a flag from the reference.
+func TestCodeCellSurvivesTableBreakingValues(t *testing.T) {
+	assert.Equal(t, "`plain`", codeCell("plain"))
+	assert.Equal(t, "", codeCell(""))
+	// The pipe has to arrive escaped, or it ends the cell and the row loses a column.
+	assert.Equal(t, "`a\\|b`", codeCell("a|b"))
+	assert.Equal(t, "`one two`", codeCell("one\ntwo"))
+	// A value holding a backtick needs a longer delimiter, which is how markdown nests
+	// code spans; without it the span closes inside the value.
+	assert.Equal(t, "`` a`b ``", codeCell("a`b"))
+	assert.Equal(t, "``` a``b ```", codeCell("a``b"))
+}
+
+// TestRenderMarkdownEscapesADefaultContainingAPipe is the end-to-end version: the row
+// has to stay a five-column row.
+func TestRenderMarkdownEscapesADefaultContainingAPipe(t *testing.T) {
+	root := newTestTree()
+	scan, _, err := root.Find([]string{"scan"})
+	require.NoError(t, err)
+	scan.Flags().String("pattern", "a|b", "a default that would break the table")
+
+	for _, line := range strings.Split(string(RenderMarkdown(Walk(root))), "\n") {
+		if strings.Contains(line, "--pattern") {
+			assert.Equal(t, 6, strings.Count(line, "|")-strings.Count(line, "\\|"),
+				"the row keeps five columns: %s", line)
+			return
+		}
+	}
+	t.Fatal("--pattern was not rendered at all")
+}


### PR DESCRIPTION
Part 2 of 6. Pure functions over the model from PR 1 — no I/O, no cobra.

**Review focus:** `surfaceHash` deliberately excludes prose (`Short`, `Usage`, `Example`) so rewording help text does not move a hash downstream consumers pin, while any change to a name, shorthand, type, default or usability does. `Diff` reports in both directions.

## Review stack (ENG-6871)

Split out of #331 so each layer can be read on its own. Review **in order**; each targets the one before it.

| # | PR | Scope | Hand-written |
|---|---|---|---|
| 1 | #338 | Walk the cobra tree into a comparable surface | ~855 |
| 2 | #339 | Render a surface, and diff two of them | ~1257 |
| 3 | #340 | Lint documents and Go comments against a surface | ~1225 |
| 4 | #341 | Repo-level artifact and lint plumbing | ~650 |
| 5 | #342 | Turn on the gate, commit the generated artifacts | ~290 + 6.1k generated |
| 6 | #343 | Run it in CI, ship the artifact | ~109 |

PRs 1–4 are the library and touch nothing outside `internal/clisurface`. Nothing is wired up until #342.

Every stage compiles and passes `go test -short ./...`, `golangci-lint run ./...` (`0 issues.`) and `gofmt` **on its own**, so you can stop after any one of them. The tip of the stack is byte-identical to #331 as reviewed.

Three small refactors were needed to make the layers separable, and they are the only content not in #331: the shared path constants and `GeneratedPaths` moved into `paths.go`, `LintReport` moved beside the linter, and one test assertion moved from the walk's tests to the renderer's.

