### PR TITLE
feat(cmd/brutus): turn on the drift gate and commit the generated artifacts (ENG-6871, 5/6)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Modern credential brute-forcing library in pure Go
 
 .PHONY: all build build-packed build-wasm clean test test-integration lint install help \
-	services-up services-down
+	services-up services-down cli-docs
 
 # Build configuration
 BINARY_NAME := brutus
@@ -111,6 +111,15 @@ lint:
 		echo "golangci-lint not installed, running go vet..."; \
 		GOWORK=off go vet ./...; \
 	fi
+
+# Regenerate the documented CLI surface from the live cobra tree.
+#
+# This is the single command to run after a deliberate rename: it rewrites
+# docs/cli-surface.json, docs/CLI.md and the generated regions of README.md from
+# whatever cobra actually registers. CI runs the same walk in check mode and fails when
+# the committed copies disagree.
+cli-docs:
+	GOWORK=off go test ./cmd/brutus -run 'TestCLISurface' -count=1 -update
 
 # Install to GOPATH/bin
 install:
@@ -269,6 +278,7 @@ help:
 	@echo "  services-up      Start integration test services (Docker)"
 	@echo "  services-down    Stop integration test services"
 	@echo "  lint             Run linter"
+	@echo "  cli-docs         Regenerate CLI docs from cobra (docs/, README.md)"
 	@echo "  deps             Check build dependencies"
 	@echo "  version          Show version info"
 	@echo ""

--- a/README.md
+++ b/README.md
@@ -156,27 +156,33 @@ go install github.com/praetorian-inc/brutus/cmd/brutus@latest
 
 ### Subcommands
 
-Brutus organizes its functionality into six focused subcommands:
+<!-- BEGIN generated: cli-subcommands -->
+Brutus organizes its functionality into these focused subcommands:
 
 ```bash
-brutus creds    # Non-HTTP credential auditing (SSH, databases, SMB, etc.)
-brutus web      # HTTP/web panel auditing (Basic Auth, form login, AI-powered)
-brutus snmp     # SNMP community string testing
-brutus badkeys  # Known weak/compromised SSH key testing
-brutus logon    # Windows logon-screen backdoor detection (sticky keys, utilman)
-brutus enum     # Account enumeration (account-existence oracles, Kerberos, Teams auth, email generation)
+brutus badkeys    # Test known weak/compromised SSH keys against targets
+brutus creds      # Test default credentials on non-HTTP services (SSH, databases, SMB, etc.)
+brutus enum       # Enumerate accounts against account-existence oracles or Active Directory
+brutus logon      # Detect Windows logon-screen backdoors (runs both sticky keys and utilman)
+brutus snmp       # Test SNMP community strings against targets
+brutus stickykeys # Detect the Windows sticky-keys (sethc.exe) logon backdoor only
+brutus utilman    # Detect the Windows utilman (Ease of Access) logon backdoor only
+brutus web        # Audit HTTP/web panel credentials (AI-powered or credential list)
 ```
+<!-- END generated: cli-subcommands -->
 
-Each subcommand has aliases for discoverability:
+<!-- BEGIN generated: cli-aliases -->
+Some subcommands carry aliases for discoverability:
 
 | Subcommand | Aliases |
-|------------|---------|
-| `creds` | `services`, `defaults`, `credentials` |
-| `web` | `http`, `panels` |
-| `snmp` | `community` |
+| --- | --- |
 | `badkeys` | `keys`, `ssh-keys`, `badkey` |
-| `logon` | `stickykeys`, `sticky-keys`, `utilman`, `sethc`, `winlogon`, `accessibility` |
-| `enum` | *(none)* |
+| `creds` | `services`, `defaults`, `credentials` |
+| `snmp` | `community` |
+| `web` | `http`, `panels` |
+
+The full reference — every subcommand, alias and flag, including the ones hidden from `--help` — is generated into [docs/CLI.md](docs/CLI.md).
+<!-- END generated: cli-aliases -->
 
 ```bash
 # Test SSH credentials

--- a/cmd/brutus/cli_surface_test.go
+++ b/cmd/brutus/cli_surface_test.go
@@ -1,0 +1,181 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/brutus/internal/clisurface"
+)
+
+// updateGoldens rewrites the generated CLI-surface artifacts instead of
+// checking them. "make cli-docs" is the documented way to set it.
+var updateGoldens = flag.Bool("update", false,
+	"rewrite docs/cli-surface.json, docs/CLI.md and the generated README.md regions from the live cobra tree")
+
+// TestCLISurface is the drift gate. It walks the live cobra tree, compares it
+// against the committed surface, and compares the committed generated files
+// against what that surface renders. Without -update it never writes.
+func TestCLISurface(t *testing.T) {
+	root := repoRoot(t)
+	live := clisurface.Walk(rootCmd)
+
+	if *updateGoldens {
+		require.NoError(t, clisurface.Write(root, live))
+		t.Logf("regenerated %s", strings.Join(clisurface.GeneratedPaths(), ", "))
+		return
+	}
+
+	golden, err := os.ReadFile(filepath.Join(root, clisurface.JSONPath))
+	require.NoErrorf(t, err, "%s is missing; create it with %q", clisurface.JSONPath, clisurface.RegenerateCommand)
+	documented, err := clisurface.ParseJSON(golden)
+	require.NoError(t, err)
+
+	// Fail with require.Fail rather than require.Empty: Empty dumps the raw
+	// findings slice on one unwrapped line before printing the formatted
+	// message, so every finding prints twice, once unreadable and once
+	// formatted. Fail only prints the formatted report.
+	if findings := clisurface.Diff(documented, live); len(findings) > 0 {
+		require.Fail(t, "CLI surface drift",
+			clisurface.Report(findings, clisurface.GeneratedPaths(), clisurface.RegenerateCommand))
+	}
+
+	stale, err := clisurface.CheckArtifacts(root, live)
+	require.NoError(t, err)
+	if len(stale) > 0 {
+		assert.Fail(t, "generated CLI documentation is stale", stalenessReport(stale))
+	}
+}
+
+// TestCLISurfaceDocLint fails when a document or a Go comment names a flag or a
+// subcommand the CLI does not accept.
+func TestCLISurfaceDocLint(t *testing.T) {
+	root := repoRoot(t)
+	allow, err := clisurface.LoadAllowlist(root)
+	require.NoError(t, err)
+
+	issues, err := clisurface.LintRepo(root, clisurface.Walk(rootCmd), allow)
+	require.NoError(t, err)
+	if len(issues) > 0 {
+		assert.Fail(t, "documentation names flags the CLI does not accept", clisurface.LintReport(issues))
+	}
+}
+
+// TestCLISurfaceGateDetectsRename proves the gate reddens. A gate only ever
+// observed passing is not known to work, so this renames a real flag on the
+// real tree and asserts the diff reports exactly that rename, then feeds the
+// linter a document naming a removed flag and asserts it is reported with
+// file:line.
+func TestCLISurfaceGateDetectsRename(t *testing.T) {
+	documented := clisurface.Walk(rootCmd)
+
+	t.Run("renaming a registered flag is reported", func(t *testing.T) {
+		// This mutates a flag on the shared package-level logonCmd and restores it in
+		// Cleanup. It is safe only because nothing in this package calls t.Parallel:
+		// do not add it here or to any test that reads the command tree, or the two
+		// will race on the rename. pflag also keys its lookup map by the original
+		// name, so only VisitAll -- which is what Walk uses -- observes the change.
+		flagObj := logonCmd.Flags().Lookup("experimental-ai")
+		require.NotNil(t, flagObj, "the fixture flag must exist for this test to mean anything")
+		t.Cleanup(func() { flagObj.Name = "experimental-ai" })
+		flagObj.Name = "experimental-ay"
+
+		findings := clisurface.Diff(documented, clisurface.Walk(rootCmd))
+
+		require.Len(t, findings, 2, "a rename is exactly one removal and one addition, and nothing else:\n%s",
+			clisurface.Report(findings, clisurface.GeneratedPaths(), clisurface.RegenerateCommand))
+		// Findings are sorted by command then flag name, so the old name
+		// ("experimental-ai") is reported before the new one.
+		assert.Equal(t, clisurface.FlagRemoved, findings[0].Kind)
+		assert.Equal(t, "experimental-ai", findings[0].Flag)
+		assert.Equal(t, "brutus logon", findings[0].Command)
+		assert.Equal(t, clisurface.FlagUndocumented, findings[1].Kind)
+		assert.Equal(t, "experimental-ay", findings[1].Flag)
+		assert.Equal(t, "brutus logon", findings[1].Command)
+		assert.Contains(t, findings[0].String(),
+			`flag --experimental-ai on "brutus logon" is in the generated docs but cobra no longer accepts it`)
+		assert.Contains(t, findings[1].String(),
+			`flag --experimental-ay on "brutus logon" is registered by cobra but missing from the generated docs`)
+	})
+
+	t.Run("the tree is restored", func(t *testing.T) {
+		assert.Empty(t, clisurface.Diff(documented, clisurface.Walk(rootCmd)),
+			"the rename above must not leak into the rest of the suite")
+	})
+
+	t.Run("a document naming a removed flag is reported", func(t *testing.T) {
+		empty, err := clisurface.ParseAllowlist("")
+		require.NoError(t, err)
+
+		doc := "Historic note.\n\n```bash\nbrutus logon --target host:3389 --sticky-keys-exec \"whoami\"\n```\n"
+		issues := clisurface.LintMarkdown(documented, "docs/example.md", doc, empty)
+
+		require.Len(t, issues, 1)
+		assert.Equal(t, "--sticky-keys-exec", issues[0].Token)
+		assert.Equal(t, "brutus logon", issues[0].Command)
+		assert.Contains(t, issues[0].String(),
+			`docs/example.md:4: --sticky-keys-exec is not a flag of "brutus logon"`)
+		assert.Contains(t, issues[0].String(), clisurface.AllowlistPath,
+			"the message says how to allow a deliberate mention")
+	})
+
+	t.Run("the allowlist suppresses a deliberate mention", func(t *testing.T) {
+		allow, err := clisurface.ParseAllowlist("--sticky-keys-exec # renamed to --exec; the rename note names the old flag\n")
+		require.NoError(t, err)
+
+		doc := "```bash\nbrutus logon --sticky-keys-exec \"whoami\"\n```\n"
+		assert.Empty(t, clisurface.LintMarkdown(documented, "docs/example.md", doc, allow))
+	})
+
+	t.Run("the logon family rejects the inherited --timeout", func(t *testing.T) {
+		empty, err := clisurface.ParseAllowlist("")
+		require.NoError(t, err)
+
+		doc := "```bash\nbrutus logon --target host:3389 --timeout 30s\n```\n"
+		issues := clisurface.LintMarkdown(documented, "docs/example.md", doc, empty)
+
+		require.Len(t, issues, 1,
+			"--timeout is inherited from the root but guardLogonTimeoutFlag refuses it, so documenting it is drift")
+		assert.Equal(t, "--timeout", issues[0].Token)
+		assert.Contains(t, issues[0].Reason, "use --scan-timeout")
+	})
+}
+
+// repoRoot locates the repository root; a test's working directory is its own
+// package directory, and the generated artifacts are repo-relative.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	root, err := clisurface.FindRepoRoot(wd)
+	require.NoError(t, err)
+	return root
+}
+
+// stalenessReport renders stale artifacts one per line.
+func stalenessReport(stale []clisurface.Staleness) string {
+	lines := make([]string, 0, len(stale))
+	for i := range stale {
+		lines = append(lines, stale[i].String())
+	}
+	return strings.Join(lines, "\n")
+}

