### PR TITLE
feat(logon): attach baseline and response PNGs to findings

### DIFF
--- a/cmd/brutus/runner.go
+++ b/cmd/brutus/runner.go
@@ -503,7 +503,7 @@ func runScanSingleTarget(target string, base *runConfig) []logon.Finding {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	return scanTargetFn(ctx, target, base)
+	return dropScreenshots(scanTargetFn(ctx, target, base))
 }
 
 // scanTargetFn performs detection for a single target. It is a package-level
@@ -511,6 +511,14 @@ func runScanSingleTarget(target string, base *runConfig) []logon.Finding {
 var scanTargetFn = func(ctx context.Context, target string, base *runConfig) []logon.Finding {
 	return logon.DetectBackdoors(ctx, target, base.connectTimeout, base.timeout, base.aiMode, base.maxRetries, base.checks,
 		base.proxyURL, base.noNLAProbe, base.fast)
+}
+
+func dropScreenshots(findings []logon.Finding) []logon.Finding {
+	for i := range findings {
+		findings[i].BaselinePNG = nil
+		findings[i].ResponsePNG = nil
+	}
+	return findings
 }
 
 // runScanTargetsConcurrent runs sticky-keys/utilman detection across many targets
@@ -571,7 +579,7 @@ func runScanTargetsConcurrentCtx(ctx context.Context, targets []string, base *ru
 				perTarget[idx] = logon.CancelledResults(target, base.checks)
 				return nil
 			}
-			perTarget[idx] = scanTargetFn(ctx, target, base)
+			perTarget[idx] = dropScreenshots(scanTargetFn(ctx, target, base))
 			return nil
 		})
 	}

--- a/cmd/brutus/scan_concurrency_test.go
+++ b/cmd/brutus/scan_concurrency_test.go
@@ -66,6 +66,23 @@ func TestRunScanTargetsConcurrent_PreservesInputOrder(t *testing.T) {
 	assert.Equal(t, expectedOrder, actualOrder)
 }
 
+func TestRunScanTargetsConcurrent_DropsScreenshots(t *testing.T) {
+	withScanTargetFn(t, func(_ context.Context, target string, _ *runConfig) []logon.Finding {
+		return []logon.Finding{{
+			Target:      target,
+			Check:       logon.BackdoorStickyKeys,
+			Verdict:     logon.VerdictBackdoorLikely,
+			BaselinePNG: []byte{0x89, 0x50},
+			ResponsePNG: []byte{0x89, 0x51},
+		}}
+	})
+
+	findings := runScanTargetsConcurrent([]string{"a:3389"}, &runConfig{baseConfigOptions: &baseConfigOptions{threads: 1}})
+	assert.Len(t, findings, 1)
+	assert.Nil(t, findings[0].BaselinePNG)
+	assert.Nil(t, findings[0].ResponsePNG)
+}
+
 // TestRunScanTargetsConcurrent_BoundedByThreads verifies that concurrency is
 // bounded by base.threads and that parallelism actually occurs. We track peak
 // observed concurrency with an atomic counter incremented on entry and

--- a/internal/plugins/rdp/detect.go
+++ b/internal/plugins/rdp/detect.go
@@ -155,6 +155,8 @@ func (p *Plugin) runStickyKeysDetection(ctx context.Context, inst *wasmInstance,
 	}
 	analysis := runStickyKeysAnalysis(ctx, baseline, response, width, height, visionAPIKey)
 	finalizeStickyKeysResult(result, &analysis, diag, stabilized, fast)
+	result.BaselinePNG = encodeFramePNG(baseline, width, height)
+	result.ResponsePNG = encodeFramePNG(response, width, height)
 
 	return result, nil
 }
@@ -216,6 +218,8 @@ func (p *Plugin) runUtilmanDetection(ctx context.Context, inst *wasmInstance, ad
 	}
 	analysis := runUtilmanAnalysis(ctx, baseline, response, width, height, visionAPIKey)
 	finalizeUtilmanResult(result, &analysis, diag, stabilized, fast)
+	result.BaselinePNG = encodeFramePNG(baseline, width, height)
+	result.ResponsePNG = encodeFramePNG(response, width, height)
 
 	return result, nil
 }
@@ -229,6 +233,18 @@ func stabilizedVerdict(verdict string, stabilized, fast bool) string {
 		return verdictIndeterminate
 	}
 	return verdict
