### PR TITLE
feat(clisurface): add the repo-level artifact and lint plumbing (ENG-6871, 4/6)

### DIFF
--- a/internal/clisurface/artifacts.go
+++ b/internal/clisurface/artifacts.go
@@ -1,0 +1,313 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clisurface
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// LintedMarkdown are the hand-written documents whose examples and prose are
+// checked against the surface, in addition to every file under docs/.
+var LintedMarkdown = []string{READMEPath, "CONTRIBUTING.md"}
+
+// LintedGoDirs are the trees whose Go comments are checked against the surface.
+//
+// internal/ is included: a comment naming a flag that no longer exists is the
+// drift this gate was built for, and it does not become harmless by living
+// outside cmd/ and pkg/. Adding it found two RDP comments still describing
+// Vision confirmation as something a removed opt-out flag disabled, when it had
+// become opt-in.
+//
+// A package whose subject is flag syntax has to write its placeholders in
+// angle brackets rather than as bare dashed words, or its own documentation
+// reads as a reference to a flag that does not exist. See this package's
+// comments -- and note that this very comment had to be reworded, because the
+// gate caught it naming the flags above.
+var LintedGoDirs = []string{"cmd", "internal", "pkg"}
+
+// FindRepoRoot walks up from start until it finds the directory holding go.mod.
+// The gate runs as a test, whose working directory is the package directory, so
+// it needs the repository root to read and write repo-relative artifacts.
+func FindRepoRoot(start string) (string, error) {
+	dir, err := filepath.Abs(start)
+	if err != nil {
+		return "", fmt.Errorf("resolving %s: %w", start, err)
+	}
+	for {
+		if _, statErr := os.Stat(filepath.Join(dir, "go.mod")); statErr == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("no go.mod found in %s or any parent directory", start)
+		}
+		dir = parent
+	}
+}
+
+// Artifact is one generated file and the content it must have.
+type Artifact struct {
+	// Path is repo-relative.
+	Path string
+	// Content is the full file content the surface renders to. For README.md
+	// it is the on-disk file with the generated regions replaced.
+	Content []byte
+}
+
+// Artifacts renders every generated artifact for s. README.md is spliced from
+// its current on-disk content, so the hand-written parts of it are preserved.
+func Artifacts(repoRoot string, s Surface) ([]Artifact, error) {
+	jsonBytes, err := RenderJSON(s)
+	if err != nil {
+		return nil, err
+	}
+
+	readmePath := filepath.Join(repoRoot, READMEPath)
+	readme, err := os.ReadFile(readmePath)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", READMEPath, err)
+	}
+	spliced := string(readme)
+	for _, region := range RenderRegions(s) {
+		spliced, err = Splice(spliced, region.Name, region.Body)
+		if err != nil {
+			return nil, fmt.Errorf("splicing region %q into %s: %w", region.Name, READMEPath, err)
+		}
+	}
+
+	return []Artifact{
+		{Path: JSONPath, Content: jsonBytes},
+		{Path: MarkdownPath, Content: RenderMarkdown(s)},
+		{Path: READMEPath, Content: []byte(spliced)},
+	}, nil
+}
+
+// Write writes every generated artifact. This is the -update path; the drift
+// gate itself must never call it.
+func Write(repoRoot string, s Surface) error {
+	artifacts, err := Artifacts(repoRoot, s)
+	if err != nil {
+		return err
+	}
+	for i := range artifacts {
+		path := filepath.Join(repoRoot, artifacts[i].Path)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return fmt.Errorf("creating directory for %s: %w", artifacts[i].Path, err)
+		}
+		if err := os.WriteFile(path, artifacts[i].Content, 0o644); err != nil {
+			return fmt.Errorf("writing %s: %w", artifacts[i].Path, err)
+		}
+	}
+	return nil
+}
+
+// Staleness is a generated artifact whose committed content no longer matches
+// what the surface renders.
+type Staleness struct {
+	// Path is the repo-relative artifact.
+	Path string
+	// Detail says how it differs, naming the first differing line.
+	Detail string
+}
+
+// String renders the staleness as one actionable line.
+func (s Staleness) String() string {
+	return fmt.Sprintf("%s is stale: %s. Regenerate it with '%s'", s.Path, s.Detail, RegenerateCommand)
+}
+
+// CheckArtifacts compares the committed artifacts against what the surface
+// renders, without writing anything.
+//
+// Line endings are normalized before comparing. The repository carries no
+// .gitattributes, so a contributor with core.autocrlf=true has CRLF on disk
+// while the renderers emit LF — comparing raw bytes would report every
+// generated file as stale on Windows, which is exactly the unexplained friction
+// that gets a gate disabled.
+func CheckArtifacts(repoRoot string, s Surface) ([]Staleness, error) {
+	artifacts, err := Artifacts(repoRoot, s)
+	if err != nil {
+		return nil, err
+	}
+
+	var stale []Staleness
+	for i := range artifacts {
+		path := filepath.Join(repoRoot, artifacts[i].Path)
+		onDisk, readErr := os.ReadFile(path)
+		if readErr != nil {
+			stale = append(stale, Staleness{Path: artifacts[i].Path, Detail: "cannot be read (" + readErr.Error() + ")"})
+			continue
+		}
+		if bytes.Equal(normalizeNewlines(onDisk), normalizeNewlines(artifacts[i].Content)) {
+			continue
+		}
+		stale = append(stale, Staleness{
+			Path:   artifacts[i].Path,
+			Detail: firstDifference(onDisk, artifacts[i].Content),
+		})
+	}
+	return stale, nil
+}
+
+// normalizeNewlines rewrites CRLF to LF so that a checkout's line-ending
+// convention cannot look like documentation drift.
+func normalizeNewlines(b []byte) []byte {
+	return bytes.ReplaceAll(b, []byte("\r\n"), []byte("\n"))
+}
+
+// firstDifference describes the first line where committed and generated
+// content diverge. Both sides are normalized first, so the line it names is a
+// real difference rather than an invisible carriage return.
+func firstDifference(committed, generated []byte) string {
+	got := strings.Split(string(normalizeNewlines(committed)), "\n")
+	want := strings.Split(string(normalizeNewlines(generated)), "\n")
+	for i := 0; i < len(got) && i < len(want); i++ {
+		if got[i] == want[i] {
+			continue
+		}
+		return fmt.Sprintf("line %d is %q, generated content has %q", i+1, got[i], want[i])
+	}
+	return fmt.Sprintf("committed content has %d lines, generated content has %d", len(got), len(want))
+}
+
+// LoadAllowlist reads the deliberate-mention allowlist. A missing file is an
+// empty allowlist, not an error.
+func LoadAllowlist(repoRoot string) (Allowlist, error) {
+	content, err := os.ReadFile(filepath.Join(repoRoot, AllowlistPath))
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		return ParseAllowlist("")
+	case err != nil:
+		return Allowlist{}, fmt.Errorf("reading %s: %w", AllowlistPath, err)
+	}
+	return ParseAllowlist(string(content))
+}
+
+// LintRepo checks every documented CLI reference in the repository against the surface:
+// shell examples and prose in the markdown documents, and flag names in Go comments
+// under the trees LintedGoDirs names. Issues come back sorted by file and line.
+//
+// The trees are named by the variable rather than spelled out here, because the last
+// time this comment listed them it went stale the moment internal/ was added -- in a
+// gate whose whole job is catching that.
+func LintRepo(repoRoot string, s Surface, allow Allowlist) ([]Issue, error) {
+	var issues []Issue
+
+	docs, err := lintedMarkdownFiles(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	for _, rel := range docs {
+		content, readErr := os.ReadFile(filepath.Join(repoRoot, rel))
+		if readErr != nil {
+			return nil, fmt.Errorf("reading %s: %w", rel, readErr)
+		}
+		issues = append(issues, LintMarkdown(s, rel, string(content), allow)...)
+	}
+
+	goFiles, err := lintedGoFiles(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	for _, rel := range goFiles {
+		src, readErr := os.ReadFile(filepath.Join(repoRoot, rel))
+		if readErr != nil {
+			return nil, fmt.Errorf("reading %s: %w", rel, readErr)
+		}
+		found, lintErr := LintGoComments(s, rel, src, allow)
+		if lintErr != nil {
+			return nil, lintErr
+		}
+		issues = append(issues, found...)
+	}
+
+	sort.SliceStable(issues, func(i, j int) bool {
+		if issues[i].File != issues[j].File {
+			return issues[i].File < issues[j].File
+		}
+		if issues[i].Line != issues[j].Line {
+			return issues[i].Line < issues[j].Line
+		}
+		return issues[i].Token < issues[j].Token
+	})
+	return issues, nil
+}
+
+// lintedMarkdownFiles lists the markdown documents to check, sorted.
+//
+// The docs/ tree is walked recursively: a document that names a removed flag
+// escapes the gate just as thoroughly from docs/guides/ as from docs/, and a
+// check with a silent blind spot is worse than one whose reach is obvious.
+func lintedMarkdownFiles(repoRoot string) ([]string, error) {
+	files := append([]string(nil), LintedMarkdown...)
+
+	docsRoot := filepath.Join(repoRoot, "docs")
+	err := filepath.WalkDir(docsRoot, func(path string, d fs.DirEntry, walkErr error) error {
+		switch {
+		case walkErr != nil:
+			return walkErr
+		case d.IsDir(), !strings.HasSuffix(d.Name(), ".md"):
+			return nil
+		}
+		rel, relErr := filepath.Rel(repoRoot, path)
+		if relErr != nil {
+			return relErr
+		}
+		files = append(files, filepath.ToSlash(rel))
+		return nil
+	})
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return nil, fmt.Errorf("walking docs/: %w", err)
+	}
+
+	sort.Strings(files)
+	return files, nil
+}
+
+// lintedGoFiles lists the Go files whose comments to check, sorted.
+func lintedGoFiles(repoRoot string) ([]string, error) {
+	var files []string
+	for _, dir := range LintedGoDirs {
+		root := filepath.Join(repoRoot, dir)
+		if _, statErr := os.Stat(root); errors.Is(statErr, fs.ErrNotExist) {
+			continue
+		}
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			switch {
+			case err != nil:
+				return err
+			case d.IsDir(), !strings.HasSuffix(d.Name(), ".go"):
+				return nil
+			}
+			rel, relErr := filepath.Rel(repoRoot, path)
+			if relErr != nil {
+				return relErr
+			}
+			files = append(files, filepath.ToSlash(rel))
+			return nil
+		})
+		if err != nil {
+			return nil, fmt.Errorf("walking %s: %w", dir, err)
+		}
+	}
+	sort.Strings(files)
+	return files, nil
+}