--- a/cmd/brutus/runner.go
+++ b/cmd/brutus/runner.go
@@ -36,7 +36,7 @@ import (
 // runs the configured brute force against each one. Order matches the file;
 // a per-target failure does not abort the whole run.
 //
-// Output behavior mirrors --nerva (multi-target) mode: in human output we
+// Output behavior mirrors Nerva-fingerprinted multi-target mode: in human output we
 // stream "valid only" findings per target as soon as they're produced, and
 // in JSON mode the caller flushes the full JSONL after the loop returns.
 //
@@ -421,8 +421,9 @@ func detectTLS(baseTLSMode string, tlsDetected, verbose bool) string {
 	return baseTLSMode
 }
 
-// runStickyKeysInteractive handles the --sticky-keys-exec and --sticky-keys-web modes.
-// These bypass normal brute force and instead exploit the sticky keys backdoor interactively.
+// runStickyKeysInteractive handles the --exec and --web interactive modes of the
+// logon family. These bypass normal brute force and instead exploit the sticky
+// keys backdoor interactively.
 func runStickyKeysInteractive(target string, base *runConfig) ([]brutus.Result, bool) {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,1858 @@
+<!-- Generated from the live cobra command tree by 'make cli-docs'. Do not edit by hand. -->
+
+# brutus CLI reference
+
+Every command, alias and flag below is derived from the cobra command tree, not from prose.
+Schema version 1, surface hash `sha256:1d4cc140290018ebec0060e5db81bb43f05ff38068f9deacee1592ed70cadfa2`.
+
+Regenerate with `make cli-docs` after adding, removing or renaming a command or a flag.
+
+## Command index
+
+| Command | Aliases | Description |
+| --- | --- | --- |
+| [`brutus`](#brutus) | *(none)* | Brutus - Et tu, Brute? |
+| [`brutus badkeys`](#brutus-badkeys) | `keys`, `ssh-keys`, `badkey` | Test known weak/compromised SSH keys against targets |
+| [`brutus creds`](#brutus-creds) | `services`, `defaults`, `credentials` | Test default credentials on non-HTTP services (SSH, databases, SMB, etc.) |
+| [`brutus enum`](#brutus-enum) | *(none)* | Enumerate accounts against account-existence oracles or Active Directory |
+| [`brutus enum active`](#brutus-enum-active) | *(none)* | Active account-existence enumeration against live oracles & directories |
+| [`brutus enum active custom`](#brutus-enum-active-custom) | *(none)* | Run a declaratively-described enumeration oracle from a spec file |
+| [`brutus enum active github`](#brutus-enum-active-github) | *(none)* | Enumerate GitHub accounts by email (existence + username reveal) |
+| [`brutus enum active github map`](#brutus-enum-active-github-map) | *(none)* | Correlate known emails to GitHub usernames (reveal-only, skips existence checks) |
+| [`brutus enum active google`](#brutus-enum-active-google) | *(none)* | Enumerate Google Workspace accounts (existence + SSO/IdP) |
+| [`brutus enum active gravatar`](#brutus-enum-active-gravatar) | *(none)* | Enumerate accounts with a registered Gravatar (by email) |
+| [`brutus enum active kerberos`](#brutus-enum-active-kerberos) | *(none)* | Enumerate Active Directory users via Kerberos AS-REQ |
+| [`brutus enum active microsoft365`](#brutus-enum-active-microsoft365) | *(none)* | Enumerate Microsoft 365 accounts (existence + federation/tenant) |
+| [`brutus enum active oracles`](#brutus-enum-active-oracles) | *(none)* | Enumerate which account-existence oracles work for an organization |
+| [`brutus enum active oracles discover`](#brutus-enum-active-oracles-discover) | *(none)* | Discover working oracles by testing a known-valid email |
+| [`brutus enum active teams`](#brutus-enum-active-teams) | *(none)* | Microsoft Teams: device-code auth, user enumeration, and tenant posture audit |
+| [`brutus enum active teams audit`](#brutus-enum-active-teams-audit) | *(none)* | Audit a Microsoft Teams tenant's external posture into graded findings |
+| [`brutus enum active teams auth`](#brutus-enum-active-teams-auth) | *(none)* | Obtain Microsoft access token and refresh token via device code flow |
+| [`brutus enum active teams users`](#brutus-enum-active-teams-users) | *(none)* | Enumerate corporate Microsoft Teams users by email address |
+| [`brutus enum apollo`](#brutus-enum-apollo) | *(none)* | Discover people for a domain via Apollo.io (free; --enrich reveals emails) (deprecated: use "brutus enum passive apollo" instead) |
+| [`brutus enum dehashed`](#brutus-enum-dehashed) | *(none)* | Collect breach-exposed identity data for a domain via DeHashed (deprecated: use "brutus enum passive dehashed" instead) |
+| [`brutus enum generate`](#brutus-enum-generate) | *(none)* | Generate email addresses or usernames from embedded name lists |
+| [`brutus enum hunter`](#brutus-enum-hunter) | *(none)* | Discover people and emails for a domain via Hunter.io Domain Search (deprecated: use "brutus enum passive hunter" instead) |
+| [`brutus enum lusha`](#brutus-enum-lusha) | *(none)* | Enrich a single person identity to emails and phones via Lusha v3 (deprecated: use "brutus enum passive lusha" instead) |
+| [`brutus enum passive`](#brutus-enum-passive) | *(none)* | API-key OSINT/HUMINT sources — employee email/contact discovery & enrichment |
+| [`brutus enum passive apollo`](#brutus-enum-passive-apollo) | *(none)* | Discover people for a domain via Apollo.io (free; --enrich reveals emails) |
+| [`brutus enum passive dehashed`](#brutus-enum-passive-dehashed) | *(none)* | Collect breach-exposed identity data for a domain via DeHashed |
+| [`brutus enum passive hunter`](#brutus-enum-passive-hunter) | *(none)* | Discover people and emails for a domain via Hunter.io Domain Search |
+| [`brutus enum passive linkedin`](#brutus-enum-passive-linkedin) | *(none)* | Scrape LinkedIn Sales Navigator profiles via PhantomBuster |
+| [`brutus enum passive lusha`](#brutus-enum-passive-lusha) | *(none)* | Enrich a single person identity to emails and phones via Lusha v3 |
+| [`brutus logon`](#brutus-logon) | *(none)* | Detect Windows logon-screen backdoors (runs both sticky keys and utilman) |
+| [`brutus snmp`](#brutus-snmp) | `community` | Test SNMP community strings against targets |
+| [`brutus stickykeys`](#brutus-stickykeys) | *(none)* | Detect the Windows sticky-keys (sethc.exe) logon backdoor only |
+| [`brutus utilman`](#brutus-utilman) | *(none)* | Detect the Windows utilman (Ease of Access) logon backdoor only |
+| [`brutus web`](#brutus-web) | `http`, `panels` | Audit HTTP/web panel credentials (AI-powered or credential list) |
+
+## `brutus`
+
+Brutus - Et tu, Brute?
+
+- Usage: `brutus`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+| `--version` |  | bool | `false` | Show version information |
+
+## `brutus badkeys`
+
+Test known weak/compromised SSH keys against targets
+
+- Usage: `brutus badkeys`
+- Aliases: `keys`, `ssh-keys`, `badkey`
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--connect-timeout` |  | duration | `3s` | TCP connect timeout for scan dials (separate from --scan-timeout, which is the per-host settle deadline). A reachable host completes the handshake in ~1 RTT, so the short default only accelerates dead-host rejection; raise it for high-latency target sets. |
+| `--masscan-file` |  | string |  | Masscan JSON file (-oJ output) to import targets from |
+| `--mode` | `-m` | string | `default` | Aggressiveness tier: cautious, default, aggressive |
+| `--nmap-file` |  | string |  | Nmap XML file (-oX output) to import targets from |
+| `--retries` |  | int | `2` | Max retries on connection error (0 = disabled) |
+| `--target` |  | string |  | Target host:port |
+| `--targets-file` |  | string |  | File of targets to test, one host:port per line (fingerprints with Nerva unless --protocol is set) |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Single target
+brutus badkeys --target 192.168.1.10:22
+
+# Targets file (auto-fingerprinted, only SSH services tested)
+brutus badkeys --targets-file targets.txt
+
+# Pipeline mode
+naabu -host 10.0.0.0/24 -p 22 -silent | nerva --json | brutus badkeys
+
+# Pipe plain targets
+echo "192.168.1.10:22" | brutus badkeys
+
+# URI format
+echo "ssh://192.168.1.10:22" | brutus badkeys
+
+# Import targets from nmap XML scan (only SSH services tested)
+brutus badkeys --nmap-file scan.xml
+```
+
+## `brutus creds`
+
+Test default credentials on non-HTTP services (SSH, databases, SMB, etc.)
+
+- Usage: `brutus creds`
+- Aliases: `services`, `defaults`, `credentials`
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--connect-timeout` |  | duration | `3s` | TCP connect timeout for scan dials (separate from --scan-timeout, which is the per-host settle deadline). A reachable host completes the handshake in ~1 RTT, so the short default only accelerates dead-host rejection; raise it for high-latency target sets. |
+| `--credentials` | `-c` | string |  | Comma-separated user:pass pairs (e.g., admin:admin,root:toor) |
+| `--credentials-file` | `-C` | string |  | Credentials file (user:pass per line) |
+| `--key` | `-k` | string |  | SSH private key file |
+| `--masscan-file` |  | string |  | Masscan JSON file (-oJ output) to import targets from |
+| `--max-attempts` |  | int | `0` | Max password attempts per user (0 = unlimited) |
+| `--mode` | `-m` | string | `default` | Aggressiveness tier: cautious, default, aggressive |
+| `--nmap-file` |  | string |  | Nmap XML file (-oX output) to import targets from |
+| `--password-file` | `-P` | string |  | Password file (one per line) |
+| `--passwords` | `-p` | string |  | Comma-separated passwords |
+| `--protocol` |  | string |  | Protocol to use (auto-detected from nerva) |
+| `--retries` |  | int | `2` | Max retries on connection error (0 = disabled) |
+| `--target` |  | string |  | Target host:port |
+| `--targets-file` |  | string |  | File of targets to test, one host:port per line (fingerprints with Nerva unless --protocol is set) |
+| `--username-file` | `-U` | string |  | Username file (one per line) |
+| `--usernames` | `-u` | string | `root,admin` | Comma-separated usernames |
+| `--verify` |  | bool | `false` | Require strict TLS certificate verification |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Single target
+brutus creds --target 192.168.1.10:22 --protocol ssh -p "password,Password1"
+
+# Pre-paired user:pass combos (no Cartesian product)
+brutus creds --target 10.0.0.50:22 -c "admin:admin,root:toor,deploy:deploy123"
+
+# Credentials file (user:pass per line)
+brutus creds --target 10.0.0.50:3306 -C creds.txt
+
+# Targets file (auto-fingerprinted with Nerva)
+brutus creds --targets-file targets.txt -u admin -P passwords.txt
+
+# Pipeline mode with Nerva JSON (HTTP and SNMP services are skipped)
+naabu -host 10.0.0.0/24 -silent | nerva --json | brutus creds -P passwords.txt
+
+# Pipe URI targets (protocol from scheme, no fingerprinting needed)
+echo "ssh://192.168.1.10:22" | brutus creds -p "password,Password1"
+
+# Import targets from nmap XML scan
+brutus creds --nmap-file scan.xml -P passwords.txt
+
+# Import targets from masscan (requires --protocol or auto-fingerprints with Nerva)
+brutus creds --masscan-file scan.json --protocol ssh -P passwords.txt
+```
+
+## `brutus enum`
+
+Enumerate accounts against account-existence oracles or Active Directory
+
+- Usage: `brutus enum`
+- Aliases: *(none)*
+- Requires a subcommand
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Account-existence oracle enumeration
+brutus enum active oracles --domain praetorian.com -e test@praetorian.com --known-valid admin@praetorian.com
+
+# Kerberos user enumeration
+brutus enum active kerberos --dc 10.0.0.1 --domain CORP.LOCAL -u administrator
+
+# Authenticate with Microsoft Entra ID via device code
+brutus enum active teams auth --tenant contoso.com
+
+# GitHub account enumeration by email
+brutus enum active github -e alice@example.com,bob@example.com
+
+# Generate emails for enumeration
+brutus enum generate --domain example.com --format flast
+
+# API-key OSINT/HUMINT sources (employee email/contact discovery)
+brutus enum passive hunter --domain example.com
+brutus enum passive apollo --domain example.com
+brutus enum passive lusha --first-name Jane --last-name Doe --company "Example Inc"
+brutus enum passive dehashed --domain example.com
+```
+
+## `brutus enum active`
+
+Active account-existence enumeration against live oracles & directories
+
+- Usage: `brutus enum active`
+- Aliases: *(none)*
+- Requires a subcommand
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Account-existence oracle enumeration
+brutus enum active oracles --domain example.com --known-valid admin@example.com
+
+# Google Workspace account enumeration
+brutus enum active google -e alice@example.com,bob@example.com
+
+# Microsoft 365 account enumeration
+brutus enum active microsoft365 -e alice@example.com,bob@example.com
+
+# Kerberos user enumeration
+brutus enum active kerberos --dc 10.0.0.1 --domain CORP.LOCAL -u administrator
+
+# Authenticate with Microsoft Entra ID via device code
+brutus enum active teams auth --tenant contoso.com
+
+# GitHub account enumeration by email
+brutus enum active github -e alice@example.com,bob@example.com
+
+# Gravatar account enumeration by email
+brutus enum active gravatar -e alice@example.com,bob@example.com
+
+# Enumerate against a custom oracle definition
+brutus enum active custom -f oracle.json -e jsmith,asmith
+```
+
+## `brutus enum active custom`
+
+Run a declaratively-described enumeration oracle from a spec file
+
+- Usage: `brutus enum active custom`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--domain` | `-d` | string |  | Domain for email generation (with --generate) |
+| `--email-file` | `-E` | string |  | File of subjects to enumerate (one per line, use - for stdin) |
+| `--emails` | `-e` | string |  | Comma-separated subjects (usernames or emails) to enumerate |
+| `--file` | `-f` | string |  | Oracle spec file (JSON or YAML, required) |
+| `--format` |  | string | `first.last` | Username format for generation (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first) |
+| `--generate` |  | bool | `false` | Generate subjects from embedded name lists |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Run an oracle against inline subjects
+brutus enum active custom -f oracle.json -e jsmith,asmith
+
+# Run against a subject file
+brutus enum active custom -f oracle.yaml -E users.txt
+
+# Generate usernames and run
+brutus enum active custom -f oracle.json --generate --format flast
+
+# JSON output to a file
+brutus enum active custom -f oracle.json -e jsmith -o results.jsonl
+```
+
+## `brutus enum active github`
+
+Enumerate GitHub accounts by email (existence + username reveal)
+
+- Usage: `brutus enum active github`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--domain` | `-d` | string |  | Generate candidate emails for this domain (statistically-likely first/last combos) |
+| `--email-file` | `-E` | string |  | File of email addresses, one per line ("-" for stdin) |
+| `--emails` | `-e` | string |  | Comma-separated email addresses to check |
+| `--format` |  | string | `first.last` | Username format for --domain generation (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first) |
+| `--limit` |  | int | `0` | When generating with --domain, cap to the first N (most-likely) candidates (0 = all) |
+| `--no-reveal` |  | bool | `false` | Skip username reveal after existence enumeration (existence-only; no token used, no temp repo created) |
+| `--rotating-proxy` |  | bool | `false` | Signal that --proxy rotates exit IPs (e.g. Bright Data): reduces per-IP rate-limit backoff during GitHub existence enumeration (short retry delay, higher retry ceiling). No effect on token-rate-limited reveal. |
+| `--token` |  | string |  | GitHub PAT for username reveal (overrides GITHUB_TOKEN; visible in process list — prefer the env var) |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Existence-only enumeration (unauthenticated)
+brutus enum active github -e alice@example.com,bob@example.com
+
+# Generate candidate emails for a domain and enumerate the 5000 most likely
+brutus enum active github --domain target.com --format first.last --limit 5000
+
+# Enumerate emails from a file
+brutus enum active github -E emails.txt
+
+# Reveal usernames for existing accounts (requires a PAT with repo+delete_repo)
+export GITHUB_TOKEN=ghp_...
+brutus enum active github -E emails.txt
+
+# Pace requests to avoid GitHub's existence-endpoint rate limiting
+brutus enum active github -E emails.txt --threads 2 --rate-limit 1
+```
+
+## `brutus enum active github map`
+
+Correlate known emails to GitHub usernames (reveal-only, skips existence checks)
+
+- Usage: `brutus enum active github map`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--email-file` | `-E` | string |  | File of email addresses, one per line ("-" for stdin) |
+| `--emails` | `-e` | string |  | Comma-separated email addresses to correlate |
+| `--token` |  | string |  | GitHub PAT (overrides GITHUB_TOKEN; visible in process list — prefer the env var) |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--rotating-proxy` |  | bool | `false` | Signal that --proxy rotates exit IPs (e.g. Bright Data): reduces per-IP rate-limit backoff during GitHub existence enumeration (short retry delay, higher retry ceiling). No effect on token-rate-limited reveal. |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Correlate emails from a file (token from the environment)
+export GITHUB_TOKEN=ghp_...
+brutus enum active github map -E emails.txt
+
+# Correlate a couple of emails inline
+brutus enum active github map -e alice@example.com,bob@example.com
+```
+
+## `brutus enum active google`
+
+Enumerate Google Workspace accounts (existence + SSO/IdP)
+
+- Usage: `brutus enum active google`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--domain` | `-d` | string |  | Generate candidate emails for this domain (statistically-likely first/last combos) |
+| `--email-file` | `-E` | string |  | File of email addresses, one per line ("-" for stdin) |
+| `--emails` | `-e` | string |  | Comma-separated email addresses to check |
+| `--format` |  | string | `first.last` | Username format for --domain generation (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first) |
+| `--limit` |  | int | `0` | When generating with --domain, cap to the first N (most-likely) candidates (0 = all) |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Enumerate a couple of emails
+brutus enum active google -e alice@example.com,bob@example.com
+
+# Generate candidate emails for a domain and enumerate the 5000 most likely
+brutus enum active google --domain target.com --format first.last --limit 5000
+
+# Enumerate emails from a file
+brutus enum active google -E emails.txt
+
+# Route through a SOCKS5 proxy and raise concurrency
+brutus enum active google -E emails.txt --proxy socks5://127.0.0.1:1080 --threads 20
+```
+
+## `brutus enum active gravatar`
+
+Enumerate accounts with a registered Gravatar (by email)
+
+- Usage: `brutus enum active gravatar`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--domain` | `-d` | string |  | Generate candidate emails for this domain (statistically-likely first/last combos) |
+| `--email-file` | `-E` | string |  | File of email addresses, one per line ("-" for stdin) |
+| `--emails` | `-e` | string |  | Comma-separated email addresses to check |
+| `--format` |  | string | `first.last` | Username format for --domain generation (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first) |
+| `--limit` |  | int | `0` | When generating with --domain, cap to the first N (most-likely) candidates (0 = all) |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Enumerate a couple of emails
+brutus enum active gravatar -e alice@example.com,bob@example.com
+
+# Generate candidate emails for a domain and enumerate the 5000 most likely
+brutus enum active gravatar --domain target.com --format first.last --limit 5000
+
+# Enumerate emails from a file
+brutus enum active gravatar -E emails.txt
+
+# Route through a SOCKS5 proxy and raise concurrency
+brutus enum active gravatar -E emails.txt --proxy socks5://127.0.0.1:1080 --threads 20
+```
+
+## `brutus enum active kerberos`
+
+Enumerate Active Directory users via Kerberos AS-REQ
+
+- Usage: `brutus enum active kerberos`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--dc` |  | string |  | KDC (Domain Controller) address (host or host:port) |
+| `--domain` | `-d` | string |  | Kerberos realm / AD domain (e.g., CORP.LOCAL) |
+| `--user-file` | `-U` | string |  | File of usernames (one per line, use - for stdin) |
+| `--users` | `-u` | string |  | Comma-separated usernames to enumerate |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Enumerate specific users
+brutus enum active kerberos --dc 10.0.0.1 --domain CORP.LOCAL -u administrator,guest,krbtgt
+
+# Enumerate from file
+brutus enum active kerberos --dc dc01.corp.local --domain CORP.LOCAL -U users.txt
+
+# Generate usernames and enumerate
+brutus enum generate --format flast | brutus enum active kerberos --dc 10.0.0.1 --domain CORP.LOCAL -U -
+
+# JSON output
+brutus enum active kerberos --dc 10.0.0.1 --domain CORP.LOCAL -u administrator --json
+```
+
+## `brutus enum active microsoft365`
+
+Enumerate Microsoft 365 accounts (existence + federation/tenant)
+
+- Usage: `brutus enum active microsoft365`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--domain` | `-d` | string |  | Generate candidate emails for this domain (statistically-likely first/last combos) |
+| `--email-file` | `-E` | string |  | File of email addresses, one per line ("-" for stdin) |
+| `--emails` | `-e` | string |  | Comma-separated email addresses to check |
+| `--format` |  | string | `first.last` | Username format for --domain generation (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first) |
+| `--limit` |  | int | `0` | When generating with --domain, cap to the first N (most-likely) candidates (0 = all) |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Enumerate a couple of emails
+brutus enum active microsoft365 -e alice@example.com,bob@example.com
+
+# Generate candidate emails for a domain and enumerate the 5000 most likely
+brutus enum active microsoft365 --domain target.com --format first.last --limit 5000
+
+# Enumerate emails from a file
+brutus enum active microsoft365 -E emails.txt
+
+# Route through a SOCKS5 proxy and raise concurrency
+brutus enum active microsoft365 -E emails.txt --proxy socks5://127.0.0.1:1080 --threads 20
+```
+
+## `brutus enum active oracles`
+
+Enumerate which account-existence oracles work for an organization
+
+- Usage: `brutus enum active oracles`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--domain` | `-d` | string |  | Domain to enumerate for DNS recon and email generation (defaults to the --known-valid email's domain) |
+| `--email-file` | `-E` | string |  | File of emails to enumerate (one per line, use - for stdin) |
+| `--emails` | `-e` | string |  | Comma-separated emails to enumerate |
+| `--format` |  | string | `first.last` | Username format for generation (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first) |
+| `--generate` |  | bool | `false` | Generate emails from embedded name lists |
+| `--known-valid` |  | string |  | Known-valid email to validate oracles before enumeration (required) |
+| `--services` | `-s` | string |  | Comma-separated oracles to check (default: all discovered/registered) |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Discover candidate oracles via DNS and report which ones work
+# (domain defaults to the --known-valid email's domain)
+brutus enum active oracles --known-valid admin@praetorian.com
+
+# Enumerate specific emails against the working oracles
+brutus enum active oracles --domain praetorian.com -e test@praetorian.com,admin@praetorian.com --known-valid admin@praetorian.com
+
+# Enumerate emails from file
+brutus enum active oracles --domain praetorian.com -E emails.txt --known-valid admin@praetorian.com
+
+# Generate emails and enumerate against working oracles
+brutus enum active oracles --domain target.com --generate --format first.last --known-valid admin@target.com
+
+# Check / enumerate against specific oracles only
+brutus enum active oracles -e user@example.com -s microsoft365,google --known-valid admin@example.com
+
+# JSON output
+brutus enum active oracles --domain praetorian.com -e test@praetorian.com --known-valid admin@praetorian.com --json
+```
+
+## `brutus enum active oracles discover`
+
+Discover working oracles by testing a known-valid email
+
+- Usage: `brutus enum active oracles discover`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--domain` | `-d` | string |  | Domain to discover candidate oracles from DNS TXT records |
+| `--known-valid` |  | string |  | Known-valid email to test against oracles (required) |
+| `--services` | `-s` | string |  | Comma-separated oracles to test (default: all registered) |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Test oracles for a domain (auto-discovers candidate oracles from DNS)
+brutus enum active oracles discover --domain praetorian.com --known-valid admin@praetorian.com
+
+# Test specific oracles only
+brutus enum active oracles discover --known-valid admin@example.com -s microsoft365,google
+```
+
+## `brutus enum active teams`
+
+Microsoft Teams: device-code auth, user enumeration, and tenant posture audit
+
+- Usage: `brutus enum active teams`
+- Aliases: *(none)*
+- Requires a subcommand
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+## `brutus enum active teams audit`
+
+Audit a Microsoft Teams tenant's external posture into graded findings
+
+- Usage: `brutus enum active teams audit`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--access-token` |  | string |  | Access token to use (instead of device-code or --token-file) |
+| `--client-id` |  | string | `1fec8e78-bce4-4aaf-ab1b-5451cc387264` | Azure app (client) ID (device-code path) |
+| `--email` |  | string |  | Single known-valid seed email address to audit (required) |
+| `--include-consumer` |  | bool | `false` | Count consumer/personal (8:live:) Teams accounts as hits (default: only corporate 8:orgid: accounts) |
+| `--no-browser` |  | bool | `false` | Don't automatically open the verification URL in a browser |
+| `--no-presence` |  | bool | `false` | Skip Teams presence / out-of-office lookups (fewer requests; presence is gathered by default) |
+| `--refresh-token` |  | string |  | Refresh token used to renew an expired access token |
+| `--scope` |  | string | `offline_access https://api.spaces.skype.com/.default` | Space-separated OAuth2 scopes (device-code path) |
+| `--tenant` |  | string | `organizations` | Tenant ID, domain, or "organizations"/"common" (device-code path) |
+| `--token-file` |  | string |  | JSONL token file from "enum active teams auth -o" to reuse |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Audit a tenant via a single known-valid seed address (device-code auth inline)
+brutus enum active teams audit --email alice@contoso.com
+
+# Skip presence/out-of-office lookups (presence/OOO findings not evaluated)
+brutus enum active teams audit --email alice@contoso.com --no-presence
+
+# Reuse a token captured earlier with "enum active teams auth -o"
+brutus enum active teams auth -o token.jsonl
+brutus enum active teams audit --email alice@contoso.com --token-file token.jsonl
+
+# Emit findings as JSONL
+brutus enum active teams audit --email alice@contoso.com --json
+```
+
+## `brutus enum active teams auth`
+
+Obtain Microsoft access token and refresh token via device code flow
+
+- Usage: `brutus enum active teams auth`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--client-id` |  | string | `1fec8e78-bce4-4aaf-ab1b-5451cc387264` | Azure app (client) ID |
+| `--no-browser` |  | bool | `false` | Don't automatically open the verification URL in a browser |
+| `--scope` | `-s` | string | `offline_access https://api.spaces.skype.com/.default` | Space-separated OAuth2 scopes |
+| `--tenant` |  | string | `organizations` | Tenant ID, domain, or "organizations"/"common" |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Authenticate against the default (organizations / work-school) tenant (interactive)
+brutus enum active teams auth
+
+# Headless / SSH: print the URL and code, don't open a browser
+brutus enum active teams auth --no-browser
+
+# Authenticate against a specific tenant by domain
+brutus enum active teams auth --tenant contoso.com
+
+# Use a custom app registration and scopes
+brutus enum active teams auth --client-id 00000000-0000-0000-0000-000000000000 \
+  --scope "offline_access https://api.spaces.skype.com/.default"
+
+# Capture the full token set as JSON
+brutus enum active teams auth -o token.jsonl
+```
+
+## `brutus enum active teams users`
+
+Enumerate corporate Microsoft Teams users by email address
+
+- Usage: `brutus enum active teams users`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--access-token` |  | string |  | Access token to use (instead of device-code or --token-file) |
+| `--client-id` |  | string | `1fec8e78-bce4-4aaf-ab1b-5451cc387264` | Azure app (client) ID (device-code path) |
+| `--domain` | `-d` | string |  | Generate candidate emails for this domain (statistically-likely first/last combos) |
+| `--email-file` | `-E` | string |  | File of email addresses, one per line ("-" for stdin) |
+| `--emails` | `-e` | string |  | Comma-separated email addresses to check |
+| `--format` |  | string | `first.last` | Username format for --domain generation (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first) |
+| `--include-consumer` |  | bool | `false` | Count consumer/personal (8:live:) Teams accounts as hits (default: only corporate 8:orgid: accounts) |
+| `--limit` |  | int | `0` | When generating with --domain, cap to the first N (most-likely) candidates (0 = all) |
+| `--no-browser` |  | bool | `false` | Don't automatically open the verification URL in a browser |
+| `--no-presence` |  | bool | `false` | Skip Teams presence / out-of-office lookups (fewer requests; presence is gathered by default) |
+| `--refresh-token` |  | string |  | Refresh token used to renew an expired access token |
+| `--scope` |  | string | `offline_access https://api.spaces.skype.com/.default` | Space-separated OAuth2 scopes (device-code path) |
+| `--tenant` |  | string | `organizations` | Tenant ID, domain, or "organizations"/"common" (device-code path) |
+| `--token-file` |  | string |  | JSONL token file from "enum active teams auth -o" to reuse |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Device-code auth inline, then enumerate a few emails
+brutus enum active teams users -e alice@contoso.com,bob@contoso.com
+
+# Generate candidate emails for a domain and enumerate the 5000 most likely
+brutus enum active teams users --domain target.com --format first.last --limit 5000
+
+# Generate first_last candidates (presence is fetched by default for hits)
+brutus enum active teams users --domain target.com --format first_last
+
+# Enumerate emails from a file, skipping presence lookups
+brutus enum active teams users -E emails.txt --no-presence
+
+# Reuse a token captured earlier with "enum active teams auth -o"
+brutus enum active teams auth -o token.jsonl
+brutus enum active teams users -E emails.txt --token-file token.jsonl
+
+# Provide an access token directly
+brutus enum active teams users -e alice@contoso.com --access-token "$TOKEN"
+
+# Route through a SOCKS5 proxy and raise concurrency
+brutus enum active teams users -E emails.txt --proxy socks5://127.0.0.1:1080 --threads 20
+```
+
+## `brutus enum apollo`
+
+Discover people for a domain via Apollo.io (free; --enrich reveals emails)
+
+- Usage: `brutus enum apollo`
+- Aliases: *(none)*
+- Hidden: not shown in `--help` output
+- Deprecated: use "brutus enum passive apollo" instead
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--api-key` |  | string |  | Apollo.io API key (overrides APOLLO_API_KEY; WARNING: visible in process list and shell history — prefer APOLLO_API_KEY) |
+| `--domain` | `-d` | string |  | Company domain to discover people for (required) |
+| `--enrich` |  | bool | `false` | Reveal emails for all discovered people via people/match (CONSUMES CREDITS; bounded by --limit) |
+| `--limit` |  | int | `0` | Max people to discover AND (with --enrich) to reveal (bounds credit spend; 0 = no cap) |
+| `--titles` |  | stringSlice | `[]` | Optional job-title filter (repeatable or comma-separated) |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Discover people (DEFAULT — FREE, no credits; shows email/phone availability)
+brutus enum passive apollo --domain example.com
+
+# Filter by job titles
+brutus enum passive apollo -d example.com --titles "VP Engineering" --titles "CTO"
+
+# Enrich all discovered people (CONSUMES CREDITS, bounded by --limit)
+brutus enum passive apollo -d example.com --enrich --limit 50
+
+# Provide the key explicitly (note: visible in process list / shell history)
+brutus enum passive apollo -d example.com --api-key abc123
+```
+
+## `brutus enum dehashed`
+
+Collect breach-exposed identity data for a domain via DeHashed
+
+- Usage: `brutus enum dehashed`
+- Aliases: *(none)*
+- Hidden: not shown in `--help` output
+- Deprecated: use "brutus enum passive dehashed" instead
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--all-emails` |  | bool | `false` | Keep all emails, not just those @<domain> (disables corporate-only filtering) |
+| `--api-key` |  | string |  | DeHashed API key (overrides DEHASHED_API_KEY; WARNING: visible in process list and shell history — prefer DEHASHED_API_KEY) |
+| `--detailed` |  | bool | `false` | Emit a single structured JSON document with full per-contact detail (ip addresses, addresses, dobs, obtained dates) and run metadata |
+| `--domain` | `-d` | string |  | Domain to search (required) |
+| `--exclude-combolists` |  | bool | `false` | Drop records from known aggregator/combolist source databases (combolists are included by default) |
+| `--limit` |  | int | `100` | Maximum number of records to collect (bounds credit spend) |
+| `--no-credentials` |  | bool | `false` | Suppress breach-exposed plaintext passwords from the output |
+| `--no-dedup` |  | bool | `false` | Do not merge records that share an email |
+| `--sources` |  | stringSlice | `[]` | Restrict results to these DeHashed source databases (comma-separated, exact names) |
+| `--with-credentials` |  | bool | `false` | Include breach-exposed plaintext passwords in --detailed output (off by default; hashes are never included) |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Collect refined breach contacts for a domain (key from DEHASHED_API_KEY)
+brutus enum passive dehashed --domain example.com
+
+# Same, but suppress the breach-exposed plaintext passwords from output
+brutus enum passive dehashed --domain example.com --no-credentials
+
+# Keep every email (not just @example.com), unmerged; drop combolist DBs for clean identity-only enumeration
+brutus enum passive dehashed -d example.com --all-emails --no-dedup --exclude-combolists
+
+# Restrict to specific source databases (exact names, comma-separated)
+brutus enum passive dehashed -d example.com --sources "Adobe,LinkedIn"
+
+# Emit one structured JSON document with full per-contact detail + run metadata
+brutus enum passive dehashed -d example.com --detailed -o breaches.json
+
+# Same detailed export, including breach-exposed plaintext passwords
+brutus enum passive dehashed -d example.com --detailed --with-credentials -o breaches.json
+
+# Provide the key explicitly (note: visible in process list / shell history)
+brutus enum passive dehashed -d example.com --api-key abc123
+
+# Cap results (and credit spend) and write JSONL to a file
+brutus enum passive dehashed -d example.com --limit 50 -o breaches.jsonl
+```
+
+## `brutus enum generate`
+
+Generate email addresses or usernames from embedded name lists
+
+- Usage: `brutus enum generate`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--domain` | `-d` | string |  | Domain to append to generated usernames (omit to generate usernames only) |
+| `--format` |  | string | `first.last` | Username format (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first) |
+| `--limit` |  | int | `0` | Emit only the first N (most-likely) results (0 = no limit, emit all) |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Generate emails: jsmith@example.com
+brutus enum generate --domain example.com --format flast
+
+# Generate usernames only: jsmith
+brutus enum generate --format flast
+
+# Generate john.smith@example.com (default format)
+brutus enum generate --domain example.com
+
+# Emit only the 1000 most-likely emails
+brutus enum generate --domain example.com --limit 1000
+
+# Pipe the 500 most-likely usernames to Kerberos enum
+brutus enum generate --format flast --limit 500 | brutus enum active kerberos --dc 10.0.0.1 --domain CORP.LOCAL -U -
+```
+
+## `brutus enum hunter`
+
+Discover people and emails for a domain via Hunter.io Domain Search
+
+- Usage: `brutus enum hunter`
+- Aliases: *(none)*
+- Hidden: not shown in `--help` output
+- Deprecated: use "brutus enum passive hunter" instead
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--api-key` |  | string |  | Hunter.io API key (overrides HUNTER_API_KEY; WARNING: visible in process list and shell history — prefer HUNTER_API_KEY) |
+| `--domain` | `-d` | string |  | Domain to search (required) |
+| `--limit` |  | int | `0` | Maximum number of people to return (0 = no cap, return all) |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Discover people for a domain (key from HUNTER_API_KEY)
+brutus enum passive hunter --domain example.com
+
+# Provide the key explicitly (note: visible in process list / shell history)
+brutus enum passive hunter -d example.com --api-key abc123
+
+# JSONL output to a file
+brutus enum passive hunter -d example.com -o people.jsonl
+```
+
+## `brutus enum lusha`
+
+Enrich a single person identity to emails and phones via Lusha v3
+
+- Usage: `brutus enum lusha`
+- Aliases: *(none)*
+- Hidden: not shown in `--help` output
+- Deprecated: use "brutus enum passive lusha" instead
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--api-key` |  | string |  | Lusha API key (overrides LUSHA_API_KEY; WARNING: visible in process list and shell history — prefer LUSHA_API_KEY) |
+| `--company` |  | string |  | Company name (with the name pair) |
+| `--domain` |  | string |  | Company domain (alternative to --company) |
+| `--email` |  | string |  | Enrich by email address (mutually exclusive identity) |
+| `--email-only` |  | bool | `false` | Request only email datapoints (mutually exclusive with --phone) |
+| `--first-name` |  | string |  | First name (with --last-name and --company or --domain) |
+| `--last-name` |  | string |  | Last name (with --first-name) |
+| `--limit` |  | int | `0` | Roster mode (--domain only): max contacts to search + enrich; 0 = collect all (consumes ~1 credit/contact) |
+| `--linkedin` |  | string |  | Enrich by LinkedIn profile URL (mutually exclusive identity) |
+| `--phone` |  | bool | `false` | Request phone datapoints in addition to email |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Enrich by name + company (key from LUSHA_API_KEY)
+brutus enum passive lusha --first-name Ada --last-name Lovelace --company Analytical
+
+# Enrich by name + company domain
+brutus enum passive lusha --first-name Ada --last-name Lovelace --domain example.com
+
+# Enrich by email
+brutus enum passive lusha --email ada@example.com
+
+# Enrich by LinkedIn URL, also request phone numbers
+brutus enum passive lusha --linkedin https://linkedin.com/in/ada --phone
+
+# Roster: enumerate an entire company by domain (collect all — consumes credits)
+brutus enum passive lusha --domain example.com
+
+# Roster: cap the roster (and credit spend) at 25 contacts
+brutus enum passive lusha --domain example.com --limit 25
+
+# Provide the key explicitly (note: visible in process list / shell history)
+brutus enum passive lusha --email ada@example.com --api-key abc123
+```
+
+## `brutus enum passive`
+
+API-key OSINT/HUMINT sources — employee email/contact discovery & enrichment
+
+- Usage: `brutus enum passive`
+- Aliases: *(none)*
+- Requires a subcommand
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Discover people via Hunter.io
+brutus enum passive hunter --domain example.com
+
+# Discover and enrich people via Apollo.io
+brutus enum passive apollo --domain example.com
+
+# Enrich a contact via Lusha
+brutus enum passive lusha --first-name Jane --last-name Doe --company "Example Inc"
+
+# Collect breach-exposed identity data via DeHashed
+brutus enum passive dehashed --domain example.com
+
+# Scrape LinkedIn Sales Navigator profiles via PhantomBuster
+brutus enum passive linkedin --agent-id 1234567890
+```
+
+## `brutus enum passive apollo`
+
+Discover people for a domain via Apollo.io (free; --enrich reveals emails)
+
+- Usage: `brutus enum passive apollo`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--api-key` |  | string |  | Apollo.io API key (overrides APOLLO_API_KEY; WARNING: visible in process list and shell history — prefer APOLLO_API_KEY) |
+| `--domain` | `-d` | string |  | Company domain to discover people for (required) |
+| `--enrich` |  | bool | `false` | Reveal emails for all discovered people via people/match (CONSUMES CREDITS; bounded by --limit) |
+| `--limit` |  | int | `0` | Max people to discover AND (with --enrich) to reveal (bounds credit spend; 0 = no cap) |
+| `--titles` |  | stringSlice | `[]` | Optional job-title filter (repeatable or comma-separated) |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Discover people (DEFAULT — FREE, no credits; shows email/phone availability)
+brutus enum passive apollo --domain example.com
+
+# Filter by job titles
+brutus enum passive apollo -d example.com --titles "VP Engineering" --titles "CTO"
+
+# Enrich all discovered people (CONSUMES CREDITS, bounded by --limit)
+brutus enum passive apollo -d example.com --enrich --limit 50
+
+# Provide the key explicitly (note: visible in process list / shell history)
+brutus enum passive apollo -d example.com --api-key abc123
+```
+
+## `brutus enum passive dehashed`
+
+Collect breach-exposed identity data for a domain via DeHashed
+
+- Usage: `brutus enum passive dehashed`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--all-emails` |  | bool | `false` | Keep all emails, not just those @<domain> (disables corporate-only filtering) |
+| `--api-key` |  | string |  | DeHashed API key (overrides DEHASHED_API_KEY; WARNING: visible in process list and shell history — prefer DEHASHED_API_KEY) |
+| `--detailed` |  | bool | `false` | Emit a single structured JSON document with full per-contact detail (ip addresses, addresses, dobs, obtained dates) and run metadata |
+| `--domain` | `-d` | string |  | Domain to search (required) |
+| `--exclude-combolists` |  | bool | `false` | Drop records from known aggregator/combolist source databases (combolists are included by default) |
+| `--limit` |  | int | `100` | Maximum number of records to collect (bounds credit spend) |
+| `--no-credentials` |  | bool | `false` | Suppress breach-exposed plaintext passwords from the output |
+| `--no-dedup` |  | bool | `false` | Do not merge records that share an email |
+| `--sources` |  | stringSlice | `[]` | Restrict results to these DeHashed source databases (comma-separated, exact names) |
+| `--with-credentials` |  | bool | `false` | Include breach-exposed plaintext passwords in --detailed output (off by default; hashes are never included) |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Collect refined breach contacts for a domain (key from DEHASHED_API_KEY)
+brutus enum passive dehashed --domain example.com
+
+# Same, but suppress the breach-exposed plaintext passwords from output
+brutus enum passive dehashed --domain example.com --no-credentials
+
+# Keep every email (not just @example.com), unmerged; drop combolist DBs for clean identity-only enumeration
+brutus enum passive dehashed -d example.com --all-emails --no-dedup --exclude-combolists
+
+# Restrict to specific source databases (exact names, comma-separated)
+brutus enum passive dehashed -d example.com --sources "Adobe,LinkedIn"
+
+# Emit one structured JSON document with full per-contact detail + run metadata
+brutus enum passive dehashed -d example.com --detailed -o breaches.json
+
+# Same detailed export, including breach-exposed plaintext passwords
+brutus enum passive dehashed -d example.com --detailed --with-credentials -o breaches.json
+
+# Provide the key explicitly (note: visible in process list / shell history)
+brutus enum passive dehashed -d example.com --api-key abc123
+
+# Cap results (and credit spend) and write JSONL to a file
+brutus enum passive dehashed -d example.com --limit 50 -o breaches.jsonl
+```
+
+## `brutus enum passive hunter`
+
+Discover people and emails for a domain via Hunter.io Domain Search
+
+- Usage: `brutus enum passive hunter`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--api-key` |  | string |  | Hunter.io API key (overrides HUNTER_API_KEY; WARNING: visible in process list and shell history — prefer HUNTER_API_KEY) |
+| `--domain` | `-d` | string |  | Domain to search (required) |
+| `--limit` |  | int | `0` | Maximum number of people to return (0 = no cap, return all) |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Discover people for a domain (key from HUNTER_API_KEY)
+brutus enum passive hunter --domain example.com
+
+# Provide the key explicitly (note: visible in process list / shell history)
+brutus enum passive hunter -d example.com --api-key abc123
+
+# JSONL output to a file
+brutus enum passive hunter -d example.com -o people.jsonl
+```
+
+## `brutus enum passive linkedin`
+
+Scrape LinkedIn Sales Navigator profiles via PhantomBuster
+
+- Usage: `brutus enum passive linkedin`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--agent-id` |  | string |  | PhantomBuster agent ID for the Sales Navigator scraper (required) |
+| `--api-key` |  | string |  | PhantomBuster API key (overrides PHANTOMBUSTER_KEY; WARNING: visible in process list and shell history — prefer PHANTOMBUSTER_KEY) |
+| `--result-file` |  | string | `result.csv` | Result filename to download from S3 (default: result.csv) |
+| `--skip-launch` |  | bool | `false` | Skip launching the agent — fetch results from the most recent run instead |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Launch a Sales Nav scraper and fetch results
+brutus enum passive linkedin --agent-id 1234567890
+
+# Fetch results from a previous run (skip launching a new one)
+brutus enum passive linkedin --agent-id 1234567890 --skip-launch
+
+# Specify a custom result filename
+brutus enum passive linkedin --agent-id 1234567890 --result-file result.json
+
+# Provide the key explicitly (note: visible in process list / shell history)
+brutus enum passive linkedin --agent-id 1234567890 --api-key abc123
+```
+
+## `brutus enum passive lusha`
+
+Enrich a single person identity to emails and phones via Lusha v3
+
+- Usage: `brutus enum passive lusha`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--api-key` |  | string |  | Lusha API key (overrides LUSHA_API_KEY; WARNING: visible in process list and shell history — prefer LUSHA_API_KEY) |
+| `--company` |  | string |  | Company name (with the name pair) |
+| `--domain` |  | string |  | Company domain (alternative to --company) |
+| `--email` |  | string |  | Enrich by email address (mutually exclusive identity) |
+| `--email-only` |  | bool | `false` | Request only email datapoints (mutually exclusive with --phone) |
+| `--first-name` |  | string |  | First name (with --last-name and --company or --domain) |
+| `--last-name` |  | string |  | Last name (with --first-name) |
+| `--limit` |  | int | `0` | Roster mode (--domain only): max contacts to search + enrich; 0 = collect all (consumes ~1 credit/contact) |
+| `--linkedin` |  | string |  | Enrich by LinkedIn profile URL (mutually exclusive identity) |
+| `--phone` |  | bool | `false` | Request phone datapoints in addition to email |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Enrich by name + company (key from LUSHA_API_KEY)
+brutus enum passive lusha --first-name Ada --last-name Lovelace --company Analytical
+
+# Enrich by name + company domain
+brutus enum passive lusha --first-name Ada --last-name Lovelace --domain example.com
+
+# Enrich by email
+brutus enum passive lusha --email ada@example.com
+
+# Enrich by LinkedIn URL, also request phone numbers
+brutus enum passive lusha --linkedin https://linkedin.com/in/ada --phone
+
+# Roster: enumerate an entire company by domain (collect all — consumes credits)
+brutus enum passive lusha --domain example.com
+
+# Roster: cap the roster (and credit spend) at 25 contacts
+brutus enum passive lusha --domain example.com --limit 25
+
+# Provide the key explicitly (note: visible in process list / shell history)
+brutus enum passive lusha --email ada@example.com --api-key abc123
+```
+
+## `brutus logon`
+
+Detect Windows logon-screen backdoors (runs both sticky keys and utilman)
+
+- Usage: `brutus logon`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--connect-timeout` |  | duration | `3s` | TCP connect timeout for scan dials (separate from --scan-timeout, which is the per-host settle deadline). A reachable host completes the handshake in ~1 RTT, so the short default only accelerates dead-host rejection; raise it for high-latency target sets. |
+| `--exec` |  | string |  | Execute command via detected backdoor |
+| `--experimental-ai` |  | bool | `false` | Enable Vision API for backdoor confirmation |
+| `--fast` |  | bool | `false` | fast triage: shorter settle budget for internet-scale sweeps; reports HIGH/CRITICAL or indeterminate, never clean (rerun indeterminates without --fast for a careful verdict) |
+| `--masscan-file` |  | string |  | Masscan JSON file (-oJ output) to import targets from |
+| `--mode` | `-m` | string | `default` | Aggressiveness tier: cautious, default, aggressive |
+| `--nmap-file` |  | string |  | Nmap XML file (-oX output) to import targets from |
+| `--no-nla-probe` |  | bool | `false` | Disable the pre-WASM RDP negotiation probe (always run the full WASM session) |
+| `--open` |  | bool | `false` | Auto-open browser when web terminal starts |
+| `--retries` |  | int | `2` | Max retries on connection error (0 = disabled) |
+| `--scan-timeout` |  | duration | `10s` | Per-host settle/scan deadline (post-connect): how long to watch the logon screen after the trigger before deciding. Distinct from --connect-timeout (the TCP dial timeout). |
+| `--target` |  | string |  | Target host:port |
+| `--targets-file` |  | string |  | File of targets to test, one host:port per line (fingerprints with Nerva unless --protocol is set) |
+| `--web` |  | bool | `false` | Start interactive web terminal via detected backdoor |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Rejected flags
+
+These flags reach `brutus logon` through inheritance, but the command refuses them:
+
+| Flag | Why |
+| --- | --- |
+| `--timeout` | --timeout is not valid here; use --scan-timeout (settle deadline) and/or --connect-timeout (TCP connect) |
+
+### Examples
+
+```bash
+# Detect sticky keys and utilman backdoors (heuristic)
+brutus logon --target 10.0.0.50:3389
+
+# Vision API confirmation (more accurate)
+brutus logon --target 10.0.0.50:3389 --experimental-ai
+
+# Execute a command via detected backdoor
+brutus logon --target 10.0.0.50:3389 --exec "whoami"
+
+# Interactive web terminal via backdoor
+brutus logon --target 10.0.0.50:3389 --web --open
+
+# Pipeline mode with Nerva JSON (only RDP targets are tested)
+naabu -host 10.0.0.0/24 -p 3389 -silent | nerva --json | brutus logon
+
+# Pipe plain targets (auto-fingerprinted, only RDP services scanned)
+echo "10.0.0.50:3389" | brutus logon
+
+# Pipe URI targets
+echo "rdp://10.0.0.50:3389" | brutus logon
+
+# Import targets from nmap XML scan (only RDP services tested)
+brutus logon --nmap-file scan.xml
+```
+
+## `brutus snmp`
+
+Test SNMP community strings against targets
+
+- Usage: `brutus snmp`
+- Aliases: `community`
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--community` | `-c` | string |  | Custom community strings (comma-separated) |
+| `--community-file` | `-C` | string |  | Community string file (one per line) |
+| `--connect-timeout` |  | duration | `3s` | TCP connect timeout for scan dials (separate from --scan-timeout, which is the per-host settle deadline). A reachable host completes the handshake in ~1 RTT, so the short default only accelerates dead-host rejection; raise it for high-latency target sets. |
+| `--masscan-file` |  | string |  | Masscan JSON file (-oJ output) to import targets from |
+| `--mode` | `-m` | string | `default` | Aggressiveness tier: cautious, default, aggressive |
+| `--nmap-file` |  | string |  | Nmap XML file (-oX output) to import targets from |
+| `--retries` |  | int | `2` | Max retries on connection error (0 = disabled) |
+| `--target` |  | string |  | Target host:port |
+| `--targets-file` |  | string |  | File of targets to test, one host:port per line (fingerprints with Nerva unless --protocol is set) |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# Test with default community strings
+brutus snmp --target 192.168.1.1:161
+
+# Aggressive mode for comprehensive testing (~200+ strings)
+brutus snmp --target 10.0.0.1:161 --mode aggressive
+
+# Custom community strings
+brutus snmp --target 192.168.1.1:161 -c "mycommunity,secretstring"
+
+# Pipeline mode
+naabu -host 10.0.0.0/24 -p 161 -silent | nerva --json | brutus snmp
+
+# Targets file
+brutus snmp --targets-file snmp-hosts.txt --mode aggressive
+
+# Import targets from nmap XML scan (only SNMP services tested)
+brutus snmp --nmap-file scan.xml --mode aggressive
+```
+
+## `brutus stickykeys`
+
+Detect the Windows sticky-keys (sethc.exe) logon backdoor only
+
+- Usage: `brutus stickykeys`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--connect-timeout` |  | duration | `3s` | TCP connect timeout for scan dials (separate from --scan-timeout, which is the per-host settle deadline). A reachable host completes the handshake in ~1 RTT, so the short default only accelerates dead-host rejection; raise it for high-latency target sets. |
+| `--exec` |  | string |  | Execute command via detected backdoor |
+| `--experimental-ai` |  | bool | `false` | Enable Vision API for backdoor confirmation |
+| `--fast` |  | bool | `false` | fast triage: shorter settle budget for internet-scale sweeps; reports HIGH/CRITICAL or indeterminate, never clean (rerun indeterminates without --fast for a careful verdict) |
+| `--masscan-file` |  | string |  | Masscan JSON file (-oJ output) to import targets from |
+| `--mode` | `-m` | string | `default` | Aggressiveness tier: cautious, default, aggressive |
+| `--nmap-file` |  | string |  | Nmap XML file (-oX output) to import targets from |
+| `--no-nla-probe` |  | bool | `false` | Disable the pre-WASM RDP negotiation probe (always run the full WASM session) |
+| `--open` |  | bool | `false` | Auto-open browser when web terminal starts |
+| `--retries` |  | int | `2` | Max retries on connection error (0 = disabled) |
+| `--scan-timeout` |  | duration | `10s` | Per-host settle/scan deadline (post-connect): how long to watch the logon screen after the trigger before deciding. Distinct from --connect-timeout (the TCP dial timeout). |
+| `--target` |  | string |  | Target host:port |
+| `--targets-file` |  | string |  | File of targets to test, one host:port per line (fingerprints with Nerva unless --protocol is set) |
+| `--web` |  | bool | `false` | Start interactive web terminal via detected backdoor |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Rejected flags
+
+These flags reach `brutus stickykeys` through inheritance, but the command refuses them:
+
+| Flag | Why |
+| --- | --- |
+| `--timeout` | --timeout is not valid here; use --scan-timeout (settle deadline) and/or --connect-timeout (TCP connect) |
+
+### Examples
+
+```bash
+# Detect the sticky-keys backdoor only
+brutus stickykeys --target 10.0.0.50:3389
+
+# Vision API confirmation (more accurate)
+brutus stickykeys --target 10.0.0.50:3389 --experimental-ai
+```
+
+## `brutus utilman`
+
+Detect the Windows utilman (Ease of Access) logon backdoor only
+
+- Usage: `brutus utilman`
+- Aliases: *(none)*
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--connect-timeout` |  | duration | `3s` | TCP connect timeout for scan dials (separate from --scan-timeout, which is the per-host settle deadline). A reachable host completes the handshake in ~1 RTT, so the short default only accelerates dead-host rejection; raise it for high-latency target sets. |
+| `--exec` |  | string |  | Execute command via detected backdoor |
+| `--experimental-ai` |  | bool | `false` | Enable Vision API for backdoor confirmation |
+| `--fast` |  | bool | `false` | fast triage: shorter settle budget for internet-scale sweeps; reports HIGH/CRITICAL or indeterminate, never clean (rerun indeterminates without --fast for a careful verdict) |
+| `--masscan-file` |  | string |  | Masscan JSON file (-oJ output) to import targets from |
+| `--mode` | `-m` | string | `default` | Aggressiveness tier: cautious, default, aggressive |
+| `--nmap-file` |  | string |  | Nmap XML file (-oX output) to import targets from |
+| `--no-nla-probe` |  | bool | `false` | Disable the pre-WASM RDP negotiation probe (always run the full WASM session) |
+| `--open` |  | bool | `false` | Auto-open browser when web terminal starts |
+| `--retries` |  | int | `2` | Max retries on connection error (0 = disabled) |
+| `--scan-timeout` |  | duration | `10s` | Per-host settle/scan deadline (post-connect): how long to watch the logon screen after the trigger before deciding. Distinct from --connect-timeout (the TCP dial timeout). |
+| `--target` |  | string |  | Target host:port |
+| `--targets-file` |  | string |  | File of targets to test, one host:port per line (fingerprints with Nerva unless --protocol is set) |
+| `--web` |  | bool | `false` | Start interactive web terminal via detected backdoor |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Rejected flags
+
+These flags reach `brutus utilman` through inheritance, but the command refuses them:
+
+| Flag | Why |
+| --- | --- |
+| `--timeout` | --timeout is not valid here; use --scan-timeout (settle deadline) and/or --connect-timeout (TCP connect) |
+
+### Examples
+
+```bash
+# Detect the utilman backdoor only
+brutus utilman --target 10.0.0.50:3389
+
+# Vision API confirmation (more accurate)
+brutus utilman --target 10.0.0.50:3389 --experimental-ai
+```
+
+## `brutus web`
+
+Audit HTTP/web panel credentials (AI-powered or credential list)
+
+- Usage: `brutus web`
+- Aliases: `http`, `panels`
+
+### Flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--browser-tabs` |  | int | `3` | Number of concurrent browser tabs |
+| `--browser-timeout` |  | duration | `1m0s` | Total timeout for browser operations |
+| `--browser-visible` |  | bool | `false` | Show browser window (demo mode) |
+| `--connect-timeout` |  | duration | `3s` | TCP connect timeout for scan dials (separate from --scan-timeout, which is the per-host settle deadline). A reachable host completes the handshake in ~1 RTT, so the short default only accelerates dead-host rejection; raise it for high-latency target sets. |
+| `--credentials` | `-c` | string |  | Comma-separated user:pass pairs (e.g., admin:admin,root:toor) |
+| `--credentials-file` | `-C` | string |  | Credentials file (user:pass per line) |
+| `--experimental-ai` |  | bool | `false` | Enable AI-powered credential detection and Vision verification |
+| `--https` |  | bool | `false` | Use HTTPS for browser connections |
+| `--masscan-file` |  | string |  | Masscan JSON file (-oJ output) to import targets from |
+| `--mode` | `-m` | string | `default` | Aggressiveness tier: cautious, default, aggressive |
+| `--nmap-file` |  | string |  | Nmap XML file (-oX output) to import targets from |
+| `--protocol` |  | string |  | Protocol override (http or https) |
+| `--retries` |  | int | `2` | Max retries on connection error (0 = disabled) |
+| `--target` |  | string |  | Target host:port |
+| `--targets-file` |  | string |  | File of targets to test, one host:port per line (fingerprints with Nerva unless --protocol is set) |
+| `--verify` |  | bool | `false` | Require strict TLS certificate verification |
+
+### Inherited flags
+
+| Flag | Short | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `--jitter` |  | duration | `0s` | Random delay variance for rate limiting |
+| `--json` |  | bool | `false` | JSON output format |
+| `--no-color` |  | bool | `false` | Disable colored output |
+| `--output` | `-o` | string |  | Output file for JSON results (implies --json) |
+| `--proxy` |  | string |  | Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080 |
+| `--proxy-user` |  | string |  | Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history. |
+| `--quiet` | `-q` | bool | `false` | Quiet mode - only show successful credentials |
+| `--rate-limit` |  | float64 | `0` | Max requests per second (0 = unlimited) |
+| `--threads` | `-t` | int | `10` | Number of concurrent threads |
+| `--timeout` |  | duration | `10s` | Per-target timeout |
+| `--verbose` | `-v` | bool | `false` | Verbose mode - show detailed progress to stderr |
+
+### Examples
+
+```bash
+# AI-powered credential detection (recommended)
+brutus web --target 192.168.1.1:80 --experimental-ai
+
+# Pipeline mode with Nerva JSON
+naabu -host 192.168.1.0/24 -p 80,443,8080 -silent | nerva --json | brutus web --experimental-ai
+
+# Manual credential list
+brutus web --target 192.168.1.1:80 -c "admin:admin,root:toor"
+brutus web --target 192.168.1.1:80 -C creds.txt
+
+# HTTPS target
+brutus web --target 192.168.1.1:443 --https --experimental-ai
+
+# Browser with visible window (demo mode)
+brutus web --target 192.168.1.1:8080 --experimental-ai --browser-visible
+
+# Import targets from nmap XML scan
+brutus web --nmap-file scan.xml --experimental-ai
+```

--- a/docs/cli-surface-allow.txt
+++ b/docs/cli-surface-allow.txt
@@ -1,0 +1,14 @@
+# Flag names documentation may mention even though the CLI does not accept them.
+#
+# The CLI-surface doc lint (see CONTRIBUTING.md) checks every brutus invocation in
+# a fenced code block, every backticked flag name in prose, and every flag name in
+# a Go comment under cmd/ and pkg/ against the flags cobra actually registers.
+# This file is the escape hatch for deliberate mentions. Every entry MUST carry a
+# '#' reason: the gate rejects an entry without one, because an unexplained
+# exception is how a stale flag reference survives forever.
+#
+# Keep this list as short as possible. If a mention is not deliberate, fix the
+# document instead of allowing it.
+
+--reveal            # Apollo's old reveal flag, renamed to --enrich by the discover/enrich split. The apollo command test deliberately names the removed flag to pin the new behavior: "Discovery note must mention --enrich (not --reveal)".
+--domain-generated  # Not a flag: a prose compound. The enum-source comments say "--domain-generated candidates", meaning the candidates generated from --domain.

--- a/docs/cli-surface.json
+++ b/docs/cli-surface.json
@@ -1,0 +1,4305 @@
+{
+  "schemaVersion": 1,
+  "surfaceHash": "sha256:1d4cc140290018ebec0060e5db81bb43f05ff38068f9deacee1592ed70cadfa2",
+  "commands": [
+    {
+      "path": "brutus",
+      "use": "brutus",
+      "short": "Brutus - Et tu, Brute?",
+      "runnable": true,
+      "flags": [
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting"
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output"
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)"
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080"
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history."
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials"
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)"
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads"
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout"
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr"
+        },
+        {
+          "name": "version",
+          "type": "bool",
+          "default": "false",
+          "usage": "Show version information"
+        }
+      ]
+    },
+    {
+      "path": "brutus badkeys",
+      "use": "badkeys",
+      "short": "Test known weak/compromised SSH keys against targets",
+      "aliases": [
+        "keys",
+        "ssh-keys",
+        "badkey"
+      ],
+      "runnable": true,
+      "example": "  # Single target\n  brutus badkeys --target 192.168.1.10:22\n\n  # Targets file (auto-fingerprinted, only SSH services tested)\n  brutus badkeys --targets-file targets.txt\n\n  # Pipeline mode\n  naabu -host 10.0.0.0/24 -p 22 -silent | nerva --json | brutus badkeys\n\n  # Pipe plain targets\n  echo \"192.168.1.10:22\" | brutus badkeys\n\n  # URI format\n  echo \"ssh://192.168.1.10:22\" | brutus badkeys\n\n  # Import targets from nmap XML scan (only SSH services tested)\n  brutus badkeys --nmap-file scan.xml",
+      "flags": [
+        {
+          "name": "connect-timeout",
+          "type": "duration",
+          "default": "3s",
+          "usage": "TCP connect timeout for scan dials (separate from --scan-timeout, which is the per-host settle deadline). A reachable host completes the handshake in ~1 RTT, so the short default only accelerates dead-host rejection; raise it for high-latency target sets."
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "masscan-file",
+          "type": "string",
+          "usage": "Masscan JSON file (-oJ output) to import targets from"
+        },
+        {
+          "name": "mode",
+          "shorthand": "m",
+          "type": "string",
+          "default": "default",
+          "usage": "Aggressiveness tier: cautious, default, aggressive"
+        },
+        {
+          "name": "nmap-file",
+          "type": "string",
+          "usage": "Nmap XML file (-oX output) to import targets from"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "retries",
+          "type": "int",
+          "default": "2",
+          "usage": "Max retries on connection error (0 = disabled)"
+        },
+        {
+          "name": "target",
+          "type": "string",
+          "usage": "Target host:port"
+        },
+        {
+          "name": "targets-file",
+          "type": "string",
+          "usage": "File of targets to test, one host:port per line (fingerprints with Nerva unless --protocol is set)"
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus creds",
+      "use": "creds",
+      "short": "Test default credentials on non-HTTP services (SSH, databases, SMB, etc.)",
+      "aliases": [
+        "services",
+        "defaults",
+        "credentials"
+      ],
+      "runnable": true,
+      "example": "  # Single target\n  brutus creds --target 192.168.1.10:22 --protocol ssh -p \"password,Password1\"\n\n  # Pre-paired user:pass combos (no Cartesian product)\n  brutus creds --target 10.0.0.50:22 -c \"admin:admin,root:toor,deploy:deploy123\"\n\n  # Credentials file (user:pass per line)\n  brutus creds --target 10.0.0.50:3306 -C creds.txt\n\n  # Targets file (auto-fingerprinted with Nerva)\n  brutus creds --targets-file targets.txt -u admin -P passwords.txt\n\n  # Pipeline mode with Nerva JSON (HTTP and SNMP services are skipped)\n  naabu -host 10.0.0.0/24 -silent | nerva --json | brutus creds -P passwords.txt\n\n  # Pipe URI targets (protocol from scheme, no fingerprinting needed)\n  echo \"ssh://192.168.1.10:22\" | brutus creds -p \"password,Password1\"\n\n  # Import targets from nmap XML scan\n  brutus creds --nmap-file scan.xml -P passwords.txt\n\n  # Import targets from masscan (requires --protocol or auto-fingerprints with Nerva)\n  brutus creds --masscan-file scan.json --protocol ssh -P passwords.txt",
+      "flags": [
+        {
+          "name": "connect-timeout",
+          "type": "duration",
+          "default": "3s",
+          "usage": "TCP connect timeout for scan dials (separate from --scan-timeout, which is the per-host settle deadline). A reachable host completes the handshake in ~1 RTT, so the short default only accelerates dead-host rejection; raise it for high-latency target sets."
+        },
+        {
+          "name": "credentials",
+          "shorthand": "c",
+          "type": "string",
+          "usage": "Comma-separated user:pass pairs (e.g., admin:admin,root:toor)"
+        },
+        {
+          "name": "credentials-file",
+          "shorthand": "C",
+          "type": "string",
+          "usage": "Credentials file (user:pass per line)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "key",
+          "shorthand": "k",
+          "type": "string",
+          "usage": "SSH private key file"
+        },
+        {
+          "name": "masscan-file",
+          "type": "string",
+          "usage": "Masscan JSON file (-oJ output) to import targets from"
+        },
+        {
+          "name": "max-attempts",
+          "type": "int",
+          "default": "0",
+          "usage": "Max password attempts per user (0 = unlimited)"
+        },
+        {
+          "name": "mode",
+          "shorthand": "m",
+          "type": "string",
+          "default": "default",
+          "usage": "Aggressiveness tier: cautious, default, aggressive"
+        },
+        {
+          "name": "nmap-file",
+          "type": "string",
+          "usage": "Nmap XML file (-oX output) to import targets from"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "password-file",
+          "shorthand": "P",
+          "type": "string",
+          "usage": "Password file (one per line)"
+        },
+        {
+          "name": "passwords",
+          "shorthand": "p",
+          "type": "string",
+          "usage": "Comma-separated passwords"
+        },
+        {
+          "name": "protocol",
+          "type": "string",
+          "usage": "Protocol to use (auto-detected from nerva)"
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "retries",
+          "type": "int",
+          "default": "2",
+          "usage": "Max retries on connection error (0 = disabled)"
+        },
+        {
+          "name": "target",
+          "type": "string",
+          "usage": "Target host:port"
+        },
+        {
+          "name": "targets-file",
+          "type": "string",
+          "usage": "File of targets to test, one host:port per line (fingerprints with Nerva unless --protocol is set)"
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "username-file",
+          "shorthand": "U",
+          "type": "string",
+          "usage": "Username file (one per line)"
+        },
+        {
+          "name": "usernames",
+          "shorthand": "u",
+          "type": "string",
+          "default": "root,admin",
+          "usage": "Comma-separated usernames"
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        },
+        {
+          "name": "verify",
+          "type": "bool",
+          "default": "false",
+          "usage": "Require strict TLS certificate verification"
+        }
+      ]
+    },
+    {
+      "path": "brutus enum",
+      "use": "enum",
+      "short": "Enumerate accounts against account-existence oracles or Active Directory",
+      "runnable": false,
+      "example": "  # Account-existence oracle enumeration\n  brutus enum active oracles --domain praetorian.com -e test@praetorian.com --known-valid admin@praetorian.com\n\n  # Kerberos user enumeration\n  brutus enum active kerberos --dc 10.0.0.1 --domain CORP.LOCAL -u administrator\n\n  # Authenticate with Microsoft Entra ID via device code\n  brutus enum active teams auth --tenant contoso.com\n\n  # GitHub account enumeration by email\n  brutus enum active github -e alice@example.com,bob@example.com\n\n  # Generate emails for enumeration\n  brutus enum generate --domain example.com --format flast\n\n  # API-key OSINT/HUMINT sources (employee email/contact discovery)\n  brutus enum passive hunter --domain example.com\n  brutus enum passive apollo --domain example.com\n  brutus enum passive lusha --first-name Jane --last-name Doe --company \"Example Inc\"\n  brutus enum passive dehashed --domain example.com",
+      "flags": [
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum active",
+      "use": "active",
+      "short": "Active account-existence enumeration against live oracles & directories",
+      "runnable": false,
+      "example": "  # Account-existence oracle enumeration\n  brutus enum active oracles --domain example.com --known-valid admin@example.com\n\n  # Google Workspace account enumeration\n  brutus enum active google -e alice@example.com,bob@example.com\n\n  # Microsoft 365 account enumeration\n  brutus enum active microsoft365 -e alice@example.com,bob@example.com\n\n  # Kerberos user enumeration\n  brutus enum active kerberos --dc 10.0.0.1 --domain CORP.LOCAL -u administrator\n\n  # Authenticate with Microsoft Entra ID via device code\n  brutus enum active teams auth --tenant contoso.com\n\n  # GitHub account enumeration by email\n  brutus enum active github -e alice@example.com,bob@example.com\n\n  # Gravatar account enumeration by email\n  brutus enum active gravatar -e alice@example.com,bob@example.com\n\n  # Enumerate against a custom oracle definition\n  brutus enum active custom -f oracle.json -e jsmith,asmith",
+      "flags": [
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum active custom",
+      "use": "custom",
+      "short": "Run a declaratively-described enumeration oracle from a spec file",
+      "runnable": true,
+      "example": "  # Run an oracle against inline subjects\n  brutus enum active custom -f oracle.json -e jsmith,asmith\n\n  # Run against a subject file\n  brutus enum active custom -f oracle.yaml -E users.txt\n\n  # Generate usernames and run\n  brutus enum active custom -f oracle.json --generate --format flast\n\n  # JSON output to a file\n  brutus enum active custom -f oracle.json -e jsmith -o results.jsonl",
+      "flags": [
+        {
+          "name": "domain",
+          "shorthand": "d",
+          "type": "string",
+          "usage": "Domain for email generation (with --generate)"
+        },
+        {
+          "name": "email-file",
+          "shorthand": "E",
+          "type": "string",
+          "usage": "File of subjects to enumerate (one per line, use - for stdin)"
+        },
+        {
+          "name": "emails",
+          "shorthand": "e",
+          "type": "string",
+          "usage": "Comma-separated subjects (usernames or emails) to enumerate"
+        },
+        {
+          "name": "file",
+          "shorthand": "f",
+          "type": "string",
+          "usage": "Oracle spec file (JSON or YAML, required)"
+        },
+        {
+          "name": "format",
+          "type": "string",
+          "default": "first.last",
+          "usage": "Username format for generation (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first)"
+        },
+        {
+          "name": "generate",
+          "type": "bool",
+          "default": "false",
+          "usage": "Generate subjects from embedded name lists"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum active github",
+      "use": "github",
+      "short": "Enumerate GitHub accounts by email (existence + username reveal)",
+      "runnable": true,
+      "example": "  # Existence-only enumeration (unauthenticated)\n  brutus enum active github -e alice@example.com,bob@example.com\n\n  # Generate candidate emails for a domain and enumerate the 5000 most likely\n  brutus enum active github --domain target.com --format first.last --limit 5000\n\n  # Enumerate emails from a file\n  brutus enum active github -E emails.txt\n\n  # Reveal usernames for existing accounts (requires a PAT with repo+delete_repo)\n  export GITHUB_TOKEN=ghp_...\n  brutus enum active github -E emails.txt\n\n  # Pace requests to avoid GitHub's existence-endpoint rate limiting\n  brutus enum active github -E emails.txt --threads 2 --rate-limit 1",
+      "flags": [
+        {
+          "name": "domain",
+          "shorthand": "d",
+          "type": "string",
+          "usage": "Generate candidate emails for this domain (statistically-likely first/last combos)"
+        },
+        {
+          "name": "email-file",
+          "shorthand": "E",
+          "type": "string",
+          "usage": "File of email addresses, one per line (\"-\" for stdin)"
+        },
+        {
+          "name": "emails",
+          "shorthand": "e",
+          "type": "string",
+          "usage": "Comma-separated email addresses to check"
+        },
+        {
+          "name": "format",
+          "type": "string",
+          "default": "first.last",
+          "usage": "Username format for --domain generation (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "limit",
+          "type": "int",
+          "default": "0",
+          "usage": "When generating with --domain, cap to the first N (most-likely) candidates (0 = all)"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "no-reveal",
+          "type": "bool",
+          "default": "false",
+          "usage": "Skip username reveal after existence enumeration (existence-only; no token used, no temp repo created)"
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "rotating-proxy",
+          "type": "bool",
+          "default": "false",
+          "usage": "Signal that --proxy rotates exit IPs (e.g. Bright Data): reduces per-IP rate-limit backoff during GitHub existence enumeration (short retry delay, higher retry ceiling). No effect on token-rate-limited reveal."
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "token",
+          "type": "string",
+          "usage": "GitHub PAT for username reveal (overrides GITHUB_TOKEN; visible in process list — prefer the env var)"
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum active github map",
+      "use": "map",
+      "short": "Correlate known emails to GitHub usernames (reveal-only, skips existence checks)",
+      "runnable": true,
+      "example": "  # Correlate emails from a file (token from the environment)\n  export GITHUB_TOKEN=ghp_...\n  brutus enum active github map -E emails.txt\n\n  # Correlate a couple of emails inline\n  brutus enum active github map -e alice@example.com,bob@example.com",
+      "flags": [
+        {
+          "name": "email-file",
+          "shorthand": "E",
+          "type": "string",
+          "usage": "File of email addresses, one per line (\"-\" for stdin)"
+        },
+        {
+          "name": "emails",
+          "shorthand": "e",
+          "type": "string",
+          "usage": "Comma-separated email addresses to correlate"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "rotating-proxy",
+          "type": "bool",
+          "default": "false",
+          "usage": "Signal that --proxy rotates exit IPs (e.g. Bright Data): reduces per-IP rate-limit backoff during GitHub existence enumeration (short retry delay, higher retry ceiling). No effect on token-rate-limited reveal.",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "token",
+          "type": "string",
+          "usage": "GitHub PAT (overrides GITHUB_TOKEN; visible in process list — prefer the env var)"
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum active google",
+      "use": "google",
+      "short": "Enumerate Google Workspace accounts (existence + SSO/IdP)",
+      "runnable": true,
+      "example": "  # Enumerate a couple of emails\n  brutus enum active google -e alice@example.com,bob@example.com\n\n  # Generate candidate emails for a domain and enumerate the 5000 most likely\n  brutus enum active google --domain target.com --format first.last --limit 5000\n\n  # Enumerate emails from a file\n  brutus enum active google -E emails.txt\n\n  # Route through a SOCKS5 proxy and raise concurrency\n  brutus enum active google -E emails.txt --proxy socks5://127.0.0.1:1080 --threads 20",
+      "flags": [
+        {
+          "name": "domain",
+          "shorthand": "d",
+          "type": "string",
+          "usage": "Generate candidate emails for this domain (statistically-likely first/last combos)"
+        },
+        {
+          "name": "email-file",
+          "shorthand": "E",
+          "type": "string",
+          "usage": "File of email addresses, one per line (\"-\" for stdin)"
+        },
+        {
+          "name": "emails",
+          "shorthand": "e",
+          "type": "string",
+          "usage": "Comma-separated email addresses to check"
+        },
+        {
+          "name": "format",
+          "type": "string",
+          "default": "first.last",
+          "usage": "Username format for --domain generation (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "limit",
+          "type": "int",
+          "default": "0",
+          "usage": "When generating with --domain, cap to the first N (most-likely) candidates (0 = all)"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum active gravatar",
+      "use": "gravatar",
+      "short": "Enumerate accounts with a registered Gravatar (by email)",
+      "runnable": true,
+      "example": "  # Enumerate a couple of emails\n  brutus enum active gravatar -e alice@example.com,bob@example.com\n\n  # Generate candidate emails for a domain and enumerate the 5000 most likely\n  brutus enum active gravatar --domain target.com --format first.last --limit 5000\n\n  # Enumerate emails from a file\n  brutus enum active gravatar -E emails.txt\n\n  # Route through a SOCKS5 proxy and raise concurrency\n  brutus enum active gravatar -E emails.txt --proxy socks5://127.0.0.1:1080 --threads 20",
+      "flags": [
+        {
+          "name": "domain",
+          "shorthand": "d",
+          "type": "string",
+          "usage": "Generate candidate emails for this domain (statistically-likely first/last combos)"
+        },
+        {
+          "name": "email-file",
+          "shorthand": "E",
+          "type": "string",
+          "usage": "File of email addresses, one per line (\"-\" for stdin)"
+        },
+        {
+          "name": "emails",
+          "shorthand": "e",
+          "type": "string",
+          "usage": "Comma-separated email addresses to check"
+        },
+        {
+          "name": "format",
+          "type": "string",
+          "default": "first.last",
+          "usage": "Username format for --domain generation (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "limit",
+          "type": "int",
+          "default": "0",
+          "usage": "When generating with --domain, cap to the first N (most-likely) candidates (0 = all)"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum active kerberos",
+      "use": "kerberos",
+      "short": "Enumerate Active Directory users via Kerberos AS-REQ",
+      "runnable": true,
+      "example": "  # Enumerate specific users\n  brutus enum active kerberos --dc 10.0.0.1 --domain CORP.LOCAL -u administrator,guest,krbtgt\n\n  # Enumerate from file\n  brutus enum active kerberos --dc dc01.corp.local --domain CORP.LOCAL -U users.txt\n\n  # Generate usernames and enumerate\n  brutus enum generate --format flast | brutus enum active kerberos --dc 10.0.0.1 --domain CORP.LOCAL -U -\n\n  # JSON output\n  brutus enum active kerberos --dc 10.0.0.1 --domain CORP.LOCAL -u administrator --json",
+      "flags": [
+        {
+          "name": "dc",
+          "type": "string",
+          "usage": "KDC (Domain Controller) address (host or host:port)"
+        },
+        {
+          "name": "domain",
+          "shorthand": "d",
+          "type": "string",
+          "usage": "Kerberos realm / AD domain (e.g., CORP.LOCAL)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "user-file",
+          "shorthand": "U",
+          "type": "string",
+          "usage": "File of usernames (one per line, use - for stdin)"
+        },
+        {
+          "name": "users",
+          "shorthand": "u",
+          "type": "string",
+          "usage": "Comma-separated usernames to enumerate"
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum active microsoft365",
+      "use": "microsoft365",
+      "short": "Enumerate Microsoft 365 accounts (existence + federation/tenant)",
+      "runnable": true,
+      "example": "  # Enumerate a couple of emails\n  brutus enum active microsoft365 -e alice@example.com,bob@example.com\n\n  # Generate candidate emails for a domain and enumerate the 5000 most likely\n  brutus enum active microsoft365 --domain target.com --format first.last --limit 5000\n\n  # Enumerate emails from a file\n  brutus enum active microsoft365 -E emails.txt\n\n  # Route through a SOCKS5 proxy and raise concurrency\n  brutus enum active microsoft365 -E emails.txt --proxy socks5://127.0.0.1:1080 --threads 20",
+      "flags": [
+        {
+          "name": "domain",
+          "shorthand": "d",
+          "type": "string",
+          "usage": "Generate candidate emails for this domain (statistically-likely first/last combos)"
+        },
+        {
+          "name": "email-file",
+          "shorthand": "E",
+          "type": "string",
+          "usage": "File of email addresses, one per line (\"-\" for stdin)"
+        },
+        {
+          "name": "emails",
+          "shorthand": "e",
+          "type": "string",
+          "usage": "Comma-separated email addresses to check"
+        },
+        {
+          "name": "format",
+          "type": "string",
+          "default": "first.last",
+          "usage": "Username format for --domain generation (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "limit",
+          "type": "int",
+          "default": "0",
+          "usage": "When generating with --domain, cap to the first N (most-likely) candidates (0 = all)"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum active oracles",
+      "use": "oracles",
+      "short": "Enumerate which account-existence oracles work for an organization",
+      "runnable": true,
+      "example": "  # Discover candidate oracles via DNS and report which ones work\n  # (domain defaults to the --known-valid email's domain)\n  brutus enum active oracles --known-valid admin@praetorian.com\n\n  # Enumerate specific emails against the working oracles\n  brutus enum active oracles --domain praetorian.com -e test@praetorian.com,admin@praetorian.com --known-valid admin@praetorian.com\n\n  # Enumerate emails from file\n  brutus enum active oracles --domain praetorian.com -E emails.txt --known-valid admin@praetorian.com\n\n  # Generate emails and enumerate against working oracles\n  brutus enum active oracles --domain target.com --generate --format first.last --known-valid admin@target.com\n\n  # Check / enumerate against specific oracles only\n  brutus enum active oracles -e user@example.com -s microsoft365,google --known-valid admin@example.com\n\n  # JSON output\n  brutus enum active oracles --domain praetorian.com -e test@praetorian.com --known-valid admin@praetorian.com --json",
+      "flags": [
+        {
+          "name": "domain",
+          "shorthand": "d",
+          "type": "string",
+          "usage": "Domain to enumerate for DNS recon and email generation (defaults to the --known-valid email's domain)"
+        },
+        {
+          "name": "email-file",
+          "shorthand": "E",
+          "type": "string",
+          "usage": "File of emails to enumerate (one per line, use - for stdin)"
+        },
+        {
+          "name": "emails",
+          "shorthand": "e",
+          "type": "string",
+          "usage": "Comma-separated emails to enumerate"
+        },
+        {
+          "name": "format",
+          "type": "string",
+          "default": "first.last",
+          "usage": "Username format for generation (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first)"
+        },
+        {
+          "name": "generate",
+          "type": "bool",
+          "default": "false",
+          "usage": "Generate emails from embedded name lists"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "known-valid",
+          "type": "string",
+          "usage": "Known-valid email to validate oracles before enumeration (required)"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "services",
+          "shorthand": "s",
+          "type": "string",
+          "usage": "Comma-separated oracles to check (default: all discovered/registered)"
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum active oracles discover",
+      "use": "discover",
+      "short": "Discover working oracles by testing a known-valid email",
+      "runnable": true,
+      "example": "  # Test oracles for a domain (auto-discovers candidate oracles from DNS)\n  brutus enum active oracles discover --domain praetorian.com --known-valid admin@praetorian.com\n\n  # Test specific oracles only\n  brutus enum active oracles discover --known-valid admin@example.com -s microsoft365,google",
+      "flags": [
+        {
+          "name": "domain",
+          "shorthand": "d",
+          "type": "string",
+          "usage": "Domain to discover candidate oracles from DNS TXT records"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "known-valid",
+          "type": "string",
+          "usage": "Known-valid email to test against oracles (required)"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "services",
+          "shorthand": "s",
+          "type": "string",
+          "usage": "Comma-separated oracles to test (default: all registered)"
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum active teams",
+      "use": "teams",
+      "short": "Microsoft Teams: device-code auth, user enumeration, and tenant posture audit",
+      "runnable": false,
+      "flags": [
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum active teams audit",
+      "use": "audit",
+      "short": "Audit a Microsoft Teams tenant's external posture into graded findings",
+      "runnable": true,
+      "example": "  # Audit a tenant via a single known-valid seed address (device-code auth inline)\n  brutus enum active teams audit --email alice@contoso.com\n\n  # Skip presence/out-of-office lookups (presence/OOO findings not evaluated)\n  brutus enum active teams audit --email alice@contoso.com --no-presence\n\n  # Reuse a token captured earlier with \"enum active teams auth -o\"\n  brutus enum active teams auth -o token.jsonl\n  brutus enum active teams audit --email alice@contoso.com --token-file token.jsonl\n\n  # Emit findings as JSONL\n  brutus enum active teams audit --email alice@contoso.com --json",
+      "flags": [
+        {
+          "name": "access-token",
+          "type": "string",
+          "usage": "Access token to use (instead of device-code or --token-file)"
+        },
+        {
+          "name": "client-id",
+          "type": "string",
+          "default": "1fec8e78-bce4-4aaf-ab1b-5451cc387264",
+          "usage": "Azure app (client) ID (device-code path)"
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "usage": "Single known-valid seed email address to audit (required)"
+        },
+        {
+          "name": "include-consumer",
+          "type": "bool",
+          "default": "false",
+          "usage": "Count consumer/personal (8:live:) Teams accounts as hits (default: only corporate 8:orgid: accounts)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "no-browser",
+          "type": "bool",
+          "default": "false",
+          "usage": "Don't automatically open the verification URL in a browser"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "no-presence",
+          "type": "bool",
+          "default": "false",
+          "usage": "Skip Teams presence / out-of-office lookups (fewer requests; presence is gathered by default)"
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "refresh-token",
+          "type": "string",
+          "usage": "Refresh token used to renew an expired access token"
+        },
+        {
+          "name": "scope",
+          "type": "string",
+          "default": "offline_access https://api.spaces.skype.com/.default",
+          "usage": "Space-separated OAuth2 scopes (device-code path)"
+        },
+        {
+          "name": "tenant",
+          "type": "string",
+          "default": "organizations",
+          "usage": "Tenant ID, domain, or \"organizations\"/\"common\" (device-code path)"
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "token-file",
+          "type": "string",
+          "usage": "JSONL token file from \"enum active teams auth -o\" to reuse"
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum active teams auth",
+      "use": "auth",
+      "short": "Obtain Microsoft access token and refresh token via device code flow",
+      "runnable": true,
+      "example": "  # Authenticate against the default (organizations / work-school) tenant (interactive)\n  brutus enum active teams auth\n\n  # Headless / SSH: print the URL and code, don't open a browser\n  brutus enum active teams auth --no-browser\n\n  # Authenticate against a specific tenant by domain\n  brutus enum active teams auth --tenant contoso.com\n\n  # Use a custom app registration and scopes\n  brutus enum active teams auth --client-id 00000000-0000-0000-0000-000000000000 \\\n    --scope \"offline_access https://api.spaces.skype.com/.default\"\n\n  # Capture the full token set as JSON\n  brutus enum active teams auth -o token.jsonl",
+      "flags": [
+        {
+          "name": "client-id",
+          "type": "string",
+          "default": "1fec8e78-bce4-4aaf-ab1b-5451cc387264",
+          "usage": "Azure app (client) ID"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "no-browser",
+          "type": "bool",
+          "default": "false",
+          "usage": "Don't automatically open the verification URL in a browser"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "scope",
+          "shorthand": "s",
+          "type": "string",
+          "default": "offline_access https://api.spaces.skype.com/.default",
+          "usage": "Space-separated OAuth2 scopes"
+        },
+        {
+          "name": "tenant",
+          "type": "string",
+          "default": "organizations",
+          "usage": "Tenant ID, domain, or \"organizations\"/\"common\""
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum active teams users",
+      "use": "users",
+      "short": "Enumerate corporate Microsoft Teams users by email address",
+      "runnable": true,
+      "example": "  # Device-code auth inline, then enumerate a few emails\n  brutus enum active teams users -e alice@contoso.com,bob@contoso.com\n\n  # Generate candidate emails for a domain and enumerate the 5000 most likely\n  brutus enum active teams users --domain target.com --format first.last --limit 5000\n\n  # Generate first_last candidates (presence is fetched by default for hits)\n  brutus enum active teams users --domain target.com --format first_last\n\n  # Enumerate emails from a file, skipping presence lookups\n  brutus enum active teams users -E emails.txt --no-presence\n\n  # Reuse a token captured earlier with \"enum active teams auth -o\"\n  brutus enum active teams auth -o token.jsonl\n  brutus enum active teams users -E emails.txt --token-file token.jsonl\n\n  # Provide an access token directly\n  brutus enum active teams users -e alice@contoso.com --access-token \"$TOKEN\"\n\n  # Route through a SOCKS5 proxy and raise concurrency\n  brutus enum active teams users -E emails.txt --proxy socks5://127.0.0.1:1080 --threads 20",
+      "flags": [
+        {
+          "name": "access-token",
+          "type": "string",
+          "usage": "Access token to use (instead of device-code or --token-file)"
+        },
+        {
+          "name": "client-id",
+          "type": "string",
+          "default": "1fec8e78-bce4-4aaf-ab1b-5451cc387264",
+          "usage": "Azure app (client) ID (device-code path)"
+        },
+        {
+          "name": "domain",
+          "shorthand": "d",
+          "type": "string",
+          "usage": "Generate candidate emails for this domain (statistically-likely first/last combos)"
+        },
+        {
+          "name": "email-file",
+          "shorthand": "E",
+          "type": "string",
+          "usage": "File of email addresses, one per line (\"-\" for stdin)"
+        },
+        {
+          "name": "emails",
+          "shorthand": "e",
+          "type": "string",
+          "usage": "Comma-separated email addresses to check"
+        },
+        {
+          "name": "format",
+          "type": "string",
+          "default": "first.last",
+          "usage": "Username format for --domain generation (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first)"
+        },
+        {
+          "name": "include-consumer",
+          "type": "bool",
+          "default": "false",
+          "usage": "Count consumer/personal (8:live:) Teams accounts as hits (default: only corporate 8:orgid: accounts)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "limit",
+          "type": "int",
+          "default": "0",
+          "usage": "When generating with --domain, cap to the first N (most-likely) candidates (0 = all)"
+        },
+        {
+          "name": "no-browser",
+          "type": "bool",
+          "default": "false",
+          "usage": "Don't automatically open the verification URL in a browser"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "no-presence",
+          "type": "bool",
+          "default": "false",
+          "usage": "Skip Teams presence / out-of-office lookups (fewer requests; presence is gathered by default)"
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "refresh-token",
+          "type": "string",
+          "usage": "Refresh token used to renew an expired access token"
+        },
+        {
+          "name": "scope",
+          "type": "string",
+          "default": "offline_access https://api.spaces.skype.com/.default",
+          "usage": "Space-separated OAuth2 scopes (device-code path)"
+        },
+        {
+          "name": "tenant",
+          "type": "string",
+          "default": "organizations",
+          "usage": "Tenant ID, domain, or \"organizations\"/\"common\" (device-code path)"
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "token-file",
+          "type": "string",
+          "usage": "JSONL token file from \"enum active teams auth -o\" to reuse"
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum apollo",
+      "use": "apollo",
+      "short": "Discover people for a domain via Apollo.io (free; --enrich reveals emails)",
+      "hidden": true,
+      "deprecated": "use \"brutus enum passive apollo\" instead",
+      "runnable": true,
+      "example": "  # Discover people (DEFAULT — FREE, no credits; shows email/phone availability)\n  brutus enum passive apollo --domain example.com\n\n  # Filter by job titles\n  brutus enum passive apollo -d example.com --titles \"VP Engineering\" --titles \"CTO\"\n\n  # Enrich all discovered people (CONSUMES CREDITS, bounded by --limit)\n  brutus enum passive apollo -d example.com --enrich --limit 50\n\n  # Provide the key explicitly (note: visible in process list / shell history)\n  brutus enum passive apollo -d example.com --api-key abc123",
+      "flags": [
+        {
+          "name": "api-key",
+          "type": "string",
+          "usage": "Apollo.io API key (overrides APOLLO_API_KEY; WARNING: visible in process list and shell history — prefer APOLLO_API_KEY)"
+        },
+        {
+          "name": "domain",
+          "shorthand": "d",
+          "type": "string",
+          "usage": "Company domain to discover people for (required)"
+        },
+        {
+          "name": "enrich",
+          "type": "bool",
+          "default": "false",
+          "usage": "Reveal emails for all discovered people via people/match (CONSUMES CREDITS; bounded by --limit)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "limit",
+          "type": "int",
+          "default": "0",
+          "usage": "Max people to discover AND (with --enrich) to reveal (bounds credit spend; 0 = no cap)"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "titles",
+          "type": "stringSlice",
+          "default": "[]",
+          "usage": "Optional job-title filter (repeatable or comma-separated)"
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum dehashed",
+      "use": "dehashed",
+      "short": "Collect breach-exposed identity data for a domain via DeHashed",
+      "hidden": true,
+      "deprecated": "use \"brutus enum passive dehashed\" instead",
+      "runnable": true,
+      "example": "  # Collect refined breach contacts for a domain (key from DEHASHED_API_KEY)\n  brutus enum passive dehashed --domain example.com\n\n  # Same, but suppress the breach-exposed plaintext passwords from output\n  brutus enum passive dehashed --domain example.com --no-credentials\n\n  # Keep every email (not just @example.com), unmerged; drop combolist DBs for clean identity-only enumeration\n  brutus enum passive dehashed -d example.com --all-emails --no-dedup --exclude-combolists\n\n  # Restrict to specific source databases (exact names, comma-separated)\n  brutus enum passive dehashed -d example.com --sources \"Adobe,LinkedIn\"\n\n  # Emit one structured JSON document with full per-contact detail + run metadata\n  brutus enum passive dehashed -d example.com --detailed -o breaches.json\n\n  # Same detailed export, including breach-exposed plaintext passwords\n  brutus enum passive dehashed -d example.com --detailed --with-credentials -o breaches.json\n\n  # Provide the key explicitly (note: visible in process list / shell history)\n  brutus enum passive dehashed -d example.com --api-key abc123\n\n  # Cap results (and credit spend) and write JSONL to a file\n  brutus enum passive dehashed -d example.com --limit 50 -o breaches.jsonl",
+      "flags": [
+        {
+          "name": "all-emails",
+          "type": "bool",
+          "default": "false",
+          "usage": "Keep all emails, not just those @<domain> (disables corporate-only filtering)"
+        },
+        {
+          "name": "api-key",
+          "type": "string",
+          "usage": "DeHashed API key (overrides DEHASHED_API_KEY; WARNING: visible in process list and shell history — prefer DEHASHED_API_KEY)"
+        },
+        {
+          "name": "detailed",
+          "type": "bool",
+          "default": "false",
+          "usage": "Emit a single structured JSON document with full per-contact detail (ip addresses, addresses, dobs, obtained dates) and run metadata"
+        },
+        {
+          "name": "domain",
+          "shorthand": "d",
+          "type": "string",
+          "usage": "Domain to search (required)"
+        },
+        {
+          "name": "exclude-combolists",
+          "type": "bool",
+          "default": "false",
+          "usage": "Drop records from known aggregator/combolist source databases (combolists are included by default)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "limit",
+          "type": "int",
+          "default": "100",
+          "usage": "Maximum number of records to collect (bounds credit spend)"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "no-credentials",
+          "type": "bool",
+          "default": "false",
+          "usage": "Suppress breach-exposed plaintext passwords from the output"
+        },
+        {
+          "name": "no-dedup",
+          "type": "bool",
+          "default": "false",
+          "usage": "Do not merge records that share an email"
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "sources",
+          "type": "stringSlice",
+          "default": "[]",
+          "usage": "Restrict results to these DeHashed source databases (comma-separated, exact names)"
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        },
+        {
+          "name": "with-credentials",
+          "type": "bool",
+          "default": "false",
+          "usage": "Include breach-exposed plaintext passwords in --detailed output (off by default; hashes are never included)"
+        }
+      ]
+    },
+    {
+      "path": "brutus enum generate",
+      "use": "generate",
+      "short": "Generate email addresses or usernames from embedded name lists",
+      "runnable": true,
+      "example": "  # Generate emails: jsmith@example.com\n  brutus enum generate --domain example.com --format flast\n\n  # Generate usernames only: jsmith\n  brutus enum generate --format flast\n\n  # Generate john.smith@example.com (default format)\n  brutus enum generate --domain example.com\n\n  # Emit only the 1000 most-likely emails\n  brutus enum generate --domain example.com --limit 1000\n\n  # Pipe the 500 most-likely usernames to Kerberos enum\n  brutus enum generate --format flast --limit 500 | brutus enum active kerberos --dc 10.0.0.1 --domain CORP.LOCAL -U -",
+      "flags": [
+        {
+          "name": "domain",
+          "shorthand": "d",
+          "type": "string",
+          "usage": "Domain to append to generated usernames (omit to generate usernames only)"
+        },
+        {
+          "name": "format",
+          "type": "string",
+          "default": "first.last",
+          "usage": "Username format (first.last, first_last, flast, firstl, f.last, lastf, last.first, lastfirst, first)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "limit",
+          "type": "int",
+          "default": "0",
+          "usage": "Emit only the first N (most-likely) results (0 = no limit, emit all)"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum hunter",
+      "use": "hunter",
+      "short": "Discover people and emails for a domain via Hunter.io Domain Search",
+      "hidden": true,
+      "deprecated": "use \"brutus enum passive hunter\" instead",
+      "runnable": true,
+      "example": "  # Discover people for a domain (key from HUNTER_API_KEY)\n  brutus enum passive hunter --domain example.com\n\n  # Provide the key explicitly (note: visible in process list / shell history)\n  brutus enum passive hunter -d example.com --api-key abc123\n\n  # JSONL output to a file\n  brutus enum passive hunter -d example.com -o people.jsonl",
+      "flags": [
+        {
+          "name": "api-key",
+          "type": "string",
+          "usage": "Hunter.io API key (overrides HUNTER_API_KEY; WARNING: visible in process list and shell history — prefer HUNTER_API_KEY)"
+        },
+        {
+          "name": "domain",
+          "shorthand": "d",
+          "type": "string",
+          "usage": "Domain to search (required)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "limit",
+          "type": "int",
+          "default": "0",
+          "usage": "Maximum number of people to return (0 = no cap, return all)"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum lusha",
+      "use": "lusha",
+      "short": "Enrich a single person identity to emails and phones via Lusha v3",
+      "hidden": true,
+      "deprecated": "use \"brutus enum passive lusha\" instead",
+      "runnable": true,
+      "example": "  # Enrich by name + company (key from LUSHA_API_KEY)\n  brutus enum passive lusha --first-name Ada --last-name Lovelace --company Analytical\n\n  # Enrich by name + company domain\n  brutus enum passive lusha --first-name Ada --last-name Lovelace --domain example.com\n\n  # Enrich by email\n  brutus enum passive lusha --email ada@example.com\n\n  # Enrich by LinkedIn URL, also request phone numbers\n  brutus enum passive lusha --linkedin https://linkedin.com/in/ada --phone\n\n  # Roster: enumerate an entire company by domain (collect all — consumes credits)\n  brutus enum passive lusha --domain example.com\n\n  # Roster: cap the roster (and credit spend) at 25 contacts\n  brutus enum passive lusha --domain example.com --limit 25\n\n  # Provide the key explicitly (note: visible in process list / shell history)\n  brutus enum passive lusha --email ada@example.com --api-key abc123",
+      "flags": [
+        {
+          "name": "api-key",
+          "type": "string",
+          "usage": "Lusha API key (overrides LUSHA_API_KEY; WARNING: visible in process list and shell history — prefer LUSHA_API_KEY)"
+        },
+        {
+          "name": "company",
+          "type": "string",
+          "usage": "Company name (with the name pair)"
+        },
+        {
+          "name": "domain",
+          "type": "string",
+          "usage": "Company domain (alternative to --company)"
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "usage": "Enrich by email address (mutually exclusive identity)"
+        },
+        {
+          "name": "email-only",
+          "type": "bool",
+          "default": "false",
+          "usage": "Request only email datapoints (mutually exclusive with --phone)"
+        },
+        {
+          "name": "first-name",
+          "type": "string",
+          "usage": "First name (with --last-name and --company or --domain)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "last-name",
+          "type": "string",
+          "usage": "Last name (with --first-name)"
+        },
+        {
+          "name": "limit",
+          "type": "int",
+          "default": "0",
+          "usage": "Roster mode (--domain only): max contacts to search + enrich; 0 = collect all (consumes ~1 credit/contact)"
+        },
+        {
+          "name": "linkedin",
+          "type": "string",
+          "usage": "Enrich by LinkedIn profile URL (mutually exclusive identity)"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "phone",
+          "type": "bool",
+          "default": "false",
+          "usage": "Request phone datapoints in addition to email"
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum passive",
+      "use": "passive",
+      "short": "API-key OSINT/HUMINT sources — employee email/contact discovery & enrichment",
+      "runnable": false,
+      "example": "  # Discover people via Hunter.io\n  brutus enum passive hunter --domain example.com\n\n  # Discover and enrich people via Apollo.io\n  brutus enum passive apollo --domain example.com\n\n  # Enrich a contact via Lusha\n  brutus enum passive lusha --first-name Jane --last-name Doe --company \"Example Inc\"\n\n  # Collect breach-exposed identity data via DeHashed\n  brutus enum passive dehashed --domain example.com\n\n  # Scrape LinkedIn Sales Navigator profiles via PhantomBuster\n  brutus enum passive linkedin --agent-id 1234567890",
+      "flags": [
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum passive apollo",
+      "use": "apollo",
+      "short": "Discover people for a domain via Apollo.io (free; --enrich reveals emails)",
+      "runnable": true,
+      "example": "  # Discover people (DEFAULT — FREE, no credits; shows email/phone availability)\n  brutus enum passive apollo --domain example.com\n\n  # Filter by job titles\n  brutus enum passive apollo -d example.com --titles \"VP Engineering\" --titles \"CTO\"\n\n  # Enrich all discovered people (CONSUMES CREDITS, bounded by --limit)\n  brutus enum passive apollo -d example.com --enrich --limit 50\n\n  # Provide the key explicitly (note: visible in process list / shell history)\n  brutus enum passive apollo -d example.com --api-key abc123",
+      "flags": [
+        {
+          "name": "api-key",
+          "type": "string",
+          "usage": "Apollo.io API key (overrides APOLLO_API_KEY; WARNING: visible in process list and shell history — prefer APOLLO_API_KEY)"
+        },
+        {
+          "name": "domain",
+          "shorthand": "d",
+          "type": "string",
+          "usage": "Company domain to discover people for (required)"
+        },
+        {
+          "name": "enrich",
+          "type": "bool",
+          "default": "false",
+          "usage": "Reveal emails for all discovered people via people/match (CONSUMES CREDITS; bounded by --limit)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "limit",
+          "type": "int",
+          "default": "0",
+          "usage": "Max people to discover AND (with --enrich) to reveal (bounds credit spend; 0 = no cap)"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "titles",
+          "type": "stringSlice",
+          "default": "[]",
+          "usage": "Optional job-title filter (repeatable or comma-separated)"
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum passive dehashed",
+      "use": "dehashed",
+      "short": "Collect breach-exposed identity data for a domain via DeHashed",
+      "runnable": true,
+      "example": "  # Collect refined breach contacts for a domain (key from DEHASHED_API_KEY)\n  brutus enum passive dehashed --domain example.com\n\n  # Same, but suppress the breach-exposed plaintext passwords from output\n  brutus enum passive dehashed --domain example.com --no-credentials\n\n  # Keep every email (not just @example.com), unmerged; drop combolist DBs for clean identity-only enumeration\n  brutus enum passive dehashed -d example.com --all-emails --no-dedup --exclude-combolists\n\n  # Restrict to specific source databases (exact names, comma-separated)\n  brutus enum passive dehashed -d example.com --sources \"Adobe,LinkedIn\"\n\n  # Emit one structured JSON document with full per-contact detail + run metadata\n  brutus enum passive dehashed -d example.com --detailed -o breaches.json\n\n  # Same detailed export, including breach-exposed plaintext passwords\n  brutus enum passive dehashed -d example.com --detailed --with-credentials -o breaches.json\n\n  # Provide the key explicitly (note: visible in process list / shell history)\n  brutus enum passive dehashed -d example.com --api-key abc123\n\n  # Cap results (and credit spend) and write JSONL to a file\n  brutus enum passive dehashed -d example.com --limit 50 -o breaches.jsonl",
+      "flags": [
+        {
+          "name": "all-emails",
+          "type": "bool",
+          "default": "false",
+          "usage": "Keep all emails, not just those @<domain> (disables corporate-only filtering)"
+        },
+        {
+          "name": "api-key",
+          "type": "string",
+          "usage": "DeHashed API key (overrides DEHASHED_API_KEY; WARNING: visible in process list and shell history — prefer DEHASHED_API_KEY)"
+        },
+        {
+          "name": "detailed",
+          "type": "bool",
+          "default": "false",
+          "usage": "Emit a single structured JSON document with full per-contact detail (ip addresses, addresses, dobs, obtained dates) and run metadata"
+        },
+        {
+          "name": "domain",
+          "shorthand": "d",
+          "type": "string",
+          "usage": "Domain to search (required)"
+        },
+        {
+          "name": "exclude-combolists",
+          "type": "bool",
+          "default": "false",
+          "usage": "Drop records from known aggregator/combolist source databases (combolists are included by default)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "limit",
+          "type": "int",
+          "default": "100",
+          "usage": "Maximum number of records to collect (bounds credit spend)"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "no-credentials",
+          "type": "bool",
+          "default": "false",
+          "usage": "Suppress breach-exposed plaintext passwords from the output"
+        },
+        {
+          "name": "no-dedup",
+          "type": "bool",
+          "default": "false",
+          "usage": "Do not merge records that share an email"
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "sources",
+          "type": "stringSlice",
+          "default": "[]",
+          "usage": "Restrict results to these DeHashed source databases (comma-separated, exact names)"
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        },
+        {
+          "name": "with-credentials",
+          "type": "bool",
+          "default": "false",
+          "usage": "Include breach-exposed plaintext passwords in --detailed output (off by default; hashes are never included)"
+        }
+      ]
+    },
+    {
+      "path": "brutus enum passive hunter",
+      "use": "hunter",
+      "short": "Discover people and emails for a domain via Hunter.io Domain Search",
+      "runnable": true,
+      "example": "  # Discover people for a domain (key from HUNTER_API_KEY)\n  brutus enum passive hunter --domain example.com\n\n  # Provide the key explicitly (note: visible in process list / shell history)\n  brutus enum passive hunter -d example.com --api-key abc123\n\n  # JSONL output to a file\n  brutus enum passive hunter -d example.com -o people.jsonl",
+      "flags": [
+        {
+          "name": "api-key",
+          "type": "string",
+          "usage": "Hunter.io API key (overrides HUNTER_API_KEY; WARNING: visible in process list and shell history — prefer HUNTER_API_KEY)"
+        },
+        {
+          "name": "domain",
+          "shorthand": "d",
+          "type": "string",
+          "usage": "Domain to search (required)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "limit",
+          "type": "int",
+          "default": "0",
+          "usage": "Maximum number of people to return (0 = no cap, return all)"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum passive linkedin",
+      "use": "linkedin",
+      "short": "Scrape LinkedIn Sales Navigator profiles via PhantomBuster",
+      "runnable": true,
+      "example": "  # Launch a Sales Nav scraper and fetch results\n  brutus enum passive linkedin --agent-id 1234567890\n\n  # Fetch results from a previous run (skip launching a new one)\n  brutus enum passive linkedin --agent-id 1234567890 --skip-launch\n\n  # Specify a custom result filename\n  brutus enum passive linkedin --agent-id 1234567890 --result-file result.json\n\n  # Provide the key explicitly (note: visible in process list / shell history)\n  brutus enum passive linkedin --agent-id 1234567890 --api-key abc123",
+      "flags": [
+        {
+          "name": "agent-id",
+          "type": "string",
+          "usage": "PhantomBuster agent ID for the Sales Navigator scraper (required)"
+        },
+        {
+          "name": "api-key",
+          "type": "string",
+          "usage": "PhantomBuster API key (overrides PHANTOMBUSTER_KEY; WARNING: visible in process list and shell history — prefer PHANTOMBUSTER_KEY)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "result-file",
+          "type": "string",
+          "default": "result.csv",
+          "usage": "Result filename to download from S3 (default: result.csv)"
+        },
+        {
+          "name": "skip-launch",
+          "type": "bool",
+          "default": "false",
+          "usage": "Skip launching the agent — fetch results from the most recent run instead"
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus enum passive lusha",
+      "use": "lusha",
+      "short": "Enrich a single person identity to emails and phones via Lusha v3",
+      "runnable": true,
+      "example": "  # Enrich by name + company (key from LUSHA_API_KEY)\n  brutus enum passive lusha --first-name Ada --last-name Lovelace --company Analytical\n\n  # Enrich by name + company domain\n  brutus enum passive lusha --first-name Ada --last-name Lovelace --domain example.com\n\n  # Enrich by email\n  brutus enum passive lusha --email ada@example.com\n\n  # Enrich by LinkedIn URL, also request phone numbers\n  brutus enum passive lusha --linkedin https://linkedin.com/in/ada --phone\n\n  # Roster: enumerate an entire company by domain (collect all — consumes credits)\n  brutus enum passive lusha --domain example.com\n\n  # Roster: cap the roster (and credit spend) at 25 contacts\n  brutus enum passive lusha --domain example.com --limit 25\n\n  # Provide the key explicitly (note: visible in process list / shell history)\n  brutus enum passive lusha --email ada@example.com --api-key abc123",
+      "flags": [
+        {
+          "name": "api-key",
+          "type": "string",
+          "usage": "Lusha API key (overrides LUSHA_API_KEY; WARNING: visible in process list and shell history — prefer LUSHA_API_KEY)"
+        },
+        {
+          "name": "company",
+          "type": "string",
+          "usage": "Company name (with the name pair)"
+        },
+        {
+          "name": "domain",
+          "type": "string",
+          "usage": "Company domain (alternative to --company)"
+        },
+        {
+          "name": "email",
+          "type": "string",
+          "usage": "Enrich by email address (mutually exclusive identity)"
+        },
+        {
+          "name": "email-only",
+          "type": "bool",
+          "default": "false",
+          "usage": "Request only email datapoints (mutually exclusive with --phone)"
+        },
+        {
+          "name": "first-name",
+          "type": "string",
+          "usage": "First name (with --last-name and --company or --domain)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "last-name",
+          "type": "string",
+          "usage": "Last name (with --first-name)"
+        },
+        {
+          "name": "limit",
+          "type": "int",
+          "default": "0",
+          "usage": "Roster mode (--domain only): max contacts to search + enrich; 0 = collect all (consumes ~1 credit/contact)"
+        },
+        {
+          "name": "linkedin",
+          "type": "string",
+          "usage": "Enrich by LinkedIn profile URL (mutually exclusive identity)"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "phone",
+          "type": "bool",
+          "default": "false",
+          "usage": "Request phone datapoints in addition to email"
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus logon",
+      "use": "logon",
+      "short": "Detect Windows logon-screen backdoors (runs both sticky keys and utilman)",
+      "runnable": true,
+      "example": "  # Detect sticky keys and utilman backdoors (heuristic)\n  brutus logon --target 10.0.0.50:3389\n\n  # Vision API confirmation (more accurate)\n  brutus logon --target 10.0.0.50:3389 --experimental-ai\n\n  # Execute a command via detected backdoor\n  brutus logon --target 10.0.0.50:3389 --exec \"whoami\"\n\n  # Interactive web terminal via backdoor\n  brutus logon --target 10.0.0.50:3389 --web --open\n\n  # Pipeline mode with Nerva JSON (only RDP targets are tested)\n  naabu -host 10.0.0.0/24 -p 3389 -silent | nerva --json | brutus logon\n\n  # Pipe plain targets (auto-fingerprinted, only RDP services scanned)\n  echo \"10.0.0.50:3389\" | brutus logon\n\n  # Pipe URI targets\n  echo \"rdp://10.0.0.50:3389\" | brutus logon\n\n  # Import targets from nmap XML scan (only RDP services tested)\n  brutus logon --nmap-file scan.xml",
+      "flags": [
+        {
+          "name": "connect-timeout",
+          "type": "duration",
+          "default": "3s",
+          "usage": "TCP connect timeout for scan dials (separate from --scan-timeout, which is the per-host settle deadline). A reachable host completes the handshake in ~1 RTT, so the short default only accelerates dead-host rejection; raise it for high-latency target sets."
+        },
+        {
+          "name": "exec",
+          "type": "string",
+          "usage": "Execute command via detected backdoor"
+        },
+        {
+          "name": "experimental-ai",
+          "type": "bool",
+          "default": "false",
+          "usage": "Enable Vision API for backdoor confirmation"
+        },
+        {
+          "name": "fast",
+          "type": "bool",
+          "default": "false",
+          "usage": "fast triage: shorter settle budget for internet-scale sweeps; reports HIGH/CRITICAL or indeterminate, never clean (rerun indeterminates without --fast for a careful verdict)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "masscan-file",
+          "type": "string",
+          "usage": "Masscan JSON file (-oJ output) to import targets from"
+        },
+        {
+          "name": "mode",
+          "shorthand": "m",
+          "type": "string",
+          "default": "default",
+          "usage": "Aggressiveness tier: cautious, default, aggressive"
+        },
+        {
+          "name": "nmap-file",
+          "type": "string",
+          "usage": "Nmap XML file (-oX output) to import targets from"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "no-nla-probe",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable the pre-WASM RDP negotiation probe (always run the full WASM session)"
+        },
+        {
+          "name": "open",
+          "type": "bool",
+          "default": "false",
+          "usage": "Auto-open browser when web terminal starts"
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "retries",
+          "type": "int",
+          "default": "2",
+          "usage": "Max retries on connection error (0 = disabled)"
+        },
+        {
+          "name": "scan-timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-host settle/scan deadline (post-connect): how long to watch the logon screen after the trigger before deciding. Distinct from --connect-timeout (the TCP dial timeout)."
+        },
+        {
+          "name": "target",
+          "type": "string",
+          "usage": "Target host:port"
+        },
+        {
+          "name": "targets-file",
+          "type": "string",
+          "usage": "File of targets to test, one host:port per line (fingerprints with Nerva unless --protocol is set)"
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true,
+          "rejected": true,
+          "rejectedReason": "--timeout is not valid here; use --scan-timeout (settle deadline) and/or --connect-timeout (TCP connect)"
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        },
+        {
+          "name": "web",
+          "type": "bool",
+          "default": "false",
+          "usage": "Start interactive web terminal via detected backdoor"
+        }
+      ]
+    },
+    {
+      "path": "brutus snmp",
+      "use": "snmp",
+      "short": "Test SNMP community strings against targets",
+      "aliases": [
+        "community"
+      ],
+      "runnable": true,
+      "example": "  # Test with default community strings\n  brutus snmp --target 192.168.1.1:161\n\n  # Aggressive mode for comprehensive testing (~200+ strings)\n  brutus snmp --target 10.0.0.1:161 --mode aggressive\n\n  # Custom community strings\n  brutus snmp --target 192.168.1.1:161 -c \"mycommunity,secretstring\"\n\n  # Pipeline mode\n  naabu -host 10.0.0.0/24 -p 161 -silent | nerva --json | brutus snmp\n\n  # Targets file\n  brutus snmp --targets-file snmp-hosts.txt --mode aggressive\n\n  # Import targets from nmap XML scan (only SNMP services tested)\n  brutus snmp --nmap-file scan.xml --mode aggressive",
+      "flags": [
+        {
+          "name": "community",
+          "shorthand": "c",
+          "type": "string",
+          "usage": "Custom community strings (comma-separated)"
+        },
+        {
+          "name": "community-file",
+          "shorthand": "C",
+          "type": "string",
+          "usage": "Community string file (one per line)"
+        },
+        {
+          "name": "connect-timeout",
+          "type": "duration",
+          "default": "3s",
+          "usage": "TCP connect timeout for scan dials (separate from --scan-timeout, which is the per-host settle deadline). A reachable host completes the handshake in ~1 RTT, so the short default only accelerates dead-host rejection; raise it for high-latency target sets."
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "masscan-file",
+          "type": "string",
+          "usage": "Masscan JSON file (-oJ output) to import targets from"
+        },
+        {
+          "name": "mode",
+          "shorthand": "m",
+          "type": "string",
+          "default": "default",
+          "usage": "Aggressiveness tier: cautious, default, aggressive"
+        },
+        {
+          "name": "nmap-file",
+          "type": "string",
+          "usage": "Nmap XML file (-oX output) to import targets from"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "retries",
+          "type": "int",
+          "default": "2",
+          "usage": "Max retries on connection error (0 = disabled)"
+        },
+        {
+          "name": "target",
+          "type": "string",
+          "usage": "Target host:port"
+        },
+        {
+          "name": "targets-file",
+          "type": "string",
+          "usage": "File of targets to test, one host:port per line (fingerprints with Nerva unless --protocol is set)"
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        }
+      ]
+    },
+    {
+      "path": "brutus stickykeys",
+      "use": "stickykeys",
+      "short": "Detect the Windows sticky-keys (sethc.exe) logon backdoor only",
+      "runnable": true,
+      "example": "  # Detect the sticky-keys backdoor only\n  brutus stickykeys --target 10.0.0.50:3389\n\n  # Vision API confirmation (more accurate)\n  brutus stickykeys --target 10.0.0.50:3389 --experimental-ai",
+      "flags": [
+        {
+          "name": "connect-timeout",
+          "type": "duration",
+          "default": "3s",
+          "usage": "TCP connect timeout for scan dials (separate from --scan-timeout, which is the per-host settle deadline). A reachable host completes the handshake in ~1 RTT, so the short default only accelerates dead-host rejection; raise it for high-latency target sets."
+        },
+        {
+          "name": "exec",
+          "type": "string",
+          "usage": "Execute command via detected backdoor"
+        },
+        {
+          "name": "experimental-ai",
+          "type": "bool",
+          "default": "false",
+          "usage": "Enable Vision API for backdoor confirmation"
+        },
+        {
+          "name": "fast",
+          "type": "bool",
+          "default": "false",
+          "usage": "fast triage: shorter settle budget for internet-scale sweeps; reports HIGH/CRITICAL or indeterminate, never clean (rerun indeterminates without --fast for a careful verdict)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "masscan-file",
+          "type": "string",
+          "usage": "Masscan JSON file (-oJ output) to import targets from"
+        },
+        {
+          "name": "mode",
+          "shorthand": "m",
+          "type": "string",
+          "default": "default",
+          "usage": "Aggressiveness tier: cautious, default, aggressive"
+        },
+        {
+          "name": "nmap-file",
+          "type": "string",
+          "usage": "Nmap XML file (-oX output) to import targets from"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "no-nla-probe",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable the pre-WASM RDP negotiation probe (always run the full WASM session)"
+        },
+        {
+          "name": "open",
+          "type": "bool",
+          "default": "false",
+          "usage": "Auto-open browser when web terminal starts"
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "retries",
+          "type": "int",
+          "default": "2",
+          "usage": "Max retries on connection error (0 = disabled)"
+        },
+        {
+          "name": "scan-timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-host settle/scan deadline (post-connect): how long to watch the logon screen after the trigger before deciding. Distinct from --connect-timeout (the TCP dial timeout)."
+        },
+        {
+          "name": "target",
+          "type": "string",
+          "usage": "Target host:port"
+        },
+        {
+          "name": "targets-file",
+          "type": "string",
+          "usage": "File of targets to test, one host:port per line (fingerprints with Nerva unless --protocol is set)"
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true,
+          "rejected": true,
+          "rejectedReason": "--timeout is not valid here; use --scan-timeout (settle deadline) and/or --connect-timeout (TCP connect)"
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        },
+        {
+          "name": "web",
+          "type": "bool",
+          "default": "false",
+          "usage": "Start interactive web terminal via detected backdoor"
+        }
+      ]
+    },
+    {
+      "path": "brutus utilman",
+      "use": "utilman",
+      "short": "Detect the Windows utilman (Ease of Access) logon backdoor only",
+      "runnable": true,
+      "example": "  # Detect the utilman backdoor only\n  brutus utilman --target 10.0.0.50:3389\n\n  # Vision API confirmation (more accurate)\n  brutus utilman --target 10.0.0.50:3389 --experimental-ai",
+      "flags": [
+        {
+          "name": "connect-timeout",
+          "type": "duration",
+          "default": "3s",
+          "usage": "TCP connect timeout for scan dials (separate from --scan-timeout, which is the per-host settle deadline). A reachable host completes the handshake in ~1 RTT, so the short default only accelerates dead-host rejection; raise it for high-latency target sets."
+        },
+        {
+          "name": "exec",
+          "type": "string",
+          "usage": "Execute command via detected backdoor"
+        },
+        {
+          "name": "experimental-ai",
+          "type": "bool",
+          "default": "false",
+          "usage": "Enable Vision API for backdoor confirmation"
+        },
+        {
+          "name": "fast",
+          "type": "bool",
+          "default": "false",
+          "usage": "fast triage: shorter settle budget for internet-scale sweeps; reports HIGH/CRITICAL or indeterminate, never clean (rerun indeterminates without --fast for a careful verdict)"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "masscan-file",
+          "type": "string",
+          "usage": "Masscan JSON file (-oJ output) to import targets from"
+        },
+        {
+          "name": "mode",
+          "shorthand": "m",
+          "type": "string",
+          "default": "default",
+          "usage": "Aggressiveness tier: cautious, default, aggressive"
+        },
+        {
+          "name": "nmap-file",
+          "type": "string",
+          "usage": "Nmap XML file (-oX output) to import targets from"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "no-nla-probe",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable the pre-WASM RDP negotiation probe (always run the full WASM session)"
+        },
+        {
+          "name": "open",
+          "type": "bool",
+          "default": "false",
+          "usage": "Auto-open browser when web terminal starts"
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "retries",
+          "type": "int",
+          "default": "2",
+          "usage": "Max retries on connection error (0 = disabled)"
+        },
+        {
+          "name": "scan-timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-host settle/scan deadline (post-connect): how long to watch the logon screen after the trigger before deciding. Distinct from --connect-timeout (the TCP dial timeout)."
+        },
+        {
+          "name": "target",
+          "type": "string",
+          "usage": "Target host:port"
+        },
+        {
+          "name": "targets-file",
+          "type": "string",
+          "usage": "File of targets to test, one host:port per line (fingerprints with Nerva unless --protocol is set)"
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true,
+          "rejected": true,
+          "rejectedReason": "--timeout is not valid here; use --scan-timeout (settle deadline) and/or --connect-timeout (TCP connect)"
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        },
+        {
+          "name": "web",
+          "type": "bool",
+          "default": "false",
+          "usage": "Start interactive web terminal via detected backdoor"
+        }
+      ]
+    },
+    {
+      "path": "brutus web",
+      "use": "web",
+      "short": "Audit HTTP/web panel credentials (AI-powered or credential list)",
+      "aliases": [
+        "http",
+        "panels"
+      ],
+      "runnable": true,
+      "example": "  # AI-powered credential detection (recommended)\n  brutus web --target 192.168.1.1:80 --experimental-ai\n\n  # Pipeline mode with Nerva JSON\n  naabu -host 192.168.1.0/24 -p 80,443,8080 -silent | nerva --json | brutus web --experimental-ai\n\n  # Manual credential list\n  brutus web --target 192.168.1.1:80 -c \"admin:admin,root:toor\"\n  brutus web --target 192.168.1.1:80 -C creds.txt\n\n  # HTTPS target\n  brutus web --target 192.168.1.1:443 --https --experimental-ai\n\n  # Browser with visible window (demo mode)\n  brutus web --target 192.168.1.1:8080 --experimental-ai --browser-visible\n\n  # Import targets from nmap XML scan\n  brutus web --nmap-file scan.xml --experimental-ai",
+      "flags": [
+        {
+          "name": "browser-tabs",
+          "type": "int",
+          "default": "3",
+          "usage": "Number of concurrent browser tabs"
+        },
+        {
+          "name": "browser-timeout",
+          "type": "duration",
+          "default": "1m0s",
+          "usage": "Total timeout for browser operations"
+        },
+        {
+          "name": "browser-visible",
+          "type": "bool",
+          "default": "false",
+          "usage": "Show browser window (demo mode)"
+        },
+        {
+          "name": "connect-timeout",
+          "type": "duration",
+          "default": "3s",
+          "usage": "TCP connect timeout for scan dials (separate from --scan-timeout, which is the per-host settle deadline). A reachable host completes the handshake in ~1 RTT, so the short default only accelerates dead-host rejection; raise it for high-latency target sets."
+        },
+        {
+          "name": "credentials",
+          "shorthand": "c",
+          "type": "string",
+          "usage": "Comma-separated user:pass pairs (e.g., admin:admin,root:toor)"
+        },
+        {
+          "name": "credentials-file",
+          "shorthand": "C",
+          "type": "string",
+          "usage": "Credentials file (user:pass per line)"
+        },
+        {
+          "name": "experimental-ai",
+          "type": "bool",
+          "default": "false",
+          "usage": "Enable AI-powered credential detection and Vision verification"
+        },
+        {
+          "name": "https",
+          "type": "bool",
+          "default": "false",
+          "usage": "Use HTTPS for browser connections"
+        },
+        {
+          "name": "jitter",
+          "type": "duration",
+          "default": "0s",
+          "usage": "Random delay variance for rate limiting",
+          "inherited": true
+        },
+        {
+          "name": "json",
+          "type": "bool",
+          "default": "false",
+          "usage": "JSON output format",
+          "inherited": true
+        },
+        {
+          "name": "masscan-file",
+          "type": "string",
+          "usage": "Masscan JSON file (-oJ output) to import targets from"
+        },
+        {
+          "name": "mode",
+          "shorthand": "m",
+          "type": "string",
+          "default": "default",
+          "usage": "Aggressiveness tier: cautious, default, aggressive"
+        },
+        {
+          "name": "nmap-file",
+          "type": "string",
+          "usage": "Nmap XML file (-oX output) to import targets from"
+        },
+        {
+          "name": "no-color",
+          "type": "bool",
+          "default": "false",
+          "usage": "Disable colored output",
+          "inherited": true
+        },
+        {
+          "name": "output",
+          "shorthand": "o",
+          "type": "string",
+          "usage": "Output file for JSON results (implies --json)",
+          "inherited": true
+        },
+        {
+          "name": "protocol",
+          "type": "string",
+          "usage": "Protocol override (http or https)"
+        },
+        {
+          "name": "proxy",
+          "type": "string",
+          "usage": "Proxy URL. HTTP enum sources accept http, https, socks5, socks5h (a bare host:port defaults to http, like curl); raw-TCP scan plugins support socks5/socks5h only. Examples: --proxy http://host:8080, --proxy socks5://127.0.0.1:1080",
+          "inherited": true
+        },
+        {
+          "name": "proxy-user",
+          "type": "string",
+          "usage": "Proxy credentials as user:pass (curl-style); takes precedence over credentials embedded in --proxy. Note: visible in process args/shell history.",
+          "inherited": true
+        },
+        {
+          "name": "quiet",
+          "shorthand": "q",
+          "type": "bool",
+          "default": "false",
+          "usage": "Quiet mode - only show successful credentials",
+          "inherited": true
+        },
+        {
+          "name": "rate-limit",
+          "type": "float64",
+          "default": "0",
+          "usage": "Max requests per second (0 = unlimited)",
+          "inherited": true
+        },
+        {
+          "name": "retries",
+          "type": "int",
+          "default": "2",
+          "usage": "Max retries on connection error (0 = disabled)"
+        },
+        {
+          "name": "target",
+          "type": "string",
+          "usage": "Target host:port"
+        },
+        {
+          "name": "targets-file",
+          "type": "string",
+          "usage": "File of targets to test, one host:port per line (fingerprints with Nerva unless --protocol is set)"
+        },
+        {
+          "name": "threads",
+          "shorthand": "t",
+          "type": "int",
+          "default": "10",
+          "usage": "Number of concurrent threads",
+          "inherited": true
+        },
+        {
+          "name": "timeout",
+          "type": "duration",
+          "default": "10s",
+          "usage": "Per-target timeout",
+          "inherited": true
+        },
+        {
+          "name": "verbose",
+          "shorthand": "v",
+          "type": "bool",
+          "default": "false",
+          "usage": "Verbose mode - show detailed progress to stderr",
+          "inherited": true
+        },
+        {
+          "name": "verify",
+          "type": "bool",
+          "default": "false",
+          "usage": "Require strict TLS certificate verification"
+        }
+      ]
+    }
+  ]
+}

--- a/internal/plugins/rdp/detect.go
+++ b/internal/plugins/rdp/detect.go
@@ -307,8 +307,9 @@ func (p *Plugin) runStickyKeysDetection(ctx context.Context, inst *wasmInstance,
 		dumpFrame(dir, addr, "sticky_keys", "response", response, width, height)
 	}
 
-	// Vision API confirmation is optional: requires ANTHROPIC_API_KEY and
-	// can be disabled with --no-vision flag.
+	// Vision API confirmation is optional: it requires ANTHROPIC_API_KEY and is
+	// opted into with --experimental-ai, which is where noVision comes from
+	// (see workers.go: NoVision is !AIMode).
 	var visionAPIKey string
 	if !noVision {
 		visionAPIKey = os.Getenv("ANTHROPIC_API_KEY")
@@ -371,8 +372,9 @@ func (p *Plugin) runUtilmanDetection(ctx context.Context, inst *wasmInstance, ad
 		dumpFrame(dir, addr, "utilman", "response", response, width, height)
 	}
 
-	// Vision API confirmation is optional: requires ANTHROPIC_API_KEY and
-	// can be disabled with --no-vision flag.
+	// Vision API confirmation is optional: it requires ANTHROPIC_API_KEY and is
+	// opted into with --experimental-ai, which is where noVision comes from
+	// (see workers.go: NoVision is !AIMode).
 	var visionAPIKey string
 	if !noVision {
 		visionAPIKey = os.Getenv("ANTHROPIC_API_KEY")

--- a/pkg/brutus/brutus.go
+++ b/pkg/brutus/brutus.go
@@ -135,7 +135,7 @@ type Result struct {
 	LLMSuggested      bool     // was this credential suggested by LLM?
 	LLMSuggestedCreds []string // all LLM suggestions for this service
 
-	// Scan metadata (optional, used in --scan mode for backdoor detection)
+	// Scan metadata (optional, used by the logon-family scans for backdoor detection)
 	ScanType string // scan type identifier (e.g., "sticky_keys", "utilman")
 }
 


### PR DESCRIPTION
Part 5 of 6, and the first PR that changes anything a contributor notices.

**~6.1k of this diff is the two generated files** (`docs/cli-surface.json`, `docs/CLI.md`). The hand-written part is ~290 lines: the gate test, the Makefile target, the allowlist, and comment fixes.

The gate is a **test**, not a subcommand, because `cmd/brutus` is `package main` — the tree can't be reached from a separate generator binary, and a `brutus docs` subcommand would have had to document itself.

**Review focus: what turning it on found.**

- README claimed "six focused subcommands"; cobra registers **eight**.
- README gave `logon` six aliases (`stickykeys`, `sticky-keys`, `utilman`, `sethc`, `winlogon`, `accessibility`) when it declares **none** — `logon_subcommand_wiring_test.go` already asserts `sticky-keys` resolves to nothing.
- Stale comment flags: `--sticky-keys-exec`/`--sticky-keys-web` (the two the ticket named), plus `--nerva` and `--scan`, which it didn't.
- `internal/plugins/rdp/detect.go`: two comments saying Vision confirmation "can be disabled with `--no-vision`" — that opt-out had become the opt-in `--experimental-ai`. Flag gone **and** polarity inverted, so a reader got the opposite of the truth.

`TestCLISurfaceGateDetectsRename` proves the gate reddens. `make cli-docs` is the single regeneration command.

## Review stack (ENG-6871)

Split out of #331 so each layer can be read on its own. Review **in order**; each targets the one before it.

| # | PR | Scope |
|---|---|---|
| 1 | #338 | Walk the cobra tree into a comparable surface |
| 2 | #339 | Render a surface, and diff two of them |
| 3 | #340 | Lint documents and Go comments against a surface |
| 4 | #341 | Repo-level artifact and lint plumbing |
| 5 | #342 | Turn on the gate, commit the generated artifacts |
| 6 | #343 | Run it in CI, ship the artifact |

Every stage compiles and passes `go test -short ./...`, `golangci-lint run ./...` (`0 issues.`) and `gofmt` **on its own**. The tip of the stack is byte-identical to #331 as reviewed.
