### PR TITLE
fix(rdp): never score a torn-down session's framebuffer

### DIFF
--- a/internal/plugins/rdp/analyze.go
+++ b/internal/plugins/rdp/analyze.go
@@ -521,6 +521,16 @@ func runStickyKeysAnalysis(ctx context.Context, baseline, response []byte,
 
 	result := StickyKeysResult{Performed: true}
 
+	// A real screen that went flat is not an observation: the surface was torn down
+	// or never painted, so there is nothing to score. Reject it before any heuristic
+	// runs so it can never become a positive (see isUniformFrame). Both frames flat
+	// is NOT this case -- that is a genuine "nothing changed", which scores clean.
+	if isUniformFrame(response) && !isUniformFrame(baseline) {
+		result.OverallVerdict = verdictIndeterminate
+		result.HeuristicResult = "response framebuffer is a single flat color (no render observed)"
+		return result
+	}
+
 	// Step 1: Primary heuristic — dark-pixel-delta discriminator. The changed-pixels
 	// description is kept for the diagnostic banner; the VERDICT comes from darkDeltaVerdict.
 	verdict := darkDeltaVerdict(baseline, response, width, height)
@@ -581,6 +591,16 @@ func runUtilmanAnalysis(ctx context.Context, baseline, response []byte,
 
 	result := UtilmanResult{Performed: true}
 
+	// A real screen that went flat is not an observation: the surface was torn down
+	// or never painted, so there is nothing to score. Reject it before any heuristic
+	// runs so it can never become a positive (see isUniformFrame). Both frames flat
+	// is NOT this case -- that is a genuine "nothing changed", which scores clean.
+	if isUniformFrame(response) && !isUniformFrame(baseline) {
+		result.OverallVerdict = verdictIndeterminate
+		result.HeuristicResult = "response framebuffer is a single flat color (no render observed)"
+		return result
+	}
+
 	// Step 1: Primary heuristic — dark-pixel-delta discriminator. The changed-pixels
 	// description is kept for the diagnostic banner; the VERDICT comes from darkDeltaVerdict.
 	verdict := darkDeltaVerdict(baseline, response, width, height)
@@ -631,4 +651,34 @@ func runUtilmanAnalysis(ctx context.Context, baseline, response []byte,
 	result.OverallVerdict = decideVerdict(verdict, keepHigh)
 	result.Confidence, result.RegionNote = regionConfidenceAndNote(result.OverallVerdict, region, confidence)
 	return result
+}
+
+// isUniformFrame reports whether every pixel in an RGBA framebuffer carries the
+// SAME color, i.e. the surface is one flat field.
+//
+// Such a frame is never a window. It is what an RDP surface looks like before it
+// has painted or after the session has been torn down (a terminated IronRDP
+// ActiveStage hands back a zeroed DecodedImage). Scored as evidence, an all-black
+// frame differenced against a logon wallpaper that is already ~60% dark changes
+// ~39% of pixels -- inside the 2-80% window-sized band, not caught by the
+// full-screen-change guard -- forms one large contiguous rectangle, and passes
+// every console gate (mean brightness 0, darkBoxFraction 1.0), producing a
+// maximum-confidence "backdoor likely" on a host where no key was pressed.
+//
+// The test is EXACT color equality rather than "mostly dark" on purpose: a real
+// console always carries text, a cursor, or a border, so it can never be uniform,
+// which keeps the guard from suppressing a genuine finding (cardinal rule). Callers
+// gate on a flat RESPONSE against a non-flat BASELINE -- a real screen that went
+// flat. Two flat frames are a genuine "nothing changed" and stay clean.
+func isUniformFrame(buf []byte) bool {
+	if len(buf) < 8 {
+		return true // no pixels (or a single pixel) carries no evidence either
+	}
+	r, g, b := buf[0], buf[1], buf[2]
+	for i := 4; i+2 < len(buf); i += 4 {
+		if buf[i] != r || buf[i+1] != g || buf[i+2] != b {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/plugins/rdp/blackframe_test.go
+++ b/internal/plugins/rdp/blackframe_test.go
@@ -277,3 +277,150 @@ func TestTerminationBannerReachesTheOperator(t *testing.T) {
 		assert.Contains(t, got.Banner, "render did not stabilize")
 	})
 }
+
+// TestFinalizeResultKeepsTerminationDiagnostics is the regression test for the
+// ordering trap that shipped broken: the analysis functions return a FRESH result, so
+// a `*result = analysis` assignment discards anything set beforehand. When that
+// happened, SessionTerminated silently went false, the short-profile retry never
+// fired, and the banner fell back to "render did not stabilize" -- invisibly, because
+// the scan itself still succeeded. This exercises the real production tail, not a
+// mirror of it: reorder the assignments in finalize*Result and this fails.
+func TestFinalizeResultKeepsTerminationDiagnostics(t *testing.T) {
+	const reason = "session terminated: logoff by user"
+	diag := sessionDiag{terminated: true, reason: reason}
+
+	t.Run("sticky keys", func(t *testing.T) {
+		result := &StickyKeysResult{Performed: true}
+		// A torn-down session analyzes the baseline as the response -> "clean".
+		finalizeStickyKeysResult(result, StickyKeysResult{Performed: true, OverallVerdict: "clean"}, diag, false, false)
+
+		assert.True(t, result.SessionTerminated,
+			"the retry in DetectStickyKeys reads this field; zeroed, the retry never fires")
+		assert.Equal(t, reason, result.TerminationReason,
+			"the banner names the server's own reason; zeroed, the operator is told to rerun an identical scan")
+		assert.Equal(t, verdictIndeterminate, result.OverallVerdict,
+			"a clean on an unstable render is still downgraded (cardinal guard must survive the refactor)")
+		assert.False(t, result.Stabilized)
+		assert.True(t, result.Performed)
+	})
+
+	t.Run("utilman", func(t *testing.T) {
+		result := &UtilmanResult{Performed: true}
+		finalizeUtilmanResult(result, UtilmanResult{Performed: true, OverallVerdict: "clean"}, diag, false, false)
+
+		assert.True(t, result.SessionTerminated)
+		assert.Equal(t, reason, result.TerminationReason)
+		assert.Equal(t, verdictIndeterminate, result.OverallVerdict)
+	})
+
+	t.Run("a positive survives a terminated session", func(t *testing.T) {
+		// The painted-then-dropped host: a real finding carried out alongside
+		// terminated=true. It must reach the caller intact, because that pairing is
+		// exactly what retryAfterTermination has to see to refuse the retry.
+		result := &StickyKeysResult{Performed: true}
+		finalizeStickyKeysResult(result, StickyKeysResult{
+			Performed: true, OverallVerdict: "backdoor_likely", Confidence: 0.85,
+		}, diag, false, false)
+
+		assert.Equal(t, "backdoor_likely", result.OverallVerdict,
+			"a positive is never downgraded by the stabilized guard")
+		assert.True(t, result.SessionTerminated)
+		assert.False(t, retryAfterTermination(result.OverallVerdict, result.Performed),
+			"the retry must refuse to overwrite this finding")
+	})
+
+	t.Run("analysis fields are not dropped", func(t *testing.T) {
+		result := &StickyKeysResult{}
+		finalizeStickyKeysResult(result, StickyKeysResult{
+			Performed: true, OverallVerdict: "backdoor_confirmed",
+			Confidence: 0.95, HeuristicResult: "dark delta", RegionNote: "console-shaped",
+		}, sessionDiag{}, true, false)
+
+		assert.Equal(t, "backdoor_confirmed", result.OverallVerdict)
+		assert.InDelta(t, 0.95, result.Confidence, 1e-9)
+		assert.Equal(t, "dark delta", result.HeuristicResult)
+		assert.Equal(t, "console-shaped", result.RegionNote)
+		assert.False(t, result.SessionTerminated)
+		assert.Empty(t, result.TerminationReason)
+	})
+}
+
+// TestRetryOnTerminationWiring covers the retry DECISION as it is actually wired,
+// not just the predicate behind it. The predicate was correct and the call site was
+// what broke before, so this asserts the observable behaviour: whether the rerun
+// happens at all, and which result reaches the caller.
+func TestRetryOnTerminationWiring(t *testing.T) {
+	const reason = "session terminated: logoff by user"
+	terminatedClean := func() *StickyKeysResult {
+		return &StickyKeysResult{Performed: true, OverallVerdict: verdictIndeterminate,
+			SessionTerminated: true, TerminationReason: reason}
+	}
+
+	t.Run("reruns an indeterminate teardown on the short profile", func(t *testing.T) {
+		calls := 0
+		second := &StickyKeysResult{Performed: true, OverallVerdict: "backdoor_likely"}
+		got := retryStickyKeysOnTermination(false, terminatedClean(), func() *StickyKeysResult {
+			calls++
+			return second
+		})
+		assert.Equal(t, 1, calls, "a scan that observed no render must be retried")
+		assert.Same(t, second, got)
+	})
+
+	t.Run("never overwrites a finding", func(t *testing.T) {
+		for _, verdict := range []string{"backdoor_confirmed", "backdoor_likely", "vulnerable"} {
+			first := &StickyKeysResult{Performed: true, OverallVerdict: verdict,
+				SessionTerminated: true, TerminationReason: reason}
+			calls := 0
+			got := retryStickyKeysOnTermination(false, first, func() *StickyKeysResult {
+				calls++
+				return &StickyKeysResult{Performed: true, OverallVerdict: verdictIndeterminate}
+			})
+			assert.Zero(t, calls, "%s: retrying can only lose the finding (cardinal rule)", verdict)
+			assert.Same(t, first, got)
+		}
+	})
+
+	t.Run("does not fire without a teardown", func(t *testing.T) {
+		first := &StickyKeysResult{Performed: true, OverallVerdict: verdictIndeterminate}
+		calls := 0
+		got := retryStickyKeysOnTermination(false, first, func() *StickyKeysResult {
+			calls++
+			return nil
+		})
+		assert.Zero(t, calls, "a plain unstable render has no shorter profile to gain from")
+		assert.Same(t, first, got)
+	})
+
+	t.Run("does not fire in fast mode", func(t *testing.T) {
+		calls := 0
+		got := retryStickyKeysOnTermination(true, terminatedClean(), func() *StickyKeysResult {
+			calls++
+			return nil
+		})
+		assert.Zero(t, calls, "--fast is already the short profile; there is nothing to fall back to")
+		assert.True(t, got.SessionTerminated)
+	})
+
+	t.Run("tolerates a nil result", func(t *testing.T) {
+		calls := 0
+		got := retryStickyKeysOnTermination(false, nil, func() *StickyKeysResult { calls++; return nil })
+		assert.Zero(t, calls)
+		assert.Nil(t, got)
+	})
+
+	t.Run("utilman is wired the same way", func(t *testing.T) {
+		calls := 0
+		first := &UtilmanResult{Performed: true, OverallVerdict: verdictIndeterminate, SessionTerminated: true}
+		second := &UtilmanResult{Performed: true, OverallVerdict: "clean"}
+		got := retryUtilmanOnTermination(false, first, func() *UtilmanResult { calls++; return second })
+		assert.Equal(t, 1, calls)
+		assert.Same(t, second, got)
+
+		calls = 0
+		positive := &UtilmanResult{Performed: true, OverallVerdict: "backdoor_likely", SessionTerminated: true}
+		got = retryUtilmanOnTermination(false, positive, func() *UtilmanResult { calls++; return second })
+		assert.Zero(t, calls)
+		assert.Same(t, positive, got)
+	})
+}

--- a/internal/plugins/rdp/blackframe_test.go
+++ b/internal/plugins/rdp/blackframe_test.go
@@ -193,3 +193,87 @@ func TestIndeterminateBanner(t *testing.T) {
 	assert.Contains(t, noReason, "server ended the session mid-scan")
 	assert.Contains(t, noReason, "--fast")
 }
+
+// TestRetryAfterTermination pins the retry gate. A terminated session whose scan
+// still REPORTED something (responseFrame analyzes the last live frame, so a payload
+// that painted and only then dropped the session scores a genuine positive) must not
+// be re-run: the second scan can come back indeterminate and would replace a real
+// backdoor with nothing -- the false negative the cardinal rule forbids.
+func TestRetryAfterTermination(t *testing.T) {
+	for _, tc := range []struct {
+		verdict   string
+		performed bool
+		want      bool
+		why       string
+	}{
+		{"backdoor_confirmed", true, false, "a confirmed backdoor is never re-rolled"},
+		{"backdoor_likely", true, false, "a HIGH finding is never re-rolled"},
+		{"vulnerable", true, false, "the non-NLA reading is a real observation too"},
+		{verdictIndeterminate, true, true, "nothing was observed, so a retry can only improve it"},
+		{"clean", true, true, "a clean from a torn-down session saw no post-trigger render"},
+		{"", false, true, "a scan that never performed has nothing to lose"},
+		{"backdoor_likely", false, true, "a verdict without Performed is not an observation"},
+	} {
+		assert.Equal(t, tc.want, retryAfterTermination(tc.verdict, tc.performed),
+			"%s/performed=%v: %s", tc.verdict, tc.performed, tc.why)
+	}
+}
+
+// TestTerminationBannerReachesTheOperator covers every banner seam that consumes
+// SessionTerminated, including the !Performed path, where "could not connect"
+// misdirects an operator whose connect worked and whose session was torn down after.
+func TestTerminationBannerReachesTheOperator(t *testing.T) {
+	const reason = "session terminated: logoff by user"
+
+	t.Run("sticky indeterminate", func(t *testing.T) {
+		got := mapStickyResult(&StickyKeysResult{
+			Performed: true, OverallVerdict: verdictIndeterminate,
+			SessionTerminated: true, TerminationReason: reason,
+		}, "")
+		assert.True(t, got.Indeterminate)
+		assert.Contains(t, got.Banner, "server ended the session mid-scan")
+		assert.Contains(t, got.Banner, reason)
+	})
+
+	t.Run("sticky not performed", func(t *testing.T) {
+		got := mapStickyResult(&StickyKeysResult{
+			Performed: false, SkipReason: "session failed: pump baseline: session error",
+			SessionTerminated: true, TerminationReason: reason,
+		}, "")
+		assert.True(t, got.Indeterminate)
+		assert.Contains(t, got.Banner, "server ended the session mid-scan")
+		assert.NotContains(t, got.Banner, "could not connect",
+			"a mid-scan teardown is not a failed connect")
+	})
+
+	t.Run("utilman indeterminate", func(t *testing.T) {
+		got := mapUtilmanResult(&UtilmanResult{
+			Performed: true, OverallVerdict: verdictIndeterminate,
+			SessionTerminated: true, TerminationReason: reason,
+		}, "")
+		assert.Contains(t, got.Banner, "server ended the session mid-scan")
+		assert.Contains(t, got.Banner, reason)
+	})
+
+	t.Run("shared rdp path carries the reason too", func(t *testing.T) {
+		sticky := formatStickyKeysBanner("", &StickyKeysResult{
+			Performed: true, OverallVerdict: verdictIndeterminate,
+			SessionTerminated: true, TerminationReason: reason,
+		})
+		assert.Contains(t, sticky, reason,
+			"the shared `brutus rdp` path must not fall back to the generic banner")
+
+		utilman := formatUtilmanBanner("", &UtilmanResult{
+			Performed: true, OverallVerdict: verdictIndeterminate,
+			SessionTerminated: true, TerminationReason: reason,
+		})
+		assert.Contains(t, utilman, reason)
+	})
+
+	t.Run("a non-terminated indeterminate keeps the original text", func(t *testing.T) {
+		got := mapStickyResult(&StickyKeysResult{
+			Performed: true, OverallVerdict: verdictIndeterminate,
+		}, "")
+		assert.Contains(t, got.Banner, "render did not stabilize")
+	})
+}

--- a/internal/plugins/rdp/blackframe_test.go
+++ b/internal/plugins/rdp/blackframe_test.go
@@ -1,0 +1,195 @@
+// Copyright 2026 Praetorian Security, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rdp
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file is the regression suite for the torn-down-session false positive.
+//
+// Observed in the field against a Windows host whose logon screen used the default
+// Windows 10 "cave" wallpaper: the server dropped the pre-auth RDP session a few
+// seconds in, sooner than the careful settle profile needs. pumpSession returned a
+// session error, the caller discarded it, and captureFrame was then called on the
+// dead session -- session_get_frame returns image.data() unconditionally
+// (rust/src/session.rs), so a terminated ActiveStage hands back a perfectly black
+// 1024x768 frame that looks like a successful capture.
+//
+// Differenced against a wallpaper that is already ~61% dark, that black frame:
+//   - changes only ~39% of pixels, so it slips past maxChangedPercent's 80%
+//     "full-screen change, not a window" guard,
+//   - leaves the changed pixels (the bright part of the wallpaper) as one large
+//     contiguous rectangle, so detectChangedRectangle scores it window-shaped,
+//   - saturates the confidence formula at its 0.85 cap, and
+//   - passes consoleGatePasses on every arm (mean brightness 0 <= 90, large area,
+//     darkBoxFraction 1.0 >= 0.70).
+//
+// Result: "[HIGH] Sticky keys backdoor likely (confidence: 85%)" against a host
+// where the trigger keystrokes were never even sent. The host was later confirmed
+// clean -- with a short settle budget the same host renders the stock Windows
+// "Do you want to turn on Sticky Keys?" dialog and the stock Ease of Access panel.
+
+// darkWallpaperBaseline builds a baseline with the property that made the real
+// wallpaper dangerous: most of it is ALREADY dark, so blanking the screen to black
+// changes only a minority of pixels and never trips the full-screen-change guard.
+// darkFrac of the rows are near-black; the rest are bright.
+func darkWallpaperBaseline(w, h uint32, darkFrac float64) []byte {
+	buf := make([]byte, int(w)*int(h)*4)
+	darkRows := int(float64(h) * darkFrac)
+	for y := 0; y < int(h); y++ {
+		var r, g, b byte = 210, 200, 180 // bright sky/sand
+		if y < darkRows {
+			r, g, b = 6, 7, 9 // near-black cave
+		}
+		for x := 0; x < int(w); x++ {
+			i := (y*int(w) + x) * 4
+			buf[i], buf[i+1], buf[i+2], buf[i+3] = r, g, b, 255
+		}
+	}
+	return buf
+}
+
+// TestTornDownSessionFrameIsNeverPositive is the cardinal regression: an all-black
+// response against a mostly-dark real baseline must never yield a positive verdict.
+// Before the fix this exact input produced backdoor_likely at 0.85 confidence.
+func TestTornDownSessionFrameIsNeverPositive(t *testing.T) {
+	w, h := uint32(1024), uint32(768)
+	baseline := darkWallpaperBaseline(w, h, 0.61)
+	black := make([]byte, int(w)*int(h)*4)
+	for i := 3; i < len(black); i += 4 {
+		black[i] = 255 // opaque, all-zero RGB -- exactly what a dead session returns
+	}
+
+	// Characterize the trap: the raw scorer still finds this "window-shaped", which
+	// is why the guard has to sit in front of it rather than inside it.
+	rawVerdict, rawConf, _ := analyzeBackdoorResponse(baseline, black, w, h)
+	require.Equal(t, "backdoor_likely", rawVerdict,
+		"fixture no longer reproduces the trap; the raw scorer must still be fooled for this test to be meaningful")
+	require.InDelta(t, 0.85, rawConf, 0.001, "fixture should saturate the confidence cap, as the field case did")
+
+	ctx := context.Background()
+
+	sticky := runStickyKeysAnalysis(ctx, baseline, black, w, h, "")
+	assert.Equal(t, verdictIndeterminate, sticky.OverallVerdict,
+		"CARDINAL: a torn-down session's black frame must be indeterminate, never a finding")
+	assert.NotEqual(t, "backdoor_likely", sticky.OverallVerdict)
+	assert.NotEqual(t, "backdoor_confirmed", sticky.OverallVerdict)
+
+	utilman := runUtilmanAnalysis(ctx, baseline, black, w, h, "")
+	assert.Equal(t, verdictIndeterminate, utilman.OverallVerdict,
+		"CARDINAL: same guard must hold on the utilman path")
+	assert.NotEqual(t, "backdoor_likely", utilman.OverallVerdict)
+	assert.NotEqual(t, "backdoor_confirmed", utilman.OverallVerdict)
+}
+
+// TestIsUniformFrame pins the predicate. A real console always carries text, a
+// cursor or a border, so exact uniformity is the narrow signal for "no render",
+// and the guard cannot suppress a genuine finding.
+func TestIsUniformFrame(t *testing.T) {
+	flatBlack := make([]byte, 64*4)
+	for i := 3; i < len(flatBlack); i += 4 {
+		flatBlack[i] = 255
+	}
+	flatGrey := make([]byte, 64*4)
+	for i := 0; i < len(flatGrey); i += 4 {
+		flatGrey[i], flatGrey[i+1], flatGrey[i+2], flatGrey[i+3] = 100, 100, 100, 255
+	}
+	// A console body: flat dark field plus a single lit cursor pixel.
+	consoleish := make([]byte, 64*4)
+	for i := 3; i < len(consoleish); i += 4 {
+		consoleish[i] = 255
+	}
+	consoleish[40], consoleish[41], consoleish[42] = 200, 200, 200
+
+	assert.True(t, isUniformFrame(flatBlack), "all-black surface is flat")
+	assert.True(t, isUniformFrame(flatGrey), "any single color is flat, not just black")
+	assert.False(t, isUniformFrame(consoleish),
+		"one lit pixel is enough to be a render: the guard must not swallow a console")
+	assert.True(t, isUniformFrame(nil), "no pixels carries no evidence")
+}
+
+// TestFlatBaselineAndResponseStaysClean guards the other direction: two flat frames
+// are a genuine "nothing changed", not a torn-down session, and must stay clean.
+// The guard is deliberately scoped to a flat response against a NON-flat baseline.
+func TestFlatBaselineAndResponseStaysClean(t *testing.T) {
+	w, h := uint32(50), uint32(50)
+	size := int(w) * int(h) * 4
+	flat := func() []byte {
+		buf := make([]byte, size)
+		for i := 0; i < size; i += 4 {
+			buf[i], buf[i+1], buf[i+2], buf[i+3] = 100, 100, 100, 255
+		}
+		return buf
+	}
+	ctx := context.Background()
+	assert.Equal(t, "clean", runStickyKeysAnalysis(ctx, flat(), flat(), w, h, "").OverallVerdict)
+	assert.Equal(t, "clean", runUtilmanAnalysis(ctx, flat(), flat(), w, h, "").OverallVerdict)
+}
+
+// TestResponseFrameNeverReadsDeadSession covers the frame-selection seam. With a
+// pump error the live framebuffer is untrustworthy, so the last frame seen while
+// the session was alive wins, then the baseline. captureFrame is only reached on a
+// clean pump, so inst may be nil here.
+func TestResponseFrameNeverReadsDeadSession(t *testing.T) {
+	p := &Plugin{}
+	ctx := context.Background()
+	baseline := []byte{1, 2, 3, 255}
+	live := []byte{9, 9, 9, 255}
+	pumpErr := errors.New("session error: session terminated: logoff by user")
+
+	t.Run("prefers the last live frame", func(t *testing.T) {
+		got, err := p.responseFrame(ctx, nil, 0, &sessionDiag{lastFrame: live}, baseline, pumpErr)
+		require.NoError(t, err)
+		assert.Equal(t, live, got,
+			"a payload that painted before the drop must still be analyzed (no new false negatives)")
+	})
+
+	t.Run("falls back to the baseline", func(t *testing.T) {
+		got, err := p.responseFrame(ctx, nil, 0, &sessionDiag{}, baseline, pumpErr)
+		require.NoError(t, err)
+		assert.Equal(t, baseline, got,
+			"a session that died without painting analyzes as the original screen, i.e. no change")
+	})
+
+	t.Run("errors when nothing was ever observed", func(t *testing.T) {
+		_, err := p.responseFrame(ctx, nil, 0, &sessionDiag{}, nil, pumpErr)
+		require.Error(t, err, "no frame at all is a failed scan, not a clean one")
+	})
+}
+
+// TestIndeterminateBanner checks the operator-facing text. "render did not
+// stabilize -- rerun" sends the operator to repeat an identical scan that fails
+// identically; a torn-down session needs the short profile instead.
+func TestIndeterminateBanner(t *testing.T) {
+	plain := indeterminateBanner("Sticky keys", false, "")
+	assert.Contains(t, plain, "render did not stabilize")
+	assert.NotContains(t, plain, "--fast")
+
+	reason := "session terminated: [Protocol independent error] The disconnection was initiated by the user logging off his or her session on the server"
+	withReason := indeterminateBanner("Sticky keys", true, reason)
+	assert.Contains(t, withReason, "server ended the session mid-scan")
+	assert.Contains(t, withReason, reason, "the server's own reason is the diagnostic; it must not be dropped")
+	assert.Contains(t, withReason, "--fast", "the banner must name the actionable next step")
+
+	noReason := indeterminateBanner("Utilman", true, "")
+	assert.Contains(t, noReason, "server ended the session mid-scan")
+	assert.Contains(t, noReason, "--fast")
+}

--- a/internal/plugins/rdp/blackframe_test.go
+++ b/internal/plugins/rdp/blackframe_test.go
@@ -292,7 +292,7 @@ func TestFinalizeResultKeepsTerminationDiagnostics(t *testing.T) {
 	t.Run("sticky keys", func(t *testing.T) {
 		result := &StickyKeysResult{Performed: true}
 		// A torn-down session analyzes the baseline as the response -> "clean".
-		finalizeStickyKeysResult(result, StickyKeysResult{Performed: true, OverallVerdict: "clean"}, diag, false, false)
+		finalizeStickyKeysResult(result, &StickyKeysResult{Performed: true, OverallVerdict: "clean"}, diag, false, false)
 
 		assert.True(t, result.SessionTerminated,
 			"the retry in DetectStickyKeys reads this field; zeroed, the retry never fires")
@@ -306,7 +306,7 @@ func TestFinalizeResultKeepsTerminationDiagnostics(t *testing.T) {
 
 	t.Run("utilman", func(t *testing.T) {
 		result := &UtilmanResult{Performed: true}
-		finalizeUtilmanResult(result, UtilmanResult{Performed: true, OverallVerdict: "clean"}, diag, false, false)
+		finalizeUtilmanResult(result, &UtilmanResult{Performed: true, OverallVerdict: "clean"}, diag, false, false)
 
 		assert.True(t, result.SessionTerminated)
 		assert.Equal(t, reason, result.TerminationReason)
@@ -318,7 +318,7 @@ func TestFinalizeResultKeepsTerminationDiagnostics(t *testing.T) {
 		// terminated=true. It must reach the caller intact, because that pairing is
 		// exactly what retryAfterTermination has to see to refuse the retry.
 		result := &StickyKeysResult{Performed: true}
-		finalizeStickyKeysResult(result, StickyKeysResult{
+		finalizeStickyKeysResult(result, &StickyKeysResult{
 			Performed: true, OverallVerdict: "backdoor_likely", Confidence: 0.85,
 		}, diag, false, false)
 
@@ -331,7 +331,7 @@ func TestFinalizeResultKeepsTerminationDiagnostics(t *testing.T) {
 
 	t.Run("analysis fields are not dropped", func(t *testing.T) {
 		result := &StickyKeysResult{}
-		finalizeStickyKeysResult(result, StickyKeysResult{
+		finalizeStickyKeysResult(result, &StickyKeysResult{
 			Performed: true, OverallVerdict: "backdoor_confirmed",
 			Confidence: 0.95, HeuristicResult: "dark delta", RegionNote: "console-shaped",
 		}, sessionDiag{}, true, false)
@@ -347,7 +347,7 @@ func TestFinalizeResultKeepsTerminationDiagnostics(t *testing.T) {
 
 // TestRetryOnTerminationWiring covers the retry DECISION as it is actually wired,
 // not just the predicate behind it. The predicate was correct and the call site was
-// what broke before, so this asserts the observable behaviour: whether the rerun
+// what broke before, so this asserts the observable behavior: whether the rerun
 // happens at all, and which result reaches the caller.
 func TestRetryOnTerminationWiring(t *testing.T) {
 	const reason = "session terminated: logoff by user"

--- a/internal/plugins/rdp/detect.go
+++ b/internal/plugins/rdp/detect.go
@@ -55,7 +55,8 @@ func DetectStickyKeys(ctx context.Context, target string, connectTimeout, timeou
 	// observed. The short profile completes inside that window, so retry once there
 	// rather than returning a scan that saw no render. Only from the careful budget:
 	// a --fast scan has no shorter profile to fall back to.
-	if !fast && stickyResult != nil && stickyResult.SessionTerminated {
+	if !fast && stickyResult != nil && stickyResult.SessionTerminated &&
+		retryAfterTermination(stickyResult.OverallVerdict, stickyResult.Performed) {
 		stickyResult = plugin.RunStickyKeysCheck(ctx, target, "", connectTimeout, timeout, noVision, FastBudget, true)
 	}
 	result := mapStickyResult(stickyResult, username)
@@ -85,8 +86,14 @@ func mapStickyResult(stickyResult *StickyKeysResult, username string) *brutus.Re
 
 	if !stickyResult.Performed {
 		// A failed connect/instance is NOT a benign skip — it produced no
-		// verdict, so surface it loudly as indeterminate (rerun), not clean.
-		result.Banner = fmt.Sprintf("[WARN] Sticky keys check INDETERMINATE (could not connect — rerun): %s", stickyResult.SkipReason)
+		// verdict, so surface it loudly as indeterminate (rerun), not clean. A server
+		// that ended the session mid-scan gets the termination banner instead:
+		// "could not connect" misdirects an operator whose connect worked fine.
+		if stickyResult.SessionTerminated {
+			result.Banner = indeterminateBanner("Sticky keys", true, stickyResult.TerminationReason)
+		} else {
+			result.Banner = fmt.Sprintf("[WARN] Sticky keys check INDETERMINATE (could not connect — rerun): %s", stickyResult.SkipReason)
+		}
 		result.Indeterminate = true
 		return result
 	}
@@ -137,7 +144,8 @@ func DetectUtilman(ctx context.Context, target string, connectTimeout, timeout t
 	utilmanResult := plugin.RunUtilmanCheck(ctx, target, "", connectTimeout, timeout, noVision, budget, fast)
 	// See DetectStickyKeys: a host that drops the pre-auth session before the careful
 	// settle completes is still observable on the short profile.
-	if !fast && utilmanResult != nil && utilmanResult.SessionTerminated {
+	if !fast && utilmanResult != nil && utilmanResult.SessionTerminated &&
+		retryAfterTermination(utilmanResult.OverallVerdict, utilmanResult.Performed) {
 		utilmanResult = plugin.RunUtilmanCheck(ctx, target, "", connectTimeout, timeout, noVision, FastBudget, true)
 	}
 	result := mapUtilmanResult(utilmanResult, username)
@@ -167,8 +175,14 @@ func mapUtilmanResult(utilmanResult *UtilmanResult, username string) *brutus.Res
 
 	if !utilmanResult.Performed {
 		// A failed connect/instance is NOT a benign skip — it produced no
-		// verdict, so surface it loudly as indeterminate (rerun), not clean.
-		result.Banner = fmt.Sprintf("[WARN] Utilman check INDETERMINATE (could not connect — rerun): %s", utilmanResult.SkipReason)
+		// verdict, so surface it loudly as indeterminate (rerun), not clean. A server
+		// that ended the session mid-scan gets the termination banner instead:
+		// "could not connect" misdirects an operator whose connect worked fine.
+		if utilmanResult.SessionTerminated {
+			result.Banner = indeterminateBanner("Utilman", true, utilmanResult.TerminationReason)
+		} else {
+			result.Banner = fmt.Sprintf("[WARN] Utilman check INDETERMINATE (could not connect — rerun): %s", utilmanResult.SkipReason)
+		}
 		result.Indeterminate = true
 		return result
 	}
@@ -312,11 +326,10 @@ func (p *Plugin) runStickyKeysDetection(ctx context.Context, inst *wasmInstance,
 	if err != nil {
 		result.Performed = false
 		result.SessionTerminated = diag.terminated
+		result.TerminationReason = diag.reason
 		result.SkipReason = fmt.Sprintf("session failed: %v", err)
 		return result, nil
 	}
-	result.SessionTerminated = diag.terminated
-	result.TerminationReason = diag.reason
 
 	// DEBUG: dump captured frames to PNG when BRUTUS_DEBUG_SCREENSHOT_DIR is set.
 	if dir := os.Getenv("BRUTUS_DEBUG_SCREENSHOT_DIR"); dir != "" {
@@ -334,6 +347,12 @@ func (p *Plugin) runStickyKeysDetection(ctx context.Context, inst *wasmInstance,
 	*result = runStickyKeysAnalysis(ctx, baseline, response, width, height, visionAPIKey)
 	result.Performed = true
 	result.Stabilized = stabilized
+	// Assigned AFTER the whole-struct assignment above, not before it: runStickyKeysAnalysis
+	// returns a FRESH result, so anything set on *result earlier is discarded. These two
+	// fields drive the short-profile retry and the termination banner, and a
+	// response-phase teardown is exactly the case that reaches this line with err == nil.
+	result.SessionTerminated = diag.terminated
+	result.TerminationReason = diag.reason
 
 	// Cardinal false-negative guard: only a "clean" verdict on a render that
 	// never stabilized is suspect (or any clean in fast mode — never-clean
@@ -381,11 +400,10 @@ func (p *Plugin) runUtilmanDetection(ctx context.Context, inst *wasmInstance, ad
 	if err != nil {
 		result.Performed = false
 		result.SessionTerminated = diag.terminated
+		result.TerminationReason = diag.reason
 		result.SkipReason = fmt.Sprintf("session failed: %v", err)
 		return result, nil
 	}
-	result.SessionTerminated = diag.terminated
-	result.TerminationReason = diag.reason
 
 	// DEBUG: dump captured frames to PNG when BRUTUS_DEBUG_SCREENSHOT_DIR is set.
 	if dir := os.Getenv("BRUTUS_DEBUG_SCREENSHOT_DIR"); dir != "" {
@@ -403,6 +421,12 @@ func (p *Plugin) runUtilmanDetection(ctx context.Context, inst *wasmInstance, ad
 	*result = runUtilmanAnalysis(ctx, baseline, response, width, height, visionAPIKey)
 	result.Performed = true
 	result.Stabilized = stabilized
+	// Assigned AFTER the whole-struct assignment above, not before it: runUtilmanAnalysis
+	// returns a FRESH result, so anything set on *result earlier is discarded. These two
+	// fields drive the short-profile retry and the termination banner, and a
+	// response-phase teardown is exactly the case that reaches this line with err == nil.
+	result.SessionTerminated = diag.terminated
+	result.TerminationReason = diag.reason
 
 	// Cardinal false-negative guard: only a "clean" verdict on a render that
 	// never stabilized is suspect (or any clean in fast mode — never-clean
@@ -496,7 +520,11 @@ func formatStickyKeysBanner(existingBanner string, result *StickyKeysResult) str
 		}
 		// A failed connect/instance is NOT a benign skip — it produced no
 		// verdict, so surface it loudly as indeterminate (rerun), not clean.
-		banner += fmt.Sprintf("[WARN] Sticky keys check INDETERMINATE (could not connect — rerun): %s", result.SkipReason)
+		if result.SessionTerminated {
+			banner += indeterminateBanner("Sticky keys", true, result.TerminationReason)
+		} else {
+			banner += fmt.Sprintf("[WARN] Sticky keys check INDETERMINATE (could not connect — rerun): %s", result.SkipReason)
+		}
 		return banner
 	}
 
@@ -523,7 +551,7 @@ func formatStickyKeysBanner(existingBanner string, result *StickyKeysResult) str
 		banner += "[INFO] Non-NLA RDP target. Sticky Keys triggers normally (no backdoor detected).\n"
 		banner += "Target is vulnerable if sethc.exe is later replaced."
 	case verdictIndeterminate:
-		banner += "[WARN] Sticky keys check INDETERMINATE (render did not stabilize — rerun)"
+		banner += indeterminateBanner("Sticky keys", result.SessionTerminated, result.TerminationReason)
 	case "clean":
 		banner += "[INFO] Sticky keys check: clean (no response to 5x Shift)."
 	}
@@ -548,7 +576,11 @@ func formatUtilmanBanner(existingBanner string, result *UtilmanResult) string {
 		}
 		// A failed connect/instance is NOT a benign skip — it produced no
 		// verdict, so surface it loudly as indeterminate (rerun), not clean.
-		banner += fmt.Sprintf("[WARN] Utilman check INDETERMINATE (could not connect — rerun): %s", result.SkipReason)
+		if result.SessionTerminated {
+			banner += indeterminateBanner("Utilman", true, result.TerminationReason)
+		} else {
+			banner += fmt.Sprintf("[WARN] Utilman check INDETERMINATE (could not connect — rerun): %s", result.SkipReason)
+		}
 		return banner
 	}
 
@@ -575,7 +607,7 @@ func formatUtilmanBanner(existingBanner string, result *UtilmanResult) string {
 		banner += "[INFO] Non-NLA RDP target. Utilman triggers normally (no backdoor detected).\n"
 		banner += "Target is vulnerable if utilman.exe is later replaced."
 	case verdictIndeterminate:
-		banner += "[WARN] Utilman check INDETERMINATE (render did not stabilize — rerun)"
+		banner += indeterminateBanner("Utilman", result.SessionTerminated, result.TerminationReason)
 	case "clean":
 		banner += "[INFO] Utilman check: clean (no response to Win+U)."
 	}
@@ -586,6 +618,27 @@ func formatUtilmanBanner(existingBanner string, result *UtilmanResult) string {
 	}
 
 	return banner
+}
+
+// retryAfterTermination reports whether a session-terminated result is worth re-running
+// on the short settle profile. A result that already REPORTS an observation --
+// confirmed, likely, or the non-NLA "vulnerable" reading -- is NEVER retried: the retry
+// can come back indeterminate and would replace a real observation with nothing, the
+// false negative the cardinal rule forbids. This is reachable because responseFrame
+// analyzes the last frame seen while the session was alive, so a payload that painted
+// and only then dropped the session scores a genuine positive alongside terminated=true.
+// Everything else -- indeterminate, clean, or a scan that never performed -- saw no
+// trustworthy post-trigger render, so a retry can only improve it.
+func retryAfterTermination(verdict string, performed bool) bool {
+	if !performed {
+		return true
+	}
+	switch verdict {
+	case "backdoor_confirmed", "backdoor_likely", "vulnerable":
+		return false
+	default:
+		return true
+	}
 }
 
 // indeterminateBanner renders the INDETERMINATE banner for a check that produced no

--- a/internal/plugins/rdp/detect.go
+++ b/internal/plugins/rdp/detect.go
@@ -50,6 +50,14 @@ func DetectStickyKeys(ctx context.Context, target string, connectTimeout, timeou
 		budget = FastBudget
 	}
 	stickyResult := plugin.RunStickyKeysCheck(ctx, target, "", connectTimeout, timeout, noVision, budget, fast)
+	// Some hosts drop the pre-auth logon session a few seconds in -- sooner than the
+	// careful profile's ~5s settle needs, so the post-trigger screen is never
+	// observed. The short profile completes inside that window, so retry once there
+	// rather than returning a scan that saw no render. Only from the careful budget:
+	// a --fast scan has no shorter profile to fall back to.
+	if !fast && stickyResult != nil && stickyResult.SessionTerminated {
+		stickyResult = plugin.RunStickyKeysCheck(ctx, target, "", connectTimeout, timeout, noVision, FastBudget, true)
+	}
 	result := mapStickyResult(stickyResult, username)
 	result.Target = target
 	return result
@@ -95,7 +103,7 @@ func mapStickyResult(stickyResult *StickyKeysResult, username string) *brutus.Re
 		result.Banner = "[INFO] Non-NLA target, sticky keys triggers normally (no backdoor)"
 		result.Success = true
 	case verdictIndeterminate:
-		result.Banner = "[WARN] Sticky keys check INDETERMINATE (render did not stabilize — rerun)"
+		result.Banner = indeterminateBanner("Sticky keys", stickyResult.SessionTerminated, stickyResult.TerminationReason)
 		result.Indeterminate = true
 		// Success stays false
 	case "clean":
@@ -127,6 +135,11 @@ func DetectUtilman(ctx context.Context, target string, connectTimeout, timeout t
 		budget = FastBudget
 	}
 	utilmanResult := plugin.RunUtilmanCheck(ctx, target, "", connectTimeout, timeout, noVision, budget, fast)
+	// See DetectStickyKeys: a host that drops the pre-auth session before the careful
+	// settle completes is still observable on the short profile.
+	if !fast && utilmanResult != nil && utilmanResult.SessionTerminated {
+		utilmanResult = plugin.RunUtilmanCheck(ctx, target, "", connectTimeout, timeout, noVision, FastBudget, true)
+	}
 	result := mapUtilmanResult(utilmanResult, username)
 	result.Target = target
 	return result
@@ -172,7 +185,7 @@ func mapUtilmanResult(utilmanResult *UtilmanResult, username string) *brutus.Res
 		result.Banner = "[INFO] Non-NLA target, utilman triggers normally (no backdoor)"
 		result.Success = true
 	case verdictIndeterminate:
-		result.Banner = "[WARN] Utilman check INDETERMINATE (render did not stabilize — rerun)"
+		result.Banner = indeterminateBanner("Utilman", utilmanResult.SessionTerminated, utilmanResult.TerminationReason)
 		result.Indeterminate = true
 		// Success stays false
 	case "clean":
@@ -294,12 +307,16 @@ func (p *Plugin) runStickyKeysDetection(ctx context.Context, inst *wasmInstance,
 		}
 	}()
 
-	baseline, response, width, height, stabilized, err := p.runSession(ctx, inst, connHandle, 1024, 768, timeout, budget)
+	var diag sessionDiag
+	baseline, response, width, height, stabilized, err := p.runSession(ctx, inst, connHandle, 1024, 768, timeout, budget, &diag)
 	if err != nil {
 		result.Performed = false
+		result.SessionTerminated = diag.terminated
 		result.SkipReason = fmt.Sprintf("session failed: %v", err)
 		return result, nil
 	}
+	result.SessionTerminated = diag.terminated
+	result.TerminationReason = diag.reason
 
 	// DEBUG: dump captured frames to PNG when BRUTUS_DEBUG_SCREENSHOT_DIR is set.
 	if dir := os.Getenv("BRUTUS_DEBUG_SCREENSHOT_DIR"); dir != "" {
@@ -359,12 +376,16 @@ func (p *Plugin) runUtilmanDetection(ctx context.Context, inst *wasmInstance, ad
 		}
 	}()
 
-	baseline, response, width, height, stabilized, err := p.runUtilmanSession(ctx, inst, connHandle, 1024, 768, timeout, budget)
+	var diag sessionDiag
+	baseline, response, width, height, stabilized, err := p.runUtilmanSession(ctx, inst, connHandle, 1024, 768, timeout, budget, &diag)
 	if err != nil {
 		result.Performed = false
+		result.SessionTerminated = diag.terminated
 		result.SkipReason = fmt.Sprintf("session failed: %v", err)
 		return result, nil
 	}
+	result.SessionTerminated = diag.terminated
+	result.TerminationReason = diag.reason
 
 	// DEBUG: dump captured frames to PNG when BRUTUS_DEBUG_SCREENSHOT_DIR is set.
 	if dir := os.Getenv("BRUTUS_DEBUG_SCREENSHOT_DIR"); dir != "" {
@@ -565,4 +586,20 @@ func formatUtilmanBanner(existingBanner string, result *UtilmanResult) string {
 	}
 
 	return banner
+}
+
+// indeterminateBanner renders the INDETERMINATE banner for a check that produced no
+// trustworthy render. When the server ended the session mid-scan it says so and
+// names the server's own reason, because "render did not stabilize" sends the
+// operator to rerun an identical scan that will fail identically -- the actionable
+// step is the short settle profile, which completes inside the window such a host
+// allows before it drops the pre-auth session.
+func indeterminateBanner(check string, sessionTerminated bool, reason string) string {
+	if !sessionTerminated {
+		return fmt.Sprintf("[WARN] %s check INDETERMINATE (render did not stabilize — rerun)", check)
+	}
+	if reason == "" {
+		return fmt.Sprintf("[WARN] %s check INDETERMINATE (server ended the session mid-scan — retry with --fast)", check)
+	}
+	return fmt.Sprintf("[WARN] %s check INDETERMINATE (server ended the session mid-scan: %s — retry with --fast)", check, reason)
 }

--- a/internal/plugins/rdp/detect.go
+++ b/internal/plugins/rdp/detect.go
@@ -342,7 +342,8 @@ func (p *Plugin) runStickyKeysDetection(ctx context.Context, inst *wasmInstance,
 	if !noVision {
 		visionAPIKey = os.Getenv("ANTHROPIC_API_KEY")
 	}
-	finalizeStickyKeysResult(result, runStickyKeysAnalysis(ctx, baseline, response, width, height, visionAPIKey), diag, stabilized, fast)
+	analysis := runStickyKeysAnalysis(ctx, baseline, response, width, height, visionAPIKey)
+	finalizeStickyKeysResult(result, &analysis, diag, stabilized, fast)
 
 	return result, nil
 }
@@ -402,7 +403,8 @@ func (p *Plugin) runUtilmanDetection(ctx context.Context, inst *wasmInstance, ad
 	if !noVision {
 		visionAPIKey = os.Getenv("ANTHROPIC_API_KEY")
 	}
-	finalizeUtilmanResult(result, runUtilmanAnalysis(ctx, baseline, response, width, height, visionAPIKey), diag, stabilized, fast)
+	analysis := runUtilmanAnalysis(ctx, baseline, response, width, height, visionAPIKey)
+	finalizeUtilmanResult(result, &analysis, diag, stabilized, fast)
 
 	return result, nil
 }
@@ -605,8 +607,8 @@ func formatUtilmanBanner(existingBanner string, result *UtilmanResult) string {
 // verdict on a render that never stabilized is suspect (or any clean in fast mode --
 // never-clean invariant). Positive verdicts already saw the window and are never
 // downgraded.
-func finalizeStickyKeysResult(result *StickyKeysResult, analysis StickyKeysResult, diag sessionDiag, stabilized, fast bool) {
-	*result = analysis
+func finalizeStickyKeysResult(result, analysis *StickyKeysResult, diag sessionDiag, stabilized, fast bool) {
+	*result = *analysis
 	result.Performed = true
 	result.Stabilized = stabilized
 	result.SessionTerminated = diag.terminated
@@ -629,8 +631,8 @@ func finalizeStickyKeysResult(result *StickyKeysResult, analysis StickyKeysResul
 // verdict on a render that never stabilized is suspect (or any clean in fast mode --
 // never-clean invariant). Positive verdicts already saw the window and are never
 // downgraded.
-func finalizeUtilmanResult(result *UtilmanResult, analysis UtilmanResult, diag sessionDiag, stabilized, fast bool) {
-	*result = analysis
+func finalizeUtilmanResult(result, analysis *UtilmanResult, diag sessionDiag, stabilized, fast bool) {
+	*result = *analysis
 	result.Performed = true
 	result.Stabilized = stabilized
 	result.SessionTerminated = diag.terminated

--- a/internal/plugins/rdp/detect.go
+++ b/internal/plugins/rdp/detect.go
@@ -55,10 +55,9 @@ func DetectStickyKeys(ctx context.Context, target string, connectTimeout, timeou
 	// observed. The short profile completes inside that window, so retry once there
 	// rather than returning a scan that saw no render. Only from the careful budget:
 	// a --fast scan has no shorter profile to fall back to.
-	if !fast && stickyResult != nil && stickyResult.SessionTerminated &&
-		retryAfterTermination(stickyResult.OverallVerdict, stickyResult.Performed) {
-		stickyResult = plugin.RunStickyKeysCheck(ctx, target, "", connectTimeout, timeout, noVision, FastBudget, true)
-	}
+	stickyResult = retryStickyKeysOnTermination(fast, stickyResult, func() *StickyKeysResult {
+		return plugin.RunStickyKeysCheck(ctx, target, "", connectTimeout, timeout, noVision, FastBudget, true)
+	})
 	result := mapStickyResult(stickyResult, username)
 	result.Target = target
 	return result
@@ -144,10 +143,9 @@ func DetectUtilman(ctx context.Context, target string, connectTimeout, timeout t
 	utilmanResult := plugin.RunUtilmanCheck(ctx, target, "", connectTimeout, timeout, noVision, budget, fast)
 	// See DetectStickyKeys: a host that drops the pre-auth session before the careful
 	// settle completes is still observable on the short profile.
-	if !fast && utilmanResult != nil && utilmanResult.SessionTerminated &&
-		retryAfterTermination(utilmanResult.OverallVerdict, utilmanResult.Performed) {
-		utilmanResult = plugin.RunUtilmanCheck(ctx, target, "", connectTimeout, timeout, noVision, FastBudget, true)
-	}
+	utilmanResult = retryUtilmanOnTermination(fast, utilmanResult, func() *UtilmanResult {
+		return plugin.RunUtilmanCheck(ctx, target, "", connectTimeout, timeout, noVision, FastBudget, true)
+	})
 	result := mapUtilmanResult(utilmanResult, username)
 	result.Target = target
 	return result
@@ -344,21 +342,7 @@ func (p *Plugin) runStickyKeysDetection(ctx context.Context, inst *wasmInstance,
 	if !noVision {
 		visionAPIKey = os.Getenv("ANTHROPIC_API_KEY")
 	}
-	*result = runStickyKeysAnalysis(ctx, baseline, response, width, height, visionAPIKey)
-	result.Performed = true
-	result.Stabilized = stabilized
-	// Assigned AFTER the whole-struct assignment above, not before it: runStickyKeysAnalysis
-	// returns a FRESH result, so anything set on *result earlier is discarded. These two
-	// fields drive the short-profile retry and the termination banner, and a
-	// response-phase teardown is exactly the case that reaches this line with err == nil.
-	result.SessionTerminated = diag.terminated
-	result.TerminationReason = diag.reason
-
-	// Cardinal false-negative guard: only a "clean" verdict on a render that
-	// never stabilized is suspect (or any clean in fast mode — never-clean
-	// invariant). Positive verdicts (confirmed/likely/vulnerable) already saw the
-	// window and are never downgraded.
-	result.OverallVerdict = stabilizedVerdict(result.OverallVerdict, stabilized, fast)
+	finalizeStickyKeysResult(result, runStickyKeysAnalysis(ctx, baseline, response, width, height, visionAPIKey), diag, stabilized, fast)
 
 	return result, nil
 }
@@ -418,21 +402,7 @@ func (p *Plugin) runUtilmanDetection(ctx context.Context, inst *wasmInstance, ad
 	if !noVision {
 		visionAPIKey = os.Getenv("ANTHROPIC_API_KEY")
 	}
-	*result = runUtilmanAnalysis(ctx, baseline, response, width, height, visionAPIKey)
-	result.Performed = true
-	result.Stabilized = stabilized
-	// Assigned AFTER the whole-struct assignment above, not before it: runUtilmanAnalysis
-	// returns a FRESH result, so anything set on *result earlier is discarded. These two
-	// fields drive the short-profile retry and the termination banner, and a
-	// response-phase teardown is exactly the case that reaches this line with err == nil.
-	result.SessionTerminated = diag.terminated
-	result.TerminationReason = diag.reason
-
-	// Cardinal false-negative guard: only a "clean" verdict on a render that
-	// never stabilized is suspect (or any clean in fast mode — never-clean
-	// invariant). Positive verdicts (confirmed/likely/vulnerable) already saw the
-	// window and are never downgraded.
-	result.OverallVerdict = stabilizedVerdict(result.OverallVerdict, stabilized, fast)
+	finalizeUtilmanResult(result, runUtilmanAnalysis(ctx, baseline, response, width, height, visionAPIKey), diag, stabilized, fast)
 
 	return result, nil
 }
@@ -618,6 +588,84 @@ func formatUtilmanBanner(existingBanner string, result *UtilmanResult) string {
 	}
 
 	return banner
+}
+
+// finalizeStickyKeysResult folds an analysis outcome into result while KEEPING the session
+// diagnostics the analysis knows nothing about.
+//
+// It exists because `*result = analysis` is a whole-struct assignment: runStickyKeysAnalysis returns a
+// FRESH StickyKeysResult, so every field set on result beforehand is discarded. That ordering trap
+// silently zeroed SessionTerminated/TerminationReason once already, disabling the
+// short-profile retry and the termination banner for the response-phase teardown this
+// path was written to handle -- and it did so invisibly, because the scan still
+// succeeded. Keeping the order in one small function is what makes the invariant
+// test-enforceable instead of a comment someone has to notice.
+//
+// The stabilizedVerdict call is the cardinal false-negative guard: only a "clean"
+// verdict on a render that never stabilized is suspect (or any clean in fast mode --
+// never-clean invariant). Positive verdicts already saw the window and are never
+// downgraded.
+func finalizeStickyKeysResult(result *StickyKeysResult, analysis StickyKeysResult, diag sessionDiag, stabilized, fast bool) {
+	*result = analysis
+	result.Performed = true
+	result.Stabilized = stabilized
+	result.SessionTerminated = diag.terminated
+	result.TerminationReason = diag.reason
+	result.OverallVerdict = stabilizedVerdict(result.OverallVerdict, stabilized, fast)
+}
+
+// finalizeUtilmanResult folds an analysis outcome into result while KEEPING the session
+// diagnostics the analysis knows nothing about.
+//
+// It exists because `*result = analysis` is a whole-struct assignment: runUtilmanAnalysis returns a
+// FRESH UtilmanResult, so every field set on result beforehand is discarded. That ordering trap
+// silently zeroed SessionTerminated/TerminationReason once already, disabling the
+// short-profile retry and the termination banner for the response-phase teardown this
+// path was written to handle -- and it did so invisibly, because the scan still
+// succeeded. Keeping the order in one small function is what makes the invariant
+// test-enforceable instead of a comment someone has to notice.
+//
+// The stabilizedVerdict call is the cardinal false-negative guard: only a "clean"
+// verdict on a render that never stabilized is suspect (or any clean in fast mode --
+// never-clean invariant). Positive verdicts already saw the window and are never
+// downgraded.
+func finalizeUtilmanResult(result *UtilmanResult, analysis UtilmanResult, diag sessionDiag, stabilized, fast bool) {
+	*result = analysis
+	result.Performed = true
+	result.Stabilized = stabilized
+	result.SessionTerminated = diag.terminated
+	result.TerminationReason = diag.reason
+	result.OverallVerdict = stabilizedVerdict(result.OverallVerdict, stabilized, fast)
+}
+
+// retryStickyKeysOnTermination decides whether a terminated scan is re-run on the short
+// settle profile, and runs it. The decision is split from the RunStickyKeysCheck call
+// so it is reachable from a test: the wiring is the part that silently broke once
+// (see finalizeStickyKeysResult), and a predicate nobody calls correctly is no guard
+// at all. rerun is invoked at most once.
+func retryStickyKeysOnTermination(fast bool, first *StickyKeysResult, rerun func() *StickyKeysResult) *StickyKeysResult {
+	if fast || first == nil || !first.SessionTerminated {
+		return first
+	}
+	if !retryAfterTermination(first.OverallVerdict, first.Performed) {
+		return first
+	}
+	return rerun()
+}
+
+// retryUtilmanOnTermination decides whether a terminated scan is re-run on the short
+// settle profile, and runs it. The decision is split from the RunStickyKeysCheck call
+// so it is reachable from a test: the wiring is the part that silently broke once
+// (see finalizeStickyKeysResult), and a predicate nobody calls correctly is no guard
+// at all. rerun is invoked at most once.
+func retryUtilmanOnTermination(fast bool, first *UtilmanResult, rerun func() *UtilmanResult) *UtilmanResult {
+	if fast || first == nil || !first.SessionTerminated {
+		return first
+	}
+	if !retryAfterTermination(first.OverallVerdict, first.Performed) {
+		return first
+	}
+	return rerun()
 }
 
 // retryAfterTermination reports whether a session-terminated result is worth re-running

--- a/internal/plugins/rdp/session.go
+++ b/internal/plugins/rdp/session.go
@@ -234,6 +234,15 @@ func (p *Plugin) runSession(ctx context.Context, inst *wasmInstance, connHandle 
 	// Wait for response and pump — give cmd.exe time to render before capturing.
 	// The exec.go path uses 1s sleep + 2s WaitForFrame; we mirror that here.
 	time.Sleep(budget.postKeystrokeWait)
+	// Scope the retained frame to the RESPONSE phase. diag is shared with the baseline
+	// pump above, and a baseline-phase frame is NOT a post-trigger observation: left in
+	// place, a response pump that errored before observing anything would hand
+	// responseFrame a pre-trigger frame to difference against the baseline. That reads
+	// as a change the trigger never caused. Cleared, the same case falls through to the
+	// baseline -- "no change" -> indeterminate, never a positive.
+	if diag != nil {
+		diag.lastFrame = nil
+	}
 	responseStable, pumpErr := p.pumpSession(ctx, inst, sessHandle, width, height, timeout, budget, diag)
 
 	// Choose the frame to analyze. A clean pump means the live framebuffer is
@@ -326,6 +335,15 @@ func (p *Plugin) runUtilmanSession(ctx context.Context, inst *wasmInstance, conn
 
 	// Wait for response and pump — give cmd.exe time to render before capturing.
 	time.Sleep(budget.postKeystrokeWait)
+	// Scope the retained frame to the RESPONSE phase. diag is shared with the baseline
+	// pump above, and a baseline-phase frame is NOT a post-trigger observation: left in
+	// place, a response pump that errored before observing anything would hand
+	// responseFrame a pre-trigger frame to difference against the baseline. That reads
+	// as a change the trigger never caused. Cleared, the same case falls through to the
+	// baseline -- "no change" -> indeterminate, never a positive.
+	if diag != nil {
+		diag.lastFrame = nil
+	}
 	responseStable, pumpErr := p.pumpSession(ctx, inst, sessHandle, width, height, timeout, budget, diag)
 
 	// Choose the frame to analyze. A clean pump means the live framebuffer is

--- a/internal/plugins/rdp/session.go
+++ b/internal/plugins/rdp/session.go
@@ -165,7 +165,7 @@ var MinViableTimeout = CarefulBudget.minPump + CarefulBudget.quietWindow
 // backdoor on a host where no key was ever pressed. Retaining the last live frame
 // lets the caller analyze what was actually on screen instead.
 type sessionDiag struct {
-	lastFrame  []byte // last framebuffer captured while the session was alive
+	lastFrame  []byte // last framebuffer captured while the session was alive, scoped to the current pump phase
 	terminated bool   // the server ended the session mid-pump
 	reason     string // server-reported termination reason, for the operator-facing banner
 }
@@ -234,15 +234,6 @@ func (p *Plugin) runSession(ctx context.Context, inst *wasmInstance, connHandle 
 	// Wait for response and pump — give cmd.exe time to render before capturing.
 	// The exec.go path uses 1s sleep + 2s WaitForFrame; we mirror that here.
 	time.Sleep(budget.postKeystrokeWait)
-	// Scope the retained frame to the RESPONSE phase. diag is shared with the baseline
-	// pump above, and a baseline-phase frame is NOT a post-trigger observation: left in
-	// place, a response pump that errored before observing anything would hand
-	// responseFrame a pre-trigger frame to difference against the baseline. That reads
-	// as a change the trigger never caused. Cleared, the same case falls through to the
-	// baseline -- "no change" -> indeterminate, never a positive.
-	if diag != nil {
-		diag.lastFrame = nil
-	}
 	responseStable, pumpErr := p.pumpSession(ctx, inst, sessHandle, width, height, timeout, budget, diag)
 
 	// Choose the frame to analyze. A clean pump means the live framebuffer is
@@ -335,15 +326,6 @@ func (p *Plugin) runUtilmanSession(ctx context.Context, inst *wasmInstance, conn
 
 	// Wait for response and pump — give cmd.exe time to render before capturing.
 	time.Sleep(budget.postKeystrokeWait)
-	// Scope the retained frame to the RESPONSE phase. diag is shared with the baseline
-	// pump above, and a baseline-phase frame is NOT a post-trigger observation: left in
-	// place, a response pump that errored before observing anything would hand
-	// responseFrame a pre-trigger frame to difference against the baseline. That reads
-	// as a change the trigger never caused. Cleared, the same case falls through to the
-	// baseline -- "no change" -> indeterminate, never a positive.
-	if diag != nil {
-		diag.lastFrame = nil
-	}
 	responseStable, pumpErr := p.pumpSession(ctx, inst, sessHandle, width, height, timeout, budget, diag)
 
 	// Choose the frame to analyze. A clean pump means the live framebuffer is
@@ -451,6 +433,17 @@ func readRDPFrame(r io.Reader) ([]byte, error) {
 // it never settled).
 func (p *Plugin) pumpSession(ctx context.Context, inst *wasmInstance, sessHandle, width, height uint32, timeout time.Duration, budget SettleBudget, diag *sessionDiag) (stabilized bool, err error) {
 	callCtx := inst.callCtx(ctx)
+
+	// diag.lastFrame belongs to THIS pump. runSession shares one sessionDiag across the
+	// baseline and response phases, and a baseline-phase frame is not a post-trigger
+	// observation: carried over, a response pump that errored before observing anything
+	// would hand responseFrame a PRE-trigger frame to difference against the baseline,
+	// which reads as a change the trigger never caused. Clearing here rather than at the
+	// call site makes it an invariant of the pump, so no caller can forget it.
+	if diag != nil {
+		diag.lastFrame = nil
+	}
+
 	sessionStepFn := inst.mod.ExportedFunction("session_step")
 	if sessionStepFn == nil {
 		return false, fmt.Errorf("session_step not exported")

--- a/internal/plugins/rdp/session.go
+++ b/internal/plugins/rdp/session.go
@@ -53,6 +53,14 @@ type StickyKeysResult struct {
 	// indeterminate (rerun). Set only by RunStickyKeysCheck at the
 	// dialer.DialContext failure site.
 	Unreachable bool
+	// SessionTerminated records that the server ended the RDP session mid-scan
+	// (e.g. a pre-auth logon session torn down before the response settled). The
+	// scan observed no trustworthy post-trigger render, so the verdict cannot be a
+	// positive; it also selects the short-budget retry in DetectStickyKeys.
+	SessionTerminated bool
+	// TerminationReason is the server-reported reason behind SessionTerminated,
+	// surfaced in the operator-facing banner instead of being discarded.
+	TerminationReason string
 }
 
 // UtilmanResult holds the outcome of utilman backdoor detection.
@@ -71,6 +79,14 @@ type UtilmanResult struct {
 	// indeterminate (rerun). Set only by RunUtilmanCheck at the
 	// dialer.DialContext failure site.
 	Unreachable bool
+	// SessionTerminated records that the server ended the RDP session mid-scan
+	// (e.g. a pre-auth logon session torn down before the response settled). The
+	// scan observed no trustworthy post-trigger render, so the verdict cannot be a
+	// positive; it also selects the short-budget retry in DetectUtilman.
+	SessionTerminated bool
+	// TerminationReason is the server-reported reason behind SessionTerminated,
+	// surfaced in the operator-facing banner instead of being discarded.
+	TerminationReason string
 }
 
 // leftShiftScancode is the scancode for Left Shift key (used for sticky keys detection).
@@ -135,6 +151,25 @@ var FastBudget = SettleBudget{
 // with the careful settle profile (single source of truth).
 var MinViableTimeout = CarefulBudget.minPump + CarefulBudget.quietWindow
 
+// sessionDiag carries what a pump phase observed back to its caller without
+// widening the already-wide runSession return tuple.
+//
+// lastFrame is the most recent framebuffer captured while the session was still
+// alive. It exists because session_get_frame on a TERMINATED ActiveStage hands
+// back a zeroed DecodedImage rather than failing: the Rust side returns
+// image.data() unconditionally (rust/src/session.rs), so a dead session yields a
+// perfectly black 1024x768 frame that looks like a successful capture. Differenced
+// against a logon wallpaper that is already ~60% dark, that black frame lands
+// inside the 2-80% "window-sized change" band, forms one large contiguous
+// rectangle, and satisfies every console gate -- fabricating an 85%-confidence
+// backdoor on a host where no key was ever pressed. Retaining the last live frame
+// lets the caller analyze what was actually on screen instead.
+type sessionDiag struct {
+	lastFrame  []byte // last framebuffer captured while the session was alive
+	terminated bool   // the server ended the session mid-pump
+	reason     string // server-reported termination reason, for the operator-facing banner
+}
+
 // runSession creates a session from the connector, pumps it to receive the login screen bitmap,
 // sends 5x Shift key presses, then captures the post-keystroke bitmap.
 // Returns (baseline_rgba, response_rgba, width, height, stabilized, error).
@@ -143,7 +178,7 @@ var MinViableTimeout = CarefulBudget.minPump + CarefulBudget.quietWindow
 //
 //nolint:gocritic // cohesive multi-return (baseline+response frames, width, height, stabilized, err); a result struct would churn ~20 return sites in this WASM path for no behavior change
 func (p *Plugin) runSession(ctx context.Context, inst *wasmInstance, connHandle uint32,
-	width, height uint32, timeout time.Duration, budget SettleBudget) (baselineRGBA, responseRGBA []byte, outWidth, outHeight uint32, stabilized bool, err error) {
+	width, height uint32, timeout time.Duration, budget SettleBudget, diag *sessionDiag) (baselineRGBA, responseRGBA []byte, outWidth, outHeight uint32, stabilized bool, err error) {
 
 	callCtx := inst.callCtx(ctx)
 
@@ -173,7 +208,7 @@ func (p *Plugin) runSession(ctx context.Context, inst *wasmInstance, connHandle 
 	// initializing ("Please wait for the Local Session Manager") the login
 	// screen has not painted yet, and capturing/triggering now yields a
 	// half-painted baseline. baselineStable is folded into stabilized below.
-	baselineStable, pumpErr := p.pumpSession(ctx, inst, sessHandle, width, height, timeout, budget)
+	baselineStable, pumpErr := p.pumpSession(ctx, inst, sessHandle, width, height, timeout, budget, diag)
 	if pumpErr != nil {
 		return nil, nil, 0, 0, false, fmt.Errorf("pump baseline: %w", pumpErr)
 	}
@@ -199,16 +234,21 @@ func (p *Plugin) runSession(ctx context.Context, inst *wasmInstance, connHandle 
 	// Wait for response and pump — give cmd.exe time to render before capturing.
 	// The exec.go path uses 1s sleep + 2s WaitForFrame; we mirror that here.
 	time.Sleep(budget.postKeystrokeWait)
-	responseStable, pumpErr := p.pumpSession(ctx, inst, sessHandle, width, height, timeout, budget)
-	if pumpErr != nil {
-		// Non-fatal -- target might not respond
-		_ = pumpErr
-	}
+	responseStable, pumpErr := p.pumpSession(ctx, inst, sessHandle, width, height, timeout, budget, diag)
 
-	// Capture response frame
-	response, err := p.captureFrame(ctx, inst, sessHandle)
+	// Choose the frame to analyze. A clean pump means the live framebuffer is
+	// current, so capture it. A pump that ERRORED means the session is gone, and
+	// session_get_frame on a torn-down ActiveStage returns a zeroed DecodedImage
+	// that reads as a successful capture of a perfectly black screen -- the
+	// fabricated-backdoor path described on sessionDiag. Prefer the last frame
+	// seen while the session was alive, and fall back to the baseline, which
+	// analyzes as "no change" and is mapped to indeterminate by stabilizedVerdict
+	// (never a positive). The last live frame is used rather than discarding the
+	// scan so a payload that painted and only then dropped the session is still
+	// detected (cardinal rule: no new false negatives).
+	response, err := p.responseFrame(ctx, inst, sessHandle, diag, baseline, pumpErr)
 	if err != nil {
-		return nil, nil, 0, 0, false, fmt.Errorf("capture response: %w", err)
+		return nil, nil, 0, 0, false, err
 	}
 
 	// Only trust a "clean" reading when BOTH the baseline and the response
@@ -225,7 +265,7 @@ func (p *Plugin) runSession(ctx context.Context, inst *wasmInstance, connHandle 
 //
 //nolint:gocritic // cohesive multi-return (baseline+response frames, width, height, stabilized, err); a result struct would churn ~20 return sites in this WASM path for no behavior change
 func (p *Plugin) runUtilmanSession(ctx context.Context, inst *wasmInstance, connHandle uint32,
-	width, height uint32, timeout time.Duration, budget SettleBudget) (baselineRGBA, responseRGBA []byte, outWidth, outHeight uint32, stabilized bool, err error) {
+	width, height uint32, timeout time.Duration, budget SettleBudget, diag *sessionDiag) (baselineRGBA, responseRGBA []byte, outWidth, outHeight uint32, stabilized bool, err error) {
 
 	callCtx := inst.callCtx(ctx)
 
@@ -255,7 +295,7 @@ func (p *Plugin) runUtilmanSession(ctx context.Context, inst *wasmInstance, conn
 	// initializing ("Please wait for the Local Session Manager") the login
 	// screen has not painted yet, and capturing/triggering now yields a
 	// half-painted baseline. baselineStable is folded into stabilized below.
-	baselineStable, pumpErr := p.pumpSession(ctx, inst, sessHandle, width, height, timeout, budget)
+	baselineStable, pumpErr := p.pumpSession(ctx, inst, sessHandle, width, height, timeout, budget, diag)
 	if pumpErr != nil {
 		return nil, nil, 0, 0, false, fmt.Errorf("pump baseline: %w", pumpErr)
 	}
@@ -286,16 +326,21 @@ func (p *Plugin) runUtilmanSession(ctx context.Context, inst *wasmInstance, conn
 
 	// Wait for response and pump — give cmd.exe time to render before capturing.
 	time.Sleep(budget.postKeystrokeWait)
-	responseStable, pumpErr := p.pumpSession(ctx, inst, sessHandle, width, height, timeout, budget)
-	if pumpErr != nil {
-		// Non-fatal -- target might not respond
-		_ = pumpErr
-	}
+	responseStable, pumpErr := p.pumpSession(ctx, inst, sessHandle, width, height, timeout, budget, diag)
 
-	// Capture response frame
-	response, err := p.captureFrame(ctx, inst, sessHandle)
+	// Choose the frame to analyze. A clean pump means the live framebuffer is
+	// current, so capture it. A pump that ERRORED means the session is gone, and
+	// session_get_frame on a torn-down ActiveStage returns a zeroed DecodedImage
+	// that reads as a successful capture of a perfectly black screen -- the
+	// fabricated-backdoor path described on sessionDiag. Prefer the last frame
+	// seen while the session was alive, and fall back to the baseline, which
+	// analyzes as "no change" and is mapped to indeterminate by stabilizedVerdict
+	// (never a positive). The last live frame is used rather than discarding the
+	// scan so a payload that painted and only then dropped the session is still
+	// detected (cardinal rule: no new false negatives).
+	response, err := p.responseFrame(ctx, inst, sessHandle, diag, baseline, pumpErr)
 	if err != nil {
-		return nil, nil, 0, 0, false, fmt.Errorf("capture response: %w", err)
+		return nil, nil, 0, 0, false, err
 	}
 
 	// Only trust a "clean" reading when BOTH the baseline and the response
@@ -386,7 +431,7 @@ func readRDPFrame(r io.Reader) ([]byte, error) {
 // changed-pixel count used to decide whether a frame is quiet (see framesQuiet).
 // Returns false if the deadline cut it off while frames were still changing (or
 // it never settled).
-func (p *Plugin) pumpSession(ctx context.Context, inst *wasmInstance, sessHandle, width, height uint32, timeout time.Duration, budget SettleBudget) (stabilized bool, err error) {
+func (p *Plugin) pumpSession(ctx context.Context, inst *wasmInstance, sessHandle, width, height uint32, timeout time.Duration, budget SettleBudget, diag *sessionDiag) (stabilized bool, err error) {
 	callCtx := inst.callCtx(ctx)
 	sessionStepFn := inst.mod.ExportedFunction("session_step")
 	if sessionStepFn == nil {
@@ -466,6 +511,12 @@ func (p *Plugin) pumpSession(ctx context.Context, inst *wasmInstance, sessHandle
 					lastChange = time.Now()
 				}
 				prevFrame = frameData
+				// Retain the newest frame observed while the session is alive; if the
+				// server tears the session down later this is the only trustworthy
+				// view of the screen (see sessionDiag).
+				if diag != nil {
+					diag.lastFrame = frameData
+				}
 				if settled(start, lastChange, time.Now(), budget) {
 					return true, nil
 				}
@@ -490,6 +541,10 @@ func (p *Plugin) pumpSession(ctx context.Context, inst *wasmInstance, sessHandle
 			errBytes := readOutputFromSlots(callCtx, inst, outPtrSlot, outLenSlot)
 			inst.freeInWasm(callCtx, outPtrSlot, 4)
 			inst.freeInWasm(callCtx, outLenSlot, 4)
+			if diag != nil {
+				diag.terminated = true
+				diag.reason = string(errBytes)
+			}
 			return false, fmt.Errorf("session error: %s", string(errBytes))
 
 		default:
@@ -632,4 +687,34 @@ func (p *Plugin) sendKey(ctx context.Context, inst *wasmInstance, sessHandle uin
 	}
 
 	return nil
+}
+
+// responseFrame returns the post-trigger framebuffer to analyze.
+//
+// pumpErr == nil: the session is healthy, so the live framebuffer is authoritative.
+//
+// pumpErr != nil: the session errored or was terminated by the server. Its
+// framebuffer must NOT be read -- see sessionDiag for why a dead session returns
+// an all-black frame that scores as a backdoor. Preference order is the last frame
+// captured while the session was alive, then the baseline. Both are real screens,
+// so a genuine payload that painted before the drop still scores, while a session
+// that died without painting analyzes as "no change".
+func (p *Plugin) responseFrame(ctx context.Context, inst *wasmInstance, sessHandle uint32,
+	diag *sessionDiag, baseline []byte, pumpErr error) ([]byte, error) {
+
+	if pumpErr == nil {
+		frame, err := p.captureFrame(ctx, inst, sessHandle)
+		if err != nil {
+			return nil, fmt.Errorf("capture response: %w", err)
+		}
+		return frame, nil
+	}
+
+	if diag != nil && len(diag.lastFrame) > 0 {
+		return diag.lastFrame, nil
+	}
+	if len(baseline) > 0 {
+		return baseline, nil
+	}
+	return nil, fmt.Errorf("capture response: session unusable and no live frame observed: %w", pumpErr)
 }


### PR DESCRIPTION
## Problem

A server that ends the pre-auth RDP logon session mid-scan produced a **maximum-confidence backdoor finding on hosts with no backdoor at all**.

Reproducible on demand: with the trigger keystrokes **disabled entirely**, the scan still reported `[HIGH] Sticky keys backdoor likely (confidence: 85%)`. No key was ever pressed.

## Root cause

`pumpSession` returned the session error, `runSession` discarded it (`_ = pumpErr`), and `captureFrame` was then called on the dead session. `session_get_frame` returns `image.data()` unconditionally (`rust/src/session.rs`), so a terminated `ActiveStage` hands back a zeroed `DecodedImage` that reads as a *successful* capture — a perfectly black 1024x768 frame.

Differenced against a logon wallpaper that is already ~61% dark, that black frame:

1. changes only **~39%** of pixels, so it slips under `maxChangedPercent`'s 80% "full-screen change, not a window" guard — the guard that exists for exactly this;
2. leaves the changed pixels (the bright part of the wallpaper) as one large contiguous rectangle, so `detectChangedRectangle` scores it window-shaped;
3. saturates the confidence formula at its **0.85 cap**;
4. passes `consoleGatePasses` on every arm — mean brightness 0 <= 90, large area, `darkBoxFraction` 1.0 >= 0.70.

Every signal meant to *confirm* a console body fires maximally on a zeroed buffer, because a large uniformly-dark rectangle is the platonic ideal of `cmd.exe`. `stabilizedVerdict` could not catch it either: it only downgrades **clean** verdicts, on the stated assumption that "positive verdicts already saw the window" — which a torn-down session violates. The positive was reported despite `responseStable=false`.

## Fix

- **`sessionDiag` retains the last framebuffer captured while the session was alive**; new `responseFrame` never re-reads a dead session. Preference order: live capture (healthy pump) → last live frame → baseline. The last live frame is used rather than discarding the scan, so a payload that painted and only *then* dropped the session is still detected (cardinal rule: no new false negatives).
- **`isUniformFrame` guard** rejects a flat single-color response before any heuristic runs. Scoped to a flat response against a **non-flat** baseline, so two flat frames stay a genuine "nothing changed" → clean.
- **Termination is surfaced** (`SessionTerminated`/`TerminationReason`) and the banner names the server's own reason and points at the short settle profile, instead of `"render did not stabilize — rerun"`, which sends the operator to repeat an identical failing scan.
- **`DetectStickyKeys`/`DetectUtilman` retry once on the short settle profile** when the server tears the session down. It completes inside the window such hosts allow, so the check now observes the real post-trigger screen on default flags.

## Testing

- `blackframe_test.go` is the regression suite. `TestTornDownSessionFrameIsNeverPositive` reconstructs the field input (mostly-dark baseline + all-black response) and asserts it is never a positive — and additionally asserts the **raw scorer is still fooled** by the fixture, so the test cannot silently stop being meaningful.
- Coverage also pins `isUniformFrame` (a single lit pixel is a render — the guard must not swallow a console), the flat-baseline-stays-clean direction, the `responseFrame` selection seam, and the banner text.
- Full suite passes, `make lint` reports 0 issues, and the CLI surface drift gate passes. Existing real-frame fixtures still classify correctly (`tp_cmd_sticky` / `tp_cmd2_sticky` / `tp_ps_utilman` → HIGH, `fp_clean_utilman` → not-HIGH), so detection of genuine backdoors is unchanged.
- Verified live against an affected host: the default-budget run now auto-captures the real post-trigger screen (byte-identical to a manually confirmed capture) and no longer fabricates a finding.

## Follow-ups not in this PR

- **Verdict is now `INDETERMINATE`, not a confident clean, on affected hosts.** The screen never goes quiet within the short profile's 400ms window, so `stabilized=false` and the code correctly refuses to call an unstable render clean. Safe and honest, but such hosts still ask for a rerun. Separate, pre-existing settle-tuning issue.
- **Latent Rust bug, untouched:** `DeactivateAll` returns a hard session error ("server deactivation-reactivation not supported"). Any real desktop switch hits that path and lands in the same dead-session read this PR now guards. Needs a WASM rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)