### PR TITLE
ci: run the drift gate on pull requests and ship the artifact (ENG-6871, 6/6)

### DIFF
--- a/.github/workflows/cli-surface.yml
+++ b/.github/workflows/cli-surface.yml
@@ -1,0 +1,70 @@
+name: CLI Surface Drift
+
+# Fails CI when the documented brutus CLI surface no longer matches what cobra
+# registers, in either direction: a documented flag or subcommand that no longer
+# exists, or a registered one that is not documented.
+#
+# Deliberately carries NO `paths:` filter. Documentation drift usually arrives as
+# a markdown-only change, and `ci.yml` filters on '**/*.go', go.mod, go.sum,
+# '.golangci*' and 'Makefile' — so a README-only pull request runs no CI at all
+# today. This gate has to fire on every pull request to be worth anything.
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  cli-surface:
+    name: CLI Surface Drift
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      # The surface is walked out of the live cobra tree, which lives in
+      # `package main`, so the gate is a test in that package rather than a
+      # separate generator binary. `make cli-docs` is the regeneration path the
+      # failure message points contributors at.
+      # `go test -run` exits 0 when the pattern matches no tests, so renaming these
+      # away from the TestCLISurface prefix would turn the gate green with no drift
+      # protection at all. Assert by name that each one actually ran.
+      - name: Check CLI surface and documentation for drift
+        run: |
+          set -o pipefail
+          go test ./cmd/brutus -run 'TestCLISurface' -count=1 -v | tee gate.log
+          for name in TestCLISurface TestCLISurfaceDocLint TestCLISurfaceGateDetectsRename; do
+            if ! grep -qE "^--- PASS: ${name} " gate.log; then
+              echo "::error::${name} did not run. The drift gate is not executing; check the -run pattern against the test names in cmd/brutus/cli_surface_test.go."
+              exit 1
+            fi
+          done
+          rm -f gate.log
+
+      # Safety net: the gate above compares in memory and must never write. If it
+      # did, a stale golden could be silently "fixed" in CI and pass.
+      - name: Verify the gate did not rewrite the goldens
+        run: |
+          if ! git diff --quiet -- docs/ README.md; then
+            echo "::error::The drift gate modified tracked documentation. It must compare without writing; run 'make cli-docs' locally instead."
+            git --no-pager diff -- docs/ README.md
+            exit 1
+          fi
+
+      - name: Verify library unit tests
+        run: go test ./internal/clisurface/... -race -count=1

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -141,6 +141,11 @@ release:
   draft: false
   prerelease: auto
   name_template: "Brutus {{ .Tag }}"
+  # Attach the machine-readable CLI surface to every release so downstream
+  # consumers (e.g. the guard-skills drift gate) can pin the exact surface a
+  # given brutus version registered, rather than scraping prose.
+  extra_files:
+    - glob: docs/cli-surface.json
   header: |
     ## Installation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Thank you for your interest in contributing to Brutus! This document provides gu
 - [Getting Started](#getting-started)
 - [Development Setup](#development-setup)
 - [Making Changes](#making-changes)
+- [Changing the CLI Surface](#changing-the-cli-surface)
 - [Adding a New Protocol](#adding-a-new-protocol)
 - [Testing](#testing)
 - [Pull Request Process](#pull-request-process)
@@ -117,6 +118,45 @@ test(ftp): add integration tests
 - One logical change per commit
 - Keep commits small and reviewable
 - Squash WIP commits before submitting PR
+
+## Changing the CLI Surface
+
+The documented CLI surface is **generated from the live cobra command tree**, not
+maintained by hand. Three files are generated:
+
+| File | Purpose |
+|------|---------|
+| `docs/cli-surface.json` | Machine-readable surface. Downstream consumers pin this; it is attached to every GitHub release. |
+| `docs/CLI.md` | Full human-readable reference: every command, alias and flag. |
+| `README.md` | Two generated regions in Quick Start, delimited by `<!-- BEGIN generated: ... -->` markers. |
+
+If you add, remove or rename a command or a flag, regenerate them:
+
+```bash
+make cli-docs
+```
+
+Then commit the result alongside your code change.
+
+The `CLI Surface Drift` workflow runs the same walk in check mode on every pull
+request and fails when the committed copies disagree with what cobra registers,
+in either direction:
+
+- a **documented** flag or subcommand that no longer exists, or
+- a **registered** flag or subcommand that is not documented.
+
+It also lints prose. Every `brutus` invocation inside a fenced code block, every
+backticked flag name in prose, and every flag name mentioned in a Go comment
+under `cmd/`, `internal/` and `pkg/` is checked against the real surface. A flag that was
+renamed cannot survive in a comment or an example.
+
+If a document must deliberately name a flag that no longer exists — for example
+when describing a historical rename — add it to `docs/cli-surface-allow.txt`
+with a comment explaining why.
+
+Do not edit the generated files or the generated README regions by hand; the next
+`make cli-docs` will overwrite them, and the gate will reject the difference in
+the meantime.
 
 ## Adding a New Protocol
 
@@ -419,6 +459,12 @@ golangci-lint run
    ```bash
    go test -short ./...
    golangci-lint run
+   ```
+
+   If you touched a command or a flag, also regenerate the CLI documentation
+   (see [Changing the CLI Surface](#changing-the-cli-surface)):
+   ```bash
+   make cli-docs
    ```
 
 3. **Update documentation** if needed


### PR DESCRIPTION
Part 6 of 6.

**Review focus: why this is a separate workflow rather than a step in `ci.yml`.** `cli-surface.yml` carries **no `paths:` filter**, deliberately. Drift usually arrives as a markdown-only change, and `ci.yml` filters on `**/*.go`, `go.mod`, `go.sum`, `.golangci*` and `Makefile` — so a README-only PR runs no CI at all today. A gate a README-only change could skip would not have caught the drift that motivated it.

It also verifies the gate didn't rewrite the goldens: the gate compares in memory and must never write, or a stale golden could be silently "fixed" in CI and pass.

goreleaser attaches `docs/cli-surface.json` to every release, which is what ENG-6872's guard-skills check consumes ([guard-skills#1119](https://github.com/praetorian-inc/guard-skills/pull/1119)).

## Review stack (ENG-6871)

Split out of #331 so each layer can be read on its own. Review **in order**; each targets the one before it.

| # | PR | Scope |
|---|---|---|
| 1 | #338 | Walk the cobra tree into a comparable surface |
| 2 | #339 | Render a surface, and diff two of them |
| 3 | #340 | Lint documents and Go comments against a surface |
| 4 | #341 | Repo-level artifact and lint plumbing |
| 5 | #342 | Turn on the gate, commit the generated artifacts |
| 6 | #343 | Run it in CI, ship the artifact |

Every stage compiles and passes `go test -short ./...`, `golangci-lint run ./...` (`0 issues.`) and `gofmt` **on its own**. The tip of the stack is byte-identical to #331 as reviewed.
