### PR TITLE
fix(brutus): drop the vision knobs the credential path no longer reads

### DIFF
--- a/cmd/brutus/runner.go
+++ b/cmd/brutus/runner.go
@@ -376,7 +376,6 @@ func runSingleTarget(target, protocol, tlsMode string, base *runConfig, aiCreds 
 		totalAttempts, config.Threads, config.Timeout)
 	logVerbose(base.verbose, "Starting brute force...")
 
-	config.AIMode = base.aiMode
 
 	// Create context that cancels on SIGINT/SIGTERM
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)

--- a/internal/plugins/rdp/detect.go
+++ b/internal/plugins/rdp/detect.go
@@ -336,8 +336,8 @@ func (p *Plugin) runStickyKeysDetection(ctx context.Context, inst *wasmInstance,
 	}
 
 	// Vision API confirmation is optional: it requires ANTHROPIC_API_KEY and is
-	// opted into with --experimental-ai, which is where noVision comes from
-	// (see workers.go: NoVision is !AIMode).
+	// opted into with --experimental-ai, which the logon entry points pass down
+	// as the noVision parameter.
 	var visionAPIKey string
 	if !noVision {
 		visionAPIKey = os.Getenv("ANTHROPIC_API_KEY")
@@ -397,8 +397,8 @@ func (p *Plugin) runUtilmanDetection(ctx context.Context, inst *wasmInstance, ad
 	}
 
 	// Vision API confirmation is optional: it requires ANTHROPIC_API_KEY and is
-	// opted into with --experimental-ai, which is where noVision comes from
-	// (see workers.go: NoVision is !AIMode).
+	// opted into with --experimental-ai, which the logon entry points pass down
+	// as the noVision parameter.
 	var visionAPIKey string
 	if !noVision {
 		visionAPIKey = os.Getenv("ANTHROPIC_API_KEY")

--- a/pkg/brutus/brutus.go
+++ b/pkg/brutus/brutus.go
@@ -76,7 +76,6 @@ import (
 // through context.WithValue.
 type PluginConfig struct {
 	TLSMode  string // "disable", "verify", "skip-verify" (default: "disable")
-	NoVision bool   // disable Vision API for screenshot analysis (RDP)
 	ProxyURL string // SOCKS5 proxy URL (e.g., "socks5://127.0.0.1:1080")
 }
 
@@ -110,7 +109,6 @@ type Config struct {
 	MaxAttempts     int           // max password attempts per username (0 = unlimited)
 	MaxRetries      int           // max retries per credential on connection error (0 = no retry, default: 0)
 	Verbose         bool          // enable verbose logging to stderr (default: false)
-	AIMode          bool          // enable Vision API for screenshot analysis (RDP)
 	SkipUnauthCheck bool          // skip CheckUnauth probe (when Nerva already detected it)
 	Mode            Mode          // aggressiveness tier for wordlist depth (default: ModeDefault)
 	ProxyURL        string        // SOCKS5 proxy URL for all connections (e.g., "socks5://127.0.0.1:1080")

--- a/pkg/brutus/workers.go
+++ b/pkg/brutus/workers.go
@@ -99,7 +99,6 @@ func reorderForSpray(creds []credential) []credential {
 func pluginConfigFromConfig(cfg *Config) PluginConfig {
 	return PluginConfig{
 		TLSMode:  cfg.TLSMode,
-		NoVision: !cfg.AIMode,
 		ProxyURL: cfg.ProxyURL,
 	}
 }


### PR DESCRIPTION
Follow-up to #347, which introduced this. Refs ENG-7438.

## What #347 broke

Deleting the inline sticky-keys/utilman blocks from the RDP plugin's credential `Test` path also removed the **only reader** of `PluginConfig.NoVision` — it was passed to `RunStickyKeysCheck` / `RunUtilmanCheck` and nowhere else.

That left `Config.AIMode` — documented as *"enable Vision API for screenshot analysis (RDP)"* — with exactly one reader: the `pluginConfigFromConfig` mapping that feeds the now-unread `NoVision`. A library caller could set it and get nothing.

That is the same dead-knob trap #347 existed to remove, reintroduced by #347 itself one field over. Codex flagged it on that PR as a suggestion; it was right, and it is a defect rather than a nit — the whole argument for deleting `Config.StickyKeys` instead of deprecating it was that *a field which silently does nothing is the trap*.

## What this removes

- `PluginConfig.NoVision` — zero readers
- `Config.AIMode` — only reader was the mapping to the above
- the `pluginConfigFromConfig` mapping
- the `config.AIMode = base.aiMode` writer in `runSingleTarget`

## `--experimental-ai` is unaffected

Vision confirmation now happens only on the logon path, which takes `base.aiMode` **directly** — `logon.DetectBackdoors(..., base.aiMode, ...)` and `logon.ExecConfig.AIMode` — neither of which routes through `brutus.Config`. The CLI-side `base.aiMode` also still drives HTTP AI credential detection (`root.go`, `output.go`) and the badkeys/creds/snmp overrides.

Verified: **`make cli-docs` produces no diff.** Library-API change only, same as #347.

Also corrects two comments in `detect.go` that cited `workers.go: NoVision is !AIMode` as the provenance of `noVision`. It now arrives as a parameter from the logon entry points.

## Verification

| Check | Result |
|---|---|
| `go build ./...` | OK |
| `go vet ./...` | OK |
| `go test ./...` | all packages pass |
| `make cli-docs` | no diff |
| `gofmt -l` on changed files | clean |
| dangling readers of `NoVision` / `Config.AIMode` | none (remaining grep hits are test *names*) |

`golangci-lint` is not installed locally, so `make lint` falls back to `go vet` — stating that rather than implying the linter ran.

## Note on #347's review

Gemini's review job **failed to complete** on #347 (run [33539985593](https://github.com/praetorian-inc/brutus/actions/runs/33539985593)), so that PR merged with one reviewer silently absent rather than clean. Claude reviewed it and found no critical issues; Codex found this one. Worth a look at that run if the failure is recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