+}
+
+func encodeFramePNG(rgba []byte, w, h uint32) []byte {
+	if len(rgba) == 0 || w == 0 || h == 0 {
+		return nil
+	}
+	pngData, err := rgbaToPNG(rgba, w, h)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[!] screenshot encode: %v\n", err)
+		return nil
+	}
+	return pngData
 }
 
 // dumpFrame is an env-var-gated DEBUG aid: when dir is non-empty it saves the

--- a/internal/plugins/rdp/detect.go
+++ b/internal/plugins/rdp/detect.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net"
 	"os"
 	"path/filepath"
@@ -236,7 +237,12 @@ func stabilizedVerdict(verdict string, stabilized, fast bool) string {
 }
 
 func encodeFramePNG(rgba []byte, w, h uint32) []byte {
-	if len(rgba) == 0 || w == 0 || h == 0 {
+	pixels := uint64(w) * uint64(h)
+	if pixels == 0 || pixels > uint64(math.MaxInt/4) {
+		return nil
+	}
+	need := int(pixels * 4)
+	if len(rgba) < need {
 		return nil
 	}
 	pngData, err := rgbaToPNG(rgba, w, h)

--- a/internal/plugins/rdp/detect_test.go
+++ b/internal/plugins/rdp/detect_test.go
@@ -457,6 +457,9 @@ func TestOutcome_CarriesScreenshots(t *testing.T) {
 func TestEncodeFramePNG(t *testing.T) {
 	assert.Nil(t, encodeFramePNG(nil, 1, 1))
 	assert.Nil(t, encodeFramePNG([]byte{0, 0, 0, 255}, 0, 1))
+	assert.Nil(t, encodeFramePNG([]byte{0, 0, 0}, 1, 1))
+	assert.Nil(t, encodeFramePNG(make([]byte, 4), 2, 1))
+	assert.Nil(t, encodeFramePNG([]byte{1}, ^uint32(0), ^uint32(0)))
 
 	pngData := encodeFramePNG([]byte{0, 0, 0, 255}, 1, 1)
 	require.NotEmpty(t, pngData)

--- a/internal/plugins/rdp/detect_test.go
+++ b/internal/plugins/rdp/detect_test.go
@@ -441,6 +441,29 @@ func TestOutcome_CarriesEveryDiagnostic(t *testing.T) {
 	assert.Equal(t, "server initiated disconnect", out.TerminationReason)
 }
 
+func TestOutcome_CarriesScreenshots(t *testing.T) {
+	baseline := []byte{0x89, 0x50, 0x4E, 0x47, 0x01}
+	response := []byte{0x89, 0x50, 0x4E, 0x47, 0x02}
+
+	sticky := stickyOutcome(&StickyKeysResult{BaselinePNG: baseline, ResponsePNG: response})
+	assert.Equal(t, baseline, sticky.BaselinePNG)
+	assert.Equal(t, response, sticky.ResponsePNG)
+
+	utilman := utilmanOutcome(&UtilmanResult{BaselinePNG: baseline, ResponsePNG: response})
+	assert.Equal(t, baseline, utilman.BaselinePNG)
+	assert.Equal(t, response, utilman.ResponsePNG)
+}
+
+func TestEncodeFramePNG(t *testing.T) {
+	assert.Nil(t, encodeFramePNG(nil, 1, 1))
+	assert.Nil(t, encodeFramePNG([]byte{0, 0, 0, 255}, 0, 1))
+
+	pngData := encodeFramePNG([]byte{0, 0, 0, 255}, 1, 1)
+	require.NotEmpty(t, pngData)
+	assert.Equal(t, byte(0x89), pngData[0])
+	assert.Equal(t, byte(0x50), pngData[1])
+}
+
 // TestSafeFilenameComponentCannotEscapeADirectory pins the traversal fix. A target
 // reaches dumpFrame straight from the scan list, and ParseTarget validates a host's
 // shape but not its contents, so a hostile targets-file line arrives intact.

--- a/internal/plugins/rdp/outcome.go
+++ b/internal/plugins/rdp/outcome.go
@@ -33,6 +33,8 @@ type CheckOutcome struct {
 	RegionNote        string
 	SessionTerminated bool
 	TerminationReason string
+	BaselinePNG       []byte
+	ResponsePNG       []byte
 }
 
 func stickyOutcome(r *StickyKeysResult) *CheckOutcome {
@@ -49,6 +51,8 @@ func stickyOutcome(r *StickyKeysResult) *CheckOutcome {
 		RegionNote:        r.RegionNote,
 		SessionTerminated: r.SessionTerminated,
 		TerminationReason: r.TerminationReason,
+		BaselinePNG:       r.BaselinePNG,
+		ResponsePNG:       r.ResponsePNG,
 	}
 }
 
@@ -66,6 +70,8 @@ func utilmanOutcome(r *UtilmanResult) *CheckOutcome {
 		RegionNote:        r.RegionNote,
 		SessionTerminated: r.SessionTerminated,
 		TerminationReason: r.TerminationReason,
+		BaselinePNG:       r.BaselinePNG,
+		ResponsePNG:       r.ResponsePNG,
 	}
 }
 

--- a/internal/plugins/rdp/session.go
+++ b/internal/plugins/rdp/session.go
@@ -61,6 +61,11 @@ type StickyKeysResult struct {
 	// TerminationReason is the server-reported reason behind SessionTerminated,
 	// surfaced in the operator-facing banner instead of being discarded.
 	TerminationReason string
+	// BaselinePNG / ResponsePNG are the captured frames encoded as PNG, or nil
+	// when the check never produced a framebuffer (or encode failed). Set after
+	// finalizeStickyKeysResult so the analysis overwrite cannot drop them.
+	BaselinePNG []byte
+	ResponsePNG []byte
 }
 
 // UtilmanResult holds the outcome of utilman backdoor detection.
@@ -87,6 +92,8 @@ type UtilmanResult struct {
 	// TerminationReason is the server-reported reason behind SessionTerminated,
 	// surfaced in the operator-facing banner instead of being discarded.
 	TerminationReason string
+	BaselinePNG       []byte
+	ResponsePNG       []byte
 }
 
 // leftShiftScancode is the scancode for Left Shift key (used for sticky keys detection).

--- a/pkg/brutus/logon/finding.go
+++ b/pkg/brutus/logon/finding.go
@@ -63,6 +63,10 @@ type Finding struct {
 	Confidence  float64
 	Stabilized  bool
 	Diagnostics Diagnostics
+	// BaselinePNG / ResponsePNG are the captured frames, or nil when the check
+	// never produced a framebuffer. Not serialized by the CLI JSONL path.
+	BaselinePNG []byte
+	ResponsePNG []byte
 }
 
 func AnyPositive(findings []Finding) bool {
@@ -114,6 +118,8 @@ func findingFrom(target string, out *rdp.CheckOutcome) Finding {
 			SessionTerminated: out.SessionTerminated,
 			TerminationReason: out.TerminationReason,
 		},
+		BaselinePNG: out.BaselinePNG,
+		ResponsePNG: out.ResponsePNG,
 	}
 
 	switch {

--- a/pkg/brutus/logon/finding_test.go
+++ b/pkg/brutus/logon/finding_test.go
@@ -120,6 +120,20 @@ func TestFindingFrom_CarriesVerdictAndDiagnostics(t *testing.T) {
 	assert.Equal(t, "logoff by user", f.Diagnostics.TerminationReason)
 }
 
+func TestFindingFrom_CarriesScreenshots(t *testing.T) {
+	baseline := []byte{0x89, 0x50, 0x4E, 0x47, 0x01}
+	response := []byte{0x89, 0x50, 0x4E, 0x47, 0x02}
+	f := findingFrom("10.0.0.5:3389", &rdp.CheckOutcome{
+		Check:       rdp.BackdoorStickyKeys,
+		Performed:   true,
+		Verdict:     "backdoor_likely",
+		BaselinePNG: baseline,
+		ResponsePNG: response,
+	})
+	assert.Equal(t, baseline, f.BaselinePNG)
+	assert.Equal(t, response, f.ResponsePNG)
+}
+
 func TestTerminalFindings_RespectsSelector(t *testing.T) {
 	for _, tc := range []struct {
 		checks Check


### PR DESCRIPTION
## Summary

Logon-screen detection already captures baseline and response frames for the pixel-diff verdict, but it only kept them when `BRUTUS_DEBUG_SCREENSHOT_DIR` was set. Guard needs those frames on the typed `Finding` so a triager (or agent) can corroborate a `backdoor_likely` reading.

This carries the PNG-encoded frames on `StickyKeysResult` / `UtilmanResult` → `CheckOutcome` → `logon.Finding`. Encode failures are non-fatal (stderr + nil), matching `dumpFrame`. The CLI JSONL path still does not serialize them.

## Test plan

- [x] `go test -short ./pkg/brutus/logon/ ./internal/plugins/rdp/`
- [ ] Guard consumes `Finding.BaselinePNG` / `Finding.ResponsePNG` in the structured proof follow-up