--- a/internal/clisurface/artifacts_test.go
+++ b/internal/clisurface/artifacts_test.go
@@ -1,0 +1,341 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clisurface
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newFakeRepo lays out a temporary repository with a README carrying both
+// generated regions, and returns its root.
+func newFakeRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "docs"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, READMEPath), []byte(strings.Join([]string{
+		"# tool",
+		"",
+		"## Quick Start",
+		"",
+		BeginMarker(RegionSubcommands),
+		"stale listing",
+		EndMarker(RegionSubcommands),
+		"",
+		BeginMarker(RegionAliases),
+		"stale aliases",
+		EndMarker(RegionAliases),
+		"",
+		"hand-written tail",
+		"",
+	}, "\n")), 0o644))
+	return root
+}
+
+func TestArtifactsRendersEveryGeneratedFile(t *testing.T) {
+	root := newFakeRepo(t)
+	s := Walk(newTestTree())
+
+	artifacts, err := Artifacts(root, s)
+	require.NoError(t, err)
+
+	require.Len(t, artifacts, 3)
+	assert.Equal(t, []string{JSONPath, MarkdownPath, READMEPath}, []string{
+		artifacts[0].Path, artifacts[1].Path, artifacts[2].Path,
+	}, "artifacts come back in a stable order")
+	assert.Equal(t, GeneratedPaths(), []string{artifacts[0].Path, artifacts[1].Path, artifacts[2].Path})
+
+	readme := string(artifacts[2].Content)
+	assert.Contains(t, readme, "hand-written tail", "the hand-written parts of README.md survive")
+	assert.NotContains(t, readme, "stale listing", "the generated region is replaced")
+	assert.Contains(t, readme, "into these focused subcommands")
+	assert.Contains(t, readme, "| `scan` | `sc`, `scanner` |")
+}
+
+func TestArtifactsFailsLoudlyWhenTheREADMEHasNoRegionMarkers(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, READMEPath), []byte("# tool\n"), 0o644))
+
+	_, err := Artifacts(root, Walk(newTestTree()))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "splicing region \"cli-subcommands\" into README.md")
+}
+
+func TestArtifactsFailsWhenTheREADMEIsMissing(t *testing.T) {
+	_, err := Artifacts(t.TempDir(), Walk(newTestTree()))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading README.md")
+}
+
+func TestWriteThenCheckIsClean(t *testing.T) {
+	root := newFakeRepo(t)
+	s := Walk(newTestTree())
+
+	require.NoError(t, Write(root, s))
+
+	stale, err := CheckArtifacts(root, s)
+	require.NoError(t, err)
+	assert.Empty(t, stale, "freshly written artifacts are not stale")
+
+	for _, rel := range GeneratedPaths() {
+		_, statErr := os.Stat(filepath.Join(root, rel))
+		require.NoError(t, statErr, "%s must exist on disk", rel)
+	}
+}
+
+func TestWriteIsIdempotent(t *testing.T) {
+	root := newFakeRepo(t)
+	s := Walk(newTestTree())
+
+	require.NoError(t, Write(root, s))
+	first := readAll(t, root)
+	require.NoError(t, Write(root, s))
+	second := readAll(t, root)
+
+	assert.Equal(t, first, second, "regenerating twice must produce byte-identical files")
+}
+
+func TestCheckArtifactsNamesTheStaleFileAndTheFirstDifference(t *testing.T) {
+	root := newFakeRepo(t)
+	s := Walk(newTestTree())
+	require.NoError(t, Write(root, s))
+
+	// Hand-edit the generated reference, the way a well-meaning contributor would.
+	mdPath := filepath.Join(root, MarkdownPath)
+	content, err := os.ReadFile(mdPath)
+	require.NoError(t, err)
+	edited := strings.Replace(string(content), "# tool CLI reference", "# Tool CLI Reference", 1)
+	require.NoError(t, os.WriteFile(mdPath, []byte(edited), 0o644))
+
+	stale, err := CheckArtifacts(root, s)
+	require.NoError(t, err)
+
+	require.Len(t, stale, 1)
+	assert.Equal(t, MarkdownPath, stale[0].Path)
+	assert.Contains(t, stale[0].Detail, `line 3 is "# Tool CLI Reference", generated content has "# tool CLI reference"`)
+	assert.Contains(t, stale[0].String(), "docs/CLI.md is stale")
+	assert.Contains(t, stale[0].String(), "Regenerate it with 'make cli-docs'")
+}
+
+func TestCheckArtifactsReportsMissingFiles(t *testing.T) {
+	root := newFakeRepo(t)
+	s := Walk(newTestTree())
+
+	stale, err := CheckArtifacts(root, s)
+	require.NoError(t, err)
+
+	require.Len(t, stale, 3, "nothing has been generated yet: the JSON and markdown are missing and the README is stale")
+	assert.Equal(t, JSONPath, stale[0].Path)
+	assert.Contains(t, stale[0].Detail, "cannot be read")
+}
+
+func TestCheckArtifactsReportsATruncatedFile(t *testing.T) {
+	root := newFakeRepo(t)
+	s := Walk(newTestTree())
+	require.NoError(t, Write(root, s))
+
+	// A truncation that keeps every surviving line identical can only be
+	// described by the line counts.
+	full, err := os.ReadFile(filepath.Join(root, JSONPath))
+	require.NoError(t, err)
+	truncated := strings.Join(strings.Split(string(full), "\n")[:3], "\n")
+	require.NoError(t, os.WriteFile(filepath.Join(root, JSONPath), []byte(truncated), 0o644))
+
+	stale, err := CheckArtifacts(root, s)
+	require.NoError(t, err)
+
+	require.Len(t, stale, 1)
+	assert.Equal(t, JSONPath, stale[0].Path)
+	assert.Contains(t, stale[0].Detail, "committed content has 3 lines, generated content has")
+}
+
+func TestLintRepoChecksMarkdownAndGoComments(t *testing.T) {
+	root := newFakeRepo(t)
+	s := Walk(newTestTree())
+	require.NoError(t, Write(root, s))
+
+	require.NoError(t, os.WriteFile(filepath.Join(root, "CONTRIBUTING.md"),
+		[]byte("Run `tool scan --target host`.\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "docs", "guide.md"),
+		[]byte("```bash\ntool scan --removed-flag\n```\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "cmd", "tool"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "cmd", "tool", "main.go"),
+		[]byte("package main\n\n// handles the --gone-from-comments mode.\nfunc main() {}\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "pkg", "lib"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "pkg", "lib", "lib.go"),
+		[]byte("package lib\n\n// Uses --timeout, which still exists.\nconst A = 1\n"), 0o644))
+
+	issues, err := LintRepo(root, s, emptyAllowlist(t))
+	require.NoError(t, err)
+
+	require.Len(t, issues, 2)
+	assert.Equal(t, "cmd/tool/main.go", issues[0].File, "issues are sorted by file then line")
+	assert.Equal(t, "--gone-from-comments", issues[0].Token)
+	assert.Equal(t, "docs/guide.md", issues[1].File)
+	assert.Equal(t, "--removed-flag", issues[1].Token)
+}
+
+func TestLintRepoAcceptsTheDocumentsItJustGenerated(t *testing.T) {
+	root := newFakeRepo(t)
+	s := Walk(newTestTree())
+	require.NoError(t, Write(root, s))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "CONTRIBUTING.md"), []byte("Run `make cli-docs`.\n"), 0o644))
+
+	issues, err := LintRepo(root, s, emptyAllowlist(t))
+	require.NoError(t, err)
+	assert.Empty(t, issues,
+		"the generated reference and README regions must lint clean against the surface they came from")
+}
+
+func TestLintRepoSurvivesAMissingDocsDirectory(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, READMEPath), []byte("# tool\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "CONTRIBUTING.md"), []byte("hi\n"), 0o644))
+
+	issues, err := LintRepo(root, Walk(newTestTree()), emptyAllowlist(t))
+	require.NoError(t, err)
+	assert.Empty(t, issues)
+}
+
+func TestLintRepoFailsWhenAConfiguredDocumentIsMissing(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, READMEPath), []byte("# tool\n"), 0o644))
+
+	_, err := LintRepo(root, Walk(newTestTree()), emptyAllowlist(t))
+	require.Error(t, err, "a document the linter is configured to read must not be skipped silently")
+	assert.Contains(t, err.Error(), "reading CONTRIBUTING.md")
+}
+
+func TestLoadAllowlist(t *testing.T) {
+	root := t.TempDir()
+
+	allow, err := LoadAllowlist(root)
+	require.NoError(t, err, "a missing allowlist is an empty allowlist, not an error")
+	assert.Empty(t, allow.Entries())
+
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "docs"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, AllowlistPath),
+		[]byte("--old-name # renamed in v1.9, the migration note has to name it\n"), 0o644))
+
+	allow, err = LoadAllowlist(root)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"--old-name"}, allow.Entries())
+
+	require.NoError(t, os.WriteFile(filepath.Join(root, AllowlistPath), []byte("--no-reason\n"), 0o644))
+	_, err = LoadAllowlist(root)
+	require.Error(t, err, "an entry without a reason is a hard error")
+}
+
+func TestFindRepoRoot(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/tool\n"), 0o644))
+	nested := filepath.Join(root, "cmd", "tool")
+	require.NoError(t, os.MkdirAll(nested, 0o755))
+
+	found, err := FindRepoRoot(nested)
+	require.NoError(t, err)
+	assert.Equal(t, root, found, "the root is the nearest ancestor holding go.mod")
+
+	_, err = FindRepoRoot(filepath.Join(t.TempDir(), "nowhere"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no go.mod found")
+}
+
+// readAll reads every generated artifact into a map keyed by repo-relative path.
+func readAll(t *testing.T, root string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	for _, rel := range GeneratedPaths() {
+		content, err := os.ReadFile(filepath.Join(root, rel))
+		require.NoError(t, err)
+		out[rel] = string(content)
+	}
+	return out
+}
+
+// TestLintRepoWalksNestedDocsDirectories pins the recursive docs/ walk. A
+// document in docs/guides/ names removed flags exactly as effectively as one in
+// docs/, and a check with a silent blind spot is worse than one whose reach is
+// obvious.
+func TestLintRepoWalksNestedDocsDirectories(t *testing.T) {
+	root := newFakeRepo(t)
+	s := Walk(newTestTree())
+	require.NoError(t, Write(root, s))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "CONTRIBUTING.md"), []byte("hi\n"), 0o644))
+
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "docs", "guides", "deep"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "docs", "guides", "nested.md"),
+		[]byte("```bash\ntool scan --nested-gone\n```\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "docs", "guides", "deep", "deeper.md"),
+		[]byte("```bash\ntool scan --deeper-gone\n```\n"), 0o644))
+
+	issues, err := LintRepo(root, s, emptyAllowlist(t))
+	require.NoError(t, err)
+
+	require.Len(t, issues, 2, "both nested documents must be reached")
+	assert.Equal(t, "docs/guides/deep/deeper.md", issues[0].File)
+	assert.Equal(t, "--deeper-gone", issues[0].Token)
+	assert.Equal(t, "docs/guides/nested.md", issues[1].File)
+	assert.Equal(t, "--nested-gone", issues[1].Token)
+}
+
+// TestCheckArtifactsToleratesCRLF checks that a checkout's line-ending
+// convention cannot look like documentation drift. The repository carries no
+// .gitattributes, so a contributor with core.autocrlf=true has CRLF on disk
+// while the renderers emit LF.
+func TestCheckArtifactsToleratesCRLF(t *testing.T) {
+	root := newFakeRepo(t)
+	s := Walk(newTestTree())
+	require.NoError(t, Write(root, s))
+
+	for _, rel := range GeneratedPaths() {
+		path := filepath.Join(root, rel)
+		content, err := os.ReadFile(path)
+		require.NoError(t, err)
+		crlf := strings.ReplaceAll(strings.ReplaceAll(string(content), "\r\n", "\n"), "\n", "\r\n")
+		require.NoError(t, os.WriteFile(path, []byte(crlf), 0o644))
+	}
+
+	stale, err := CheckArtifacts(root, s)
+	require.NoError(t, err)
+	assert.Empty(t, stale, "CRLF line endings are not drift")
+}
+
+// TestCheckArtifactsStillCatchesRealDriftInACRLFCheckout guards the tolerance
+// above from swallowing a genuine difference.
+func TestCheckArtifactsStillCatchesRealDriftInACRLFCheckout(t *testing.T) {
+	root := newFakeRepo(t)
+	s := Walk(newTestTree())
+	require.NoError(t, Write(root, s))
+
+	path := filepath.Join(root, MarkdownPath)
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	edited := strings.ReplaceAll(string(content), "--timeout", "--timeuot")
+	require.NotEqual(t, string(content), edited, "the fixture must actually change")
+	require.NoError(t, os.WriteFile(path, []byte(strings.ReplaceAll(edited, "\n", "\r\n")), 0o644))
+
+	stale, err := CheckArtifacts(root, s)
+	require.NoError(t, err)
+
+	require.Len(t, stale, 1)
+	assert.Equal(t, MarkdownPath, stale[0].Path)
+	assert.NotContains(t, stale[0].Detail, `\r`, "the reported line must not be noisy with carriage returns")
+}


