### PR TITLE
ci: pin golangci-lint v2.13.1 for Go 1.27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
       - 'go.sum'
       - '.golangci*'
       - 'Makefile'
+      - '.github/workflows/ci.yml'
   workflow_dispatch:
 
 concurrency:
@@ -26,6 +27,7 @@ jobs:
     permissions:
       contents: read
     with:
+      golangci-lint-version: "v2.13.1"
       build-cmd-path: ./cmd/brutus
       build-binary-name: brutus
     secrets: inherit


### PR DESCRIPTION
## Summary

#357 merged the nerva 1.64.3 → 1.69.5 bump, which pulled `go 1.27.0` into `go.mod`. Lint then failed:

```
can't load config: the Go language version (go1.26) used to build golangci-lint is lower than the targeted Go version (1.27.0)
```

Pin `golangci-lint-version: v2.13.1` on the reusable Go CI workflow — the same pin augustus/titus/julius/etc. already use. v2.13.0 added Go 1.27 support.

Also add `.github/workflows/ci.yml` to the PR path filter so this pin (and future CI-only changes) actually run the workflow.

## Test plan

- [ ] CI lint job on this PR is green
- [ ] Remaining CI jobs (test, build, module integrity) stay green