### PR TITLE
feat(clisurface): lint documents and Go comments against a surface (ENG-6871, 3/6)

### DIFF
--- a/internal/clisurface/lint.go
+++ b/internal/clisurface/lint.go
@@ -1,0 +1,765 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clisurface
+
+import (
+	"fmt"
+	"go/parser"
+	"go/token"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// AllowlistPath is the repo-relative file listing flag names documentation may
+// mention even though the CLI does not (or no longer does) accept them.
+const AllowlistPath = "docs/cli-surface-allow.txt"
+
+// longFlagPattern matches a long flag token in prose or in a Go comment.
+// Group 2 is the token. The leading group requires the dashes to start a word,
+// so neither "// -----" rule comments, nor "--" used as a dash-dash separator,
+// nor "dash--dash" inside a word can look like a flag.
+var longFlagPattern = regexp.MustCompile(`(^|[^A-Za-z0-9_])(--[a-zA-Z0-9][a-zA-Z0-9._-]*)`)
+
+// backtickPattern matches an inline code span on a single line.
+var backtickPattern = regexp.MustCompile("`[^`\n]+`")
+
+// Issue is one documentation reference to a flag or subcommand that the CLI
+// does not accept.
+type Issue struct {
+	// File is the repo-relative file the reference appears in.
+	File string
+	// Line is the 1-based line the reference appears on.
+	Line int
+	// Token is the offending token exactly as written, dashes included. No
+	// example of a removed flag is given here: this package's own comments are
+	// linted, and allowlisting a real removed flag to quote it would suppress
+	// that name everywhere, including in the README the gate exists to police.
+	Token string
+	// Command is the command the token was checked against, empty when the
+	// token was checked against the whole surface (prose and Go comments).
+	Command string
+	// Reason says what is wrong.
+	Reason string
+	// Suggestion is the nearest real flag or subcommand, empty when nothing is
+	// close.
+	Suggestion string
+	// Subcommand reports whether Token is a subcommand name rather than a flag.
+	// The two get different advice: the allowlist only holds flag tokens (see
+	// ParseAllowlist), so offering it for a misspelled subcommand would send the
+	// reader to write an entry the allowlist parser rejects.
+	Subcommand bool
+}
+
+// String renders the issue as one actionable line.
+func (i Issue) String() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s:%d: %s %s", i.File, i.Line, i.Token, i.Reason)
+	if i.Command != "" {
+		// Every command-scoped reason ends in a preposition, so the command
+		// reads as part of the sentence: `--exec is not a flag of "brutus logon"`.
+		fmt.Fprintf(&b, " %s", strconv.Quote(i.Command))
+	}
+	if i.Suggestion != "" {
+		label := "nearest real flag"
+		if i.Subcommand {
+			label = "nearest subcommand"
+		}
+		fmt.Fprintf(&b, "; %s: %s", label, i.Suggestion)
+	}
+	// An issue inside a generated file is a symptom of a stale artifact, not
+	// something to hand-edit or allowlist: say so, or the reader "fixes" a file
+	// the next regeneration overwrites.
+	if whollyGenerated(i.File) {
+		fmt.Fprintf(&b, ". %s is generated: regenerate it with '%s' rather than editing it",
+			i.File, RegenerateCommand)
+		return b.String()
+	}
+	if i.Subcommand {
+		fmt.Fprintf(&b, ". Fix the documentation: %s holds flag tokens only", AllowlistPath)
+		return b.String()
+	}
+	fmt.Fprintf(&b, ". Fix the documentation, or add %s to %s with a '#' reason if the mention is deliberate",
+		i.Token, AllowlistPath)
+	return b.String()
+}
+
+// whollyGenerated reports whether every line of path is generated, and so must
+// never be hand-edited. README.md is deliberately excluded: only two regions of
+// it are generated, so a lint hit there is normally in hand-written prose.
+func whollyGenerated(path string) bool {
+	return path == JSONPath || path == MarkdownPath
+}
+
+// Allowlist holds deliberately documented tokens and why each is allowed.
+type Allowlist struct {
+	reasons map[string]string
+}
+
+// ParseAllowlist reads an allowlist file. Every entry is one token
+// ("--<flag>" or "-<x>") followed by a '#' comment giving the reason; blank lines
+// and whole-line comments are ignored. The reason is mandatory: an entry
+// without one is an error, because an unexplained exception is how a stale
+// reference survives forever.
+func ParseAllowlist(content string) (Allowlist, error) {
+	out := Allowlist{reasons: map[string]string{}}
+	for i, raw := range strings.Split(content, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		entry, reason, found := strings.Cut(line, "#")
+		entry = strings.TrimSpace(entry)
+		reason = strings.TrimSpace(reason)
+		switch {
+		case !strings.HasPrefix(entry, "-"):
+			return Allowlist{}, fmt.Errorf("%s:%d: entry %q must start with '-'", AllowlistPath, i+1, entry)
+		case !found || reason == "":
+			return Allowlist{}, fmt.Errorf("%s:%d: entry %q needs a '# reason' explaining why it is allowed", AllowlistPath, i+1, entry)
+		}
+		out.reasons[entry] = reason
+	}
+	return out, nil
+}
+
+// Allows reports whether the token is allowlisted.
+func (a Allowlist) Allows(entry string) bool {
+	_, ok := a.reasons[entry]
+	return ok
+}
+
+// Entries returns the allowlisted tokens in sorted order.
+func (a Allowlist) Entries() []string {
+	out := make([]string, 0, len(a.reasons))
+	for entry := range a.reasons {
+		out = append(out, entry)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// LintMarkdown checks one markdown document against the surface.
+//
+// Fenced code blocks are parsed as shell: line continuations are joined,
+// pipelines are split, and only segments whose argv[0] is the CLI binary are
+// checked — every flag of every other tool in an example pipeline is ignored,
+// which is what keeps the false-positive rate at zero. Prose outside fences is
+// checked more loosely: only backticked long-flag tokens, and only against the
+// union of every flag in the tree, because prose rarely says which command it
+// means.
+//
+// The argv[0] rule is what buys the zero false-positive rate, and it costs
+// reach: an invocation the binary does not lead — "sudo brutus …", "time brutus
+// …", "FOO=bar brutus …" — is skipped rather than checked. Recognizing prefixes
+// one at a time would trade a guarantee for a list that is never finished, so
+// examples are written with the binary first. There are none of the other shape
+// in this repository.
+func LintMarkdown(s Surface, file, content string, allow Allowlist) []Issue {
+	var issues []Issue
+
+	var (
+		inFence    bool
+		fence      string
+		pending    string
+		pendingAt  int
+		flushFence = func() {
+			if pending == "" {
+				return
+			}
+			issues = append(issues, lintShellLine(s, file, pendingAt, pending, allow)...)
+			pending = ""
+		}
+	)
+
+	for i, raw := range strings.Split(content, "\n") {
+		lineNo := i + 1
+		trimmed := strings.TrimSpace(raw)
+
+		if !inFence {
+			if delim := fenceDelimiter(trimmed); delim != "" {
+				inFence, fence = true, delim
+				continue
+			}
+			issues = append(issues, lintProseLine(s, file, lineNo, raw, allow)...)
+			continue
+		}
+
+		if isFenceClose(trimmed, fence) {
+			flushFence()
+			inFence, fence = false, ""
+			continue
+		}
+
+		body := strings.TrimRight(raw, " \t")
+		if pending == "" {
+			pendingAt = lineNo
+		}
+		if strings.HasSuffix(body, `\`) {
+			pending += strings.TrimSuffix(body, `\`) + " "
+			continue
+		}
+		pending += body
+		flushFence()
+	}
+	flushFence()
+
+	return issues
+}
+
+// fenceDelimiter returns the fence a line opens a code block with, or "" when the line
+// does not open one.
+//
+// It returns the whole run of backticks or tildes, not just three of them. The length
+// is load-bearing: a block opened with four backticks may contain a three-backtick line
+// as content, and closing on it early would read the rest of the document as prose and
+// the following prose as shell.
+func fenceDelimiter(trimmed string) string {
+	for _, marker := range []byte{'`', '~'} {
+		n := 0
+		for n < len(trimmed) && trimmed[n] == marker {
+			n++
+		}
+		if n >= 3 {
+			return trimmed[:n]
+		}
+	}
+	return ""
+}
+
+// isFenceClose reports whether the line closes the open fence: the same marker, at
+// least as long as the opener, and nothing else on the line.
+func isFenceClose(trimmed, fence string) bool {
+	if len(trimmed) < len(fence) || !strings.HasPrefix(trimmed, fence) {
+		return false
+	}
+	return strings.Trim(trimmed, fence[:1]) == ""
+}
+
+// flagName strips a long-flag token down to its name. Only a trailing "." can survive
+// the pattern -- its character class does not include the other sentence punctuation --
+// and prose ending a sentence on a flag is common enough to be worth trimming.
+func flagName(tok string) string {
+	return strings.TrimRight(strings.TrimPrefix(tok, "--"), ".")
+}
+
+// lintProseLine checks the backticked long-flag tokens of one prose line
+// against the union of every flag in the tree.
+func lintProseLine(s Surface, file string, line int, raw string, allow Allowlist) []Issue {
+	var issues []Issue
+	known := vocabulary(s)
+	for _, span := range backtickPattern.FindAllString(raw, -1) {
+		for _, tok := range longFlagTokens(span) {
+			name := flagName(tok)
+			if allow.Allows("--"+name) || contains(known, name) {
+				continue
+			}
+			issues = append(issues, Issue{
+				File:       file,
+				Line:       line,
+				Token:      tok,
+				Reason:     "is not a flag of any command in the CLI",
+				Suggestion: nearest(name, known),
+			})
+		}
+	}
+	return issues
+}
+
+// lintShellLine checks one logical shell line from a fenced code block.
+func lintShellLine(s Surface, file string, line int, text string, allow Allowlist) []Issue {
+	var issues []Issue
+	root := s.Root()
+	for _, argv := range shellSegments(text) {
+		if len(argv) == 0 || baseName(argv[0]) != root {
+			continue
+		}
+		issues = append(issues, lintInvocation(s, file, line, argv, allow)...)
+	}
+	return issues
+}
+
+// lintInvocation checks one "brutus ..." invocation.
+//
+// It works in the two stages cobra works in. First it resolves the command,
+// stepping over flags and the values they consume; then it validates every flag
+// in the invocation against the command that was finally resolved. That order is
+// not incidental — cobra dispatches to the resolved command and parses the whole
+// argv against *that* command's flag set, so where a flag sits relative to the
+// subcommand does not change whether it is accepted.
+//
+// Validating each flag against whichever command happened to be resolved when it
+// was read gets this wrong in both directions:
+//
+//   - Reporting a flag against the root because it was written before the
+//     subcommand. `brutus --json enum apollo --domain example.com` is legal, but
+//     --domain would be reported as not existing on "brutus".
+//   - Missing a flag the resolved command refuses. `brutus --timeout 5s logon`
+//     fails at runtime because the logon family rejects the inherited --timeout,
+//     and `brutus --version logon` fails because --version is local to the root
+//     — neither is excused by being written early.
+//
+// Values are stepped over using the command resolved so far, which is what cobra
+// does too: a non-boolean flag takes the next argument, a value-taking shorthand
+// takes the rest of its token ("-oresults.json") or the next argument, and "--"
+// ends flag parsing. Reading a value as a flag would report its characters as
+// nonexistent shorthands.
+func lintInvocation(s Surface, file string, line int, argv []string, allow Allowlist) []Issue {
+	cmd, ok := s.Command(s.Root())
+	if !ok {
+		return nil
+	}
+
+	var (
+		issues []Issue
+		flags  []string
+	)
+
+	// resolving stays true across flags and goes false at the first positional
+	// that is not a subcommand: from there on argv holds this command's
+	// arguments, and an argument that happens to spell a subcommand name is not
+	// one.
+	resolving := true
+	for i := 1; i < len(argv); i++ {
+		arg := argv[i]
+		next := ""
+		if i+1 < len(argv) {
+			next = argv[i+1]
+		}
+
+		switch {
+		case arg == "--":
+			// pflag stops parsing here: everything after is positional,
+			// however much it looks like a flag.
+			i = len(argv)
+		case arg == "-":
+			// A bare "-" is a positional, conventionally stdin.
+			resolving = false
+		case strings.HasPrefix(arg, "--"):
+			flags = append(flags, arg)
+			if longFlagTakesNext(cmd, arg, next) {
+				i++
+			}
+		case strings.HasPrefix(arg, "-") && len(arg) > 1:
+			flags = append(flags, arg)
+			if shortFlagTakesNext(cmd, arg, next) {
+				i++
+			}
+		case resolving:
+			child := resolveChild(s, cmd.Path, arg)
+			switch {
+			case child != nil:
+				cmd = child
+			case len(s.Children(cmd.Path)) > 0:
+				issues = append(issues, Issue{
+					File: file, Line: line, Token: arg, Command: cmd.Path,
+					Reason:     "is not a subcommand of",
+					Suggestion: nearestCommand(s, cmd.Path, arg),
+					Subcommand: true,
+				})
+				resolving = false
+			default:
+				resolving = false
+			}
+		}
+	}
+
+	for _, arg := range flags {
+		if strings.HasPrefix(arg, "--") {
+			issues = append(issues, checkLongFlag(s, cmd, file, line, arg, allow)...)
+			continue
+		}
+		issues = append(issues, checkShortFlags(cmd, file, line, arg, allow)...)
+	}
+	return issues
+}
+
+// longFlagTakesNext reports whether the argument after a "--<name>" token is
+// that flag's value rather than a token of its own.
+//
+// A "--<name>=<value>" token carries its own value. Otherwise any non-boolean
+// flag takes the next argument. A flag cmd does not declare is guessed from
+// shape — anything that does not itself look like a flag — so that one unknown
+// flag does not also get its value read as a bogus subcommand.
+func longFlagTakesNext(cmd *Command, arg, next string) bool {
+	name, _, carriesValue := strings.Cut(strings.TrimPrefix(arg, "--"), "=")
+	if next == "" || carriesValue || name == "" || name == HelpFlag {
+		return false
+	}
+	if flag, known := cmd.Flag(name); known {
+		return flag.Type != "bool"
+	}
+	return !strings.HasPrefix(next, "-")
+}
+
+// shortFlagTakesNext reports whether the argument after a "-x" token, or a
+// "-xyz" cluster, is a value of that cluster. pflag clusters booleans freely,
+// and the first flag that takes a value swallows the rest of the token
+// ("-oresults.json", "-o=results.json") or, when the token ends there, the next
+// argument ("-o results.json").
+func shortFlagTakesNext(cmd *Command, arg, next string) bool {
+	if next == "" {
+		return false
+	}
+	cluster := []rune(strings.TrimPrefix(arg, "-"))
+	for i := 0; i < len(cluster); i++ {
+		r := cluster[i]
+		if !isShorthandRune(r) {
+			return false
+		}
+		if r == 'h' {
+			continue
+		}
+		flag, ok := cmd.FlagByShorthand(string(r))
+		switch {
+		case !ok:
+			// Unknown, so whether the rest of the token is more shorthands or a
+			// value is unknowable. Reported by checkShortFlags; guessing here
+			// would only move the damage.
+			return false
+		case flag.Type == "bool":
+			continue
+		}
+		return strings.TrimPrefix(string(cluster[i+1:]), "=") == ""
+	}
+	return false
+}
+
+// checkLongFlag validates a "--<name>" or "--<name>=<value>" token against cmd.
+func checkLongFlag(s Surface, cmd *Command, file string, line int, arg string, allow Allowlist) []Issue {
+	name, _, _ := strings.Cut(strings.TrimPrefix(arg, "--"), "=")
+	written := "--" + name
+	if name == "" || name == HelpFlag || allow.Allows(written) {
+		return nil
+	}
+
+	flag, ok := cmd.Flag(name)
+	switch {
+	case ok && flag.Rejected:
+		// No edit-distance suggestion here: the command's own rejection
+		// message already names the flag to use instead.
+		return []Issue{{
+			File: file, Line: line, Token: written, Command: cmd.Path,
+			Reason: "is rejected by this command: " + flag.RejectedReason + ", so it is not usable on",
+		}}
+	case ok:
+		return nil
+	}
+
+	reason := "is not a flag of"
+	if contains(s.FlagNames(), name) {
+		reason = "exists on other commands but not on"
+	}
+	return []Issue{{
+		File: file, Line: line, Token: written, Command: cmd.Path,
+		Reason:     reason,
+		Suggestion: nearest(name, usableFlagNames(cmd)),
+	}}
+}
+
+// checkShortFlags validates a "-x" token, or a "-xyz" cluster, against cmd. It
+// reads the cluster the way pflag does (see shortFlagTakesNext): scanning a
+// flag's value as more shorthands is how "-oresults.json" turns into six
+// invented flags.
+func checkShortFlags(cmd *Command, file string, line int, arg string, allow Allowlist) []Issue {
+	var issues []Issue
+
+	cluster := []rune(strings.TrimPrefix(arg, "-"))
+	for i := 0; i < len(cluster); i++ {
+		r := cluster[i]
+		if !isShorthandRune(r) {
+			// Not a shorthand, so this token is a value rather than a cluster.
+			return issues
+		}
+
+		written := "-" + string(r)
+		// -h is cobra's help shorthand, present on every command.
+		if r == 'h' || allow.Allows(written) {
+			continue
+		}
+
+		flag, ok := cmd.FlagByShorthand(string(r))
+		if !ok {
+			issues = append(issues, Issue{
+				File: file, Line: line, Token: written, Command: cmd.Path,
+				Reason: "is not a shorthand flag of",
+			})
+			// Stop here. Without knowing whether this shorthand takes a value
+			// there is no way to tell whether the rest of the token is more
+			// shorthands or that value, and guessing invents findings.
+			return issues
+		}
+		if flag.Rejected {
+			issues = append(issues, Issue{
+				File: file, Line: line, Token: written, Command: cmd.Path,
+				Reason: "is rejected by this command: " + flag.RejectedReason + ", so it is not usable on",
+			})
+		}
+		if flag.Type != "bool" {
+			// A value-taking shorthand ends the cluster.
+			return issues
+		}
+	}
+	return issues
+}
+
+// isShorthandRune reports whether r can be a pflag shorthand. Anything else
+// (a digit sign, a slash, a dot) means the token is a value, not a flag
+// cluster, and the rest of it must not be validated.
+func isShorthandRune(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
+}
+
+// resolveChild resolves one path segment to a direct subcommand of path, by
+// name or by alias.
+func resolveChild(s Surface, path, segment string) *Command {
+	if c, ok := s.Command(path + " " + segment); ok {
+		return c
+	}
+	for _, c := range s.Children(path) {
+		if contains(c.Aliases, segment) {
+			return c
+		}
+	}
+	return nil
+}
+
+// vocabulary is every flag name documentation may name without saying which
+// command it means: the union of the tree's flags plus cobra's help flag.
+func vocabulary(s Surface) []string {
+	return append(s.FlagNames(), HelpFlag)
+}
+
+// usableFlagNames lists the flags actually usable on cmd.
+func usableFlagNames(cmd *Command) []string {
+	out := make([]string, 0, len(cmd.Flags))
+	for i := range cmd.Flags {
+		if !cmd.Flags[i].Rejected {
+			out = append(out, cmd.Flags[i].Name)
+		}
+	}
+	return out
+}
+
+// LintGoComments checks every long-flag token in the comments of one Go file.
+// This is the check that keeps a renamed flag from surviving in a comment that
+// no compiler and no test would ever read.
+func LintGoComments(s Surface, file string, src []byte, allow Allowlist) ([]Issue, error) {
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, file, src, parser.ParseComments|parser.SkipObjectResolution)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", file, err)
+	}
+
+	known := vocabulary(s)
+	var issues []Issue
+	for _, group := range parsed.Comments {
+		for _, comment := range group.List {
+			line := fset.Position(comment.Slash).Line
+			for _, tok := range longFlagTokens(comment.Text) {
+				name := flagName(tok)
+				if name == "" || allow.Allows("--"+name) || contains(known, name) {
+					continue
+				}
+				issues = append(issues, Issue{
+					File:       file,
+					Line:       line,
+					Token:      "--" + name,
+					Reason:     "is named in a comment but is not a flag of any command in the CLI",
+					Suggestion: nearest(name, known),
+				})
+			}
+		}
+	}
+	return issues, nil
+}
+
+// LintReport renders lint issues as a failure message.
+func LintReport(issues []Issue) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "documentation references %d CLI flag(s) or subcommand(s) that do not exist:\n\n", len(issues))
+	for i := range issues {
+		fmt.Fprintf(&b, "  %d. %s\n", i+1, issues[i].String())
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// --- shell tokenising -------------------------------------------------------
+
+// shellSegments splits one logical shell line into pipeline segments of argv
+// tokens. It is quote-aware (so a flag value containing '&&', '|' or '#' stays
+// one token), honors backslash escapes outside quotes, drops a leading "$"
+// prompt, and stops at an unquoted '#' comment.
+func shellSegments(line string) [][]string {
+	var (
+		segments [][]string
+		argv     []string
+		cur      strings.Builder
+		quote    rune
+		// quoted records that the current token came from an explicit "" or '', so an
+		// empty argument is still an argument. Dropping it shifts everything after it:
+		// given `--<flag> "" --<next>`, the empty value disappears, --<next> is read as
+		// the value of --<flag>, and an invalid --<next> goes unreported.
+		quoted bool
+	)
+
+	endToken := func() {
+		if cur.Len() > 0 || quoted {
+			argv = append(argv, cur.String())
+			cur.Reset()
+		}
+		quoted = false
+	}
+	endSegment := func() {
+		endToken()
+		if len(argv) > 0 {
+			segments = append(segments, argv)
+			argv = nil
+		}
+	}
+
+	runes := []rune(line)
+	for i := 0; i < len(runes); i++ {
+		c := runes[i]
+		switch {
+		case quote != 0:
+			if c == quote {
+				quote = 0
+				continue
+			}
+			if c == '\\' && quote == '"' && i+1 < len(runes) {
+				i++
+				cur.WriteRune(runes[i])
+				continue
+			}
+			cur.WriteRune(c)
+		case c == '\'' || c == '"':
+			quote = c
+			quoted = true
+		case c == '\\' && i+1 < len(runes):
+			i++
+			cur.WriteRune(runes[i])
+		case c == ' ' || c == '\t':
+			endToken()
+		case c == '#' && cur.Len() == 0:
+			endSegment()
+			return segments
+		case c == '|' || c == ';' || c == '&' || c == '>' || c == '<' || c == '(' || c == ')':
+			endSegment()
+		default:
+			cur.WriteRune(c)
+		}
+	}
+	endSegment()
+
+	for i := range segments {
+		if len(segments[i]) > 1 && segments[i][0] == "$" {
+			segments[i] = segments[i][1:]
+		}
+	}
+	return segments
+}
+
+// longFlagTokens returns the long-flag tokens in text, in order.
+func longFlagTokens(text string) []string {
+	matches := longFlagPattern.FindAllStringSubmatch(text, -1)
+	out := make([]string, 0, len(matches))
+	for _, m := range matches {
+		out = append(out, m[2])
+	}
+	return out
+}
+
+// baseName is the last path element of an argv[0], so "./brutus" and
+// "/usr/local/bin/brutus" both name the binary.
+func baseName(arg string) string {
+	if i := strings.LastIndexAny(arg, `/\`); i >= 0 {
+		return arg[i+1:]
+	}
+	return arg
+}
+
+// --- suggestions ------------------------------------------------------------
+
+// contains reports whether want is in list.
+func contains(list []string, want string) bool {
+	for _, v := range list {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}
+
+// nearest returns the closest candidate to name as a "--<flag>" string, or "" if
+// nothing is close enough to be a useful suggestion.
+func nearest(name string, candidates []string) string {
+	best, bestDistance := "", 0
+	for _, c := range candidates {
+		d := editDistance(name, c)
+		if best == "" || d < bestDistance {
+			best, bestDistance = c, d
+		}
+	}
+	limit := len(name) / 2
+	if limit < 2 {
+		limit = 2
+	}
+	if best == "" || bestDistance > limit {
+		return ""
+	}
+	return "--" + best
+}
+
+// nearestCommand returns the closest subcommand name of path to token.
+func nearestCommand(s Surface, path, segment string) string {
+	var names []string
+	for _, c := range s.Children(path) {
+		names = append(names, name(c.Path))
+		names = append(names, c.Aliases...)
+	}
+	best, bestDistance := "", 0
+	for _, n := range names {
+		d := editDistance(segment, n)
+		if best == "" || d < bestDistance {
+			best, bestDistance = n, d
+		}
+	}
+	if best == "" || bestDistance > 3 {
+		return ""
+	}
+	return best
+}
+
+// editDistance is the Levenshtein distance between a and b.
+func editDistance(a, b string) int {
+	prev := make([]int, len(b)+1)
+	curr := make([]int, len(b)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(a); i++ {
+		curr[0] = i
+		for j := 1; j <= len(b); j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			curr[j] = min(prev[j]+1, min(curr[j-1]+1, prev[j-1]+cost))
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(b)]
+}

--- a/internal/clisurface/lint_test.go
+++ b/internal/clisurface/lint_test.go
@@ -1,0 +1,542 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clisurface
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// emptyAllowlist is the allowlist used by tests that do not exercise it.
+func emptyAllowlist(t *testing.T) Allowlist {
+	t.Helper()
+	allow, err := ParseAllowlist("")
+	require.NoError(t, err)
+	return allow
+}
+
+// tokensOf flattens issues to their offending tokens.
+func tokensOf(issues []Issue) []string {
+	out := make([]string, 0, len(issues))
+	for i := range issues {
+		out = append(out, issues[i].Token)
+	}
+	return out
+}
+
+func TestShellSegmentsSplitsPipelines(t *testing.T) {
+	segments := shellSegments("naabu -host 10.0.0.0/24 -silent | nerva --json | brutus creds -P passwords.txt")
+
+	require.Len(t, segments, 3)
+	assert.Equal(t, []string{"naabu", "-host", "10.0.0.0/24", "-silent"}, segments[0])
+	assert.Equal(t, []string{"nerva", "--json"}, segments[1])
+	assert.Equal(t, []string{"brutus", "creds", "-P", "passwords.txt"}, segments[2])
+}
+
+func TestShellSegmentsKeepsQuotedValuesWhole(t *testing.T) {
+	segments := shellSegments(`brutus logon --target host --exec "net user attacker P@ssw0rd /add && net localgroup administrators attacker /add"`)
+
+	require.Len(t, segments, 1, "the && inside quotes must not split the command")
+	assert.Equal(t, []string{
+		"brutus", "logon", "--target", "host", "--exec",
+		"net user attacker P@ssw0rd /add && net localgroup administrators attacker /add",
+	}, segments[0])
+}
+
+func TestShellSegmentsHandlesPromptsCommentsAndSeparators(t *testing.T) {
+	assert.Equal(t, [][]string{{"brutus", "creds"}}, shellSegments("$ brutus creds"),
+		"a copied shell prompt is not argv[0]")
+	assert.Equal(t, [][]string{{"brutus", "creds"}}, shellSegments("brutus creds    # test SSH, MySQL, ..."),
+		"an unquoted # starts a comment")
+	assert.Empty(t, shellSegments("# only a comment"))
+	assert.Equal(t, [][]string{{"brutus", "creds"}, {"results.json"}}, shellSegments("brutus creds > results.json"),
+		"a redirect target is its own segment, so it is never read as a flag")
+	assert.Equal(t, [][]string{{"jq", "-r", `"\(.target) \(.username)"`, "findings.json"}},
+		shellSegments(`jq -r '"\(.target) \(.username)"' findings.json`),
+		"single quotes are literal")
+}
+
+func TestLintMarkdownOnlyChecksTheCLIsOwnInvocations(t *testing.T) {
+	s := Walk(newTestTree())
+	doc := strings.Join([]string{
+		"```bash",
+		"naabu -host 10.0.0.0/24 -p 3389 -silent | nerva --json | tool scan",
+		"curl -LO https://example.com/tool.tar.gz | tar -xzf -",
+		"go install example.com/cmd/tool@latest",
+		"sudo mv tool /usr/local/bin/",
+		"jq 'select(.finding)' findings.json",
+		"```",
+	}, "\n")
+
+	issues := LintMarkdown(s, "README.md", doc, emptyAllowlist(t))
+
+	assert.Empty(t, issues, "flags belonging to other tools in the pipeline must never be validated")
+}
+
+func TestLintMarkdownReportsFlagsTheCommandDoesNotHave(t *testing.T) {
+	s := Walk(newTestTree())
+	doc := strings.Join([]string{
+		"prose line",
+		"```bash",
+		"tool scan --target host --targt host",
+		"```",
+	}, "\n")
+
+	issues := LintMarkdown(s, "README.md", doc, emptyAllowlist(t))
+
+	require.Len(t, issues, 1)
+	assert.Equal(t, "--targt", issues[0].Token)
+	assert.Equal(t, 3, issues[0].Line, "the issue points at the line inside the fence")
+	assert.Equal(t, "tool scan", issues[0].Command)
+	assert.Equal(t, "--target", issues[0].Suggestion, "the nearest real flag is offered")
+	assert.Contains(t, issues[0].String(), `README.md:3: --targt is not a flag of "tool scan"`,
+		"the message names the file, the line, the token and the command")
+	assert.Contains(t, issues[0].String(), AllowlistPath, "the message says how to allow a deliberate mention")
+}
+
+func TestLintMarkdownReportsFlagsRejectedByTheCommand(t *testing.T) {
+	s := Walk(newTestTree())
+	doc := "```bash\ntool guarded --timeout 30s\n```"
+
+	issues := LintMarkdown(s, "README.md", doc, emptyAllowlist(t))
+
+	require.Len(t, issues, 1, "--timeout is inherited but the command refuses it")
+	assert.Equal(t, "--timeout", issues[0].Token)
+	assert.Equal(t, "tool guarded", issues[0].Command)
+	assert.Contains(t, issues[0].Reason, "use --scan-timeout", "the command's own error explains the rejection")
+	assert.Empty(t, issues[0].Suggestion, "the rejection message is the guidance; an edit-distance guess would add noise")
+}
+
+func TestLintMarkdownAcceptsInheritedAndHiddenFlags(t *testing.T) {
+	s := Walk(newTestTree())
+	doc := "```bash\ntool scan --target host --timeout 5s --json\ntool guarded --scan-timeout 15s --json\n```"
+
+	assert.Empty(t, LintMarkdown(s, "README.md", doc, emptyAllowlist(t)),
+		"a flag inherited from the root is usable unless the command rejects it")
+}
+
+func TestLintMarkdownJoinsLineContinuations(t *testing.T) {
+	s := Walk(newTestTree())
+	doc := strings.Join([]string{
+		"```bash",
+		"naabu -host 10.0.0.0/24 -silent | \\",
+		"  nerva --json | \\",
+		"  tool scan --nope",
+		"```",
+	}, "\n")
+
+	issues := LintMarkdown(s, "README.md", doc, emptyAllowlist(t))
+
+	require.Len(t, issues, 1, "the continued pipeline is one logical command line")
+	assert.Equal(t, "--nope", issues[0].Token)
+	assert.Equal(t, 2, issues[0].Line, "a continued line is reported at the line it starts on")
+}
+
+func TestLintMarkdownChecksShorthandFlags(t *testing.T) {
+	s := Walk(newTestTree())
+
+	assert.Empty(t, LintMarkdown(s, "README.md", "```bash\ntool scan -t host -j\n```", emptyAllowlist(t)))
+
+	issues := LintMarkdown(s, "README.md", "```bash\ntool scan -Z host\n```", emptyAllowlist(t))
+	require.Len(t, issues, 1)
+	assert.Equal(t, "-Z", issues[0].Token)
+	assert.Contains(t, issues[0].Reason, "is not a shorthand flag of")
+}
+
+func TestLintMarkdownIgnoresValuesThatLookLikeFlags(t *testing.T) {
+	s := Walk(newTestTree())
+	doc := "```bash\ntool scan --target - -t -\n```"
+
+	assert.Empty(t, LintMarkdown(s, "README.md", doc, emptyAllowlist(t)),
+		"a bare - is stdin, not a flag")
+}
+
+func TestLintMarkdownResolvesSubcommandsAndAliases(t *testing.T) {
+	s := Walk(newTestTree())
+
+	assert.Empty(t, LintMarkdown(s, "README.md", "```bash\ntool sc --target host\ntool group leaf --only-here x\n```", emptyAllowlist(t)),
+		"aliases and nested paths must resolve")
+
+	issues := LintMarkdown(s, "README.md", "```bash\ntool group leef --only-here x\n```", emptyAllowlist(t))
+	require.Len(t, issues, 2, "the unknown subcommand and the flag it cannot carry are both reported")
+	assert.Equal(t, "leef", issues[0].Token)
+	assert.Contains(t, issues[0].Reason, "is not a subcommand of")
+	assert.Equal(t, "leaf", issues[0].Suggestion)
+}
+
+func TestLintMarkdownTreatsPositionalArgumentsAsValues(t *testing.T) {
+	s := Walk(newTestTree())
+
+	assert.Empty(t, LintMarkdown(s, "README.md", "```bash\ntool scan somehost:22\n```", emptyAllowlist(t)),
+		"a leaf command's positional argument is not a subcommand")
+}
+
+func TestLintMarkdownChecksBacktickedFlagsInProse(t *testing.T) {
+	s := Walk(newTestTree())
+	doc := strings.Join([]string{
+		"Route traffic through `--timeout 5s` or use `--mode cautious|default|aggressive`.",
+		"Unbackticked --alsogone is ignored because prose says things loosely.",
+		"```bash",
+		"tool scan --target host",
+		"```",
+	}, "\n")
+
+	issues := LintMarkdown(s, "README.md", doc, emptyAllowlist(t))
+
+	require.Len(t, issues, 1)
+	assert.Equal(t, "--mode", issues[0].Token)
+	assert.Equal(t, 1, issues[0].Line)
+	assert.Empty(t, issues[0].Command, "prose is checked against the whole surface, not one command")
+	assert.Contains(t, issues[0].Reason, "is not a flag of any command")
+}
+
+func TestLintMarkdownIgnoresProseInsideFencesAndFencesInsideProse(t *testing.T) {
+	s := Walk(newTestTree())
+	doc := strings.Join([]string{
+		"~~~",
+		"tool scan --gone",
+		"~~~",
+		"`--gone` in prose is reported once more",
+	}, "\n")
+
+	issues := LintMarkdown(s, "README.md", doc, emptyAllowlist(t))
+
+	require.Len(t, issues, 2, "a tilde fence is a fence, and prose after it is prose")
+	assert.Equal(t, 2, issues[0].Line)
+	assert.Equal(t, "tool scan", issues[0].Command)
+	assert.Equal(t, 4, issues[1].Line)
+	assert.Empty(t, issues[1].Command)
+}
+
+func TestLintGoCommentsReportsRenamedFlags(t *testing.T) {
+	s := Walk(newTestTree())
+	src := []byte(`package demo
+
+// runInteractive handles the --scan-timeout and --sticky-keys-exec modes.
+func runInteractive() {}
+
+// ---------------------------------------------------------------------------
+// A rule comment and a dash--dash word must not look like flags.
+`)
+
+	issues, err := LintGoComments(s, "cmd/demo/demo.go", src, emptyAllowlist(t))
+	require.NoError(t, err)
+
+	require.Len(t, issues, 1)
+	assert.Equal(t, "--sticky-keys-exec", issues[0].Token)
+	assert.Equal(t, "cmd/demo/demo.go", issues[0].File)
+	assert.Equal(t, 3, issues[0].Line)
+	assert.Contains(t, issues[0].Reason, "is named in a comment")
+}
+
+func TestLintGoCommentsIgnoresStringLiteralsAndCode(t *testing.T) {
+	s := Walk(newTestTree())
+	src := []byte(`package demo
+
+func run() string { return "--not-a-real-flag" }
+`)
+
+	issues, err := LintGoComments(s, "cmd/demo/demo.go", src, emptyAllowlist(t))
+	require.NoError(t, err)
+	assert.Empty(t, issues, "only comments are checked; string literals are out of scope")
+}
+
+func TestLintGoCommentsFailsOnUnparseableSource(t *testing.T) {
+	_, err := LintGoComments(Walk(newTestTree()), "cmd/demo/demo.go", []byte("not go at all"), emptyAllowlist(t))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parsing cmd/demo/demo.go")
+}
+
+func TestAllowlistSuppressesDeliberateMentions(t *testing.T) {
+	s := Walk(newTestTree())
+	allow, err := ParseAllowlist(strings.Join([]string{
+		"# deliberate historical references",
+		"--sticky-keys-exec  # renamed to --exec in v1.9; the rename note has to name the old flag",
+		"",
+		"-Z # nmap's -Z, quoted in a pipeline example",
+	}, "\n"))
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"--sticky-keys-exec", "-Z"}, allow.Entries())
+	assert.True(t, allow.Allows("--sticky-keys-exec"))
+	assert.False(t, allow.Allows("--something-else"))
+
+	doc := "`--sticky-keys-exec` was renamed.\n```bash\ntool scan -Z --sticky-keys-exec\n```"
+	assert.Empty(t, LintMarkdown(s, "README.md", doc, allow))
+	assert.NotEmpty(t, LintMarkdown(s, "README.md", doc, emptyAllowlist(t)),
+		"without the allowlist the same document is reported")
+}
+
+func TestParseAllowlistRequiresAReason(t *testing.T) {
+	_, err := ParseAllowlist("--orphan\n")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "needs a '# reason'")
+
+	_, err = ParseAllowlist("--orphan #   \n")
+	require.Error(t, err)
+
+	_, err = ParseAllowlist("orphan # missing dashes\n")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must start with '-'")
+}
+
+func TestIssueInAGeneratedFilePointsAtRegeneration(t *testing.T) {
+	generated := Issue{File: MarkdownPath, Line: 12, Token: "--gone", Reason: "is not a flag of any command in the CLI"}
+	assert.Equal(t,
+		"docs/CLI.md:12: --gone is not a flag of any command in the CLI. docs/CLI.md is generated: regenerate it with 'make cli-docs' rather than editing it",
+		generated.String(),
+		"a stale generated file must not be advertised as something to hand-edit or allowlist")
+
+	for _, file := range []string{"CONTRIBUTING.md", READMEPath} {
+		handWritten := Issue{File: file, Line: 12, Token: "--gone", Reason: "is not a flag of any command in the CLI"}
+		assert.Contains(t, handWritten.String(), AllowlistPath,
+			"%s still offers the allowlist escape hatch: only two regions of README.md are generated", file)
+		assert.NotContains(t, handWritten.String(), RegenerateCommand, "%s", file)
+	}
+}
+
+func TestLintReportNumbersEveryIssue(t *testing.T) {
+	report := LintReport([]Issue{
+		{File: "README.md", Line: 7, Token: "--gone", Reason: "is not a flag of any command in the CLI"},
+		{File: "docs/CLI.md", Line: 9, Token: "--also-gone", Reason: "is not a flag of any command in the CLI"},
+	})
+
+	assert.Contains(t, report, "references 2 CLI flag(s)")
+	assert.Contains(t, report, "1. README.md:7: --gone")
+	assert.Contains(t, report, "2. docs/CLI.md:9: --also-gone")
+}
+
+func TestNearestOnlySuggestsPlausibleMatches(t *testing.T) {
+	assert.Equal(t, "--target", nearest("targt", []string{"target", "timeout"}))
+	assert.Empty(t, nearest("wildly-different", []string{"target", "timeout"}),
+		"a distant token gets no suggestion rather than a misleading one")
+}
+
+func TestTokensOfIssuesAreStable(t *testing.T) {
+	s := Walk(newTestTree())
+	doc := "```bash\ntool scan --aaa --bbb\n```"
+	assert.Equal(t, []string{"--aaa", "--bbb"}, tokensOf(LintMarkdown(s, "README.md", doc, emptyAllowlist(t))))
+}
+
+// TestLintMarkdownResolvesSubcommandsAcrossGlobalFlags pins the fix for the
+// linter's worst failure mode: a global flag written before the subcommand used
+// to stop subcommand resolution, so every later flag was validated against the
+// root and a perfectly valid example was reported as drift.
+func TestLintMarkdownResolvesSubcommandsAcrossGlobalFlags(t *testing.T) {
+	s := Walk(newTestTree())
+
+	for _, line := range []string{
+		"tool --json scan --target host",             // boolean global first
+		"tool --timeout 5s scan --target host",       // value-taking global first
+		"tool --timeout=5s group leaf --only-here x", // attached value, nested path
+		"tool -j scan --target host",                 // boolean shorthand first
+		"tool -j --timeout 5s sc --target host",      // several globals, then an alias
+	} {
+		assert.Empty(t, LintMarkdown(s, "README.md", "```bash\n"+line+"\n```", emptyAllowlist(t)),
+			"%q is a valid invocation: cobra accepts a global flag before the subcommand", line)
+	}
+}
+
+// TestLintMarkdownCatchesABadSubcommandAfterAGlobalFlag is the other half of the
+// same fix. Resolution used to stop at the first flag, which silently swallowed
+// a misspelled subcommand written after one.
+func TestLintMarkdownCatchesABadSubcommandAfterAGlobalFlag(t *testing.T) {
+	s := Walk(newTestTree())
+
+	issues := LintMarkdown(s, "README.md", "```bash\ntool --json groop leaf\n```", emptyAllowlist(t))
+
+	require.Len(t, issues, 1)
+	assert.Equal(t, "groop", issues[0].Token)
+	assert.Equal(t, "tool", issues[0].Command)
+	assert.Contains(t, issues[0].Reason, "is not a subcommand of")
+	assert.Equal(t, "group", issues[0].Suggestion)
+}
+
+// TestLintMarkdownDoesNotReadFlagValuesAsFlags pins the second false-positive
+// class: a value that pflag reads as one token used to be scanned as a cluster
+// of shorthands, so "-thost" became -t plus five invented flags.
+func TestLintMarkdownDoesNotReadFlagValuesAsFlags(t *testing.T) {
+	s := Walk(newTestTree())
+
+	for _, line := range []string{
+		"tool scan -thost",                  // value attached to the shorthand
+		"tool scan -t=host",                 // value attached with =
+		"tool scan -t host",                 // value as the next argument
+		"tool scan -jt host",                // boolean clustered before a value-taking flag
+		"tool scan --target -weird-looking", // a value that starts with a dash
+	} {
+		assert.Empty(t, LintMarkdown(s, "README.md", "```bash\n"+line+"\n```", emptyAllowlist(t)),
+			"%q: the flag's value must not be scanned as flags", line)
+	}
+}
+
+// TestLintMarkdownStopsAtTheDashDashSeparator checks that a token after "--" is
+// a positional argument, however much it looks like a flag.
+func TestLintMarkdownStopsAtTheDashDashSeparator(t *testing.T) {
+	s := Walk(newTestTree())
+
+	assert.Empty(t, LintMarkdown(s, "README.md", "```bash\ntool scan -- --not-a-flag-here\n```", emptyAllowlist(t)),
+		"pflag stops parsing flags at a bare --")
+}
+
+// TestLintMarkdownStillCatchesFlagsAfterAResolvedSubcommand guards against the
+// resolution fix loosening the check: the flags of a correctly resolved deep
+// command must still be validated against that command.
+func TestLintMarkdownStillCatchesFlagsAfterAResolvedSubcommand(t *testing.T) {
+	s := Walk(newTestTree())
+
+	issues := LintMarkdown(s, "README.md", "```bash\ntool --json group leaf --only-here x --gone y\n```", emptyAllowlist(t))
+
+	require.Len(t, issues, 1)
+	assert.Equal(t, "--gone", issues[0].Token)
+	assert.Equal(t, "tool group leaf", issues[0].Command,
+		"the flag is checked against the command the global flag did not hide")
+}
+
+// TestSubcommandIssueDoesNotOfferTheFlagAllowlist checks the advice matches the
+// token. The allowlist holds flag tokens only, so pointing a misspelled
+// subcommand at it would send the reader to write an entry ParseAllowlist
+// rejects.
+func TestSubcommandIssueDoesNotOfferTheFlagAllowlist(t *testing.T) {
+	issue := Issue{
+		File: "README.md", Line: 3, Token: "groop", Command: "tool",
+		Reason: "is not a subcommand of", Suggestion: "group", Subcommand: true,
+	}
+
+	rendered := issue.String()
+	assert.Contains(t, rendered, `README.md:3: groop is not a subcommand of "tool"`)
+	assert.Contains(t, rendered, "nearest subcommand: group")
+	assert.NotContains(t, rendered, "add groop to", "the allowlist parser rejects an entry that is not a flag")
+
+	_, err := ParseAllowlist("groop # what the old message told the reader to write\n")
+	require.Error(t, err, "the advice the message used to give was not even valid")
+}
+
+// TestLintMarkdownTreatsHelpAsBoolean checks that --help and -h do not swallow
+// the token after them: both are boolean, and cobra registers them on every
+// command without them appearing in the surface.
+func TestLintMarkdownTreatsHelpAsBoolean(t *testing.T) {
+	s := Walk(newTestTree())
+
+	issues := LintMarkdown(s, "README.md", "```bash\ntool --help groop\ntool -h groop\n```", emptyAllowlist(t))
+
+	require.Len(t, issues, 2, "the subcommand after --help/-h is still resolved and still checked")
+	for i := range issues {
+		assert.Equal(t, "groop", issues[i].Token)
+		assert.Equal(t, "group", issues[i].Suggestion)
+	}
+}
+
+// TestLintMarkdownJudgesEveryFlagAgainstTheResolvedCommand pins the order of the
+// two stages. cobra dispatches to the resolved command and parses the whole argv
+// against that command's flag set, so writing a flag before the subcommand does
+// not excuse it: a flag the command rejects, and a flag local to the root, both
+// fail at runtime wherever they appear.
+func TestLintMarkdownJudgesEveryFlagAgainstTheResolvedCommand(t *testing.T) {
+	s := Walk(newTestTree())
+
+	t.Run("a rejected inherited flag is caught before the subcommand too", func(t *testing.T) {
+		for _, line := range []string{
+			"tool guarded --timeout 30s",
+			"tool --timeout 30s guarded",
+			"tool --timeout=30s guarded --scan-timeout 5s",
+		} {
+			issues := LintMarkdown(s, "README.md", "```bash\n"+line+"\n```", emptyAllowlist(t))
+			require.Len(t, issues, 1, "%q: guarded refuses --timeout wherever it is written", line)
+			assert.Equal(t, "--timeout", issues[0].Token)
+			assert.Equal(t, "tool guarded", issues[0].Command,
+				"the flag is judged against the command cobra would dispatch to")
+			assert.Contains(t, issues[0].Reason, "use --scan-timeout")
+		}
+	})
+
+	t.Run("a root-local flag is not usable once a subcommand is named", func(t *testing.T) {
+		assert.Empty(t, LintMarkdown(s, "README.md", "```bash\ntool --version\n```", emptyAllowlist(t)),
+			"--version is a flag of the root itself")
+
+		issues := LintMarkdown(s, "README.md", "```bash\ntool --version scan\n```", emptyAllowlist(t))
+		require.Len(t, issues, 1, "--version is local to the root, not persistent, so scan does not accept it")
+		assert.Equal(t, "--version", issues[0].Token)
+		assert.Equal(t, "tool scan", issues[0].Command)
+	})
+
+	t.Run("a persistent flag stays usable everywhere", func(t *testing.T) {
+		for _, line := range []string{
+			"tool --json scan --target host",
+			"tool scan --json --target host",
+			"tool --json group leaf --only-here x",
+		} {
+			assert.Empty(t, LintMarkdown(s, "README.md", "```bash\n"+line+"\n```", emptyAllowlist(t)), "%q", line)
+		}
+	})
+}
+
+// TestLintMarkdownKeepsExplicitlyEmptyArguments pins the quoted-empty-token fix. Dropping
+// an explicit "" shifts every later token: the flag after it became its value, and an
+// invalid flag went unreported.
+func TestLintMarkdownKeepsExplicitlyEmptyArguments(t *testing.T) {
+	assert.Equal(t, [][]string{{"tool", "scan", "--target", "", "--gone"}},
+		shellSegments(`tool scan --target "" --gone`),
+		"an explicitly quoted empty argument is still an argument")
+
+	issues := LintMarkdown(Walk(newTestTree()), "README.md",
+		"```bash\ntool group leaf --only-here \"\" --gone\n```", emptyAllowlist(t))
+
+	require.Len(t, issues, 1, "--gone must not be swallowed as the value of --only-here")
+	assert.Equal(t, "--gone", issues[0].Token)
+}
+
+// TestLintMarkdownRespectsFenceLength pins the fence run length. A block opened with
+// four backticks may contain a three-backtick line as content, and closing on it early
+// inverts the fence state for the whole rest of the document -- so prose afterwards is
+// read as shell and never checked as prose.
+func TestLintMarkdownRespectsFenceLength(t *testing.T) {
+	s := Walk(newTestTree())
+	doc := strings.Join([]string{
+		"````text", // opens a four-backtick block
+		"```",      // content, not a close: shorter than the opener
+		"````",     // the real close
+		"",
+		"Prose mentioning `--gone-from-prose`.",
+	}, "\n")
+
+	issues := LintMarkdown(s, "README.md", doc, emptyAllowlist(t))
+
+	require.Len(t, issues, 1, "the trailing line is prose and must be checked as prose:\n%v", tokensOf(issues))
+	assert.Equal(t, "--gone-from-prose", issues[0].Token)
+	assert.Empty(t, issues[0].Command, "a prose hit is checked against the whole surface, not one command")
+	assert.Equal(t, 5, issues[0].Line)
+}
+
+// TestLintGoCommentsIgnoresSentencePunctuation pins the shared token cleanup. A Go
+// comment is not delimited the way a backticked prose span is, so a flag ending a
+// sentence arrives with the period attached and would be reported as nonexistent.
+func TestLintGoCommentsIgnoresSentencePunctuation(t *testing.T) {
+	s := Walk(newTestTree())
+	src := []byte("package demo\n\n// Pass --timeout. Or use --json.\nconst A = 1\n")
+
+	issues, err := LintGoComments(s, "cmd/demo/demo.go", src, emptyAllowlist(t))
+	require.NoError(t, err)
+	assert.Empty(t, issues, "a trailing period is punctuation, not part of the flag")
+
+	issues, err = LintGoComments(s, "cmd/demo/demo.go",
+		[]byte("package demo\n\n// Pass --nonexistent.\nconst A = 1\n"), emptyAllowlist(t))
+	require.NoError(t, err)
+	require.Len(t, issues, 1, "a real unknown flag is still reported")
+	assert.Equal(t, "--nonexistent", issues[0].Token, "and reported without the punctuation")
+}


