### PR TITLE
docs(release): stop the CLI-surface comment naming the drift gate as a consumer

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -141,9 +141,14 @@ release:
   draft: false
   prerelease: auto
   name_template: "Brutus {{ .Tag }}"
-  # Attach the machine-readable CLI surface to every release so downstream
-  # consumers (e.g. the guard-skills drift gate) can pin the exact surface a
-  # given brutus version registered, rather than scraping prose.
+  # Attach the machine-readable CLI surface to every release so a consumer can pin the
+  # exact surface a given brutus version registered, rather than scraping prose.
+  #
+  # The guard-skills drift gate does NOT read this asset, and that is deliberate: it
+  # pins tip-of-main, reading docs/cli-surface.json at a resolved commit, so an
+  # upstream flag rename reddens its next scheduled run instead of waiting for a
+  # release. Do not "reconcile" the two by rewiring that gate or dropping this block --
+  # the attachment serves consumers that want the surface a released version exposes.
   extra_files:
     - glob: docs/cli-surface.json
   header: |

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -144,11 +144,11 @@ release:
   # Attach the machine-readable CLI surface to every release so a consumer can pin the
   # exact surface a given brutus version registered, rather than scraping prose.
   #
-  # The guard-skills drift gate does NOT read this asset, and that is deliberate: it
-  # pins tip-of-main, reading docs/cli-surface.json at a resolved commit, so an
-  # upstream flag rename reddens its next scheduled run instead of waiting for a
-  # release. Do not "reconcile" the two by rewiring that gate or dropping this block --
-  # the attachment serves consumers that want the surface a released version exposes.
+  # This asset and the guard-skills drift gate are independent by design. The gate
+  # does not read the release asset: it pins tip-of-main, reading docs/cli-surface.json
+  # at a resolved commit, so an upstream flag rename reddens its next scheduled run
+  # instead of waiting for a release. The attachment exists for consumers that want the
+  # surface a released version exposes, which is why both mechanisms coexist.
   extra_files:
     - glob: docs/cli-surface.json
   header: |


### PR DESCRIPTION
Closes [ENG-7495](https://linear.app/praetorianlabs/issue/ENG-7495/correct-brutus-goreleaseryaml-cli-surface-comment-to-stop-naming-the) — this diff is the comment correction the ticket asks for.

## What

The comment above `release.extra_files` in `.goreleaser.yaml` justified attaching `docs/cli-surface.json` by naming a consumer that does not consume it:

> Attach the machine-readable CLI surface to every release so downstream consumers (e.g. the guard-skills drift gate) can pin the exact surface a given brutus version registered, rather than scraping prose.

## Why it was wrong

The guard-skills drift gate does not read the release asset. As of guard-skills `705046a4`, `scripts/validate_brutus_cli_surface.py` has a single fetch path — `fetch_artifact` resolves its `--ref` (default `main`) through the commits API, then reads `ARTIFACT_PATH` from raw.githubusercontent at that resolved commit. Grepping that script for `releases|assets|browser_download|tag_name` returns zero matches.

Measured on 2026-09-02: a `workflow_dispatch` run of that gate on guard-skills `main` passed, reporting

```
brutus CLI surface matches the pin (sha256:1d4cc140...) via praetorian-inc/brutus@3cd94587
```

— a commit on `main`, not a release tag.

Pinning tip-of-`main` there is deliberate, not an oversight: it reddens the morning after an upstream flag rename instead of waiting for a release, and the brutus Guard capability imports `pkg/brutus` directly and never execs the CLI, so the pinned surface describes what an operator or agent is told to type rather than what a released binary exposes.

Left as-is, the comment invites the next reader to either rewire that gate to consume an asset it deliberately ignores, or delete `extra_files` believing the gate depends on it.

## What this does

Keeps `extra_files` — the attachment is still useful to any consumer wanting the surface a specific released version exposes — and replaces the consumer claim with the deliberate tip-of-`main` note.

## Verification

- Diff is comment-only: `git diff -U0` shows no changed line that is not a comment.
- `.goreleaser.yaml` parses, with `release.extra_files == [{'glob': 'docs/cli-surface.json'}]` unchanged.
- `goreleaser check` was not run — goreleaser is not installed on this workstation. It is not load-bearing here: YAML comments are not part of the parsed document, so a comment-only change cannot alter goreleaser's configuration. CI covers it regardless.
- Repo-wide sweep for the same class of claim (`guard-skills` across `*.md`, `*.yaml`, `*.yml`, `*.go`) found no other instance. `CONTRIBUTING.md`'s "Downstream consumers pin this; it is attached to every GitHub release" is accurate and names no specific consumer, so it is unchanged.

## Premise gate

Skipped, and recorded per the standing gate: the trigger is a change that builds non-trivial machinery, and this is a comment-only edit that defines no behavior — the gate's literal complement. No layer question arises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