### PR DESCRIPTION
Part 4 of 6, last of the library. Everything before this is pure; this touches the filesystem.

**Review focus:** `CheckArtifacts` is compare-only — the gate must never write, or a stale golden could be silently "fixed" in CI and pass. Line endings are normalized before comparing, since the repo has no `.gitattributes` and `core.autocrlf=true` would otherwise report every generated file stale on Windows.

## Review stack (ENG-6871)

Split out of #331 so each layer can be read on its own. Review **in order**; each targets the one before it.

| # | PR | Scope | Hand-written |
|---|---|---|---|
| 1 | #338 | Walk the cobra tree into a comparable surface | ~855 |
| 2 | #339 | Render a surface, and diff two of them | ~1257 |
| 3 | #340 | Lint documents and Go comments against a surface | ~1225 |
| 4 | #341 | Repo-level artifact and lint plumbing | ~650 |
| 5 | #342 | Turn on the gate, commit the generated artifacts | ~290 + 6.1k generated |
| 6 | #343 | Run it in CI, ship the artifact | ~109 |

PRs 1–4 are the library and touch nothing outside `internal/clisurface`. Nothing is wired up until #342.

Every stage compiles and passes `go test -short ./...`, `golangci-lint run ./...` (`0 issues.`) and `gofmt` **on its own**, so you can stop after any one of them. The tip of the stack is byte-identical to #331 as reviewed.

Three small refactors were needed to make the layers separable, and they are the only content not in #331: the shared path constants and `GeneratedPaths` moved into `paths.go`, `LintReport` moved beside the linter, and one test assertion moved from the walk's tests to the renderer's.

