### PR TITLE
chore(rdp): remove RDP integration tests that never run

### DIFF
--- a/internal/plugins/rdp/rdp_test.go
+++ b/internal/plugins/rdp/rdp_test.go
@@ -17,7 +17,6 @@ package rdp
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -205,81 +204,4 @@ func TestClassifyError(t *testing.T) {
 			}
 		})
 	}
-}
-
-// --- Integration Tests ---
-// These require a real RDP server. Set environment variables to enable:
-//   RDP_TEST_HOST=host:3389
-//   RDP_TEST_USER=administrator
-//   RDP_TEST_PASS=password
-
-func getTestConfig(t *testing.T) (host, user, pass string) {
-	t.Helper()
-	host = os.Getenv("RDP_TEST_HOST")
-	if host == "" {
-		t.Skip("RDP_TEST_HOST not set, skipping integration test. Set to run: export RDP_TEST_HOST=host:3389")
-	}
-	user = os.Getenv("RDP_TEST_USER")
-	if user == "" {
-		user = "administrator"
-	}
-	pass = os.Getenv("RDP_TEST_PASS")
-	if pass == "" {
-		pass = "password"
-	}
-	return
-}
-
-func TestPlugin_Integration_ValidCredentials(t *testing.T) {
-	host, user, pass := getTestConfig(t)
-
-	p := &Plugin{}
-	ctx := context.Background()
-
-	result := p.Test(ctx, host, user, pass, 10*time.Second, brutus.PluginConfig{})
-
-	assert.NotNil(t, result)
-	assert.Equal(t, "rdp", result.Protocol)
-	assert.Equal(t, host, result.Target)
-	assert.Equal(t, user, result.Username)
-	assert.Equal(t, pass, result.Password)
-	assert.True(t, result.Success, "valid credentials should succeed")
-	assert.Nil(t, result.Error)
-	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
-}
-
-func TestPlugin_Integration_InvalidCredentials(t *testing.T) {
-	host, user, _ := getTestConfig(t)
-
-	p := &Plugin{}
-	ctx := context.Background()
-
-	result := p.Test(ctx, host, user, "definitely-wrong-password-xyz", 10*time.Second, brutus.PluginConfig{})
-
-	assert.NotNil(t, result)
-	assert.Equal(t, "rdp", result.Protocol)
-	assert.Equal(t, host, result.Target)
-	assert.False(t, result.Success, "wrong password should fail")
-	assert.Nil(t, result.Error, "auth failure should return nil error (not connection error)")
-	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
-}
-
-func TestPlugin_Integration_DomainUsername(t *testing.T) {
-	host, _, pass := getTestConfig(t)
-
-	domainUser := os.Getenv("RDP_TEST_DOMAIN_USER")
-	if domainUser == "" {
-		t.Skip("RDP_TEST_DOMAIN_USER not set (format: DOMAIN\\user)")
-	}
-
-	p := &Plugin{}
-	ctx := context.Background()
-
-	result := p.Test(ctx, host, domainUser, pass, 10*time.Second, brutus.PluginConfig{})
-
-	assert.NotNil(t, result)
-	assert.Equal(t, "rdp", result.Protocol)
-	assert.Equal(t, host, result.Target)
-	assert.Equal(t, domainUser, result.Username)
-	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }


### PR DESCRIPTION
## What

Removes `TestPlugin_Integration_ValidCredentials`, `_InvalidCredentials` and `_DomainUsername` from `internal/plugins/rdp/rdp_test.go`.

## Why

All three skip unless `RDP_TEST_HOST` is set, and nothing sets it — `ci-integration.yml` provisions no RDP service. They have skipped on every CI run since they were added:

```
--- SKIP: TestPlugin_Integration_ValidCredentials (0.00s)
    RDP_TEST_HOST not set, skipping integration test.
--- SKIP: TestPlugin_Integration_InvalidCredentials (0.00s)
--- SKIP: TestPlugin_Integration_DomainUsername (0.00s)
```

A permanently-skipping test is worse than no test, because it reads as coverage that does not exist.

## The tradeoff, on the record

These tests are **correct**, and running them by hand against a real server finds a genuine defect.

Pointed at a non-NLA server (xrdp), the credential check reports `Success=true` for a deliberately wrong password. The connector offers CredSSP, the server declines, it proceeds anyway, and reports the completed connection as a successful authentication:

```
CORRECT password   rawError=<nil>   => Success would be true
WRONG password     rawError=<nil>   => Success would be true
```

`_InvalidCredentials` asserts `Success == false` and fails on exactly that.

So there are two ways to resolve the skipping:

1. **Delete them** (this PR) — smaller change, removes the false impression of coverage.
2. **Provision an RDP server in `ci-integration.yml`** and let them run — larger change, and it would have caught the defect above automatically.

I have gone with (1) as requested, but (2) is the more useful outcome and I would suggest it as a follow-up. Happy to raise that PR if wanted.

## Testing

`go test ./internal/plugins/rdp/` passes; nothing else references the removed helpers.