### PR DESCRIPTION
Part 3 of 6, and the largest. This is the half that reads hand-written prose — where the drift that motivated the ticket actually lived.

**Review focus:** `lintInvocation` walks argv the way cobra does, in two stages: resolve the command, then validate every flag against the command finally resolved. Getting either stage wrong invents findings on valid documentation, which is the failure mode the ticket warns about. The `argv[0]` rule is what keeps false positives at zero in a README full of `naabu`/`nerva`/`jq` examples, and it is also the stated limit — `sudo brutus …` is skipped.

## Review stack (ENG-6871)

Split out of #331 so each layer can be read on its own. Review **in order**; each targets the one before it.

| # | PR | Scope | Hand-written |
|---|---|---|---|
| 1 | #338 | Walk the cobra tree into a comparable surface | ~855 |
| 2 | #339 | Render a surface, and diff two of them | ~1257 |
| 3 | #340 | Lint documents and Go comments against a surface | ~1225 |
| 4 | #341 | Repo-level artifact and lint plumbing | ~650 |
| 5 | #342 | Turn on the gate, commit the generated artifacts | ~290 + 6.1k generated |
| 6 | #343 | Run it in CI, ship the artifact | ~109 |

PRs 1–4 are the library and touch nothing outside `internal/clisurface`. Nothing is wired up until #342.

Every stage compiles and passes `go test -short ./...`, `golangci-lint run ./...` (`0 issues.`) and `gofmt` **on its own**, so you can stop after any one of them. The tip of the stack is byte-identical to #331 as reviewed.

Three small refactors were needed to make the layers separable, and they are the only content not in #331: the shared path constants and `GeneratedPaths` moved into `paths.go`, `LintReport` moved beside the linter, and one test assertion moved from the walk's tests to the renderer's.

