### PR TITLE
style: strip decorative banners and restating comments

### DIFF
--- a/cmd/brutus/browser_test.go
+++ b/cmd/brutus/browser_test.go
@@ -22,10 +22,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ---------------------------------------------------------------------------
-// TestIsAllowedVerificationURL
-// ---------------------------------------------------------------------------
-
 func TestIsAllowedVerificationURL(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -115,10 +111,6 @@ func TestIsAllowedVerificationURL(t *testing.T) {
 		})
 	}
 }
-
-// ---------------------------------------------------------------------------
-// TestBrowserCommand
-// ---------------------------------------------------------------------------
 
 func TestBrowserCommand(t *testing.T) {
 	const url = "https://login.microsoft.com/device"

--- a/cmd/brutus/cmd_enum_apollo_test.go
+++ b/cmd/brutus/cmd_enum_apollo_test.go
@@ -29,10 +29,6 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/enum/apollo"
 )
 
-// ---------------------------------------------------------------------------
-// T004: resolveApolloAPIKey + classifyApolloError (security: no key leak)
-// ---------------------------------------------------------------------------
-
 func TestResolveApolloAPIKey(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -138,10 +134,6 @@ func TestClassifyApolloError_NetworkWrap(t *testing.T) {
 	assert.Contains(t, result.Error(), "timeout")
 }
 
-// ---------------------------------------------------------------------------
-// T005: runEnumApollo input validation (--limit < 0, --reveal with --limit 0)
-// ---------------------------------------------------------------------------
-
 // resetApolloFlags resets the package-level apollo flag vars to safe defaults.
 // Discover is the default (flagApolloEnrich=false). --enrich opts in to enrichment.
 func resetApolloFlags() {
@@ -216,10 +208,6 @@ func TestRunEnumApollo_EnrichWithPositiveLimitPassesGuard(t *testing.T) {
 	assert.NotContains(t, err.Error(), "--enrich requires",
 		"positive --limit must clear the --enrich credit guard")
 }
-
-// ---------------------------------------------------------------------------
-// T003 cmd: outputApolloJSONL + outputApolloHuman
-// ---------------------------------------------------------------------------
 
 func TestOutputApolloJSONL(t *testing.T) {
 	t.Run("discovery person emits has_email/has_phone availability, no email values", func(t *testing.T) {
@@ -395,10 +383,6 @@ func TestOutputApolloHuman(t *testing.T) {
 		assert.Contains(t, out, "No people found")
 	})
 }
-
-// ---------------------------------------------------------------------------
-// T006: enumApolloCmd registration
-// ---------------------------------------------------------------------------
 
 func TestEnumApolloRegistered(t *testing.T) {
 	// 1. enumCmd must have a "passive" subcommand.

--- a/cmd/brutus/cmd_enum_custom_test.go
+++ b/cmd/brutus/cmd_enum_custom_test.go
@@ -30,10 +30,6 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/enum/custom"
 )
 
-// ---------------------------------------------------------------------------
-// T11: Command registration
-// ---------------------------------------------------------------------------
-
 // TestEnumCustomRegistered verifies that "custom" is registered as a
 // subcommand of enumCmd with the required flags, shorthands, and required
 // annotation — mirrors cmd_enum_hunter_test.go::TestEnumHunterRegistered.
@@ -92,10 +88,6 @@ func TestEnumCustomRegistered(t *testing.T) {
 	}
 	require.True(t, found, "custom subcommand must be registered with enumActiveCmd")
 }
-
-// ---------------------------------------------------------------------------
-// T11: runEnumCustom error paths
-// ---------------------------------------------------------------------------
 
 // TestRunEnumCustom_BadSpec verifies that runEnumCustom returns a non-nil
 // error when the spec file contains invalid content.
@@ -190,10 +182,6 @@ func TestRunEnumCustom_OversizeFile(t *testing.T) {
 	err = runEnumCustom(enumCustomCmd, nil)
 	require.Error(t, err, "oversize spec file must be rejected before parse (R8)")
 }
-
-// ---------------------------------------------------------------------------
-// F1: Subject-building helpers (dedupe, buildCustomSubjects)
-// ---------------------------------------------------------------------------
 
 // TestDedupe_RemovesDuplicatesPreservingOrder verifies that dedupe removes
 // repeated values while preserving the first-seen order.
@@ -364,10 +352,6 @@ func TestBuildCustomSubjects_ConstraintRateLimitDefault(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"seed@example.com"}, got)
 }
-
-// ---------------------------------------------------------------------------
-// New: TestRunEnumCustom_EndToEnd — 32% → higher coverage of runEnumCustom
-// ---------------------------------------------------------------------------
 
 // oracleSpecForTest builds the JSON for a schema-v1 oracle whose URL points at
 // srv. The oracle uses a POST with a JSON body that includes the {{username}}

--- a/cmd/brutus/cmd_enum_dehashed_output.go
+++ b/cmd/brutus/cmd_enum_dehashed_output.go
@@ -25,10 +25,6 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/enum/dehashed"
 )
 
-// ---------------------------------------------------------------------------
-// DeHashed output functions
-// ---------------------------------------------------------------------------
-
 // outputDehashedHuman renders refined DeHashed contacts as an aligned table.
 // All strings are breach-sourced and therefore hostile-controlled, so every
 // field is sanitized via sanitizeTerminal and truncated (P0-4) — including the

--- a/cmd/brutus/cmd_enum_dehashed_test.go
+++ b/cmd/brutus/cmd_enum_dehashed_test.go
@@ -41,10 +41,6 @@ func firstElem(t *testing.T, v interface{}) interface{} {
 	return s[0]
 }
 
-// ---------------------------------------------------------------------------
-// Task 7: resolveDehashedAPIKey
-// ---------------------------------------------------------------------------
-
 func TestResolveDehashedAPIKey(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -87,10 +83,6 @@ func TestResolveDehashedAPIKey(t *testing.T) {
 		})
 	}
 }
-
-// ---------------------------------------------------------------------------
-// Task 8: classifyDehashedError — key must never appear in output
-// ---------------------------------------------------------------------------
 
 func TestClassifyDehashedError_NoKeyLeak(t *testing.T) {
 	tests := []struct {
@@ -141,10 +133,6 @@ func TestClassifyDehashedError_NoKeyLeak(t *testing.T) {
 		})
 	}
 }
-
-// ---------------------------------------------------------------------------
-// Task 9 (updated): outputDehashedHuman — showCredentials bool param
-// ---------------------------------------------------------------------------
 
 func TestOutputDehashedHuman(t *testing.T) {
 	t.Run("renders entries with email name username phone sources columns", func(t *testing.T) {
@@ -256,10 +244,6 @@ func TestOutputDehashedHuman(t *testing.T) {
 			"hashed_password must never appear in human output")
 	})
 }
-
-// ---------------------------------------------------------------------------
-// Task 10 (updated): outputDehashedJSONL — showCredentials bool param
-// ---------------------------------------------------------------------------
 
 func TestOutputDehashedJSONL(t *testing.T) {
 	t.Run("single entry emits one JSONL line with expected fields", func(t *testing.T) {
@@ -399,10 +383,6 @@ func TestOutputDehashedJSONL(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
-// Task 11: enumDehashedCmd registration and flags (updated — passive regroup)
-// ---------------------------------------------------------------------------
-
 func TestEnumDehashedRegistered(t *testing.T) {
 	// 1. enumCmd must have a "passive" subcommand.
 	var passive *cobra.Command
@@ -468,10 +448,6 @@ func TestEnumDehashedRegistered(t *testing.T) {
 	assert.True(t, alias.Hidden, "back-compat dehashed alias must be Hidden")
 	assert.NotEmpty(t, alias.Deprecated, "back-compat dehashed alias must be Deprecated")
 }
-
-// ---------------------------------------------------------------------------
-// outputDehashedDetailedJSON
-// ---------------------------------------------------------------------------
 
 func TestOutputDehashedDetailedJSON(t *testing.T) {
 	collectedAt := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)

--- a/cmd/brutus/cmd_enum_generate_test.go
+++ b/cmd/brutus/cmd_enum_generate_test.go
@@ -20,10 +20,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// ---------------------------------------------------------------------------
-// capResults
-// ---------------------------------------------------------------------------
-
 // TestCapResults_LimitToN verifies that capResults returns exactly N items
 // when limit <= len(results).
 func TestCapResults_LimitToN(t *testing.T) {

--- a/cmd/brutus/cmd_enum_github_map_test.go
+++ b/cmd/brutus/cmd_enum_github_map_test.go
@@ -24,10 +24,6 @@ import (
 	githubenum "github.com/praetorian-inc/brutus/pkg/enum/github"
 )
 
-// ---------------------------------------------------------------------------
-// Flag registration
-// ---------------------------------------------------------------------------
-
 // TestEnumGithubMapCmd_Flags verifies that enumGithubMapCmd carries the
 // required flags and shorthands, and that no shorthand collides with the
 // global persistent --threads/-t flag.
@@ -56,10 +52,6 @@ func TestEnumGithubMapCmd_Flags(t *testing.T) {
 		"enumGithubMapCmd must not define a local -t shorthand (collides with global --threads/-t)")
 }
 
-// ---------------------------------------------------------------------------
-// Command wiring
-// ---------------------------------------------------------------------------
-
 // TestEnumGithubMapCmd_WiredUnderGithub verifies that enumGithubMapCmd is
 // registered as a child of enumGithubCmd with Use == "map".
 func TestEnumGithubMapCmd_WiredUnderGithub(t *testing.T) {
@@ -72,10 +64,6 @@ func TestEnumGithubMapCmd_WiredUnderGithub(t *testing.T) {
 	}
 	assert.True(t, found, `enumGithubCmd must have a "map" subcommand`)
 }
-
-// ---------------------------------------------------------------------------
-// collectGithubEmails
-// ---------------------------------------------------------------------------
 
 // TestCollectGithubEmails exercises the shared email-collection helper with
 // table-driven cases covering CSV dedup+trim, generated appending, and the
@@ -137,10 +125,6 @@ func TestCollectGithubEmails(t *testing.T) {
 		})
 	}
 }
-
-// ---------------------------------------------------------------------------
-// githubMapResults
-// ---------------------------------------------------------------------------
 
 // TestGithubMapResults verifies that githubMapResults builds per-email results
 // from the reveal mapping, preserving input order and correctly marking

--- a/cmd/brutus/cmd_enum_github_test.go
+++ b/cmd/brutus/cmd_enum_github_test.go
@@ -29,10 +29,6 @@ import (
 	githubenum "github.com/praetorian-inc/brutus/pkg/enum/github"
 )
 
-// ---------------------------------------------------------------------------
-// Flag registration
-// ---------------------------------------------------------------------------
-
 // TestEnumGithubCmd_Flags verifies that enumGithubCmd carries the required
 // flags and shorthands, and that no shorthand collides with the global
 // persistent --threads/-t flag.
@@ -76,10 +72,6 @@ func TestEnumGithubCmd_Flags(t *testing.T) {
 	require.Nil(t, noT,
 		"enumGithubCmd must not define a local -t shorthand (collides with global --threads/-t)")
 }
-
-// ---------------------------------------------------------------------------
-// Command wiring (HARD MOVE assertion)
-// ---------------------------------------------------------------------------
 
 // TestEnumGithubCmd_WiredUnderActiveCmd verifies the cobra tree after the
 // "enum active" hard move:
@@ -128,10 +120,6 @@ func TestEnumGithubCmd_WiredUnderActiveCmd(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// --no-reveal flag contract
-// ---------------------------------------------------------------------------
-
 // TestEnumGithubCmd_NoRevealFlag asserts the flag-level contract for the
 // boolean --no-reveal flag registered on enumGithubCmd:
 //  1. The flag exists on the command.
@@ -146,7 +134,6 @@ func TestEnumGithubCmd_NoRevealFlag(t *testing.T) {
 	assert.Equal(t, "", f.Shorthand, "--no-reveal must have no shorthand")
 }
 
-// ---------------------------------------------------------------------------
 // githubEnumTargetList
 //
 // 10T-535 (3/8): githubEnumTargets() ([]string, error) is retargeted onto
@@ -155,7 +142,6 @@ func TestEnumGithubCmd_NoRevealFlag(t *testing.T) {
 // assertion (dedup, "provide" error) is preserved; the tests are
 // strengthened to also assert the never-invent-a-name rule for
 // CLI-supplied addresses.
-// ---------------------------------------------------------------------------
 
 func resetGithubEnumTargetFlags() (restore func()) {
 	origEmails := flagGithubEnumEmails
@@ -277,10 +263,6 @@ func TestGithubEnumTargetList_DedupPrecedence(t *testing.T) {
 	assert.Empty(t, got[0].Last, "the surviving deduplicated entry must be the CLI-supplied one and carry no name")
 }
 
-// ---------------------------------------------------------------------------
-// resolveGithubToken
-// ---------------------------------------------------------------------------
-
 // TestResolveGithubToken verifies the flag-overrides-env, env-fallback, and
 // empty-allowed behaviors. The token is never required (existence-only mode is
 // valid with an empty token).
@@ -341,10 +323,6 @@ func TestResolveGithubToken_FlagValueReturned(t *testing.T) {
 	assert.Equal(t, "flag-overrides", got,
 		"flag value must take precedence over GITHUB_TOKEN env var")
 }
-
-// ---------------------------------------------------------------------------
-// outputGithubEnumJSONL
-// ---------------------------------------------------------------------------
 
 // TestOutputGithubEnumJSONL verifies the JSON structure of each output line:
 // type, email, exists, optional username and error fields.
@@ -438,10 +416,6 @@ func TestOutputGithubEnumJSONL(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// outputGithubEnumJSONL — First/Last name propagation (10T-535, 3/8)
-// ---------------------------------------------------------------------------
-
 // TestOutputGithubEnumJSONL_NameFields pins the never-invent-a-name rule: a
 // Result carrying First/Last (from --domain generation) must emit
 // "first"/"last" in the JSONL row, while a Result with empty First/Last
@@ -527,10 +501,6 @@ func TestOutputGithubEnumJSONL_NameFields(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
-// outputGithubEnumResultLine
-// ---------------------------------------------------------------------------
-
 // TestOutputGithubEnumResultLine_Error verifies that a result with a non-nil
 // Error renders the dedicated error row: the red "[-]" symbol, the literal
 // word "error", and a truncated/sanitized chunk of the error message. It must
@@ -569,10 +539,6 @@ func TestOutputGithubEnumResultLine_NotFoundStillWorks(t *testing.T) {
 	assert.NotContains(t, out, " error ", "a not-found result must not render the error row")
 }
 
-// ---------------------------------------------------------------------------
-// outputGithubEnumSummary
-// ---------------------------------------------------------------------------
-
 // TestOutputGithubEnumSummary_ShowsRepresentativeError verifies that when
 // errored results are present, the summary shows an "Errors: N" line followed
 // by a representative "e.g. <msg>" line containing the FIRST errored
@@ -597,10 +563,6 @@ func TestOutputGithubEnumSummary_ShowsRepresentativeError(t *testing.T) {
 		"summary need only show the first errored result's message, not every one")
 }
 
-// ---------------------------------------------------------------------------
-// firstGithubEnumError
-// ---------------------------------------------------------------------------
-
 // TestFirstGithubEnumError verifies that firstGithubEnumError returns the
 // first non-nil error's message, and "" when no result has an error.
 func TestFirstGithubEnumError(t *testing.T) {
@@ -624,7 +586,6 @@ func TestFirstGithubEnumError(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
 // stampGithubResultNames (10T-535, 3/8)
 //
 // pkg/enum/github/existence.go's EnumerateWith does `results[i] = res;
@@ -637,7 +598,6 @@ func TestFirstGithubEnumError(t *testing.T) {
 // without a network call. These tests pin exactly the property the loop
 // exists for: index-based, in-place mutation of the caller's slice — a
 // by-value `for _, r := range results` "simplification" must fail them.
-// ---------------------------------------------------------------------------
 
 // TestStampGithubResultNames_HitStampsNameFromIndex verifies that a result
 // whose email is present in the index gets its First/Last stamped from the

--- a/cmd/brutus/cmd_enum_google_test.go
+++ b/cmd/brutus/cmd_enum_google_test.go
@@ -26,11 +26,9 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/enum/google"
 )
 
-// ---------------------------------------------------------------------------
 // TestEnumGoogleCmd_Flags
 // Verifies that all documented flags exist on enumGoogleCmd and that
 // no shorthand collides with the global --threads/-t flag.
-// ---------------------------------------------------------------------------
 
 func TestEnumGoogleCmd_Flags(t *testing.T) {
 	// --emails / -e
@@ -91,10 +89,8 @@ func TestEnumGoogleCmd_RegisteredUnderActiveCmd(t *testing.T) {
 	assert.True(t, found, "enumGoogleCmd must be registered as a subcommand of enumActiveCmd (hard move)")
 }
 
-// ---------------------------------------------------------------------------
 // TestOutputGoogleEnumJSONL
 // Feeds google.Result values and asserts the type/method/idp fields.
-// ---------------------------------------------------------------------------
 
 func TestOutputGoogleEnumJSONL(t *testing.T) {
 	tests := []struct {
@@ -192,10 +188,6 @@ func TestOutputGoogleEnumJSONL(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// outputGoogleEnumJSONL — First/Last name propagation (10T-535, 4/8)
-// ---------------------------------------------------------------------------
-
 // TestOutputGoogleEnumJSONL_NameFields pins the never-invent-a-name rule: a
 // Result carrying First/Last (from --domain generation) must emit
 // "first"/"last" in the JSONL row, while a Result with empty First/Last
@@ -283,10 +275,8 @@ func TestOutputGoogleEnumJSONL_NameFields(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
 // TestOutputGoogleEnumResultLine
 // Verifies human-readable line output for EXISTS, gmail, and ANSI safety.
-// ---------------------------------------------------------------------------
 
 func TestOutputGoogleEnumResultLine(t *testing.T) {
 	t.Run("workspace-sso with IdP shows EXISTS and IdP", func(t *testing.T) {
@@ -361,7 +351,6 @@ func TestOutputGoogleEnumResultLine(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
 // googleEnumTargetList
 //
 // 10T-535 (4/8): googleEnumTargets() ([]string, error) is retargeted onto
@@ -370,7 +359,6 @@ func TestOutputGoogleEnumResultLine(t *testing.T) {
 // assertion (dedup, "provide" error) is preserved; the tests are
 // strengthened to also assert the never-invent-a-name rule for
 // CLI-supplied addresses.
-// ---------------------------------------------------------------------------
 
 func resetGoogleEnumTargetFlags() (restore func()) {
 	origEmails := flagGoogleEnumEmails

--- a/cmd/brutus/cmd_enum_gravatar_output.go
+++ b/cmd/brutus/cmd_enum_gravatar_output.go
@@ -23,10 +23,6 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/enum/gravatar"
 )
 
-// ---------------------------------------------------------------------------
-// Gravatar account enumeration output functions
-// ---------------------------------------------------------------------------
-
 // outputGravatarEnumResultLine prints ONE Gravatar enumeration result row.
 // EXISTS rows show the email and an "[+] EXISTS" label; not-found rows render as
 // "[ ] not found". Callers decide which results to print (e.g. EXISTS only,

--- a/cmd/brutus/cmd_enum_gravatar_test.go
+++ b/cmd/brutus/cmd_enum_gravatar_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/enum/gravatar"
 )
 
-// ---------------------------------------------------------------------------
 // gravatarEnumTargetList / gravatarEnumGenerate
 //
 // 10T-535 (5/8): gravatarEnumTargets() ([]string, error) is retargeted onto
@@ -39,7 +38,6 @@ import (
 // reason. Every prior assertion (trim, case-insensitive dedup, "provide"
 // error, --limit capping, invalid-format error) is preserved; there is no
 // dead adapter left behind pinning the old []string signatures.
-// ---------------------------------------------------------------------------
 
 func resetGravatarEnumFlags() (restore func()) {
 	origEmails := flagGravatarEnumEmails
@@ -142,7 +140,6 @@ func TestGravatarEnumTargetList_DomainGeneratedCarriesName(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // THE CRITICAL TRAP (10T-535, 5/8)
 //
 // cmd_enum_gravatar.go's target-building/dedup loop (formerly line ~196 of
@@ -171,7 +168,6 @@ func TestGravatarEnumTargetList_DomainGeneratedCarriesName(t *testing.T) {
 //     receive and echo back (target.Email itself, and independently its
 //     lower-cased form — asserting these are identical is exactly the
 //     invariant the fix must hold).
-// ---------------------------------------------------------------------------
 
 func TestGravatarEnumTargetList_GeneratedAddressesAreLowerCasedForNameLookup(t *testing.T) {
 	defer resetGravatarEnumFlags()()
@@ -235,10 +231,6 @@ func TestGravatarEnumTargetList_GeneratedAddressesAreLowerCasedForNameLookup(t *
 	}
 }
 
-// ---------------------------------------------------------------------------
-// gravatarEnumGenerate
-// ---------------------------------------------------------------------------
-
 func TestGravatarEnumGenerate_ProducesCandidatesForDomain(t *testing.T) {
 	defer resetGravatarEnumFlags()()
 
@@ -300,10 +292,6 @@ func TestGravatarEnumGenerate_InvalidFormatRejected(t *testing.T) {
 	require.Error(t, err, "an invalid --format must be rejected")
 	assert.Contains(t, err.Error(), "invalid --format")
 }
-
-// ---------------------------------------------------------------------------
-// outputGravatarEnumJSONL — First/Last name propagation (10T-535, 5/8)
-// ---------------------------------------------------------------------------
 
 // TestOutputGravatarEnumJSONL_NameFields pins the never-invent-a-name rule: a
 // Result carrying First/Last (from --domain generation) must emit

--- a/cmd/brutus/cmd_enum_hunter_test.go
+++ b/cmd/brutus/cmd_enum_hunter_test.go
@@ -27,10 +27,6 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/enum/hunter"
 )
 
-// ---------------------------------------------------------------------------
-// Task 4: resolveHunterAPIKey + classifyHunterError
-// ---------------------------------------------------------------------------
-
 func TestResolveHunterAPIKey(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -113,10 +109,6 @@ func TestClassifyHunterError(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Task 5: Command registration
-// ---------------------------------------------------------------------------
-
 func TestEnumHunterRegistered(t *testing.T) {
 	// 1. enumCmd must have a "passive" subcommand.
 	var passive *cobra.Command
@@ -165,10 +157,6 @@ func TestEnumHunterRegistered(t *testing.T) {
 	assert.True(t, alias.Hidden, "back-compat hunter alias must be Hidden")
 	assert.NotEmpty(t, alias.Deprecated, "back-compat hunter alias must be Deprecated")
 }
-
-// ---------------------------------------------------------------------------
-// Task 6: outputHunterJSONL + outputHunterHuman + sanitizeTerminal + truncate
-// ---------------------------------------------------------------------------
 
 func TestOutputHunterJSONL(t *testing.T) {
 	t.Run("single person emits one JSONL line", func(t *testing.T) {

--- a/cmd/brutus/cmd_enum_kerberos.go
+++ b/cmd/brutus/cmd_enum_kerberos.go
@@ -80,10 +80,8 @@ func init() {
 func runEnumKerberos(cmd *cobra.Command, args []string) error {
 	useColor := isColorEnabled(flagNoColor)
 
-	// Phase 1: Build username list
 	var usernames []string
 
-	// From --users flag
 	if flagKerbUsers != "" {
 		for _, u := range strings.Split(flagKerbUsers, ",") {
 			u = strings.TrimSpace(u)
@@ -93,7 +91,6 @@ func runEnumKerberos(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// From --user-file flag
 	if flagKerbUserFile != "" {
 		fileUsers, err := loadLinesFromFile(flagKerbUserFile)
 		if err != nil {
@@ -106,7 +103,6 @@ func runEnumKerberos(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("no usernames to enumerate — provide --users/-u or --user-file/-U")
 	}
 
-	// Phase 2: Setup output writer
 	jsonWriter, forceJSON, closeOutput, err := setupOutputWriter(flagOutputFile)
 	if err != nil {
 		return err
@@ -116,60 +112,47 @@ func runEnumKerberos(cmd *cobra.Command, args []string) error {
 		flagJSON = true
 	}
 
-	// Phase 3: Context with signal handling
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	// Phase 4: Worker pool setup
 	if !flagQuiet && !flagJSON {
 		fmt.Fprintf(os.Stderr, "%s Enumerating %d user(s) against %s (%s)...\n",
 			dim(useColor, SymbolInfo), len(usernames), flagEnumDomain, flagKerbDC)
 	}
 
-	// Create errgroup with bounded concurrency
 	g, ctx := errgroup.WithContext(ctx)
 	sem := semaphore.NewWeighted(int64(flagThreads))
 
-	// Create rate limiter if configured
 	var limiter *rate.Limiter
 	if flagRateLimit > 0 {
 		limiter = rate.NewLimiter(rate.Limit(flagRateLimit), 1)
 	}
 
-	// Result collection
 	type kerbResult struct {
 		result *kerberos.Result
 		err    error
 	}
 	resultsCh := make(chan kerbResult, len(usernames))
 
-	// Launch workers
 	for _, username := range usernames {
-		username := username // Capture loop variable
-
 		g.Go(func() error {
-			// Acquire semaphore
 			if err := sem.Acquire(ctx, 1); err != nil {
 				return err
 			}
 			defer sem.Release(1)
 
-			// Apply rate limiting
 			if limiter != nil {
 				if err := limiter.Wait(ctx); err != nil {
 					return err
 				}
 			}
 
-			// Apply jitter if configured
 			if flagJitter > 0 {
 				time.Sleep(time.Duration(flagJitter.Nanoseconds() * int64(1+rand.Float64())))
 			}
 
-			// Enumerate user
 			result := kerberos.EnumUser(ctx, flagKerbDC, flagEnumDomain, username, flagTimeout)
 
-			// Send result
 			select {
 			case resultsCh <- kerbResult{result: result, err: nil}:
 			case <-ctx.Done():
@@ -180,23 +163,19 @@ func runEnumKerberos(cmd *cobra.Command, args []string) error {
 		})
 	}
 
-	// Wait for all workers
 	if err := g.Wait(); err != nil && err != context.Canceled {
 		return fmt.Errorf("enumeration failed: %w", err)
 	}
 	close(resultsCh)
 
-	// Phase 5: Collect and output results
 	var results []*kerberos.Result
 	for r := range resultsCh {
 		results = append(results, r.result)
 	}
 
 	if flagJSON {
-		// JSONL output
 		outputKerberosJSONL(jsonWriter, results)
 	} else {
-		// Human-readable output
 		outputKerberosHuman(results, useColor)
 	}
 

--- a/cmd/brutus/cmd_enum_lusha_test.go
+++ b/cmd/brutus/cmd_enum_lusha_test.go
@@ -29,10 +29,6 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/enum/lusha"
 )
 
-// ---------------------------------------------------------------------------
-// Test helpers
-// ---------------------------------------------------------------------------
-
 // countingFailWriter is an io.Writer that always returns an error from Write
 // and counts how many times Write was called. Used to test early-exit behavior
 // in JSONL output functions (broken-pipe / stream-closed scenario).
@@ -44,10 +40,6 @@ func (f *countingFailWriter) Write(_ []byte) (int, error) {
 	f.writes++
 	return 0, errors.New("simulated write failure")
 }
-
-// ---------------------------------------------------------------------------
-// T103: outputLushaJSONL + outputLushaHuman
-// ---------------------------------------------------------------------------
 
 func TestOutputLushaJSONL(t *testing.T) {
 	t.Run("contact with email and DNC phone emits one JSON line", func(t *testing.T) {
@@ -176,10 +168,6 @@ func TestOutputLushaHuman(t *testing.T) {
 		assert.Contains(t, out, "No contact data returned")
 	})
 }
-
-// ---------------------------------------------------------------------------
-// T104: validateLushaIdentity (reads package-level flag vars directly)
-// ---------------------------------------------------------------------------
 
 // resetLushaFlags resets all lusha flag vars to zero values between subtests.
 func resetLushaFlags() {
@@ -466,10 +454,6 @@ func TestClassifyLushaError_NetworkWrap(t *testing.T) {
 	assert.Contains(t, result.Error(), "timeout")
 }
 
-// ---------------------------------------------------------------------------
-// T107: outputLushaDomainJSONL + outputLushaDomainHuman
-// ---------------------------------------------------------------------------
-
 func TestOutputLushaDomainJSONL(t *testing.T) {
 	t.Run("one JSON object per contact plus trailing lusha_summary", func(t *testing.T) {
 		r := &lusha.DomainResult{
@@ -727,10 +711,6 @@ func TestOutputLushaDomainHuman(t *testing.T) {
 			"truncated marker artifact '[DNC…' must not appear")
 	})
 }
-
-// ---------------------------------------------------------------------------
-// T105: Command registration
-// ---------------------------------------------------------------------------
 
 func TestEnumLushaRegistered(t *testing.T) {
 	// 1. enumCmd must have a "passive" subcommand.

--- a/cmd/brutus/cmd_enum_microsoft365_test.go
+++ b/cmd/brutus/cmd_enum_microsoft365_test.go
@@ -28,11 +28,9 @@ import (
 	m365 "github.com/praetorian-inc/brutus/pkg/enum/microsoft365"
 )
 
-// ---------------------------------------------------------------------------
 // TestEnumMicrosoft365Cmd_Flags
 // Verifies that all documented flags exist on enumMicrosoft365Cmd and that
 // no shorthand collides with the global --threads/-t flag.
-// ---------------------------------------------------------------------------
 
 func TestEnumMicrosoft365Cmd_Flags(t *testing.T) {
 	// --emails / -e
@@ -92,11 +90,9 @@ func TestEnumMicrosoft365Cmd_RegisteredUnderActiveCmd(t *testing.T) {
 	assert.True(t, found, "enumMicrosoft365Cmd must be registered as a subcommand of enumActiveCmd")
 }
 
-// ---------------------------------------------------------------------------
 // TestEncodeMicrosoft365EnumResult
 // Feeds m365.Result values and asserts the type/if_exists_result/federation
 // fields, including omitempty behavior.
-// ---------------------------------------------------------------------------
 
 func TestEncodeMicrosoft365EnumResult(t *testing.T) {
 	tests := []struct {
@@ -240,10 +236,8 @@ func TestEncodeMicrosoft365EnumResult(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
 // TestOutputMicrosoft365EnumResultLine
 // Verifies human-readable line output for EXISTS, federation, and ANSI safety.
-// ---------------------------------------------------------------------------
 
 func TestOutputMicrosoft365EnumResultLine(t *testing.T) {
 	t.Run("managed exists shows EXISTS and managed", func(t *testing.T) {
@@ -359,7 +353,6 @@ func TestOutputMicrosoft365EnumResultLine(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
 // microsoft365EnumTargetList / microsoft365EnumGenerate
 //
 // 10T-535 (6/8): microsoft365EnumTargets() ([]string, error) is retargeted
@@ -372,7 +365,6 @@ func TestOutputMicrosoft365EnumResultLine(t *testing.T) {
 // preserved, "provide" error, --limit capping, invalid-format error) is
 // preserved; there is no dead adapter left behind pinning the old []string
 // signatures.
-// ---------------------------------------------------------------------------
 
 func resetMicrosoft365EnumFlags() (restore func()) {
 	origEmails := flagM365EnumEmails
@@ -491,7 +483,6 @@ func TestMicrosoft365EnumTargetList_DomainGeneratedCarriesName(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // THE CRITICAL TRAP (10T-535, 6/8) — INVERSE of gravatar's (5/8) trap.
 //
 // gravatar.CheckAccount lower-cases a COPY of the address it is given (only
@@ -530,7 +521,6 @@ func TestMicrosoft365EnumTargetList_DomainGeneratedCarriesName(t *testing.T) {
 //  3. A lookup keyed on the independently lower-cased form of that same
 //     address must NOT recover a name — proving the index is keyed on the
 //     original-cased address the checker echoes, not a normalized one.
-// ---------------------------------------------------------------------------
 
 func TestMicrosoft365EnumTargetList_GeneratedAddressesRetainOriginalCasingForNameLookup(t *testing.T) {
 	defer resetMicrosoft365EnumFlags()()
@@ -600,10 +590,6 @@ func TestMicrosoft365EnumTargetList_GeneratedAddressesRetainOriginalCasingForNam
 	}
 }
 
-// ---------------------------------------------------------------------------
-// microsoft365EnumGenerate
-// ---------------------------------------------------------------------------
-
 func TestMicrosoft365EnumGenerate_ProducesCandidatesForDomain(t *testing.T) {
 	defer resetMicrosoft365EnumFlags()()
 
@@ -665,10 +651,6 @@ func TestMicrosoft365EnumGenerate_InvalidFormatRejected(t *testing.T) {
 	require.Error(t, err, "an invalid --format must be rejected")
 	assert.Contains(t, err.Error(), "invalid --format")
 }
-
-// ---------------------------------------------------------------------------
-// encodeMicrosoft365EnumResult — First/Last name propagation (10T-535, 6/8)
-// ---------------------------------------------------------------------------
 
 // TestEncodeMicrosoft365EnumResult_NameFields pins the never-invent-a-name
 // rule: a Result carrying First/Last (from --domain generation) must emit

--- a/cmd/brutus/cmd_enum_oracles_teams_test.go
+++ b/cmd/brutus/cmd_enum_oracles_teams_test.go
@@ -28,10 +28,6 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/enum/teams"
 )
 
-// ---------------------------------------------------------------------------
-// TestTeamsOracleAvailable
-// ---------------------------------------------------------------------------
-
 // TestTeamsOracleAvailable verifies that teamsOracleAvailable reports true only
 // when the DNSReconResult contains a SaaSService named "microsoft365". It also
 // verifies that teams is never injected into the Services slice by DNS parsing
@@ -108,10 +104,6 @@ func TestTeamsOracleAvailable(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// TestOutputDNSReconHuman_TeamsLine
-// ---------------------------------------------------------------------------
-
 // TestOutputDNSReconHuman_TeamsLine verifies that outputDNSReconHuman appends a
 // "teams" availability line when teamsAvailable is true, and does NOT show any
 // teams-specific text when teamsAvailable is false.
@@ -174,10 +166,6 @@ func TestOutputDNSReconHuman_EmptyServices_TeamsNotAvailable(t *testing.T) {
 		outputDNSReconHuman(empty, false, false)
 	})
 }
-
-// ---------------------------------------------------------------------------
-// TestOutputDNSReconJSONL_TeamsAvailable
-// ---------------------------------------------------------------------------
 
 // TestOutputDNSReconJSONL_TeamsAvailable verifies that outputDNSReconJSONL
 // emits "teams_available":true when teamsAvailable is true, and omits the key
@@ -276,10 +264,6 @@ func TestOutputDNSReconJSONL_TeamsAvailable(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
-// TestTeamsDiscoverLine_Mapping
-// ---------------------------------------------------------------------------
-
 // TestTeamsDiscoverLine_Mapping verifies that teamsDiscoverLine maps each of
 // the four Existence states to the correct human-readable status line. Token
 // values must never appear in the returned string.
@@ -367,10 +351,6 @@ func TestTeamsDiscoverLine_Mapping(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// TestConfirmTeamsOracle_NoToken
-// ---------------------------------------------------------------------------
-
 // TestConfirmTeamsOracle_NoToken verifies that confirmTeamsOracle returns the
 // "available (unconfirmed)" line and makes no network calls when no cached
 // token is available (empty HOME directory). Setting HOME to a temp dir ensures
@@ -408,10 +388,6 @@ func TestConfirmTeamsOracle_NoToken(t *testing.T) {
 	assert.Contains(t, line, "brutus enum active teams auth",
 		"no-token line must include the auth hint for the user")
 }
-
-// ---------------------------------------------------------------------------
-// TestResolveTeamsConfirmToken_NoCachedToken
-// ---------------------------------------------------------------------------
 
 // TestResolveTeamsConfirmToken_NoCachedToken verifies that resolveTeamsConfirmToken
 // returns ok=false when no credential store file exists (empty HOME directory).

--- a/cmd/brutus/cmd_enum_oracles_test.go
+++ b/cmd/brutus/cmd_enum_oracles_test.go
@@ -23,10 +23,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ---------------------------------------------------------------------------
-// TestEnumOracles_RequiresKnownValid
-// ---------------------------------------------------------------------------
-
 // TestEnumOracles_RequiresKnownValid confirms that "brutus enum oracles" errors at
 // flag-validation time when --known-valid is absent. registerOraclesFlags calls
 // cmd.MarkFlagRequired("known-valid"), so cobra rejects the invocation before
@@ -60,10 +56,6 @@ func TestEnumOracles_RequiresKnownValid(t *testing.T) {
 		"error message must mention \"known-valid\"; got: %q", err.Error())
 }
 
-// ---------------------------------------------------------------------------
-// TestEnumOraclesCmd_KnownValidMarkedRequired
-// ---------------------------------------------------------------------------
-
 // TestEnumOraclesCmd_KnownValidMarkedRequired asserts — without executing the
 // command — that the "known-valid" flag on enumOraclesCmd carries cobra's
 // required-flag annotation. This is a static check that complements
@@ -78,10 +70,6 @@ func TestEnumOraclesCmd_KnownValidMarkedRequired(t *testing.T) {
 	assert.True(t, required,
 		"--known-valid flag must carry cobra.BashCompOneRequiredFlag annotation (set by MarkFlagRequired)")
 }
-
-// ---------------------------------------------------------------------------
-// TestAddDomainIndependentOracles
-// ---------------------------------------------------------------------------
 
 // TestAddDomainIndependentOracles covers the helper that unions registered
 // domain-independent oracles (currently just "github") into the auto-discovered
@@ -183,10 +171,6 @@ func TestAddDomainIndependentOracles(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// TestEmailDomain
-// ---------------------------------------------------------------------------
-
 // TestEmailDomain covers the helper that extracts the domain portion of an
 // email address (the substring after the last "@"), used so --domain can
 // default to the domain of the required --known-valid email. It confirms the
@@ -214,10 +198,6 @@ func TestEmailDomain(t *testing.T) {
 		})
 	}
 }
-
-// ---------------------------------------------------------------------------
-// TestResolveOraclesDomain
-// ---------------------------------------------------------------------------
 
 // TestResolveOraclesDomain covers the helper that decides the effective org
 // domain for the oracles command. It confirms the precedence the fix relies on:

--- a/cmd/brutus/cmd_enum_output.go
+++ b/cmd/brutus/cmd_enum_output.go
@@ -300,10 +300,6 @@ func outputEnumJSONL(w io.Writer, results []enum.Result) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Hunter.io output functions
-// ---------------------------------------------------------------------------
-
 // sanitizeTerminal strips C0/C1 control code points, ESC (U+001B), and full
 // ANSI/VT100 escape sequences from s before rendering attacker-controlled
 // strings in the human table (P0-4 security requirement). It decodes
@@ -474,10 +470,6 @@ func outputHunterJSONL(w io.Writer, result *hunter.DomainResult) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Teams (Microsoft Entra ID device code) output functions
-// ---------------------------------------------------------------------------
-
 // outputTeamsDeviceCodeHuman prints device code auth instructions.
 // All server-provided strings are sanitized via sanitizeTerminal (P0-4).
 func outputTeamsDeviceCodeHuman(w io.Writer, dc *teams.DeviceCode, useColor bool) {
@@ -524,10 +516,6 @@ func outputTeamsTokenJSONL(w io.Writer, tok *teams.TokenSet) {
 		_, _ = fmt.Fprintf(os.Stderr, "Error encoding teams token JSON: %v\n", err)
 	}
 }
-
-// ---------------------------------------------------------------------------
-// Teams user enumeration output functions
-// ---------------------------------------------------------------------------
 
 // outputTeamsEnumResultLine prints ONE Teams enumeration result row: Email,
 // status label, Display Name, and MRI, with the account type appended for EXISTS
@@ -769,10 +757,6 @@ func outputTeamsPostureJSONL(w io.Writer, p *teams.TenantPosture) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Teams audit (graded findings) output functions
-// ---------------------------------------------------------------------------
-
 // auditEvidenceMaxRunes bounds how much server-derived evidence (e.g. an
 // out-of-office note) is rendered in the human report.
 const auditEvidenceMaxRunes = 200
@@ -922,10 +906,6 @@ func presence(token string) string {
 	return "<present>"
 }
 
-// ---------------------------------------------------------------------------
-// Google Workspace account enumeration output functions
-// ---------------------------------------------------------------------------
-
 // outputGoogleEnumResultLine prints ONE Google enumeration result row. EXISTS
 // rows show the email, an "[+] EXISTS" label, and a method note: workspace-sso
 // renders as " (workspace-sso -> <IdP>)" (or just " (workspace-sso)" when the
@@ -1026,10 +1006,6 @@ func outputGoogleEnumJSONL(w io.Writer, results []google.Result) {
 		}
 	}
 }
-
-// ---------------------------------------------------------------------------
-// Microsoft 365 account enumeration output functions
-// ---------------------------------------------------------------------------
 
 // microsoft365ExistsNote builds the parenthetical annotation for an EXISTS row:
 // the tenant relationship the GetCredentialType API reveals and, when the

--- a/cmd/brutus/cmd_enum_output_teams_test.go
+++ b/cmd/brutus/cmd_enum_output_teams_test.go
@@ -27,10 +27,6 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/enum/teams"
 )
 
-// ---------------------------------------------------------------------------
-// Test: outputTeamsEnumResultLine — account-type suffix for EXISTS results
-// ---------------------------------------------------------------------------
-
 func TestOutputTeamsEnumResultLine_AccountType(t *testing.T) {
 	tests := []struct {
 		name             string
@@ -113,10 +109,6 @@ func TestOutputTeamsEnumResultLine_AccountType(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Test: outputTeamsEnumResultLine — server strings are sanitized (ANSI strip)
-// ---------------------------------------------------------------------------
-
 func TestOutputTeamsEnumResultLine_Sanitizes(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -160,10 +152,6 @@ func TestOutputTeamsEnumResultLine_Sanitizes(t *testing.T) {
 		})
 	}
 }
-
-// ---------------------------------------------------------------------------
-// Test: outputTeamsEnumJSONL — account_type field presence and values
-// ---------------------------------------------------------------------------
 
 func TestOutputTeamsEnumJSONL_AccountType(t *testing.T) {
 	tests := []struct {
@@ -250,10 +238,6 @@ func TestOutputTeamsEnumJSONL_AccountType(t *testing.T) {
 		})
 	}
 }
-
-// ---------------------------------------------------------------------------
-// Test: outputTeamsEnumJSONL — ExistenceBlocked shape and existence value coverage
-// ---------------------------------------------------------------------------
 
 func TestOutputTeamsEnumJSONL_BlockedAndExistenceValues(t *testing.T) {
 	tokenFields := []string{"access_token", "refresh_token", "id_token"}
@@ -377,10 +361,6 @@ func TestOutputTeamsEnumJSONL_BlockedAndExistenceValues(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
-// Test: outputTeamsEnumJSONL — error result encodes correctly, no token fields
-// ---------------------------------------------------------------------------
-
 func TestOutputTeamsEnumJSONL_ErrorResult(t *testing.T) {
 	results := []teams.EnumResult{
 		{
@@ -414,10 +394,6 @@ func TestOutputTeamsEnumJSONL_ErrorResult(t *testing.T) {
 			"JSONL output must never contain token field %q", field)
 	}
 }
-
-// ---------------------------------------------------------------------------
-// Test: outputTeamsEnumSummary — counts ExistenceBlocked in the Exists headline
-// ---------------------------------------------------------------------------
 
 func TestOutputTeamsEnumSummary(t *testing.T) {
 	// 2 ExistenceYes, 3 ExistenceBlocked, 1 ExistenceNo, 1 ExistenceUnknown.

--- a/cmd/brutus/cmd_enum_output_test.go
+++ b/cmd/brutus/cmd_enum_output_test.go
@@ -26,10 +26,6 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/enum"
 )
 
-// ---------------------------------------------------------------------------
-// outputEnumJSONL — First/Last name propagation (10T-535 PR2)
-// ---------------------------------------------------------------------------
-
 // TestOutputEnumJSONL_NameFields pins the never-invent-a-name rule for the
 // generic enum output path: a Result carrying First/Last (from --generate)
 // must emit "first"/"last" in the JSONL row, while a Result with empty

--- a/cmd/brutus/cmd_enum_teams_audit_test.go
+++ b/cmd/brutus/cmd_enum_teams_audit_test.go
@@ -26,10 +26,6 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/enum/teams"
 )
 
-// ---------------------------------------------------------------------------
-// Test 7: TestOutputTeamsAuditJSONL
-// ---------------------------------------------------------------------------
-
 // TestOutputTeamsAuditJSONL verifies:
 //   - One JSON line per finding.
 //   - Each line has type=="teams_finding".
@@ -168,10 +164,6 @@ func TestOutputTeamsAuditJSONL_AllSeverities(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Test 8: TestOutputTeamsAuditHuman_Sanitizes
-// ---------------------------------------------------------------------------
-
 // TestOutputTeamsAuditHuman_Sanitizes verifies that:
 //   - A raw ANSI escape byte (0x1b) in Finding.Evidence is absent from the output
 //     when useColor==false (sanitizeTerminal is applied).
@@ -255,10 +247,6 @@ func TestOutputTeamsAuditHuman_Sanitizes(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
-// Test 9: TestEnumTeamsAuditCmd_Registered
-// ---------------------------------------------------------------------------
-
 // TestEnumTeamsAuditCmd_Registered verifies:
 //   - The audit subcommand is registered on enumTeamsCmd with Use=="audit".
 //   - The --email flag exists.
@@ -324,10 +312,6 @@ func TestEnumTeamsAuditCmd_Registered(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
-// outputTeamsAuditHuman: severity color labels
-// ---------------------------------------------------------------------------
-
 // TestOutputTeamsAuditHuman_SeverityLabels verifies that each severity level is
 // rendered with its uppercase label in the human output.
 func TestOutputTeamsAuditHuman_SeverityLabels(t *testing.T) {
@@ -366,10 +350,6 @@ func TestOutputTeamsAuditHuman_SeverityLabels(t *testing.T) {
 		})
 	}
 }
-
-// ---------------------------------------------------------------------------
-// outputTeamsAuditHuman: token leakage regression
-// ---------------------------------------------------------------------------
 
 // TestOutputTeamsAuditHuman_NoTokens verifies that known token-sentinel strings
 // never appear in the human audit output. The Audit function never receives

--- a/cmd/brutus/cmd_enum_teams_names_test.go
+++ b/cmd/brutus/cmd_enum_teams_names_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/enum/teams"
 )
 
-// ---------------------------------------------------------------------------
 // teamsEnumTargetList — name propagation (10T-535, 7/8)
 //
 // Mirrors TestMicrosoft365EnumTargetList_InlineEmails /
@@ -35,7 +34,6 @@ import (
 // address carries no name (a supplied address says nothing about whose it
 // is); a --domain-generated address carries the non-empty First/Last its
 // username was built from.
-// ---------------------------------------------------------------------------
 
 // TestTeamsEnumTargetList_InlineEmails verifies that --emails CSV is parsed,
 // trimmed, and deduplicated, and that every CLI-supplied target carries no
@@ -113,7 +111,6 @@ func TestTeamsEnumGenerate_ReusesSharedGenerator(t *testing.T) {
 		"teamsEnumGenerate must reuse enum.GenerateCandidates (via capResults and Candidate.Target), matching the google/gravatar/github/microsoft365 generate pattern")
 }
 
-// ---------------------------------------------------------------------------
 // THE CASING QUESTION (10T-535, 7/8).
 //
 // teams.EnumerateOne echoes the email it is given verbatim on
@@ -134,7 +131,6 @@ func TestTeamsEnumGenerate_ReusesSharedGenerator(t *testing.T) {
 // back on EnumResult.Email for a mixed-case --domain, and
 // enumNamesByEmail/enumNameFor's lookup (keyed on the exact address) would
 // silently fail to recover the generated name.
-// ---------------------------------------------------------------------------
 
 // TestTeamsEnumTargetList_CaseInsensitiveDedup verifies that dedup keys on
 // the lowercased email while preserving the first-seen casing on the
@@ -244,7 +240,6 @@ func TestTeamsEnumTargetList_GeneratedAddressesRetainOriginalCasingForNameLookup
 	}
 }
 
-// ---------------------------------------------------------------------------
 // THE WRINKLE UNIQUE TO TEAMS (10T-535, 7/8): a generated name is NOT a
 // display name.
 //
@@ -258,7 +253,6 @@ func TestTeamsEnumTargetList_GeneratedAddressesRetainOriginalCasingForNameLookup
 // either direction: a result may have a DisplayName and no generated name (a
 // supplied address), a generated name and no DisplayName (a 403 carries
 // none), both, or neither.
-// ---------------------------------------------------------------------------
 
 // TestOutputTeamsEnumJSONL_GeneratedNameVsDisplayName pins the
 // never-conflate-the-two-names rule across all four combinations, in the
@@ -375,7 +369,6 @@ func TestOutputTeamsEnumJSONL_GeneratedNameVsDisplayName(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
 // Both outputTeamsEnumJSONL branches must carry the generated name
 // (10T-535, 7/8).
 //
@@ -385,7 +378,6 @@ func TestOutputTeamsEnumJSONL_GeneratedNameVsDisplayName(t *testing.T) {
 // A generated name is a property of the ADDRESS brutus built, not of
 // whether the tenant let brutus see details about it — so it must survive
 // into the blocked branch exactly like the default branch.
-// ---------------------------------------------------------------------------
 
 // TestOutputTeamsEnumJSONL_GeneratedNameInBlockedBranch verifies that the
 // generated First/Last survive into the ExistenceBlocked branch, while

--- a/cmd/brutus/cmd_enum_teams_test.go
+++ b/cmd/brutus/cmd_enum_teams_test.go
@@ -29,10 +29,6 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/enum/teams"
 )
 
-// ---------------------------------------------------------------------------
-// Command registration
-// ---------------------------------------------------------------------------
-
 func TestTeamsCommandRegistered(t *testing.T) {
 	// Verify enumActiveCmd is a direct child of enumCmd (hard move).
 	var activeFound bool
@@ -81,10 +77,6 @@ func TestTeamsCommandRegistered(t *testing.T) {
 	require.NotNil(t, scopeShort, "-s shorthand must exist on auth subcommand")
 }
 
-// ---------------------------------------------------------------------------
-// Flag-default guards (CLI layer regressions for fixes #2 and #3)
-// ---------------------------------------------------------------------------
-
 // TestEnumTeamsAuthFlagDefaults guards two CLI-layer regressions:
 //
 //   - Fix #2: default tenant must be "organizations" (not "common"). A regression
@@ -111,10 +103,6 @@ func TestEnumTeamsAuthFlagDefaults(t *testing.T) {
 			"--no-browser must default to false (browser auto-opens unless explicitly disabled)")
 	})
 }
-
-// ---------------------------------------------------------------------------
-// Panic-regression test (fix #1: --tenant shorthand -t collision with global --threads/-t)
-// ---------------------------------------------------------------------------
 
 // TestEnumTeamsAuth_NoFlagCollisionPanic is a keystone regression test for the
 // cobra panic that fired in mergePersistentFlags when the global persistent
@@ -167,10 +155,6 @@ func TestEnumTeamsAuth_NoFlagCollisionPanic(t *testing.T) {
 	require.Nil(t, panicVal, "rootCmd.Execute() panicked: %v (flag -t shorthand collision?)", panicVal)
 }
 
-// ---------------------------------------------------------------------------
-// classifyTeamsError
-// ---------------------------------------------------------------------------
-
 func TestClassifyTeamsError(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -190,10 +174,6 @@ func TestClassifyTeamsError(t *testing.T) {
 		})
 	}
 }
-
-// ---------------------------------------------------------------------------
-// outputTeamsTokenJSONL
-// ---------------------------------------------------------------------------
 
 func TestOutputTeamsTokenJSONL(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
@@ -232,10 +212,6 @@ func TestOutputTeamsTokenJSONL(t *testing.T) {
 	_, hasExpiresAt := obj["expires_at"]
 	assert.True(t, hasExpiresAt, "expires_at must be present in JSONL output")
 }
-
-// ---------------------------------------------------------------------------
-// outputTeamsTokenHuman
-// ---------------------------------------------------------------------------
 
 func TestOutputTeamsTokenHuman(t *testing.T) {
 	t.Run("access token shows first 20 chars plus ellipsis", func(t *testing.T) {
@@ -302,14 +278,6 @@ func TestOutputTeamsTokenHuman(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
-// outputTeamsDeviceCodeHuman
-// ---------------------------------------------------------------------------
-
-// ---------------------------------------------------------------------------
-// Test: teamsEnumDomain
-// ---------------------------------------------------------------------------
-
 func TestTeamsEnumDomain(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -357,10 +325,6 @@ func TestTeamsEnumDomain(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Test: outputTeamsPostureJSONL — type discriminator, field values
-// ---------------------------------------------------------------------------
-
 func TestOutputTeamsPostureJSONL(t *testing.T) {
 	posture := teams.TenantPosture{
 		Domain:              "contoso.com",
@@ -399,10 +363,8 @@ func TestOutputTeamsPostureJSONL(t *testing.T) {
 	assert.Equal(t, "TeamsOnly", obj["coexistence_mode"])
 }
 
-// ---------------------------------------------------------------------------
 // Test: outputTeamsEnumJSONL — config fields (user_type not "type", no tokens,
 // ANSI escape sanitization)
-// ---------------------------------------------------------------------------
 
 func TestOutputTeamsEnumJSONL_ConfigFields(t *testing.T) {
 	acctEnabled := true
@@ -457,10 +419,8 @@ func TestOutputTeamsEnumJSONL_ConfigFields(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // Test: ANSI escape in OutOfOfficeNote is sanitized in human output and escaped
 // in JSONL output
-// ---------------------------------------------------------------------------
 
 func TestOutputTeamsEnumJSONL_ANSIEscapeInOOO(t *testing.T) {
 	// A malicious OutOfOfficeNote containing a raw ESC byte.
@@ -489,10 +449,6 @@ func TestOutputTeamsEnumJSONL_ANSIEscapeInOOO(t *testing.T) {
 	assert.NotEmpty(t, escObj["out_of_office_note"],
 		"out_of_office_note must be non-empty after JSON encoding")
 }
-
-// ---------------------------------------------------------------------------
-// Test: sanitizeTerminal strips ESC in CoExistenceMode (posture human output)
-// ---------------------------------------------------------------------------
 
 func TestOutputTeamsPostureHuman_SanitizesCoExistenceMode(t *testing.T) {
 	// Inject a CoExistenceMode containing an ANSI CSI sequence.

--- a/cmd/brutus/cmd_enum_teams_users_test.go
+++ b/cmd/brutus/cmd_enum_teams_users_test.go
@@ -27,10 +27,6 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/enum/teams"
 )
 
-// ---------------------------------------------------------------------------
-// Test 17: users subcommand is registered on enumTeamsCmd
-// ---------------------------------------------------------------------------
-
 func TestTeamsUsersSubcommandRegistered(t *testing.T) {
 	var usersFound bool
 	for _, cmd := range enumTeamsCmd.Commands() {
@@ -41,10 +37,6 @@ func TestTeamsUsersSubcommandRegistered(t *testing.T) {
 	}
 	require.True(t, usersFound, "users subcommand must be registered with enumTeamsCmd")
 }
-
-// ---------------------------------------------------------------------------
-// Test 18: Flag presence on enumTeamsUsersCmd, no shorthand collisions
-// ---------------------------------------------------------------------------
 
 func TestEnumTeamsUsersCmd_Flags(t *testing.T) {
 	flags := enumTeamsUsersCmd.Flags()
@@ -111,10 +103,6 @@ func TestEnumTeamsUsersCmd_Flags(t *testing.T) {
 		}
 	})
 }
-
-// ---------------------------------------------------------------------------
-// Test 19: outputTeamsEnumJSONL — type, tri-state, no token fields, control char escape
-// ---------------------------------------------------------------------------
 
 func TestOutputTeamsEnumJSONL(t *testing.T) {
 	maliciousName := "EVIL\x1b[31mRED"
@@ -190,10 +178,6 @@ func TestOutputTeamsEnumJSONL(t *testing.T) {
 		"raw ESC byte must be escaped by encoding/json in JSONL output")
 }
 
-// ---------------------------------------------------------------------------
-// Test 21: --domain, --format, --limit flags exist on enumTeamsUsersCmd
-// ---------------------------------------------------------------------------
-
 // TestEnumTeamsUsersCmd_GenerationFlags verifies that the three generation
 // flags added to enumTeamsUsersCmd are correctly registered with the right
 // shorthands, default values, and no collision with -t/-s.
@@ -237,7 +221,6 @@ func TestEnumTeamsUsersCmd_GenerationFlags(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
 // Tests 22-26: teamsEnumTargetList / teamsEnumGenerate (10T-535, 7/8)
 //
 // teamsEnumTargets() ([]string, error) is retargeted onto
@@ -250,7 +233,6 @@ func TestEnumTeamsUsersCmd_GenerationFlags(t *testing.T) {
 // invalid-format error, limit-zero-returns-all, frequency-ranked ordering)
 // is preserved below; there is no dead adapter left behind pinning the old
 // []string signatures.
-// ---------------------------------------------------------------------------
 
 // resetTeamsEnumTargetFlags saves and restores every package-level flag var
 // touched by the teamsEnumTargetList/teamsEnumGenerate tests below, so tests
@@ -433,10 +415,6 @@ func TestTeamsEnumGenerate_LimitZeroReturnsAll(t *testing.T) {
 	assert.Less(t, len(targets), 300_000,
 		"limit=0 list must be bounded (<300,000 entries; embedded wordlist sanity check)")
 }
-
-// ---------------------------------------------------------------------------
-// Test 20: outputTeamsEnumResultLine — ANSI sanitization strips ESC byte
-// ---------------------------------------------------------------------------
 
 func TestOutputTeamsEnumResultLine_Sanitization(t *testing.T) {
 	evilName := "\x1b[31mEVIL"

--- a/cmd/brutus/cmd_enum_test.go
+++ b/cmd/brutus/cmd_enum_test.go
@@ -22,14 +22,12 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/enum"
 )
 
-// ---------------------------------------------------------------------------
 // capResults — generic type parameter (10T-535, 3/8)
 //
 // cmd_enum_generate_test.go already exercises capResults over []string
 // (its original, non-generic shape). This test exercises the generic
 // signature (capResults[T any]) over a non-string element type, so the type
 // parameter itself — not just the []string instantiation — is verified.
-// ---------------------------------------------------------------------------
 
 // TestCapResults_GenericOverNonStringType verifies that capResults works over
 // a non-string type (enum.Target), proving it is generic rather than
@@ -47,10 +45,6 @@ func TestCapResults_GenericOverNonStringType(t *testing.T) {
 	assert.Equal(t, input[:2], got,
 		"capResults[enum.Target] must cap to the first N elements, same as capResults[string]")
 }
-
-// ---------------------------------------------------------------------------
-// enumTargetEmails
-// ---------------------------------------------------------------------------
 
 // TestEnumTargetEmails_PreservesOrder verifies that enumTargetEmails projects
 // []enum.Target -> []string of addresses, preserving input order.
@@ -78,10 +72,6 @@ func TestEnumTargetEmails_EmptyInput(t *testing.T) {
 	got := enumTargetEmails(nil)
 	assert.Empty(t, got, "enumTargetEmails on a nil slice must return an empty slice")
 }
-
-// ---------------------------------------------------------------------------
-// enumNamesByEmail / enumNameFor
-// ---------------------------------------------------------------------------
 
 // TestEnumNamesByEmail_IndexesGeneratedTargets verifies that
 // enumNamesByEmail builds an address -> name index from generated targets

--- a/cmd/brutus/flags.go
+++ b/cmd/brutus/flags.go
@@ -26,10 +26,6 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/brutus"
 )
 
-// ---------------------------------------------------------------------------
-// Package-level flag variables (bound to cobra/pflag)
-// ---------------------------------------------------------------------------
-
 // Target flags
 var (
 	flagTarget      string
@@ -110,10 +106,6 @@ var (
 
 // Version flag
 var flagVersion bool
-
-// ---------------------------------------------------------------------------
-// Flag registration functions
-// ---------------------------------------------------------------------------
 
 // registerSharedFlags registers persistent flags that propagate to all subcommands.
 func registerSharedFlags(cmd *cobra.Command) {
@@ -219,10 +211,6 @@ func registerLogonFlags(cmd *cobra.Command) {
 func registerRootFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&flagVersion, "version", false, "Show version information")
 }
-
-// ---------------------------------------------------------------------------
-// Config builder
-// ---------------------------------------------------------------------------
 
 // resolveProxyURL merges the --proxy and --proxy-user flags into a single
 // canonical proxy URL. Returns "" when no proxy is configured.
@@ -348,10 +336,6 @@ func isFlagChanged(cmd *cobra.Command, name string) bool {
 	pf := cmd.InheritedFlags().Lookup(name)
 	return pf != nil && pf.Changed
 }
-
-// ---------------------------------------------------------------------------
-// Utility functions (moved from main.go)
-// ---------------------------------------------------------------------------
 
 // setupAIConfig creates the LLM configuration for AI mode.
 func setupAIConfig(aiMode bool, anthropicKey, perplexityKey string) (*brutus.LLMConfig, error) {

--- a/cmd/brutus/input_test.go
+++ b/cmd/brutus/input_test.go
@@ -23,10 +23,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ---------------------------------------------------------------------------
-// parseCredentialPairs
-// ---------------------------------------------------------------------------
-
 func TestParseCredentialPairs_Basic(t *testing.T) {
 	creds, err := parseCredentialPairs("admin:admin,root:toor")
 	require.NoError(t, err)
@@ -117,10 +113,6 @@ func TestParseCredentialPairs_MixedValidAndInvalid(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid")
 }
-
-// ---------------------------------------------------------------------------
-// loadCredentials
-// ---------------------------------------------------------------------------
 
 func TestLoadCredentials_InlineOnly(t *testing.T) {
 	creds, err := loadCredentials("admin:pass,root:toor", "")

--- a/cmd/brutus/progress_test.go
+++ b/cmd/brutus/progress_test.go
@@ -24,10 +24,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ---------------------------------------------------------------------------
-// progressLine tests
-// ---------------------------------------------------------------------------
-
 // TestProgressLine_MidScan verifies the format of a mid-scan progress line with
 // a known total. The output must contain the bar brackets, percentage, count,
 // ETA label, and the custom metrics tail.
@@ -91,10 +87,6 @@ func TestProgressLine_ZeroProcessed(t *testing.T) {
 	assert.Contains(t, line, "ETA --", "ETA must be '--' when processed==0")
 }
 
-// ---------------------------------------------------------------------------
-// formatDuration table tests
-// ---------------------------------------------------------------------------
-
 // TestFormatDuration covers the coarse human-friendly rendering of durations.
 func TestFormatDuration(t *testing.T) {
 	t.Parallel()
@@ -134,10 +126,6 @@ func TestFormatDuration(t *testing.T) {
 		})
 	}
 }
-
-// ---------------------------------------------------------------------------
-// progressRate tests
-// ---------------------------------------------------------------------------
 
 // TestProgressRate covers the throughput formatting for edge cases and both
 // decimal regimes.
@@ -197,10 +185,6 @@ func TestProgressRate(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Disabled reporter produces no output
-// ---------------------------------------------------------------------------
-
 // TestProgressReporter_DisabledNoOutput verifies that a reporter constructed
 // with enabled=false is a complete no-op: Start, Update, Clear, and Stop all
 // produce no bytes in the output writer.
@@ -217,10 +201,6 @@ func TestProgressReporter_DisabledNoOutput(t *testing.T) {
 
 	assert.Equal(t, 0, buf.Len(), "disabled reporter must produce no output bytes")
 }
-
-// ---------------------------------------------------------------------------
-// Non-TTY flush: deterministic elapsed via injected clock
-// ---------------------------------------------------------------------------
 
 // TestProgressReporter_NonTTYFlush verifies that calling flush(true) on a
 // non-TTY reporter writes a newline-terminated line containing the expected

--- a/cmd/brutus/teams_credstore_test.go
+++ b/cmd/brutus/teams_credstore_test.go
@@ -28,10 +28,6 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/enum/teams"
 )
 
-// ---------------------------------------------------------------------------
-// teamsDefaultTokenPath
-// ---------------------------------------------------------------------------
-
 // TestTeamsDefaultTokenPath verifies that teamsDefaultTokenPath returns a path
 // ending with ".brutus/teams.json" rooted under the current home directory.
 // We redirect $HOME to a temp dir so the real ~/.brutus is never touched.
@@ -51,10 +47,6 @@ func TestTeamsDefaultTokenPath(t *testing.T) {
 	assert.True(t, strings.HasSuffix(got, filepath.Join(".brutus", "teams.json")),
 		`path must end with ".brutus/teams.json", got %q`, got)
 }
-
-// ---------------------------------------------------------------------------
-// saveTeamsTokenFile — permissions and content
-// ---------------------------------------------------------------------------
 
 // TestSaveTeamsTokenFile_PermsAndContent saves a well-known TokenSet and then
 // asserts:
@@ -115,10 +107,6 @@ func TestSaveTeamsTokenFile_PermsAndContent(t *testing.T) {
 		`JSON field "refresh_token" must equal the stored refresh token`)
 }
 
-// ---------------------------------------------------------------------------
-// saveTeamsTokenFile — round-trip through teamsEnumReadTokenFile
-// ---------------------------------------------------------------------------
-
 // TestSaveTeamsTokenFile_RoundTripsThroughReader saves a TokenSet to disk and
 // then loads it back with the existing teamsEnumReadTokenFile parser (the same
 // parser used by "enum teams users --token-file").  This proves that the
@@ -149,10 +137,6 @@ func TestSaveTeamsTokenFile_RoundTripsThroughReader(t *testing.T) {
 		"round-trip refresh token must match what was saved")
 }
 
-// ---------------------------------------------------------------------------
-// saveTeamsTokenFile — creates missing directory
-// ---------------------------------------------------------------------------
-
 // TestSaveTeamsTokenFile_CreatesMissingDir verifies that saveTeamsTokenFile
 // creates any missing parent directories (mode 0700) before writing the file.
 func TestSaveTeamsTokenFile_CreatesMissingDir(t *testing.T) {
@@ -181,10 +165,6 @@ func TestSaveTeamsTokenFile_CreatesMissingDir(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, os.FileMode(0o700), di.Mode().Perm())
 }
-
-// ---------------------------------------------------------------------------
-// End-to-end auto-load path resolution (no cobra command invocation)
-// ---------------------------------------------------------------------------
 
 // TestTeamsAutoLoad_DefaultPathRoundTrip simulates the load path that
 // "enum teams users" would follow when no --token-file flag is provided:
@@ -219,10 +199,6 @@ func TestTeamsAutoLoad_DefaultPathRoundTrip(t *testing.T) {
 	assert.Equal(t, "AAA", gotAccess)
 	assert.Equal(t, "RRR", gotRefresh)
 }
-
-// ---------------------------------------------------------------------------
-// P0-1: error messages must not leak token values
-// ---------------------------------------------------------------------------
 
 // TestSaveTeamsTokenFile_ErrorDoesNotLeakTokens (P0-1) verifies that when
 // saveTeamsTokenFile fails (unwritable path), the returned error message does

--- a/examples/enum-custom-demo/main.go
+++ b/examples/enum-custom-demo/main.go
@@ -64,10 +64,6 @@ func main() {
 	}
 }
 
-// =============================================================================
-// HANDLERS
-// =============================================================================
-
 // handleForgotPassword is the primary enumeration oracle. A valid email returns
 // HTTP 200 with a "reset link sent" message; an invalid one returns HTTP 404
 // with a "No account found" message. The status + message difference is the leak.
@@ -136,10 +132,6 @@ func handleIndex(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	_, _ = fmt.Fprint(w, indexText)
 }
-
-// =============================================================================
-// HELPERS
-// =============================================================================
 
 // response is the JSON envelope returned by both API endpoints. Status is
 // omitted from the login responses (which only carry a message).

--- a/internal/analyzers/claude/claude.go
+++ b/internal/analyzers/claude/claude.go
@@ -60,10 +60,6 @@ type Client struct {
 	Timeout  time.Duration
 }
 
-// =============================================================================
-// Text-based API types (for banner analysis)
-// =============================================================================
-
 type apiRequest struct {
 	Model     string    `json:"model"`
 	MaxTokens int       `json:"max_tokens"`
@@ -83,10 +79,6 @@ type textBlock struct {
 	Type string `json:"type"`
 	Text string `json:"text"`
 }
-
-// =============================================================================
-// Vision API types (for screenshot/image analysis)
-// =============================================================================
 
 type visionRequest struct {
 	Model     string          `json:"model"`
@@ -119,10 +111,6 @@ type responseContent struct {
 	Type string `json:"type"`
 	Text string `json:"text"`
 }
-
-// =============================================================================
-// BannerAnalyzer implementation (text-based)
-// =============================================================================
 
 // Analyze implements the BannerAnalyzer interface for text-based banner analysis.
 func (c *Client) Analyze(ctx context.Context, banner brutus.BannerInfo) ([]string, error) {
@@ -177,10 +165,6 @@ func (c *Client) Analyze(ctx context.Context, banner brutus.BannerInfo) ([]strin
 
 	return brutus.ValidateSuggestions(passwords), nil
 }
-
-// =============================================================================
-// VisionAnalyzer implementation (screenshot-based)
-// =============================================================================
 
 // AnalyzeScreenshot analyzes a page screenshot using Claude Vision.
 func (c *Client) AnalyzeScreenshot(ctx context.Context, screenshot []byte) (*PageAnalysis, error) {
@@ -307,10 +291,6 @@ func (c *Client) ReadTerminalOutput(ctx context.Context, screenshot []byte) (str
 	return text, nil
 }
 
-// =============================================================================
-// Shared helpers
-// =============================================================================
-
 // doVisionRequest sends a vision API request and unmarshals the JSON response into result.
 func (c *Client) doVisionRequest(ctx context.Context, reqBody visionRequest, result interface{}) error {
 	text, err := c.doVisionRequestRaw(ctx, reqBody)
@@ -383,10 +363,6 @@ func (c *Client) getTimeout() time.Duration {
 	}
 	return DefaultTimeout
 }
-
-// =============================================================================
-// Prompts
-// =============================================================================
 
 func buildVisionPrompt() string {
 	return `Analyze this web page screenshot for a security assessment.

--- a/internal/analyzers/perplexity/perplexity.go
+++ b/internal/analyzers/perplexity/perplexity.go
@@ -67,7 +67,6 @@ func (c *Client) Analyze(ctx context.Context, banner brutus.BannerInfo) ([]strin
 		return nil, err
 	}
 
-	// Extract unique passwords
 	passwords := make([]string, 0, len(creds))
 	seen := make(map[string]bool)
 	for _, cred := range creds {
@@ -83,7 +82,6 @@ func (c *Client) Analyze(ctx context.Context, banner brutus.BannerInfo) ([]strin
 // AnalyzeCredentials implements brutus.CredentialAnalyzer interface
 // Returns full credential pairs (username + password) for the identified application
 func (c *Client) AnalyzeCredentials(ctx context.Context, banner brutus.BannerInfo) ([]brutus.Credential, error) {
-	// Parse application info from banner (JSON format from vision analyzer)
 	var bannerData struct {
 		Application struct {
 			Type   string `json:"type"`
@@ -99,7 +97,6 @@ func (c *Client) AnalyzeCredentials(ctx context.Context, banner brutus.BannerInf
 		// Fallback: use banner as plain text (sanitize to prevent prompt injection)
 		creds, err = c.researchFromTextWithPairs(ctx, brutus.SanitizeBanner(banner.Banner))
 	} else {
-		// Research credentials for identified application
 		creds, err = c.ResearchCredentials(ctx,
 			bannerData.Application.Type,
 			bannerData.Application.Vendor,
@@ -111,7 +108,6 @@ func (c *Client) AnalyzeCredentials(ctx context.Context, banner brutus.BannerInf
 		return nil, err
 	}
 
-	// Convert to brutus.Credential
 	result := make([]brutus.Credential, 0, len(creds))
 	for _, cred := range creds {
 		result = append(result, brutus.Credential{
@@ -125,10 +121,8 @@ func (c *Client) AnalyzeCredentials(ctx context.Context, banner brutus.BannerInf
 
 // ResearchCredentials queries Perplexity for default credentials
 func (c *Client) ResearchCredentials(ctx context.Context, appType, vendor, model string) ([]Credential, error) {
-	// Build search query
 	query := buildSearchQuery(appType, vendor, model)
 
-	// Create API request
 	reqBody := apiRequest{
 		Model: c.getModel(),
 		Messages: []message{
@@ -139,24 +133,20 @@ func (c *Client) ResearchCredentials(ctx context.Context, appType, vendor, model
 		},
 	}
 
-	// Marshal request
 	jsonData, err := json.Marshal(reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	// Create HTTP request
 	endpoint := c.getEndpoint()
 	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(jsonData))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	// Set headers
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+c.APIKey)
 
-	// Send request
 	client := &http.Client{Timeout: c.getTimeout()}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -164,13 +154,11 @@ func (c *Client) ResearchCredentials(ctx context.Context, appType, vendor, model
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	// Check status
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("perplexity api error (status %d): %s", resp.StatusCode, string(body))
 	}
 
-	// Parse response
 	var apiResp apiResponse
 	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
 		return nil, fmt.Errorf("failed to decode response: %w", err)
@@ -180,10 +168,8 @@ func (c *Client) ResearchCredentials(ctx context.Context, appType, vendor, model
 		return []Credential{}, nil
 	}
 
-	// Extract credentials from response text
 	creds := parseCredentials(apiResp.Choices[0].Message.Content)
 
-	// Mark source
 	for i := range creds {
 		creds[i].Source = "perplexity"
 	}

--- a/internal/plugins/elasticsearch/elasticsearch_test.go
+++ b/internal/plugins/elasticsearch/elasticsearch_test.go
@@ -125,10 +125,6 @@ func TestPlugin_Test_Timeout(t *testing.T) {
 	assert.Contains(t, result.Error.Error(), "connection error")
 }
 
-// =============================================================================
-// CheckUnauth tests (using httptest for mock HTTP servers)
-// =============================================================================
-
 func TestCheckUnauth_OpenAccess(t *testing.T) {
 	// Simulate Elasticsearch with security disabled (200 OK without auth)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/plugins/mongodb/mongodb.go
+++ b/internal/plugins/mongodb/mongodb.go
@@ -53,10 +53,8 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	result := brutus.NewResult("mongodb", target, username, password)
 	defer func() { result.Duration = time.Since(start) }()
 
-	// Read TLS mode from context
 	tlsMode := pluginCfg.TLSMode
 
-	// Determine TLS parameter based on mode
 	var tlsParam string
 	switch tlsMode {
 	case "verify":
@@ -67,23 +65,18 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		tlsParam = "tls=false"
 	}
 
-	// Build MongoDB connection string
-	// Format: mongodb://username:password@host/
-	// URL-encode username and password to handle special characters (@, :, /, %, #)
+	// URL-encode username and password to handle special characters (@, :, /, %, #).
 	connStr := fmt.Sprintf("mongodb://%s:%s@%s/?%s",
 		url.QueryEscape(username), url.QueryEscape(password), target, tlsParam)
 
-	// Create client options with timeout
 	clientOpts := options.Client().
 		ApplyURI(connStr).
 		SetConnectTimeout(timeout).
 		SetServerSelectionTimeout(timeout)
 
-	// Create context with timeout
 	connectCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	// Connect to MongoDB
 	client, err := mongo.Connect(connectCtx, clientOpts)
 	if err != nil {
 		result.Error = classifyError(err)
@@ -93,7 +86,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		_ = client.Disconnect(context.Background())
 	}()
 
-	// Test connection with Ping
 	pingCtx, pingCancel := context.WithTimeout(ctx, timeout)
 	defer pingCancel()
 
@@ -103,7 +95,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		return result
 	}
 
-	// Success
 	result.Success = true
 	return result
 }

--- a/internal/plugins/rdp/analyze_test.go
+++ b/internal/plugins/rdp/analyze_test.go
@@ -167,10 +167,6 @@ func TestRgbaToPNG(t *testing.T) {
 	assert.Equal(t, byte(0x50), pngData[1])
 }
 
-// ---------------------------------------------------------------------------
-// A1: detectChangedRectangle returns bounding box
-// ---------------------------------------------------------------------------
-
 func TestDetectChangedRectangle_ReturnsBox(t *testing.T) {
 	w, h := uint32(100), uint32(100)
 	size := int(w) * int(h) * 4
@@ -194,10 +190,6 @@ func TestDetectChangedRectangle_ReturnsBox(t *testing.T) {
 	assert.Equal(t, 79, box.maxY)
 	assert.Greater(t, box.changedCount, 0)
 }
-
-// ---------------------------------------------------------------------------
-// A2: classifyRegion — console vs dialog vs unknown discrimination
-// ---------------------------------------------------------------------------
 
 // paintBox fills a rectangular region of an RGBA buffer with the given gray value.
 func paintBox(buf []byte, w, x0, y0, x1, y1 int, gray byte) {
@@ -247,13 +239,11 @@ func TestClassifyRegion_Unknown(t *testing.T) {
 	assert.Equal(t, regionUnknown, classifyRegion(resp, w, h, box))
 }
 
-// ---------------------------------------------------------------------------
 // A3: decideVerdict — gates backdoor_likely on keepHigh boolean
 // Signature: decideVerdict(verdict string, keepHigh bool) string
 // When keepHigh=false a backdoor_likely is downgraded to indeterminate.
 // All other verdicts pass through unchanged.
 // CARDINAL RULE: backdoor_likely with keepHigh=false → indeterminate, NEVER clean.
-// ---------------------------------------------------------------------------
 
 func TestDecideVerdict(t *testing.T) {
 	tests := []struct {
@@ -289,12 +279,10 @@ func TestDecideVerdict(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // A6: consoleGatePasses — pure predicate unit table
 // Signature: consoleGatePasses(response []byte, width, height uint32, box changedBox, confidence float64) bool
 // Tests cover: FP fragmented shift, full-screen console, windowed console,
 // confidence-floor path, floor boundary, below-floor non-rect, degenerate box.
-// ---------------------------------------------------------------------------
 
 func TestConsoleGatePasses(t *testing.T) {
 	const W, H = uint32(1024), uint32(768)
@@ -410,11 +398,9 @@ func TestConsoleGatePasses(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // A7: TestConsoleGate_EndToEnd — end-to-end frame→verdict gate behavior
 // Drives runUtilmanAnalysis and runStickyKeysAnalysis on 1024×768 RGBA frames.
 // No WASM, no network. Baseline = uniform mid-gray 128.
-// ---------------------------------------------------------------------------
 
 func TestConsoleGate_EndToEnd(t *testing.T) {
 	const W, H = uint32(1024), uint32(768)
@@ -531,12 +517,10 @@ func TestConsoleGate_EndToEnd(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
 // A4: runStickyKeysAnalysis — light/small/centered dialog → clean
 // A light legit dialog (gray 200) adds almost no dark pixels, so the
 // dark-delta discriminator correctly returns "clean", not indeterminate.
 // This is the better outcome vs. the old behavioral approach.
-// ---------------------------------------------------------------------------
 
 func TestRunStickyKeysAnalysis_LightDialog_NoVision_Clean(t *testing.T) {
 	w, h := uint32(1000), uint32(1000)
@@ -555,10 +539,6 @@ func TestRunStickyKeysAnalysis_LightDialog_NoVision_Clean(t *testing.T) {
 	assert.NotEqual(t, "backdoor_likely", res.OverallVerdict,
 		"a light legit dialog must not be flagged as backdoor_likely")
 }
-
-// ---------------------------------------------------------------------------
-// B: dark-pixel-delta core logic — new tests for the primary discriminator
-// ---------------------------------------------------------------------------
 
 // TestDarkPixelCount verifies the count of pixels below darkBrightnessMax.
 func TestDarkPixelCount(t *testing.T) {
@@ -698,10 +678,6 @@ func TestDarkDeltaVerdict(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
-// C1: structural guard — runStickyKeysAnalysis must have the vulnerable branch
-// ---------------------------------------------------------------------------
-
 // TestRunStickyKeysAnalysis_HasVulnerableBranch guards that runStickyKeysAnalysis
 // contains a symmetric `visionVerdict == "vulnerable"` branch matching the one
 // already present in runUtilmanAnalysis (analyze.go ~line 456).
@@ -719,10 +695,6 @@ func TestRunStickyKeysAnalysis_HasVulnerableBranch(t *testing.T) {
 		"runStickyKeysAnalysis is missing the visionVerdict == \"vulnerable\" branch; "+
 			"found %d occurrence(s), need >= 2 (one per analysis function)", count)
 }
-
-// ---------------------------------------------------------------------------
-// A5: regionConfidenceAndNote — pure verdict×region → (confidence, note)
-// ---------------------------------------------------------------------------
 
 func TestRegionConfidenceAndNote(t *testing.T) {
 	const base = 0.75

--- a/internal/plugins/rdp/detect.go
+++ b/internal/plugins/rdp/detect.go
@@ -27,10 +27,6 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/brutus"
 )
 
-// ---------------------------------------------------------------------------
-// Detection entry points (connection setup + detection sequence)
-// ---------------------------------------------------------------------------
-
 // RunStickyKeysCheck performs sticky keys detection on a separate connection.
 // The noVision flag disables Vision API confirmation. budget selects the settle
 // profile; fast enforces the never-clean invariant.
@@ -93,10 +89,6 @@ func (p *Plugin) RunUtilmanCheck(ctx context.Context, target, proxyURL string, c
 
 	return utilmanResult
 }
-
-// ---------------------------------------------------------------------------
-// Detection sequences (non-NLA connection → trigger → analyze)
-// ---------------------------------------------------------------------------
 
 // runStickyKeysDetection performs the full detection sequence on a non-NLA connection.
 // timeout is the per-host budget passed to each session pump phase. budget selects
@@ -286,10 +278,6 @@ func safeFilenameComponent(s string) string {
 	}
 	return b.String()
 }
-
-// ---------------------------------------------------------------------------
-// Banner formatting (append detection results to auth banner)
-// ---------------------------------------------------------------------------
 
 // finalizeStickyKeysResult folds an analysis outcome into result while KEEPING the session
 // diagnostics the analysis knows nothing about.

--- a/internal/plugins/rdp/detect_test.go
+++ b/internal/plugins/rdp/detect_test.go
@@ -329,10 +329,6 @@ func TestFramesQuiet(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Task 7: composition guard — gate output composes with never-clean invariant
-// ---------------------------------------------------------------------------
-
 // TestConsoleGate_ComposesWithStabilizedVerdict locks the composition invariant:
 // after the console gate downgrades backdoor_likely → indeterminate, the
 // stabilizedVerdict pass-through must leave "indeterminate" unchanged. Neither
@@ -379,13 +375,11 @@ func TestCheckLabeling(t *testing.T) {
 	assert.Equal(t, BackdoorUtilman, utilman.Check)
 }
 
-// ---------------------------------------------------------------------------
 // Outcome normalization: the dial-failure vs. other-failure distinction must
 // survive the hop out of this package, because pkg/brutus/logon turns
 // Unreachable into a TERMINAL verdict and every other !Performed failure into
 // a rerun candidate. Flattening the two together here would silently make
 // unreachable hosts retryable, or worse, clean.
-// ---------------------------------------------------------------------------
 
 func TestStickyOutcome_PreservesUnreachable(t *testing.T) {
 	out := stickyOutcome(&StickyKeysResult{Performed: false, Unreachable: true, SkipReason: "connection failed: i/o timeout"})

--- a/internal/plugins/rdp/nego_test.go
+++ b/internal/plugins/rdp/nego_test.go
@@ -29,10 +29,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ---------------------------------------------------------------------------
-// Task 1.1 — golden bytes for buildNegReq
-// ---------------------------------------------------------------------------
-
 // TestNegoBuildNegReq verifies that buildNegReq() returns exactly the 19-byte
 // TPKT+X.224 Connection Request with embedded RDP_NEG_REQ (no cookie), using
 // requestedProtocols = PROTOCOL_SSL = 0x00000001.  Offering HYBRID would cause
@@ -49,10 +45,6 @@ func TestNegoBuildNegReq(t *testing.T) {
 	}
 	assert.Equal(t, want, buildNegReq())
 }
-
-// ---------------------------------------------------------------------------
-// Task 1.2 — table-driven test for classifyNegResponse
-// ---------------------------------------------------------------------------
 
 // ccWithNeg builds a TPKT+X.224 Connection Confirm (code 0xD0) of total length
 // 19 with an 8-byte negotiation trailer so classifyNegResponse has a valid
@@ -169,10 +161,6 @@ func TestNegoClassify(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Task 1.3 — fakeConn + ProbeNLA round-trip tests
-// ---------------------------------------------------------------------------
-
 // fakeConn implements net.Conn backed by a bytes.Buffer for reads and records
 // all bytes written so tests can assert the exact wire request sent.
 // SetDeadline/SetReadDeadline/SetWriteDeadline are no-ops (return nil).
@@ -240,10 +228,6 @@ func TestProbeNLA_EmptyEOF(t *testing.T) {
 	got := ProbeNLA(context.Background(), fc, 2*time.Second)
 	assert.Equal(t, NegoProbeError, got)
 }
-
-// ---------------------------------------------------------------------------
-// Task 1 — NegoUnreachable distinct class test
-// ---------------------------------------------------------------------------
 
 // TestNegoUnreachable_IsDistinctClass verifies that NegoUnreachable is a 4th,
 // distinct NegoClass value. All four values must be distinct — if any two share

--- a/internal/plugins/telnet/telnet.go
+++ b/internal/plugins/telnet/telnet.go
@@ -62,7 +62,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	result := brutus.NewResult("telnet", target, username, password)
 	defer func() { result.Duration = time.Since(start) }()
 
-	// Connect with context-aware timeout
 	conn, err := brutus.DialWithProxy(ctx, "tcp", target, timeout, pluginCfg.ProxyURL)
 	if err != nil {
 		result.Error = classifyError(err)
@@ -70,12 +69,10 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	}
 	defer func() { _ = conn.Close() }()
 
-	// Set overall timeout
 	_ = conn.SetDeadline(time.Now().Add(timeout))
 
 	reader := bufio.NewReader(conn)
 
-	// Read until login prompt (capture banner)
 	banner, err := waitForPrompt(reader, isLoginPrompt, timeout)
 	if err != nil {
 		result.Error = brutus.WrapConnError(err)
@@ -83,40 +80,32 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	}
 	result.Banner = banner
 
-	// Send username (telnet protocol requires CR+LF line endings)
+	// Telnet requires CR+LF line endings.
 	if _, writeErr := fmt.Fprintf(conn, "%s\r\n", username); writeErr != nil {
 		result.Error = brutus.WrapConnError(writeErr)
 		return result
 	}
 
-	// Read until password prompt
 	_, err = waitForPrompt(reader, isPasswordPrompt, timeout)
 	if err != nil {
 		result.Error = brutus.WrapConnError(err)
 		return result
 	}
 
-	// Send password (telnet protocol requires CR+LF line endings)
 	if _, writeErr := fmt.Fprintf(conn, "%s\r\n", password); writeErr != nil {
 		result.Error = brutus.WrapConnError(writeErr)
 		return result
 	}
 
-	// Read response and check for success/failure
 	response, err := readResponse(reader, timeout)
 	if err != nil {
 		result.Error = brutus.WrapConnError(err)
 		return result
 	}
 
-	// Classify response
 	result.Error = classifyTelnetResponse(response)
-	if result.Error == nil {
-		// Either auth failure or success
-		if isSuccessIndicator(response) {
-			result.Success = true
-		}
-		// If not success and Error==nil, it's auth failure
+	if result.Error == nil && isSuccessIndicator(response) {
+		result.Success = true
 	}
 
 	return result
@@ -162,7 +151,6 @@ func readResponse(reader *bufio.Reader, timeout time.Duration) (string, error) {
 	for time.Now().Before(deadline) {
 		b, err := reader.ReadByte()
 		if err != nil {
-			// Check what we have so far
 			if len(buffer) > 0 {
 				return string(buffer), nil
 			}
@@ -174,7 +162,6 @@ func readResponse(reader *bufio.Reader, timeout time.Duration) (string, error) {
 
 		buffer = append(buffer, b)
 
-		// Check for success or failure indicators
 		line := string(buffer)
 		if isSuccessIndicator(line) || containsAuthFailureIndicator(line) {
 			// Read a bit more to get full response
@@ -212,22 +199,16 @@ func classifyTelnetResponse(response string) error {
 
 	respLower := strings.ToLower(response)
 
-	// Check for connection errors first
 	if strings.Contains(respLower, "connection closed") {
 		return fmt.Errorf("connection error: connection closed")
 	}
 
-	// Check for success (return nil)
 	if isSuccessIndicator(response) {
 		return nil
 	}
 
-	// Check for auth failures using shared helper (return nil for auth failures)
-	// Convert response to error for ClassifyAuthError analysis
 	responseErr := errors.New(response)
-	classifErr := brutus.ClassifyAuthError(responseErr, telnetAuthIndicators)
-	if classifErr == nil {
-		// Shared helper returned nil, indicating auth failure
+	if brutus.ClassifyAuthError(responseErr, telnetAuthIndicators) == nil {
 		return nil
 	}
 

--- a/internal/plugins/turn/turn.go
+++ b/internal/plugins/turn/turn.go
@@ -271,10 +271,6 @@ func (p *Plugin) CheckUnauth(ctx context.Context, target string,
 	return result
 }
 
-// =============================================================================
-// STUN Message Building
-// =============================================================================
-
 // deallocate sends an authenticated Refresh request with LIFETIME=0 to release
 // a successful TURN allocation. This prevents per-user quota exhaustion during
 // brute force. Errors are ignored (fire-and-forget before connection close).
@@ -391,10 +387,6 @@ func newTransactionID() [12]byte {
 	return id
 }
 
-// =============================================================================
-// STUN Message Parsing
-// =============================================================================
-
 // parseSTUNMessage parses a STUN message, returning the message type,
 // the 12-byte transaction ID, and a map of attribute type -> raw value bytes.
 // Per RFC 5389 §7.3.1, only the first occurrence of each attribute is kept.
@@ -469,10 +461,6 @@ func getStringAttr(attrs map[uint16][]byte, attrType uint16) string {
 	}
 	return string(data)
 }
-
-// =============================================================================
-// STUN Attribute Encoding
-// =============================================================================
 
 // encodeAttr encodes a STUN attribute with TLV format and 4-byte padding.
 func encodeAttr(attrType uint16, value []byte) []byte {

--- a/internal/plugins/turn/turn_test.go
+++ b/internal/plugins/turn/turn_test.go
@@ -35,10 +35,6 @@ func TestPlugin_Name(t *testing.T) {
 	assert.Equal(t, "turn", p.Name())
 }
 
-// =============================================================================
-// Mock TURN Server
-// =============================================================================
-
 // mockTURNServer starts a UDP listener that runs a scripted TURN conversation.
 func mockTURNServer(t *testing.T, handler func(pc net.PacketConn)) (addr string, cleanup func()) {
 	t.Helper()
@@ -112,10 +108,6 @@ func buildMockSuccessResponse(txID [12]byte) []byte {
 	copy(msg[8:20], txID[:])
 	return msg
 }
-
-// =============================================================================
-// Plugin Tests
-// =============================================================================
 
 func TestPlugin_Test_ValidCredentials(t *testing.T) {
 	refreshReceived := make(chan struct{}, 1)
@@ -467,10 +459,6 @@ func TestPlugin_Test_MissingRealmOrNonce(t *testing.T) {
 	assert.Contains(t, result.Error.Error(), "missing realm or nonce")
 }
 
-// =============================================================================
-// UnauthChecker Tests
-// =============================================================================
-
 func TestPlugin_CheckUnauth_OpenRelay(t *testing.T) {
 	refreshReceived := make(chan struct{}, 1)
 
@@ -535,10 +523,6 @@ func TestPlugin_CheckUnauth_Unreachable(t *testing.T) {
 
 	assert.False(t, result.Success)
 }
-
-// =============================================================================
-// STUN Encoding/Parsing Unit Tests
-// =============================================================================
 
 func TestBuildAllocateRequest(t *testing.T) {
 	txID := [12]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}

--- a/pkg/brutus/brutus.go
+++ b/pkg/brutus/brutus.go
@@ -296,9 +296,6 @@ type UnauthOnlyChecker interface {
 // which is important for concurrent usage.
 type PluginFactory func() Plugin
 
-// Configuration Validation
-// =============================================================================
-
 // applyDefaults populates protocol-specific default credentials from embedded
 // wordlists when UseDefaults is true and no credentials have been provided.
 // Existing credentials are never overwritten.
@@ -351,14 +348,12 @@ func (c *Config) validate() error {
 
 	c.applyDefaults()
 
-	// Need either: paired Credentials OR (Usernames + Passwords/Keys)
 	hasPairedCreds := len(c.Credentials) > 0
 	hasUnpairedCreds := len(c.Usernames) > 0 && (len(c.Passwords) > 0 || len(c.Keys) > 0)
 	if !hasPairedCreds && !hasUnpairedCreds {
 		return errors.New("credentials required: use Credentials for paired, or Usernames with Passwords/Keys")
 	}
 
-	// Apply defaults
 	if c.Timeout == 0 {
 		c.Timeout = 10 * time.Second
 	}
@@ -372,22 +367,16 @@ func (c *Config) validate() error {
 	return nil
 }
 
-// =============================================================================
-// Brute Force Execution
-// =============================================================================
-
 // BruteWithContext executes a brute force attack using the provided configuration and context.
 //
 // The context can be used to cancel the operation early via context cancellation.
 // The plugin is resolved once via GetPlugin and shared across all worker goroutines.
 // See the Plugin interface documentation for thread-safety requirements.
 func BruteWithContext(ctx context.Context, cfg *Config) ([]Result, error) {
-	// 1. Validate configuration
 	if err := cfg.validate(); err != nil {
 		return nil, fmt.Errorf("invalid config: %w", err)
 	}
 
-	// 2. Get protocol plugin (use provided plugin if set, otherwise lookup by name)
 	var plug Plugin
 	if cfg.Plugin != nil {
 		plug = cfg.Plugin
@@ -399,7 +388,6 @@ func BruteWithContext(ctx context.Context, cfg *Config) ([]Result, error) {
 		}
 	}
 
-	// 3. Run worker pool with provided context
 	results, err := runWorkers(ctx, cfg, plug)
 	if err != nil {
 		return results, fmt.Errorf("brute force failed: %w", err)

--- a/pkg/brutus/errors.go
+++ b/pkg/brutus/errors.go
@@ -36,16 +36,12 @@ func ClassifyAuthError(err error, authIndicators []string) error {
 
 	errStr := strings.ToLower(err.Error())
 
-	// Check if error matches any auth failure indicator
 	for _, indicator := range authIndicators {
 		if strings.Contains(errStr, strings.ToLower(indicator)) {
-			// This is an authentication failure (wrong credentials)
-			// Return nil to signal "try next credential"
 			return nil
 		}
 	}
 
-	// All other errors are connection/network problems
 	return fmt.Errorf("connection error: %w", err)
 }
 

--- a/pkg/brutus/input/nerva_test.go
+++ b/pkg/brutus/input/nerva_test.go
@@ -375,10 +375,6 @@ func TestClassifyStdinLine_Invalid(t *testing.T) {
 	}
 }
 
-// =============================================================================
-// HasNoAuth / Anonymous Access Detection
-// =============================================================================
-
 func TestHasNoAuth_TopLevelAnonymousAccess(t *testing.T) {
 	nrv := NervaResult{
 		IP:              "10.0.0.1",

--- a/pkg/brutus/proxy_test.go
+++ b/pkg/brutus/proxy_test.go
@@ -153,10 +153,6 @@ func TestNewHTTPClient_BackwardCompat(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// TestBuildProxyURL — Section A
-// ---------------------------------------------------------------------------
-
 func TestBuildProxyURL(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -280,10 +276,6 @@ func TestBuildProxyURL_BrightDataRoundTrip(t *testing.T) {
 	assert.Equal(t, wantPass, gotPass, "percent-decoded password must match")
 }
 
-// ---------------------------------------------------------------------------
-// TestProxyTransport — Section B
-// ---------------------------------------------------------------------------
-
 func TestProxyTransport(t *testing.T) {
 	t.Run("http proxy sets Transport.Proxy not DialContext", func(t *testing.T) {
 		transport, err := ProxyTransport("http://u:p@h:8080", 5*time.Second, nil)
@@ -325,10 +317,6 @@ func TestProxyTransport(t *testing.T) {
 		require.Error(t, err)
 	})
 }
-
-// ---------------------------------------------------------------------------
-// TestProxyAuthorization_EndToEnd — Section C
-// ---------------------------------------------------------------------------
 
 // TestProxyAuthorization_EndToEnd stands up an httptest server acting as an
 // HTTP forward proxy. It verifies that NewHTTPClientWithProxy produces a client

--- a/pkg/brutus/registry.go
+++ b/pkg/brutus/registry.go
@@ -20,10 +20,6 @@ import (
 	"sync"
 )
 
-// =============================================================================
-// Plugin Registry
-// =============================================================================
-
 var (
 	pluginRegistryMu sync.RWMutex
 	pluginRegistry   = make(map[string]PluginFactory)
@@ -83,10 +79,6 @@ func ResetPlugins() {
 	pluginRegistry = make(map[string]PluginFactory)
 }
 
-// =============================================================================
-// Unauth-Only Checker Registry
-// =============================================================================
-
 var (
 	unauthRegistryMu sync.RWMutex
 	unauthRegistry   = make(map[string]func() UnauthOnlyChecker)
@@ -133,10 +125,6 @@ func ResetUnauthCheckers() {
 	defer unauthRegistryMu.Unlock()
 	unauthRegistry = make(map[string]func() UnauthOnlyChecker)
 }
-
-// =============================================================================
-// Analyzer Registry
-// =============================================================================
 
 var (
 	analyzerRegistryMu sync.RWMutex

--- a/pkg/brutus/workers.go
+++ b/pkg/brutus/workers.go
@@ -74,7 +74,6 @@ func reorderForSpray(creds []credential) []credential {
 		return creds
 	}
 
-	// Group credentials by password
 	byPassword := make(map[string][]credential)
 	passwordOrder := []string{}
 
@@ -85,7 +84,6 @@ func reorderForSpray(creds []credential) []credential {
 		byPassword[c.password] = append(byPassword[c.password], c)
 	}
 
-	// Rebuild credentials list: all users for password1, then all users for password2, etc.
 	result := make([]credential, 0, len(creds))
 	for _, pass := range passwordOrder {
 		result = append(result, byPassword[pass]...)
@@ -120,14 +118,11 @@ func runWorkers(ctx context.Context, cfg *Config, plug Plugin) ([]Result, error)
 		}
 	}
 
-	// Check if LLM analysis is enabled AND protocol supports it
 	// LLM banner analysis only makes sense for HTTP Basic Auth where we can
-	// detect the application from the response headers/body
+	// detect the application from the response headers/body.
 	if cfg.LLMConfig != nil && cfg.LLMConfig.Enabled && isHTTPProtocol(cfg.Protocol) {
-		// Use LLM-enhanced flow: capture banner, analyze, test suggestions
 		return runWorkersWithLLM(ctx, cfg, plug)
 	}
-	// Default flow: test credentials without LLM analysis
 	return runWorkersDefault(ctx, cfg, plug)
 }
 
@@ -136,30 +131,24 @@ func runWorkers(ctx context.Context, cfg *Config, plug Plugin) ([]Result, error)
 // rate limiting, jitter, max attempts, retry with backoff, adaptive pacing,
 // result collection, and early stopping.
 func executeWorkerPool(ctx context.Context, cfg *Config, plug Plugin, credentials []credential, llmSuggestions []string) ([]Result, error) {
-	// Build plugin config once for all workers
 	pluginCfg := pluginConfigFromConfig(cfg)
 
-	// Create cancellable context for early stop
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	// Setup errgroup with bounded concurrency
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(cfg.Threads)
 
-	// Create rate limiter if configured
 	var limiter *rate.Limiter
 	if cfg.RateLimit > 0 {
 		limiter = rate.NewLimiter(rate.Limit(cfg.RateLimit), 1)
 	}
 
-	// Create backoff controller for retry and adaptive pacing
 	var bc *backoffController
 	if cfg.MaxRetries > 0 {
 		bc = newBackoffController(500*time.Millisecond, 30*time.Second, cfg.Verbose)
 	}
 
-	// Result collection with mutex protection
 	var (
 		results       []Result
 		attemptCounts = make(map[string]int)
@@ -168,14 +157,8 @@ func executeWorkerPool(ctx context.Context, cfg *Config, plug Plugin, credential
 		crackedUsers  = make(map[string]bool) // per-user early stop
 	)
 
-	// Launch workers
 	for _, cred := range credentials {
-
-		// Capture loop variable for closure
-		cred := cred
-
 		g.Go(func() error {
-			// Recover from plugin panics to prevent crashing the entire scan
 			defer func() {
 				if r := recover(); r != nil {
 					fmt.Fprintf(os.Stderr, "brutus: panic in worker for %s@%s: %v\n%s\n",
@@ -196,14 +179,12 @@ func executeWorkerPool(ctx context.Context, cfg *Config, plug Plugin, credential
 				}
 			}()
 
-			// Check context cancellation
 			select {
 			case <-ctx.Done():
 				return nil
 			default:
 			}
 
-			// Skip if this user already has a valid credential
 			attemptMu.Lock()
 			if crackedUsers[cred.username] {
 				attemptMu.Unlock()
@@ -211,24 +192,20 @@ func executeWorkerPool(ctx context.Context, cfg *Config, plug Plugin, credential
 			}
 			attemptMu.Unlock()
 
-			// Apply rate limiting if configured
 			if limiter != nil {
 				if err := limiter.Wait(ctx); err != nil {
-					return nil // Context canceled
+					return nil
 				}
-				// Apply jitter if configured
 				if cfg.Jitter > 0 {
 					jitterDuration := time.Duration(rand.Int63n(int64(cfg.Jitter)))
 					select {
 					case <-time.After(jitterDuration):
-						// Jitter sleep completed
 					case <-ctx.Done():
-						return nil // Context canceled during jitter
+						return nil
 					}
 				}
 			}
 
-			// Check max attempts per user
 			if cfg.MaxAttempts > 0 {
 				attemptMu.Lock()
 				if attemptCounts[cred.username] >= cfg.MaxAttempts {
@@ -247,7 +224,6 @@ func executeWorkerPool(ctx context.Context, cfg *Config, plug Plugin, credential
 			default:
 			}
 
-			// Apply adaptive pacing if backoff controller is active
 			if bc != nil {
 				if delay := bc.adaptiveDelay(); delay > 0 {
 					select {
@@ -258,7 +234,6 @@ func executeWorkerPool(ctx context.Context, cfg *Config, plug Plugin, credential
 				}
 			}
 
-			// Test credential with retry on connection errors
 			var result *Result
 			maxAttempts := 1
 			if bc != nil {
@@ -266,7 +241,6 @@ func executeWorkerPool(ctx context.Context, cfg *Config, plug Plugin, credential
 			}
 
 			for attempt := 0; attempt < maxAttempts; attempt++ {
-				// Retry backoff (skip for first attempt)
 				if attempt > 0 {
 					delay := bc.retryDelay(attempt - 1)
 					select {
@@ -277,30 +251,24 @@ func executeWorkerPool(ctx context.Context, cfg *Config, plug Plugin, credential
 				}
 
 				if cred.key != nil {
-					// Key-based authentication
 					if kp, ok := plug.(KeyPlugin); ok {
 						result = kp.TestKey(ctx, cfg.Target, cred.username, cred.key, cfg.Timeout, pluginCfg)
 					} else {
-						// Plugin doesn't support key auth, skip
 						return nil
 					}
 				} else {
-					// Password-based authentication
 					result = plug.Test(ctx, cfg.Target, cred.username, cred.password, cfg.Timeout, pluginCfg)
 				}
 
-				// If no connection error, stop retrying
 				if result.Error == nil {
 					break
 				}
 
-				// Connection error on last attempt - keep the error result
 				if attempt == maxAttempts-1 {
 					break
 				}
 			}
 
-			// Update adaptive controller
 			if bc != nil {
 				if result.Error != nil {
 					bc.recordError()
@@ -309,7 +277,6 @@ func executeWorkerPool(ctx context.Context, cfg *Config, plug Plugin, credential
 				}
 			}
 
-			// Populate LLM tracking fields if suggestions were provided
 			if len(llmSuggestions) > 0 {
 				result.LLMSuggested = cred.llmSuggested
 				result.LLMSuggestedCreds = llmSuggestions
@@ -334,7 +301,6 @@ func executeWorkerPool(ctx context.Context, cfg *Config, plug Plugin, credential
 		})
 	}
 
-	// Wait for all workers to complete
 	err := g.Wait()
 
 	// Classify every Result leaving the credential worker pool. This is the
@@ -358,10 +324,9 @@ func executeWorkerPool(ctx context.Context, cfg *Config, plug Plugin, credential
 // runWorkersDefault executes credential testing using a bounded worker pool.
 // Uses errgroup for concurrency control and context cancellation for early stopping.
 func runWorkersDefault(ctx context.Context, cfg *Config, plug Plugin) ([]Result, error) {
-	// Generate all credential combinations
 	var credentials []credential
 
-	// Add pre-paired credentials (no Cartesian product)
+	// Pre-paired credentials are used as-is (no Cartesian product).
 	for _, c := range cfg.Credentials {
 		credentials = append(credentials, credential{
 			username: c.Username,
@@ -384,7 +349,6 @@ func runWorkersDefault(ctx context.Context, cfg *Config, plug Plugin) ([]Result,
 	// before moving to the next password. This avoids account lockout.
 	credentials = reorderForSpray(credentials)
 
-	// Execute worker pool with no LLM suggestions
 	return executeWorkerPool(ctx, cfg, plug, credentials, nil)
 }
 
@@ -396,23 +360,18 @@ func runWorkersDefault(ctx context.Context, cfg *Config, plug Plugin) ([]Result,
 // elasticsearch, influxdb) where banner analysis can identify the application
 // (e.g., Grafana, Jenkins, Tomcat) and suggest relevant default credentials.
 func runWorkersWithLLM(ctx context.Context, cfg *Config, plug Plugin) ([]Result, error) {
-	// Capture banner from HTTP response
 	banner := captureBanner(ctx, cfg, plug)
 
-	// Analyze banner with LLM to get application-specific credential suggestions
 	analyzer := createAnalyzer(cfg.LLMConfig)
 	if analyzer == nil {
-		// Analyzer creation failed - fallback to defaults
 		return runWorkersDefault(ctx, cfg, plug)
 	}
 
 	suggestions, err := analyzer.Analyze(ctx, banner)
 	if err != nil {
-		// LLM analysis failed - fallback to defaults
 		return runWorkersDefault(ctx, cfg, plug)
 	}
 
-	// Phase 4: Build LLM credential list (test these first)
 	llmCreds := []credential{}
 	for _, username := range cfg.Usernames {
 		for _, password := range suggestions {
@@ -424,15 +383,12 @@ func runWorkersWithLLM(ctx context.Context, cfg *Config, plug Plugin) ([]Result,
 		}
 	}
 
-	// Phase 5: Build default credential list
 	defaultCreds := generateCredentials(cfg.Usernames, cfg.Passwords)
 
-	// Phase 6: Combine LLM suggestions first, then defaults
 	allCreds := make([]credential, 0, len(llmCreds)+len(defaultCreds))
 	allCreds = append(allCreds, llmCreds...)
 	allCreds = append(allCreds, defaultCreds...)
 
-	// Run workers with combined credentials
 	return executeWorkerPool(ctx, cfg, plug, allCreds, suggestions)
 }
 
@@ -447,9 +403,7 @@ func captureBanner(ctx context.Context, cfg *Config, plug Plugin) BannerInfo {
 	} else if len(cfg.Credentials) > 0 {
 		username = cfg.Credentials[0].Username
 	}
-	// Empty username is acceptable for banner capture (some protocols don't need it)
-
-	// Test with dummy credential just to capture banner
+	// Empty username is acceptable for banner capture (some protocols don't need it).
 	result := plug.Test(ctx, cfg.Target, username, "", cfg.Timeout, pluginConfigFromConfig(cfg))
 
 	return BannerInfo{

--- a/pkg/enum/apollo/apollo.go
+++ b/pkg/enum/apollo/apollo.go
@@ -48,10 +48,6 @@ const (
 	maxPages = 500
 )
 
-// ---------------------------------------------------------------------------
-// Public types
-// ---------------------------------------------------------------------------
-
 // Person is one discovered contact for the domain. The enrichment-only fields
 // are empty until EnrichByIDs/RevealEmails runs (consumes credits).
 type Person struct {
@@ -135,10 +131,6 @@ func (e *APIError) Unwrap() error {
 	}
 	return nil
 }
-
-// ---------------------------------------------------------------------------
-// Client
-// ---------------------------------------------------------------------------
 
 // Client holds state for querying the Apollo people search and match APIs.
 type Client struct {
@@ -293,10 +285,6 @@ func (c *Client) RevealEmails(ctx context.Context, result *DomainResult) error {
 
 	return err
 }
-
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
 
 // searchPage performs a single people-search POST and returns the mapped people
 // plus the reported total_entries.
@@ -479,7 +467,6 @@ func mergeReveal(p, m *Person) {
 	p.Revealed = true
 }
 
-// ---------------------------------------------------------------------------
 // JSON-mapping structs (unexported — map to the Apollo API shapes).
 //
 // NOTE: verified against live API 2026-06-26 (total_entries top-level;
@@ -487,7 +474,6 @@ func mergeReveal(p, m *Person) {
 // paths below are intentionally isolated here so a single edit corrects any
 // mismatch without touching control flow. httptest tests use controlled
 // payloads and pass regardless of live-schema correctness.
-// ---------------------------------------------------------------------------
 
 type apolloSearchRequest struct {
 	OrganizationDomains []string `json:"q_organization_domains_list,omitempty"`

--- a/pkg/enum/apollo/apollo_test.go
+++ b/pkg/enum/apollo/apollo_test.go
@@ -30,10 +30,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ---------------------------------------------------------------------------
-// Test helper
-// ---------------------------------------------------------------------------
-
 // newTestClient creates a Client pointed at baseURL, overriding the default
 // base URL set by NewClient. Mirrors hunter_test.go:122-126.
 func newTestClient(baseURL string) *Client {
@@ -41,10 +37,6 @@ func newTestClient(baseURL string) *Client {
 	c.baseURL = baseURL
 	return c
 }
-
-// ---------------------------------------------------------------------------
-// T001: toPerson + APIError
-// ---------------------------------------------------------------------------
 
 func TestToPerson(t *testing.T) {
 	src := apolloPerson{
@@ -123,10 +115,6 @@ func TestAPIError_Error(t *testing.T) {
 	assert.NotContains(t, msg, "SECRETKEY-DO-NOT-LEAK",
 		"APIError.Error() must not include Details (P0-1 key-leak prevention)")
 }
-
-// ---------------------------------------------------------------------------
-// T002: searchPage + matchPerson + do
-// ---------------------------------------------------------------------------
 
 func makeSearchResponse(people []apolloPerson, total int) []byte {
 	resp := apolloSearchResponse{
@@ -298,10 +286,6 @@ func TestDo_SetsAuthHeader(t *testing.T) {
 	// The key must NOT appear in the request URL (P0-1: header-based auth only).
 	assert.NotContains(t, capturedURL, "testkey", "API key must not appear in URL")
 }
-
-// ---------------------------------------------------------------------------
-// T003: Discover pagination (was SearchPeople) + EnrichByIDs + RevealEmails
-// ---------------------------------------------------------------------------
 
 // pagedSearchServer returns an httptest.Server that serves paginated Apollo
 // search results (page-based, not offset-based). Each request must include a
@@ -562,10 +546,6 @@ func TestDiscover_ContextCancellation(t *testing.T) {
 	require.Error(t, err, "expected error due to context cancellation")
 }
 
-// ---------------------------------------------------------------------------
-// T003b: EnrichByIDs — selective per-id enrichment
-// ---------------------------------------------------------------------------
-
 // makeMatchResponseForID returns a full apolloMatchResponse JSON payload for the
 // given Apollo person id. The email is derived from the id so each person gets a
 // distinct email, making assertions straightforward.
@@ -707,10 +687,6 @@ func TestEnrichByIDs_SurfacesFirstError(t *testing.T) {
 	assert.Equal(t, "p1", enriched[0].ID)
 	assert.True(t, enriched[0].Revealed)
 }
-
-// ---------------------------------------------------------------------------
-// RevealEmails tests
-// ---------------------------------------------------------------------------
 
 func TestRevealEmails_Merge(t *testing.T) {
 	// 3 people: server returns email for p1, email for p2, empty for p3.

--- a/pkg/enum/custom/match_test.go
+++ b/pkg/enum/custom/match_test.go
@@ -35,10 +35,6 @@ func newParsedSpec(t *testing.T, data []byte) *Spec {
 	return spec
 }
 
-// ---------------------------------------------------------------------------
-// T3: evaluate — status condition, first-match ordering, default
-// ---------------------------------------------------------------------------
-
 // TestEvaluate_Status verifies that a status-only rule fires correctly for
 // scalar match, list match, ordering, and the default fallback.
 func TestEvaluate_Status(t *testing.T) {
@@ -153,10 +149,6 @@ func TestEvaluate_FirstMatchOrdering(t *testing.T) {
 	assert.Equal(t, "exists", verdict, "first matching rule must win")
 	assert.Equal(t, enum.ConfidenceHigh, conf)
 }
-
-// ---------------------------------------------------------------------------
-// T4: evaluate — body_contains and body_regex
-// ---------------------------------------------------------------------------
 
 // TestEvaluate_BodyContains verifies that body_contains triggers only when
 // the substring is present in the response body.
@@ -289,10 +281,6 @@ func TestEvaluate_StatusAndBodyAND(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// T5: evaluate — json_field (path + equals/in)
-// ---------------------------------------------------------------------------
-
 // TestEvaluate_JSONField verifies json_field matching including nested path,
 // "in" set, missing path → false, and non-JSON body → false.
 func TestEvaluate_JSONField(t *testing.T) {
@@ -410,10 +398,6 @@ func TestEvaluate_JSONField(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
-// T6: evaluate — header (present + equals)
-// ---------------------------------------------------------------------------
-
 // TestEvaluate_Header verifies header matching with present=true, equals, and
 // missing header cases.
 func TestEvaluate_Header(t *testing.T) {
@@ -515,10 +499,6 @@ func TestEvaluate_Header(t *testing.T) {
 			"a header that was never set must not count as present")
 	})
 }
-
-// ---------------------------------------------------------------------------
-// T7: applyVerdict + errInconclusive (R7 no-body-in-error)
-// ---------------------------------------------------------------------------
 
 // TestApplyVerdict verifies the verdict-to-result mapping for all three
 // verdicts, and specifically that the "error" verdict message contains only

--- a/pkg/enum/custom/parse_test.go
+++ b/pkg/enum/custom/parse_test.go
@@ -106,10 +106,6 @@ func TestParse_JSONEqualsYAML(t *testing.T) {
 	assert.Equal(t, len(jsonSpec.Oracle.Match.Rules), len(yamlSpec.Oracle.Match.Rules))
 }
 
-// ---------------------------------------------------------------------------
-// Table-driven invalid-spec tests
-// ---------------------------------------------------------------------------
-
 // invalidSpecCase describes a single invalid-spec test.
 type invalidSpecCase struct {
 	name         string

--- a/pkg/enum/custom/plugin_test.go
+++ b/pkg/enum/custom/plugin_test.go
@@ -33,10 +33,6 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/enum"
 )
 
-// ---------------------------------------------------------------------------
-// T9: Plugin adapter — httptest-based tests mirroring microsoft365_test.go
-// ---------------------------------------------------------------------------
-
 // forgotPasswordSpec returns a parsed, validated Spec for the forgotpassword
 // oracle pointing at the given base URL. Used by T9 and T12 tests.
 func forgotPasswordSpec(t *testing.T, baseURL string) *Spec {
@@ -278,10 +274,6 @@ func TestName(t *testing.T) {
 	p := New(spec)
 	assert.Equal(t, "forgotpassword", p.Name())
 }
-
-// ---------------------------------------------------------------------------
-// T12: End-to-end test using testdata/forgotpassword.json
-// ---------------------------------------------------------------------------
 
 // TestE2E_ForgotPassword parses the example oracle file, points it at an
 // httptest server, runs EnumerateWithPlugin, and asserts:

--- a/pkg/enum/custom/request_test.go
+++ b/pkg/enum/custom/request_test.go
@@ -25,10 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ---------------------------------------------------------------------------
-// T8: derivePlaceholders
-// ---------------------------------------------------------------------------
-
 // TestDerivePlaceholders verifies the subject-to-placeholder mapping described
 // in architecture.md §7 (D5).
 func TestDerivePlaceholders(t *testing.T) {
@@ -80,10 +76,8 @@ func TestDerivePlaceholders(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // T8: buildRequest — per-sink escaping and rejection tests
 // One test per sink × hostile input (the P0 checks).
-// ---------------------------------------------------------------------------
 
 // buildSpecForRequest is a helper that creates a parsed, validated Spec from
 // raw JSON for request builder tests.
@@ -557,10 +551,6 @@ func TestBuildRequest_P0_5_SchemeAllowlistAtLoad(t *testing.T) {
 	require.Error(t, spec.Validate(),
 		"Validate must reject file:// scheme (P0-5 / R4)")
 }
-
-// ---------------------------------------------------------------------------
-// NF-1: userinfo authority injection — EXPECTED TO FAIL until production fix
-// ---------------------------------------------------------------------------
 
 // TestBuildRequest_RejectsUserinfoAuthority verifies that a subject whose value
 // smuggles a userinfo "@" into the authority of the post-substitution URL is

--- a/pkg/enum/dehashed/dehashed.go
+++ b/pkg/enum/dehashed/dehashed.go
@@ -49,10 +49,6 @@ const (
 	maxResults      = 10000
 )
 
-// ---------------------------------------------------------------------------
-// Public types
-// ---------------------------------------------------------------------------
-
 // Record is one breach-exposed identity entry for the domain. It carries the
 // breach-exposed plaintext Passwords for the record; hashed_password remains
 // omitted by design (P0-SCOPE: hashes omitted).
@@ -191,10 +187,6 @@ func (e *APIError) Unwrap() error {
 	return nil
 }
 
-// ---------------------------------------------------------------------------
-// Client
-// ---------------------------------------------------------------------------
-
 // Client holds state for querying the DeHashed v2 search API.
 type Client struct {
 	apiKey     string
@@ -300,10 +292,6 @@ func (c *Client) SearchWithOptions(ctx context.Context, opts SearchOptions) (*Do
 
 	return result, nil
 }
-
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
 
 // do performs a single POST to the DeHashed search API and returns the bounded
 // response body. The API key is sent only in the Dehashed-Api-Key header — it
@@ -498,12 +486,10 @@ func toRecord(e *apiEntry) Record {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // JSON-mapping structs (unexported — map to the DeHashed v2 response shape).
 // The plaintext "password" field IS mapped and flows into our data model.
 // "hashed_password" is DELIBERATELY omitted so hashes are dropped at unmarshal
 // and never enter our data model (P0-SCOPE).
-// ---------------------------------------------------------------------------
 
 type searchRequest struct {
 	Query string `json:"query"`

--- a/pkg/enum/dehashed/dehashed_test.go
+++ b/pkg/enum/dehashed/dehashed_test.go
@@ -29,19 +29,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ---------------------------------------------------------------------------
-// Test helper: same-package client pointing at a test server.
-// ---------------------------------------------------------------------------
-
 func newTestClient(baseURL string) *Client {
 	c, _ := NewClient("testkey", 5*time.Second, 10, "") // Empty proxy never errors.
 	c.baseURL = baseURL
 	return c
 }
-
-// ---------------------------------------------------------------------------
-// Task 1: toRecord identity mapping
-// ---------------------------------------------------------------------------
 
 func TestToRecord(t *testing.T) {
 	src := &apiEntry{
@@ -69,10 +61,6 @@ func TestToRecord(t *testing.T) {
 	assert.Equal(t, "2021-01", got.ObtainedDate)
 }
 
-// ---------------------------------------------------------------------------
-// Task 2: APIError Unwrap sentinel mapping
-// ---------------------------------------------------------------------------
-
 func TestAPIError_Unwrap(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -97,12 +85,10 @@ func TestAPIError_Unwrap(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // P0-SCOPE: TestSearch_CollectsCredentials
 // Verify that the API "password" field is collected into Record.Passwords and
 // surfaces through Refine into Entry.Passwords. Verify that "hashed_password"
 // is NEVER collected (not present in Record or Entry — dropped at unmarshal).
-// ---------------------------------------------------------------------------
 
 func TestSearch_CollectsCredentials(t *testing.T) {
 	// The mock API returns two entries for the same email with different passwords,
@@ -195,10 +181,6 @@ func TestSearch_CollectsCredentials(t *testing.T) {
 			"hashed_password value must never appear in Entry.Passwords")
 	}
 }
-
-// ---------------------------------------------------------------------------
-// Task A: TestRefine — table-driven coverage of Refine()
-// ---------------------------------------------------------------------------
 
 func TestRefine(t *testing.T) {
 	tests := []struct {
@@ -443,10 +425,6 @@ func TestRefine(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Task B: TestIsCombolist
-// ---------------------------------------------------------------------------
-
 func TestIsCombolist(t *testing.T) {
 	// Every entry in combolistDatabases must match itself (exact) and a variation.
 	for _, entry := range combolistDatabases {
@@ -477,10 +455,6 @@ func TestIsCombolist(t *testing.T) {
 		})
 	}
 }
-
-// ---------------------------------------------------------------------------
-// Task 3: Search pagination
-// ---------------------------------------------------------------------------
 
 // makePagedServer builds an httptest server that serves DeHashed-shaped POST
 // responses. It reads the page number from the decoded JSON body (not a query
@@ -630,10 +604,6 @@ func TestSearch_Pagination(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Task 4: Context cancellation
-// ---------------------------------------------------------------------------
-
 func TestSearch_ContextCancellation(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Slow server: block longer than the context deadline.
@@ -658,10 +628,6 @@ func TestSearch_ContextCancellation(t *testing.T) {
 	_, err := c.Search(ctx, "example.com", 0)
 	require.Error(t, err)
 }
-
-// ---------------------------------------------------------------------------
-// Task 5: do() — auth header and URL safety
-// ---------------------------------------------------------------------------
 
 func TestDo_SetsAuthHeader(t *testing.T) {
 	const testKey = "super-secret-key-xyz"
@@ -690,10 +656,6 @@ func TestDo_SetsAuthHeader(t *testing.T) {
 	assert.NotContains(t, capturedURL, testKey)
 }
 
-// ---------------------------------------------------------------------------
-// Task 6: do() — malformed JSON returns decode error
-// ---------------------------------------------------------------------------
-
 func TestDo_MalformedJSON(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -710,10 +672,6 @@ func TestDo_MalformedJSON(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "decoding dehashed response")
 }
-
-// ---------------------------------------------------------------------------
-// buildQuery
-// ---------------------------------------------------------------------------
 
 func TestBuildQuery(t *testing.T) {
 	tests := []struct {
@@ -739,10 +697,6 @@ func TestBuildQuery(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// filterBySource
-// ---------------------------------------------------------------------------
-
 func TestFilterBySource(t *testing.T) {
 	recs := []Record{
 		{Email: []string{"a@x.com"}, Database: "Adobe"},
@@ -767,10 +721,6 @@ func TestFilterBySource(t *testing.T) {
 		assert.Len(t, filterBySource(recs, nil), 3)
 	})
 }
-
-// ---------------------------------------------------------------------------
-// SearchWithOptions — source scoping (query grouping + client-side backstop)
-// ---------------------------------------------------------------------------
 
 func TestSearchWithOptions_Sources(t *testing.T) {
 	all := []apiEntry{
@@ -816,10 +766,6 @@ func TestSearchWithOptions_Sources(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, res2.Records, 1, "limit bounds matching records")
 }
-
-// ---------------------------------------------------------------------------
-// Refine — detailed fields (IPAddresses, Addresses, DOBs, ObtainedDates)
-// ---------------------------------------------------------------------------
 
 func TestRefine_DetailedFields(t *testing.T) {
 	t.Run("non-dedup single record populates ip/address/dob/obtained (deduped)", func(t *testing.T) {

--- a/pkg/enum/enum.go
+++ b/pkg/enum/enum.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// pkg/enum/enum.go
+// Package enum implements account-enumeration oracles, username generation,
+// and a shared worker pool used by the brutus enum subcommands.
 package enum
 
 import (

--- a/pkg/enum/enum_test.go
+++ b/pkg/enum/enum_test.go
@@ -22,10 +22,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// ---------------------------------------------------------------------------
-// TestHTTPClientContext — Section E: WithHTTPClient / HTTPClientFromContext
-// ---------------------------------------------------------------------------
-
 func TestHTTPClientContext_RoundTrip(t *testing.T) {
 	client := &http.Client{}
 	ctx := WithHTTPClient(context.Background(), client)
@@ -37,10 +33,6 @@ func TestHTTPClientContext_Default(t *testing.T) {
 	got := HTTPClientFromContext(context.Background())
 	assert.Nil(t, got, "HTTPClientFromContext on a plain Background context must return nil")
 }
-
-// ---------------------------------------------------------------------------
-// TestProxyURLContext — Section E: WithProxyURL / ProxyURLFromContext
-// ---------------------------------------------------------------------------
 
 func TestProxyURLContext_RoundTrip(t *testing.T) {
 	const wantURL = "http://proxy.example:8080"

--- a/pkg/enum/generate_test.go
+++ b/pkg/enum/generate_test.go
@@ -28,10 +28,6 @@ import (
 // stay valid if the wordlist is ever updated.
 const maxWordlistSize = 248231
 
-// ---------------------------------------------------------------------------
-// TestGenerateUsernames_FirstDotLast
-// ---------------------------------------------------------------------------
-
 // TestGenerateUsernames_FirstDotLast verifies that the first.last format
 // produces a non-empty, bounded, frequency-ranked result set whose head
 // entries match the expected most-likely pairs from the wordlist.
@@ -59,10 +55,6 @@ func TestGenerateUsernames_FirstDotLast(t *testing.T) {
 	assert.True(t, top5["david.smith"] || top5["michael.smith"],
 		"david.smith or michael.smith must appear in the top 5 first.last entries")
 }
-
-// ---------------------------------------------------------------------------
-// TestGenerateUsernames_DerivedFormats
-// ---------------------------------------------------------------------------
 
 // TestGenerateUsernames_DerivedFormats verifies that each format derives its
 // first entry from the #1 ranked pair (john.smith → first=john, last=smith).
@@ -104,10 +96,6 @@ func TestGenerateUsernames_DerivedFormats(t *testing.T) {
 		})
 	}
 }
-
-// ---------------------------------------------------------------------------
-// TestGenerateUsernames_Dedup
-// ---------------------------------------------------------------------------
 
 // TestGenerateUsernames_Dedup verifies that formats that collapse many source
 // pairs to the same output (e.g. "first" produces "john" from every
@@ -158,10 +146,6 @@ func TestGenerateUsernames_Dedup(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
-// TestGenerateUsernames_MultiPartSurnames
-// ---------------------------------------------------------------------------
-
 // TestGenerateUsernames_MultiPartSurnames verifies that multi-dot source lines
 // are handled correctly. For first.last format the full dotted name is
 // preserved; for concatenated formats dots are stripped.
@@ -208,10 +192,6 @@ func TestGenerateUsernames_MultiPartSurnames(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// TestGenerateUsernames_AllFormatsBoundedAndNonEmpty
-// ---------------------------------------------------------------------------
-
 // TestGenerateUsernames_AllFormatsBoundedAndNonEmpty is a table-driven test
 // that verifies every supported format produces a non-empty, bounded result
 // with no empty-string entries and all-lowercase output.
@@ -247,10 +227,6 @@ func TestGenerateUsernames_AllFormatsBoundedAndNonEmpty(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// TestGenerateUsernames_UnknownFormat
-// ---------------------------------------------------------------------------
-
 // TestGenerateUsernames_UnknownFormat verifies that an unrecognized format
 // string causes all pairs to be skipped (formatUsername returns "" for the
 // default branch), producing an empty result with no error.
@@ -262,10 +238,6 @@ func TestGenerateUsernames_UnknownFormat(t *testing.T) {
 	assert.Empty(t, result,
 		"unknown format must produce an empty result (formatUsername default branch returns \"\")")
 }
-
-// ---------------------------------------------------------------------------
-// TestGenerateEmails
-// ---------------------------------------------------------------------------
 
 // TestGenerateEmails verifies that GenerateEmails appends @domain to each
 // username and produces the same count as the corresponding GenerateUsernames
@@ -297,10 +269,6 @@ func TestGenerateEmails(t *testing.T) {
 		"GenerateEmails must produce the same count as GenerateUsernames for the same format")
 }
 
-// ---------------------------------------------------------------------------
-// TestListFormats_IncludesFirstUnderLast
-// ---------------------------------------------------------------------------
-
 // TestListFormats_IncludesFirstUnderLast verifies that ListFormats includes the
 // "first_last" format constant.
 func TestListFormats_IncludesFirstUnderLast(t *testing.T) {
@@ -310,10 +278,6 @@ func TestListFormats_IncludesFirstUnderLast(t *testing.T) {
 	assert.Contains(t, formats, FormatFirstUnderLast,
 		"ListFormats must include FormatFirstUnderLast (%q)", FormatFirstUnderLast)
 }
-
-// ---------------------------------------------------------------------------
-// TestGenerateUsernames_FirstUnderLast
-// ---------------------------------------------------------------------------
 
 // TestGenerateUsernames_FirstUnderLast verifies all structural properties of
 // the first_last format: ranked head entry, underscore separator, no dots,
@@ -370,10 +334,6 @@ func TestGenerateUsernames_FirstUnderLast(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// TestGenerateEmails_FirstUnderLast
-// ---------------------------------------------------------------------------
-
 // TestGenerateEmails_FirstUnderLast verifies that GenerateEmails with
 // first_last format produces properly formatted email addresses.
 func TestGenerateEmails_FirstUnderLast(t *testing.T) {
@@ -407,7 +367,6 @@ func TestGenerateEmails_FirstUnderLast(t *testing.T) {
 		"GenerateEmails must produce the same count as GenerateUsernames for first_last")
 }
 
-// ---------------------------------------------------------------------------
 // 10T-535: GenerateCandidates
 //
 // GenerateUsernames/GenerateEmails throw away the (first, lastRaw) pair that
@@ -416,7 +375,6 @@ func TestGenerateEmails_FirstUnderLast(t *testing.T) {
 // John, James, or Jane). GenerateCandidates must expose the name that was
 // actually used, and GenerateUsernames/GenerateEmails must become thin
 // wrappers over it so all existing call sites keep working unchanged.
-// ---------------------------------------------------------------------------
 
 // TestGenerateCandidates_UsernameParity verifies that GenerateCandidates and
 // GenerateUsernames produce the exact same usernames, in the exact same
@@ -680,7 +638,6 @@ func TestGenerateCandidates_AllFormatsPopulated(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // 10T-535: Candidate.Target
 //
 // Target carries a generated (or supplied) email together with the name it
@@ -688,7 +645,6 @@ func TestGenerateCandidates_AllFormatsPopulated(t *testing.T) {
 // so consumers never need to reverse-derive a name from an address (the
 // "jsmith" could be John/James/Jane problem). Candidate.Target(domain) is the
 // conversion point from generator output to framework input.
-// ---------------------------------------------------------------------------
 
 // TestCandidate_Target verifies that Candidate.Target(domain) produces an
 // Email identical to Candidate.Email(domain), and carries First/Last through

--- a/pkg/enum/github/existence.go
+++ b/pkg/enum/github/existence.go
@@ -27,10 +27,6 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/enum"
 )
 
-// ---------------------------------------------------------------------------
-// Existence enumeration (unauthenticated)
-// ---------------------------------------------------------------------------
-
 // Enumerate checks each email's existence using a bounded worker pool, applying
 // rate limiting and jitter when rateLimit > 0. Results preserve input order. It
 // is a thin wrapper around EnumerateWith with no per-result callback.
@@ -145,10 +141,6 @@ func (e *Enumerator) EnumerateTargetsWith(ctx context.Context, targets []enum.Ta
 
 	return e.worker(sess).Run(ctx, targets, threads, rateLimit, jitter, onResult)
 }
-
-// ---------------------------------------------------------------------------
-// Existence helpers
-// ---------------------------------------------------------------------------
 
 // establishSession fetches the join page, parses the CSRF token, and runs the
 // sanity check, retrying on transient failures. GitHub's signup page applies

--- a/pkg/enum/github/github.go
+++ b/pkg/enum/github/github.go
@@ -178,10 +178,6 @@ type session struct {
 	cookieHeader string
 }
 
-// ---------------------------------------------------------------------------
-// Constructor
-// ---------------------------------------------------------------------------
-
 // NewEnumerator builds an Enumerator. The HTTP client is built via
 // brutus.NewHTTPClientWithProxy so the SOCKS5 --proxy flag works. token may be
 // empty (existence-only mode); Reveal requires a non-empty token. When
@@ -259,10 +255,6 @@ func NewEnumerator(proxyURL string, timeout time.Duration, token string, rotatin
 		newName:             randomHexName,
 	}, nil
 }
-
-// ---------------------------------------------------------------------------
-// Package helpers
-// ---------------------------------------------------------------------------
 
 // parseCSRFToken walks the join page HTML and returns the value of the hidden
 // input nested inside the <auto-check src="/email_validity_checks"> element.

--- a/pkg/enum/github/github_hooks_test.go
+++ b/pkg/enum/github/github_hooks_test.go
@@ -40,7 +40,6 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/enum"
 )
 
-// ---------------------------------------------------------------------------
 // TestWorker_Label
 // github's pre-migration panic diagnostics were prefixed "github enum"
 // (existence.go:102,105), yielding "github enum: panic checking %s: %v" on
@@ -48,7 +47,6 @@ import (
 // reproduces that prefix verbatim via Label, so this exact string must never
 // drift -- changing it is a log-format change for anything that greps stderr
 // or a Result's Error text, not a cosmetic rename.
-// ---------------------------------------------------------------------------
 
 func TestWorker_Label(t *testing.T) {
 	t.Parallel()
@@ -63,7 +61,6 @@ func TestWorker_Label(t *testing.T) {
 	assert.Equal(t, "github enum", e.worker(&session{}).Label)
 }
 
-// ---------------------------------------------------------------------------
 // TestWorker_NewErrorShape
 //
 // github's failure results carry ONLY Email and Error -- no extra fields
@@ -71,7 +68,6 @@ func TestWorker_Label(t *testing.T) {
 // equality is deliberate here too: it fails loudly if a future change adds an
 // unexpected field to github's failure shape, not just if Email/Error are
 // individually wrong.
-// ---------------------------------------------------------------------------
 
 func TestWorker_NewErrorShape(t *testing.T) {
 	t.Parallel()
@@ -85,14 +81,12 @@ func TestWorker_NewErrorShape(t *testing.T) {
 	assert.Equal(t, Result{Email: "a@b.com", Error: sentinel}, got)
 }
 
-// ---------------------------------------------------------------------------
 // TestWorker_StampNameCopiesFirstLastOnly
 // StampName's documented contract (targetworker.go) is a one-line copy of
 // First/Last from the originating Target. This asserts both halves of that
 // contract: First/Last land correctly, and every other field on an
 // already-populated Result -- including Username, github's reveal-only
 // field -- is left untouched.
-// ---------------------------------------------------------------------------
 
 func TestWorker_StampNameCopiesFirstLastOnly(t *testing.T) {
 	t.Parallel()

--- a/pkg/enum/github/github_targets_test.go
+++ b/pkg/enum/github/github_targets_test.go
@@ -54,14 +54,12 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/enum"
 )
 
-// ---------------------------------------------------------------------------
 // TestGithubEnumerateTargetsWith_NamesRideOnResult
 // Core test: 3 targets with distinct names against a stub that reports
 // existence per the configured status map. Each returned Result must carry
 // the name of the target that produced it, correlated by email. An
 // implementation that stamps every Result with the first target's name fails
 // this test.
-// ---------------------------------------------------------------------------
 
 func TestGithubEnumerateTargetsWith_NamesRideOnResult(t *testing.T) {
 	t.Parallel()
@@ -96,11 +94,9 @@ func TestGithubEnumerateTargetsWith_NamesRideOnResult(t *testing.T) {
 	assert.True(t, byEmail["exists@example.com"].Exists, "the 422-mapped email must be reported as existing")
 }
 
-// ---------------------------------------------------------------------------
 // TestGithubEnumerateTargetsWith_NamelessTargetStaysNameless
 // A Target with no name (address supplied by the operator, not generated)
 // must yield First=="" && Last=="". The library must never invent a name.
-// ---------------------------------------------------------------------------
 
 func TestGithubEnumerateTargetsWith_NamelessTargetStaysNameless(t *testing.T) {
 	t.Parallel()
@@ -116,12 +112,10 @@ func TestGithubEnumerateTargetsWith_NamelessTargetStaysNameless(t *testing.T) {
 	assert.Empty(t, results[0].Last, "Last must stay empty for a nameless Target")
 }
 
-// ---------------------------------------------------------------------------
 // TestGithubEnumerateWith_StillWorksAndYieldsEmptyNames
 // Pins that the existing EnumerateWith([]string) entry point is unaffected by
 // the refactor: it still returns correct results, and since bare addresses
 // carry no name, First/Last must be empty.
-// ---------------------------------------------------------------------------
 
 func TestGithubEnumerateWith_StillWorksAndYieldsEmptyNames(t *testing.T) {
 	t.Parallel()
@@ -151,13 +145,11 @@ func TestGithubEnumerateWith_StillWorksAndYieldsEmptyNames(t *testing.T) {
 	assert.True(t, byEmail["exists@example.com"].Exists, "the 422-mapped email must be reported as existing")
 }
 
-// ---------------------------------------------------------------------------
 // TestGithubEnumerateTargetsWith_NamesSurviveErrorPath
 // A name is a property of the address, not of the check outcome. Drive a
 // Result whose Error is non-nil (an unmapped-status response from the
 // validity endpoint, mirroring postValidity's "default: unexpected status"
 // branch) and assert the name is still stamped.
-// ---------------------------------------------------------------------------
 
 func TestGithubEnumerateTargetsWith_NamesSurviveErrorPath(t *testing.T) {
 	t.Parallel()
@@ -183,11 +175,9 @@ func TestGithubEnumerateTargetsWith_NamesSurviveErrorPath(t *testing.T) {
 	assert.Equal(t, "fail", r.Last, "name must survive even when the probe errors")
 }
 
-// ---------------------------------------------------------------------------
 // TestGithubEnumerateTargetsWith_MixedNamedAndUnnamed
 // A single batch containing both named and unnamed targets: each Result must
 // get exactly its own target's name, or empty for the unnamed ones.
-// ---------------------------------------------------------------------------
 
 func TestGithubEnumerateTargetsWith_MixedNamedAndUnnamed(t *testing.T) {
 	t.Parallel()
@@ -218,12 +208,10 @@ func TestGithubEnumerateTargetsWith_MixedNamedAndUnnamed(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // TestGithubEnumerateTargetsWith_EveryTargetSlotFilled
 // len(results) == len(targets) and every target is present even when some
 // probes fail. Completion order is not asserted (the worker pool is
 // concurrent); correlation is by email only.
-// ---------------------------------------------------------------------------
 
 func TestGithubEnumerateTargetsWith_EveryTargetSlotFilled(t *testing.T) {
 	t.Parallel()
@@ -264,7 +252,6 @@ func TestGithubEnumerateTargetsWith_EveryTargetSlotFilled(t *testing.T) {
 	assert.NoError(t, byEmail["notexists-slot@example.com"].Error)
 }
 
-// ---------------------------------------------------------------------------
 // TestGithubEnumerateTargetsWith_SessionFailureFillsEverySlotStamped
 //
 // github's pre-pool gate: if establishSession fails, every Target is
@@ -282,7 +269,6 @@ func TestGithubEnumerateTargetsWith_EveryTargetSlotFilled(t *testing.T) {
 // stamped with their own name -- proving EnumerateTargetsWith's session-gate
 // branch calls StampName (or an equivalent inline assignment) per target,
 // not just newError.
-// ---------------------------------------------------------------------------
 
 func TestGithubEnumerateTargetsWith_SessionFailureFillsEverySlotStamped(t *testing.T) {
 	t.Parallel()
@@ -329,7 +315,6 @@ func TestGithubEnumerateTargetsWith_SessionFailureFillsEverySlotStamped(t *testi
 	assert.Len(t, cbResults, len(targets), "onResult must fire exactly once per target on the session-failure path too")
 }
 
-// ---------------------------------------------------------------------------
 // TestGithubEnumerateWith_CanceledContextNowRecordsEverySlot
 //
 // THE explicit before/after test for github's abort-path behavior change
@@ -363,7 +348,6 @@ func TestGithubEnumerateTargetsWith_SessionFailureFillsEverySlotStamped(t *testi
 // already Done, so their `select { case <-ctx.Done(): ... }` guard fires
 // deterministically -- this is exactly the branch that used to `return nil`
 // with no record call at all.
-// ---------------------------------------------------------------------------
 
 func TestGithubEnumerateWith_CanceledContextNowRecordsEverySlot(t *testing.T) {
 	t.Parallel()

--- a/pkg/enum/github/github_test.go
+++ b/pkg/enum/github/github_test.go
@@ -32,10 +32,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ---------------------------------------------------------------------------
-// Test infrastructure helpers
-// ---------------------------------------------------------------------------
-
 // noopSleep is a sleep function that returns immediately without sleeping.
 // It is used to replace the real sleepCtx in tests so rate-limit retries don't
 // cause real delays.
@@ -247,10 +243,6 @@ func newRotatingTestEnumerator(t *testing.T, webSrv *httptest.Server, existenceM
 	return e
 }
 
-// ---------------------------------------------------------------------------
-// Existence tests: 422 → Exists=true, 200 → Exists=false
-// ---------------------------------------------------------------------------
-
 // TestExistence_422_ExistsTrue verifies that an HTTP 422 from the validity
 // endpoint is mapped to Exists=true.
 func TestExistence_422_ExistsTrue(t *testing.T) {
@@ -285,10 +277,6 @@ func TestExistence_200_ExistsFalse(t *testing.T) {
 	require.NoError(t, results[0].Error)
 	assert.False(t, results[0].Exists, "HTTP 200 must map to Exists=false (address available)")
 }
-
-// ---------------------------------------------------------------------------
-// 429 retry: retries then succeeds
-// ---------------------------------------------------------------------------
 
 // TestExistence_429_RetryThenSucceed verifies that a 429 response causes a
 // retry (with noopSleep so no actual delay), and that the subsequent 422
@@ -337,10 +325,6 @@ func TestExistence_429_RetryThenSucceed(t *testing.T) {
 	assert.Equal(t, int32(2), callCount.Load(), "exactly 2 calls to validity endpoint expected (1 retry)")
 }
 
-// ---------------------------------------------------------------------------
-// Session parse failure → error on all results
-// ---------------------------------------------------------------------------
-
 // TestSessionParseFail_JoinPageMissingAutoCheck verifies that when the join
 // page HTML does not contain the expected <auto-check> block, every Result
 // carries the session error.
@@ -374,10 +358,6 @@ func TestSessionParseFail_JoinPageMissingAutoCheck(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Sanity-check: address that should not exist does not come back as 422
-// ---------------------------------------------------------------------------
-
 // TestSanityCheck_RandomAddressReturns200 is a behavioral test confirming that
 // the sanity-check path inside establishSession does NOT block session setup
 // when the random address correctly returns 200 (the expected case). The
@@ -397,10 +377,6 @@ func TestSanityCheck_RandomAddressReturns200(t *testing.T) {
 	require.NoError(t, results[0].Error)
 	assert.True(t, results[0].Exists)
 }
-
-// ---------------------------------------------------------------------------
-// Reveal: happy path — email → username mapping
-// ---------------------------------------------------------------------------
 
 // TestReveal_HappyPath verifies that Reveal creates a repo, pushes commits,
 // lists them, and returns the correct email→username mapping. Also tests that
@@ -430,10 +406,6 @@ func TestReveal_HappyPath(t *testing.T) {
 		"bob's email must be excluded from mapping when top-level author is null")
 }
 
-// ---------------------------------------------------------------------------
-// Reveal: empty token returns error
-// ---------------------------------------------------------------------------
-
 // TestReveal_EmptyToken verifies that Reveal returns an error immediately
 // when called on an Enumerator with an empty token.
 func TestReveal_EmptyToken(t *testing.T) {
@@ -455,10 +427,6 @@ func TestReveal_EmptyToken(t *testing.T) {
 	assert.Contains(t, err.Error(), "token required",
 		"error must mention that a token is required")
 }
-
-// ---------------------------------------------------------------------------
-// Reveal: repo cleanup (DELETE) is always attempted
-// ---------------------------------------------------------------------------
 
 // TestReveal_DeleteAlwaysAttempted verifies that the repo DELETE is always
 // called even when a mid-flow step (pushCommit) fails. The DELETE is the
@@ -520,10 +488,6 @@ func TestReveal_DeleteAlwaysAttempted(t *testing.T) {
 		"repo DELETE must be called exactly once as deferred cleanup, even when pushCommit fails")
 }
 
-// ---------------------------------------------------------------------------
-// Reveal: repo cleanup (DELETE) survives a canceled reveal context
-// ---------------------------------------------------------------------------
-
 // TestReveal_DeletesEvenWhenContextCancelled verifies that the deferred repo
 // DELETE is still sent even when the reveal ctx is canceled mid-flow. The
 // settle-delay sleep cancels the ctx and returns context.Canceled, after
@@ -582,10 +546,6 @@ func TestReveal_DeletesEvenWhenContextCancelled(t *testing.T) {
 	assert.Equal(t, int32(1), deleteCount.Load(),
 		"repo DELETE must still be sent even though the reveal ctx was canceled")
 }
-
-// ---------------------------------------------------------------------------
-// Auth header: PAT is sent as Bearer <token> on every API call
-// ---------------------------------------------------------------------------
 
 // TestReveal_BearerTokenSentToAPI verifies that the PAT is sent as
 // "Authorization: Bearer <token>" on every API request and is never embedded
@@ -657,10 +617,6 @@ func TestReveal_BearerTokenSentToAPI(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Token never appears in Result.Error text
-// ---------------------------------------------------------------------------
-
 // TestReveal_TokenNotLeakedInError verifies that even when the API returns an
 // unexpected error, the PAT value never appears in the error string returned
 // by Reveal.
@@ -687,10 +643,6 @@ func TestReveal_TokenNotLeakedInError(t *testing.T) {
 	assert.NotContains(t, revErr.Error(), token,
 		"PAT must never appear in Reveal error text")
 }
-
-// ---------------------------------------------------------------------------
-// Reveal: DELETE failure surfaces owner/repo for manual cleanup
-// ---------------------------------------------------------------------------
 
 // TestReveal_DeleteFailure_SurfacesRepoForManualCleanup is a focused regression
 // test for the P1-A security fix: when the deferred repo DELETE fails, Reveal
@@ -813,14 +765,6 @@ func TestReveal_MidFlowErrorAndDeleteFailure_OriginalErrorJoined(t *testing.T) {
 		"PAT must never appear in Reveal error text")
 }
 
-// ---------------------------------------------------------------------------
-// EnumerateWith: callback invoked once per email, results in input order
-// ---------------------------------------------------------------------------
-
-// ---------------------------------------------------------------------------
-// Redirect regression: /join 302 → /signup, CSRF only on final page
-// ---------------------------------------------------------------------------
-
 // TestExistence_FollowsJoinRedirectForCSRF is a regression test for the bug
 // where the existence client refused to follow redirects: the real
 // github.com/join returns a 302 to /signup, and the CSRF authenticity_token
@@ -891,10 +835,6 @@ func TestExistence_FollowsJoinRedirectForCSRF(t *testing.T) {
 		"HTTP 422 from validity endpoint must map to Exists=true")
 }
 
-// ---------------------------------------------------------------------------
-// EnumerateWith: callback invoked once per email, results in input order
-// ---------------------------------------------------------------------------
-
 // TestEnumerateWith_CallbackSerializationAndOrder verifies that onResult is
 // called exactly once per email (under concurrent workers) and that the
 // returned slice preserves input order.
@@ -950,10 +890,6 @@ func TestEnumerateWith_CallbackSerializationAndOrder(t *testing.T) {
 	assert.False(t, results[3].Exists, "d@ (200) must be Exists=false")
 }
 
-// ---------------------------------------------------------------------------
-// NewEnumerator: rotatingProxy flag wires correct backoff / retry constants
-// ---------------------------------------------------------------------------
-
 // TestNewEnumerator_RotatingProxy verifies that the rotatingProxy parameter
 // controls which 429-retry constants are stored on the Enumerator.
 // When false the defaults (rateLimitBackoff / maxRateLimitRetries) are used;
@@ -984,10 +920,6 @@ func TestNewEnumerator_RotatingProxy(t *testing.T) {
 			"existenceMaxRetries must equal rotatingProxyMaxRetries when rotatingProxy=true and a proxy is configured")
 	})
 }
-
-// ---------------------------------------------------------------------------
-// EnumerateWith: threads=0 must not deadlock (clamped to 1)
-// ---------------------------------------------------------------------------
 
 // TestEnumerateWith_ZeroThreadsDoesNotHang is a regression test for the bug
 // where passing threads=0 to EnumerateWith made errgroup.SetLimit(0) block
@@ -1023,10 +955,6 @@ func TestEnumerateWith_ZeroThreadsDoesNotHang(t *testing.T) {
 		assert.NoError(t, r.Error, "result[%d] must complete without error against the mock server", i)
 	}
 }
-
-// ---------------------------------------------------------------------------
-// establishSession retry behavior: /join non-200 is retried, 200-no-token fails fast
-// ---------------------------------------------------------------------------
 
 // TestSession_RetriesOn403ThenSucceeds verifies that establishSession retries
 // the /join fetch when GitHub's bot/rate detection returns a non-200 (e.g.
@@ -1288,10 +1216,6 @@ func TestExistence_SetsAcceptHeader(t *testing.T) {
 		"the validity-check POST must carry Accept: */*")
 }
 
-// ---------------------------------------------------------------------------
-// postValidity 403 handling: rotating-proxy retries, non-rotating fails fast
-// ---------------------------------------------------------------------------
-
 // validity403Mux builds an http.ServeMux for the postValidity 403-handling
 // tests. /join always serves a valid CSRF-bearing page. /email_validity_checks
 // always returns 200 for the sanity-check address (any @foobar.com email, per
@@ -1416,10 +1340,6 @@ func TestExistence_403ExhaustsRetries_RotatingProxy(t *testing.T) {
 		"validity endpoint must be hit existenceMaxRetries+1 times: the initial attempt plus every retry")
 }
 
-// ---------------------------------------------------------------------------
-// NewEnumerator: rotatingProxy disables HTTP keep-alives (fresh exit IP)
-// ---------------------------------------------------------------------------
-
 // closeObservingWebServer starts a fake GitHub web server whose
 // /email_validity_checks handler records, in sawClose, whether the inbound
 // request for the (non-sanity-check) target email carried r.Close == true —
@@ -1512,10 +1432,6 @@ func TestNewEnumerator_RotatingProxyDisablesKeepAlives(t *testing.T) {
 			"rotatingProxy=false must NOT set DisableKeepAlives — connections must be kept alive (r.Close == false)")
 	})
 }
-
-// ---------------------------------------------------------------------------
-// NewEnumerator: --rotating-proxy without --proxy is not effectively rotating
-// ---------------------------------------------------------------------------
 
 // TestNewEnumerator_RotatingProxyRequiresProxy is a regression test for a
 // Codex P2 fix: --rotating-proxy without --proxy connects directly, so

--- a/pkg/enum/github/persistent_repo_test.go
+++ b/pkg/enum/github/persistent_repo_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ---------------------------------------------------------------------------
 // Persistent reveal repo (SetRevealRepo)
 //
 // These tests exercise the opt-in mode in which RevealWith REUSES a named
@@ -39,7 +38,6 @@ import (
 // recording server below counts every route reveal touches, so each test can
 // assert not just the returned mapping but the request pattern — which is the
 // whole point of the mode (no repo churn, no delete, a bounded commit listing).
-// ---------------------------------------------------------------------------
 
 // revealRecorder records the requests a reveal run made against the fake API.
 type revealRecorder struct {
@@ -453,10 +451,6 @@ func boolPtr(b bool) *bool {
 	return &b
 }
 
-// ---------------------------------------------------------------------------
-// SetRevealRepo: name validation
-// ---------------------------------------------------------------------------
-
 // TestSetRevealRepo_AcceptsValidNames verifies the names GitHub itself allows
 // are accepted and actually switch the enumerator into persistent mode.
 func TestSetRevealRepo_AcceptsValidNames(t *testing.T) {
@@ -529,10 +523,6 @@ func TestSetRevealRepo_RejectionLeavesPreviousModeIntact(t *testing.T) {
 
 	assert.Equal(t, "good-name", e.revealRepo, "the previously accepted name must survive a rejected one")
 }
-
-// ---------------------------------------------------------------------------
-// Persistent mode: repo resolution
-// ---------------------------------------------------------------------------
 
 // TestRevealWith_Persistent_ReusesExistingRepo is the steady state: the repo is
 // already there, so reveal READS it (one request, which also yields the default
@@ -716,9 +706,6 @@ func TestRevealWith_Persistent_RepoReadErrorFails(t *testing.T) {
 	assert.Zero(t, got.pushes)
 }
 
-// ---------------------------------------------------------------------------
-// Persistent mode: an existing repo must be confirmed private before reuse
-// ---------------------------------------------------------------------------
 //
 // Reveal writes every target email into commit metadata. A repo it did not
 // just create itself is not one it can assume anything about, so
@@ -806,10 +793,6 @@ func TestRevealWith_Persistent_RaceRereadRefusesPublicRepo(t *testing.T) {
 	assert.Zero(t, got.pushes, "no commits may be pushed after a race onto a public repo")
 	assert.Zero(t, got.repoDeletes)
 }
-
-// ---------------------------------------------------------------------------
-// Persistent mode: the commit listing is bounded to THIS call
-// ---------------------------------------------------------------------------
 
 // TestRevealWith_Persistent_SendsNoSince pins the redesign's removal of
 // ?since=: persistent mode no longer floors the commit listing by time at
@@ -984,7 +967,6 @@ func TestRevealWith_UnlinkedEmailStopsAtShortPage(t *testing.T) {
 	assert.Len(t, got.commitQueries, 1, "a short page ends the listing")
 }
 
-// ---------------------------------------------------------------------------
 // listCommitLogins: maxPages bounds the walk
 //
 // Review feedback on the early-stop mechanism above asked for a bound: without
@@ -994,7 +976,6 @@ func TestRevealWith_UnlinkedEmailStopsAtShortPage(t *testing.T) {
 // it actually stops the walk, reaching it is not an error, a batch bigger than
 // one page still gets every page it needs, and the early stop still wins
 // first when it can.
-// ---------------------------------------------------------------------------
 
 // manyFullCommitPages returns n pages of commitsPerPage entries each, none of
 // which mention any address a test in this section requests — used to script
@@ -1170,7 +1151,6 @@ func TestRevealWith_EarlyStopWinsForBatchEvenWithLargerBound(t *testing.T) {
 		"the early stop must win as soon as every requested address resolves, even though the bound permits a second page")
 }
 
-// ---------------------------------------------------------------------------
 // Persistent mode: the returned mapping is filtered to THIS call's emails
 //
 // A reused repo's commit history holds more than this call's own pushes: an
@@ -1180,7 +1160,6 @@ func TestRevealWith_EarlyStopWinsForBatchEvenWithLargerBound(t *testing.T) {
 // never asked about — was added to the returned mapping regardless. These
 // tests pin the fix: listCommitLogins must return pairs for the REQUESTED
 // emails and nothing else, named so the intent survives refactoring.
-// ---------------------------------------------------------------------------
 
 // TestRevealWith_Persistent_OmitsForeignEmailFromSameCommitPage is the direct
 // reproduction of the bug all three reviewers found: a commits page holding
@@ -1270,7 +1249,6 @@ func TestRevealWith_Persistent_DuplicateRequestedEmailStillResolves(t *testing.T
 		"the duplicate must not prevent the early paging stop once the single distinct email resolves")
 }
 
-// ---------------------------------------------------------------------------
 // Persistent mode: the run-branch model
 //
 // The reused-repo redesign gives every RevealWith call its OWN branch,
@@ -1280,7 +1258,6 @@ func TestRevealWith_Persistent_DuplicateRequestedEmailStillResolves(t *testing.T
 // tests exercise that lifecycle directly — creation, scoping of pushes and
 // the commit listing, cleanup (including on failure), and the bounded name-
 // collision retry.
-// ---------------------------------------------------------------------------
 
 // TestRevealWith_Persistent_RunBranchLifecycle is the steady-state case: an
 // existing private repo that already has a base commit. Reveal must create
@@ -1467,14 +1444,12 @@ func TestRevealWith_Persistent_RunBranchNameCollisionExhausted(t *testing.T) {
 	assert.Zero(t, got.pushes, "no commits may be pushed once the run branch could not be created")
 }
 
-// ---------------------------------------------------------------------------
 // Persistent mode: base commit initialization
 //
 // A newly created reveal repo is empty, and an empty repo has no commit to
 // branch the run branch from. ensureBaseCommit initializes it on the first
 // call, and every later call reuses that one commit as the base. These tests
 // exercise that path directly.
-// ---------------------------------------------------------------------------
 
 // TestRevealWith_Persistent_InitializesEmptyRepoOn404 covers the ref-read
 // answer for a genuinely empty repo (no branch yet): one init commit is

--- a/pkg/enum/github/push_conflict_test.go
+++ b/pkg/enum/github/push_conflict_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ---------------------------------------------------------------------------
 // pushCommit: HTTP 409 conflict retries
 //
 // A REUSED reveal repo (SetRevealRepo) can have two runs pushing to the same
@@ -38,7 +37,6 @@ import (
 // build on the newRevealServer/revealRecorder/newPersistentEnumerator helpers
 // from persistent_repo_test.go, extended with revealServerOpts.pushStatuses so
 // the PUT .../contents/... route can answer with a scripted status sequence.
-// ---------------------------------------------------------------------------
 
 // counterName returns a newName replacement that yields a distinct value on
 // every call. newTestEnumerator (via newPersistentEnumerator) wires

--- a/pkg/enum/github/reveal.go
+++ b/pkg/enum/github/reveal.go
@@ -44,10 +44,6 @@ const (
 	commitsPerPage = 100
 )
 
-// ---------------------------------------------------------------------------
-// Username reveal (authenticated)
-// ---------------------------------------------------------------------------
-
 // Reveal resolves GitHub usernames for the given (existing) emails. It is a
 // thin wrapper over RevealWith with no progress callback, preserving the
 // original signature for existing callers and tests.
@@ -230,10 +226,6 @@ func (e *Enumerator) SetRevealRepo(name string) error {
 	e.revealRepo = name
 	return nil
 }
-
-// ---------------------------------------------------------------------------
-// Reveal helpers
-// ---------------------------------------------------------------------------
 
 // getAuthUser GETs {api}/user and returns the authenticated account's login.
 func (e *Enumerator) getAuthUser(ctx context.Context) (string, error) {

--- a/pkg/enum/github/reveal_test.go
+++ b/pkg/enum/github/reveal_test.go
@@ -22,10 +22,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ---------------------------------------------------------------------------
-// RevealWith: onProgress callback sequencing
-// ---------------------------------------------------------------------------
-
 // TestRevealWith_ProgressCallback verifies that RevealWith invokes onProgress
 // exactly once per email, with strictly increasing done values 1, 2, …, N and
 // total always equal to len(emails). The final invocation must have done ==

--- a/pkg/enum/google/google.go
+++ b/pkg/enum/google/google.go
@@ -83,10 +83,6 @@ type Enumerator struct {
 	gxluBaseURL           string
 }
 
-// ---------------------------------------------------------------------------
-// Constructor
-// ---------------------------------------------------------------------------
-
 // NewEnumerator builds an Enumerator. The HTTP client is built via
 // brutus.NewHTTPClientWithProxy so the SOCKS5 --proxy flag works. The supplied
 // timeout is used directly as the per-request budget.
@@ -108,10 +104,6 @@ func NewEnumerator(proxyURL string, timeout time.Duration) (*Enumerator, error) 
 		gxluBaseURL:           gxluBaseURLDefault,
 	}, nil
 }
-
-// ---------------------------------------------------------------------------
-// Enumeration
-// ---------------------------------------------------------------------------
 
 // Enumerate looks up each email using a bounded worker pool, applying rate
 // limiting and jitter when rateLimit > 0. Results preserve input order. It is a
@@ -218,10 +210,6 @@ func (e *Enumerator) CheckAccount(ctx context.Context, email string) Result {
 
 	return res
 }
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
 
 // checkAccountChooser checks whether Google redirects to a SAML IdP for this
 // email. SSO-configured domains redirect valid accounts to their IdP; invalid

--- a/pkg/enum/google/google_hooks_test.go
+++ b/pkg/enum/google/google_hooks_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/enum"
 )
 
-// ---------------------------------------------------------------------------
 // TestWorker_Label
 // google's pre-migration panic diagnostics were prefixed "google enum",
 // yielding "google enum: panic checking %s: %v" on stderr and "google enum:
@@ -44,7 +43,6 @@ import (
 // that prefix verbatim via Label, so this exact string must never drift --
 // changing it is a log-format change for anything that greps stderr or a
 // Result's Error text, not a cosmetic rename.
-// ---------------------------------------------------------------------------
 
 func TestWorker_Label(t *testing.T) {
 	t.Parallel()
@@ -55,7 +53,6 @@ func TestWorker_Label(t *testing.T) {
 	assert.Equal(t, "google enum", e.worker().Label)
 }
 
-// ---------------------------------------------------------------------------
 // TestWorker_NewErrorShape
 // google's failure results carry no fields beyond Email and Error (PLAN.md
 // Part 0.4). Comparing the full struct -- not just Email/Error individually --
@@ -63,7 +60,6 @@ func TestWorker_Label(t *testing.T) {
 // gravatar's Hash regression had it been applied there, so it must prove a
 // negative (nothing else got set) as well as a positive (Email/Error got
 // set).
-// ---------------------------------------------------------------------------
 
 func TestWorker_NewErrorShape(t *testing.T) {
 	t.Parallel()
@@ -77,13 +73,11 @@ func TestWorker_NewErrorShape(t *testing.T) {
 	assert.Equal(t, Result{Email: "a@b.com", Error: sentinel}, got)
 }
 
-// ---------------------------------------------------------------------------
 // TestWorker_StampNameCopiesFirstLastOnly
 // StampName's documented contract (targetworker.go) is a one-line copy of
 // First/Last from the originating Target. This asserts both halves of that
 // contract: First/Last land correctly, and every other field on an
 // already-populated Result is left untouched.
-// ---------------------------------------------------------------------------
 
 func TestWorker_StampNameCopiesFirstLastOnly(t *testing.T) {
 	t.Parallel()

--- a/pkg/enum/google/google_targets_test.go
+++ b/pkg/enum/google/google_targets_test.go
@@ -66,13 +66,11 @@ func newTargetsMockServer(t *testing.T) *httptest.Server {
 	return httptest.NewServer(mux)
 }
 
-// ---------------------------------------------------------------------------
 // TestGoogleEnumerateTargetsWith_NamesRideOnResult
 // Core test: 3 targets with distinct names against a stub that reports
 // existence for all of them. Each returned Result must carry the name of the
 // target that produced it, correlated by email. An implementation that
 // stamps every Result with the first target's name fails this test.
-// ---------------------------------------------------------------------------
 
 func TestGoogleEnumerateTargetsWith_NamesRideOnResult(t *testing.T) {
 	t.Parallel()
@@ -105,11 +103,9 @@ func TestGoogleEnumerateTargetsWith_NamesRideOnResult(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // TestGoogleEnumerateTargetsWith_NamelessTargetStaysNameless
 // A Target with no name (address supplied by the operator, not generated)
 // must yield First=="" && Last=="". The library must never invent a name.
-// ---------------------------------------------------------------------------
 
 func TestGoogleEnumerateTargetsWith_NamelessTargetStaysNameless(t *testing.T) {
 	t.Parallel()
@@ -126,12 +122,10 @@ func TestGoogleEnumerateTargetsWith_NamelessTargetStaysNameless(t *testing.T) {
 	assert.Empty(t, results[0].Last, "Last must stay empty for a nameless Target")
 }
 
-// ---------------------------------------------------------------------------
 // TestGoogleEnumerateWith_StillWorksAndYieldsEmptyNames
 // Pins that the existing EnumerateWith([]string) entry point is unaffected by
 // the refactor: it still returns correct results, and since bare addresses
 // carry no name, First/Last must be empty.
-// ---------------------------------------------------------------------------
 
 func TestGoogleEnumerateWith_StillWorksAndYieldsEmptyNames(t *testing.T) {
 	t.Parallel()
@@ -159,12 +153,10 @@ func TestGoogleEnumerateWith_StillWorksAndYieldsEmptyNames(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // TestGoogleEnumerateTargetsWith_NamesSurviveErrorPath
 // A name is a property of the address, not of the check outcome. Drive a
 // Result whose Error is non-nil (GXLU connection hijacked/closed) and assert
 // the name is still stamped.
-// ---------------------------------------------------------------------------
 
 func TestGoogleEnumerateTargetsWith_NamesSurviveErrorPath(t *testing.T) {
 	t.Parallel()
@@ -187,11 +179,9 @@ func TestGoogleEnumerateTargetsWith_NamesSurviveErrorPath(t *testing.T) {
 	assert.Equal(t, "fail", r.Last, "name must survive even when the probe errors")
 }
 
-// ---------------------------------------------------------------------------
 // TestGoogleEnumerateTargetsWith_MixedNamedAndUnnamed
 // A single batch containing both named and unnamed targets: each Result must
 // get exactly its own target's name, or empty for the unnamed ones.
-// ---------------------------------------------------------------------------
 
 func TestGoogleEnumerateTargetsWith_MixedNamedAndUnnamed(t *testing.T) {
 	t.Parallel()
@@ -223,12 +213,10 @@ func TestGoogleEnumerateTargetsWith_MixedNamedAndUnnamed(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // TestGoogleEnumerateTargetsWith_OrderingAndLength
 // len(results) == len(targets) and every index is filled even when some
 // probes fail. Completion order is not asserted (the worker pool is
 // concurrent); correlation is by email.
-// ---------------------------------------------------------------------------
 
 func TestGoogleEnumerateTargetsWith_OrderingAndLength(t *testing.T) {
 	t.Parallel()
@@ -267,7 +255,6 @@ func TestGoogleEnumerateTargetsWith_OrderingAndLength(t *testing.T) {
 	assert.NoError(t, byEmail["ok2@x.com"].Error)
 }
 
-// ---------------------------------------------------------------------------
 // TestGoogleEnumerateTargetsWith_NamesSurviveCancelledContext
 // Chokepoint test: with the context already canceled before the call, every
 // goroutine takes the <-ctx.Done() early-return branch and calls
@@ -276,7 +263,6 @@ func TestGoogleEnumerateTargetsWith_OrderingAndLength(t *testing.T) {
 // (record(i, e.CheckAccount(...))) rather than inside record() itself, these
 // Results would come back nameless. This is what makes record() the enforced
 // chokepoint rather than an incidental detail.
-// ---------------------------------------------------------------------------
 
 func TestGoogleEnumerateTargetsWith_NamesSurviveCancelledContext(t *testing.T) {
 	t.Parallel()

--- a/pkg/enum/google/google_test.go
+++ b/pkg/enum/google/google_test.go
@@ -97,11 +97,9 @@ func newMockServer(t *testing.T) *httptest.Server {
 	return httptest.NewServer(mux)
 }
 
-// ---------------------------------------------------------------------------
 // TestCheckAccount_WorkspaceSSO_SAMLHeader
 // AccountChooser responds with Google-Accounts-SAML header and no Location.
 // Existence confirmed, Method=workspace-sso, IdP="" (no Location to parse).
-// ---------------------------------------------------------------------------
 
 func TestCheckAccount_WorkspaceSSO_SAMLHeader(t *testing.T) {
 	t.Parallel()
@@ -119,11 +117,9 @@ func TestCheckAccount_WorkspaceSSO_SAMLHeader(t *testing.T) {
 	assert.Equal(t, "saml@example.com", res.Email)
 }
 
-// ---------------------------------------------------------------------------
 // TestCheckAccount_WorkspaceSSO_NonGoogleRedirect
 // AccountChooser returns Location to a non-Google host (Okta IdP redirect).
 // Existence confirmed, Method=workspace-sso, IdP="login.okta.com".
-// ---------------------------------------------------------------------------
 
 func TestCheckAccount_WorkspaceSSO_NonGoogleRedirect(t *testing.T) {
 	t.Parallel()
@@ -141,11 +137,9 @@ func TestCheckAccount_WorkspaceSSO_NonGoogleRedirect(t *testing.T) {
 	assert.Equal(t, "okta@example.com", res.Email)
 }
 
-// ---------------------------------------------------------------------------
 // TestCheckAccount_Gmail_GXLU
 // AccountChooser returns Google ServiceLogin (not found via SSO).
 // GXLU server sets GMAIL_AT cookie → Exists=true, Method=gmail, IdP="".
-// ---------------------------------------------------------------------------
 
 func TestCheckAccount_Gmail_GXLU(t *testing.T) {
 	t.Parallel()
@@ -162,12 +156,10 @@ func TestCheckAccount_Gmail_GXLU(t *testing.T) {
 	assert.Equal(t, "gmail@example.com", res.Email)
 }
 
-// ---------------------------------------------------------------------------
 // TestCheckAccount_NotFound
 // AccountChooser: Google ServiceLogin redirect (no SSO).
 // GXLU: no GMAIL_AT cookie.
 // Result: Exists=false, Method=MethodNone.
-// ---------------------------------------------------------------------------
 
 func TestCheckAccount_NotFound(t *testing.T) {
 	t.Parallel()
@@ -184,10 +176,8 @@ func TestCheckAccount_NotFound(t *testing.T) {
 	assert.Equal(t, "unknown@example.com", res.Email)
 }
 
-// ---------------------------------------------------------------------------
 // TestCheckAccount_TransportError (optional)
 // Point base URLs at a closed port → transport error → Exists=false, Error!=nil.
-// ---------------------------------------------------------------------------
 
 func TestCheckAccount_TransportError(t *testing.T) {
 	t.Parallel()
@@ -210,7 +200,6 @@ func TestCheckAccount_TransportError(t *testing.T) {
 	assert.NotNil(t, res.Error, "transport error must be reflected in Result.Error")
 }
 
-// ---------------------------------------------------------------------------
 // TestEnumerateWith_Callback
 // 6 emails, threads=4, onResult callback appends under a mutex.
 // After the run:
@@ -221,7 +210,6 @@ func TestCheckAccount_TransportError(t *testing.T) {
 //
 // Run the package under -race (go test -race ./pkg/enum/google/) to verify
 // the callback serialization guarantee.
-// ---------------------------------------------------------------------------
 
 func TestEnumerateWith_Callback(t *testing.T) {
 	t.Parallel()
@@ -281,10 +269,8 @@ func TestEnumerateWith_Callback(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // TestEnumerateWith_NilCallback
 // Passing nil as the callback must not panic and must return one result per email.
-// ---------------------------------------------------------------------------
 
 func TestEnumerateWith_NilCallback(t *testing.T) {
 	t.Parallel()
@@ -299,7 +285,6 @@ func TestEnumerateWith_NilCallback(t *testing.T) {
 	require.Len(t, results, len(emails), "nil callback must not panic; must return one result per email")
 }
 
-// ---------------------------------------------------------------------------
 // TestEnumerateWith_CanceledContextRecordsAllSlots
 // Regression guard: with an already-canceled context, every worker hits the
 // <-ctx.Done() guard before any HTTP call. Each guard must still call
@@ -307,7 +292,6 @@ func TestEnumerateWith_NilCallback(t *testing.T) {
 // order preserved) and the callback fires exactly once per email. Reverting
 // that record() call leaves the dropped slots as zero-value Result{} (empty
 // Email, nil Error) and skips the callback for those emails.
-// ---------------------------------------------------------------------------
 
 func TestEnumerateWith_CanceledContextRecordsAllSlots(t *testing.T) {
 	t.Parallel()
@@ -344,13 +328,11 @@ func TestEnumerateWith_CanceledContextRecordsAllSlots(t *testing.T) {
 	assert.Len(t, cbResults, len(emails), "onResult callback must fire exactly once per email, even on the canceled-context path")
 }
 
-// ---------------------------------------------------------------------------
 // TestEnumerateWith_ZeroOrNegativeThreadsDoesNotHang
 // Regression guard: threads<=0 must be normalized to 1 before g.SetLimit.
 // SetLimit(0) would permit zero concurrent goroutines, so no worker could ever
 // run and EnumerateWith would hang forever. Guarded by a timeout rather than
 // relying solely on `go test -timeout`, so failure is immediate and specific.
-// ---------------------------------------------------------------------------
 
 func TestEnumerateWith_ZeroOrNegativeThreadsDoesNotHang(t *testing.T) {
 	tests := []struct {
@@ -393,13 +375,11 @@ func TestEnumerateWith_ZeroOrNegativeThreadsDoesNotHang(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // TestCheckAccount_SendsBrowserUserAgent
 // Regression guard: NewEnumerator wraps its transport with enum.WithUserAgent
 // so outbound requests carry a browser User-Agent instead of Go's default
 // "Go-http-client/1.1". Captures the User-Agent seen by both the
 // AccountChooser and GXLU endpoints and asserts it looks like a browser UA.
-// ---------------------------------------------------------------------------
 
 func TestCheckAccount_SendsBrowserUserAgent(t *testing.T) {
 	t.Parallel()
@@ -434,10 +414,6 @@ func TestCheckAccount_SendsBrowserUserAgent(t *testing.T) {
 	assert.NotContains(t, ua, "Go-http-client", "requests must not carry Go's default User-Agent")
 	assert.Contains(t, ua, "Mozilla", "requests must carry a browser User-Agent")
 }
-
-// ---------------------------------------------------------------------------
-// idpHost helper (unit coverage for the unexported helper)
-// ---------------------------------------------------------------------------
 
 func Test_idpHost(t *testing.T) {
 	tests := []struct {

--- a/pkg/enum/gravatar/gravatar.go
+++ b/pkg/enum/gravatar/gravatar.go
@@ -89,10 +89,6 @@ func NewChecker(baseURL, proxyURL string, timeout time.Duration) (*Checker, erro
 	}, nil
 }
 
-// ---------------------------------------------------------------------------
-// Enumeration
-// ---------------------------------------------------------------------------
-
 // Enumerate looks up each email using a bounded worker pool, applying rate
 // limiting and jitter when rateLimit > 0. Results preserve input order. It is a
 // thin wrapper around EnumerateWith with no per-result callback.

--- a/pkg/enum/gravatar/gravatar_hooks_test.go
+++ b/pkg/enum/gravatar/gravatar_hooks_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/enum"
 )
 
-// ---------------------------------------------------------------------------
 // TestWorker_Label
 // gravatar's pre-migration panic diagnostics were prefixed "gravatar enum"
 // (gravatar.go:152,156), yielding "gravatar enum: panic checking %s: %v" on
@@ -44,7 +43,6 @@ import (
 // reproduces that prefix verbatim via Label, so this exact string must never
 // drift -- changing it is a log-format change for anything that greps stderr
 // or a Result's Error text, not a cosmetic rename.
-// ---------------------------------------------------------------------------
 
 func TestWorker_Label(t *testing.T) {
 	t.Parallel()
@@ -55,7 +53,6 @@ func TestWorker_Label(t *testing.T) {
 	assert.Equal(t, "gravatar enum", c.worker().Label)
 }
 
-// ---------------------------------------------------------------------------
 // TestWorker_NewErrorShape
 //
 // gravatar's failure results carry Email, Hash AND Error -- Hash is the one
@@ -65,7 +62,6 @@ func TestWorker_Label(t *testing.T) {
 // assertion that checked only Email and Error would pass even if Hash were
 // missing, defeating the entire point of this test. Full-struct equality
 // fails loudly on a dropped OR an unexpectedly added field.
-// ---------------------------------------------------------------------------
 
 func TestWorker_NewErrorShape(t *testing.T) {
 	t.Parallel()
@@ -79,7 +75,6 @@ func TestWorker_NewErrorShape(t *testing.T) {
 	assert.Equal(t, Result{Email: "a@b.com", Hash: HashEmail("a@b.com"), Error: sentinel}, got)
 }
 
-// ---------------------------------------------------------------------------
 // TestWorker_NewErrorShape_HashIsNormalizedNotVerbatimEmail
 //
 // HashEmail lowercases and trims internally, but Result.Email echoes the
@@ -87,7 +82,6 @@ func TestWorker_NewErrorShape(t *testing.T) {
 // Result whose Email is untouched but whose Hash is computed from the
 // normalized form -- an asymmetry worth pinning explicitly, since it is
 // exactly the kind of thing a future "fix" might flatten by accident.
-// ---------------------------------------------------------------------------
 
 func TestWorker_NewErrorShape_HashIsNormalizedNotVerbatimEmail(t *testing.T) {
 	t.Parallel()
@@ -104,14 +98,12 @@ func TestWorker_NewErrorShape_HashIsNormalizedNotVerbatimEmail(t *testing.T) {
 	assert.NotEqual(t, got.Email, got.Hash)
 }
 
-// ---------------------------------------------------------------------------
 // TestWorker_StampNameCopiesFirstLastOnly
 // StampName's documented contract (targetworker.go) is a one-line copy of
 // First/Last from the originating Target. This asserts both halves of that
 // contract: First/Last land correctly, and every other field on an
 // already-populated Result -- including Hash, gravatar's own extra field --
 // is left untouched.
-// ---------------------------------------------------------------------------
 
 func TestWorker_StampNameCopiesFirstLastOnly(t *testing.T) {
 	t.Parallel()

--- a/pkg/enum/gravatar/gravatar_targets_test.go
+++ b/pkg/enum/gravatar/gravatar_targets_test.go
@@ -84,13 +84,11 @@ func newTargetsMockServer(t *testing.T) *httptest.Server {
 	}))
 }
 
-// ---------------------------------------------------------------------------
 // TestGravatarEnumerateTargetsWith_NamesRideOnResult
 // Core test: 3 targets with distinct names against a stub that reports
 // existence for all of them. Each returned Result must carry the name of the
 // target that produced it, correlated by email. An implementation that
 // stamps every Result with the first target's name fails this test.
-// ---------------------------------------------------------------------------
 
 func TestGravatarEnumerateTargetsWith_NamesRideOnResult(t *testing.T) {
 	t.Parallel()
@@ -124,11 +122,9 @@ func TestGravatarEnumerateTargetsWith_NamesRideOnResult(t *testing.T) {
 	assert.True(t, byEmail[registeredEmail].Exists, "registeredEmail must be reported as existing by the stub")
 }
 
-// ---------------------------------------------------------------------------
 // TestGravatarEnumerateTargetsWith_NamelessTargetStaysNameless
 // A Target with no name (address supplied by the operator, not generated)
 // must yield First=="" && Last=="". The library must never invent a name.
-// ---------------------------------------------------------------------------
 
 func TestGravatarEnumerateTargetsWith_NamelessTargetStaysNameless(t *testing.T) {
 	t.Parallel()
@@ -146,12 +142,10 @@ func TestGravatarEnumerateTargetsWith_NamelessTargetStaysNameless(t *testing.T) 
 	assert.Empty(t, results[0].Last, "Last must stay empty for a nameless Target")
 }
 
-// ---------------------------------------------------------------------------
 // TestGravatarEnumerateWith_StillWorksAndYieldsEmptyNames
 // Pins that the existing EnumerateWith([]string) entry point is unaffected by
 // the refactor: it still returns correct results, and since bare addresses
 // carry no name, First/Last must be empty.
-// ---------------------------------------------------------------------------
 
 func TestGravatarEnumerateWith_StillWorksAndYieldsEmptyNames(t *testing.T) {
 	t.Parallel()
@@ -180,12 +174,10 @@ func TestGravatarEnumerateWith_StillWorksAndYieldsEmptyNames(t *testing.T) {
 	assert.True(t, byEmail[registeredEmail].Exists, "registeredEmail must be reported as existing by the stub")
 }
 
-// ---------------------------------------------------------------------------
 // TestGravatarEnumerateTargetsWith_NamesSurviveErrorPath
 // A name is a property of the address, not of the check outcome. Drive a
 // Result whose Error is non-nil (the mock server's 500 for failingEmail) and
 // assert the name is still stamped.
-// ---------------------------------------------------------------------------
 
 func TestGravatarEnumerateTargetsWith_NamesSurviveErrorPath(t *testing.T) {
 	t.Parallel()
@@ -209,11 +201,9 @@ func TestGravatarEnumerateTargetsWith_NamesSurviveErrorPath(t *testing.T) {
 	assert.Equal(t, "fail", r.Last, "name must survive even when the probe errors")
 }
 
-// ---------------------------------------------------------------------------
 // TestGravatarEnumerateTargetsWith_MixedNamedAndUnnamed
 // A single batch containing both named and unnamed targets: each Result must
 // get exactly its own target's name, or empty for the unnamed ones.
-// ---------------------------------------------------------------------------
 
 func TestGravatarEnumerateTargetsWith_MixedNamedAndUnnamed(t *testing.T) {
 	t.Parallel()
@@ -246,12 +236,10 @@ func TestGravatarEnumerateTargetsWith_MixedNamedAndUnnamed(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // TestGravatarEnumerateTargetsWith_EveryTargetSlotFilled
 // len(results) == len(targets) and every target is present even when some
 // probes fail. Completion order is not asserted (the worker pool is
 // concurrent); correlation is by email only.
-// ---------------------------------------------------------------------------
 
 func TestGravatarEnumerateTargetsWith_EveryTargetSlotFilled(t *testing.T) {
 	t.Parallel()
@@ -289,14 +277,12 @@ func TestGravatarEnumerateTargetsWith_EveryTargetSlotFilled(t *testing.T) {
 	assert.NoError(t, byEmail["notexists@example.com"].Error)
 }
 
-// ---------------------------------------------------------------------------
 // TestGravatarEnumerateTargetsWith_NamesSurviveCancelledContext
 // Chokepoint test: with the context already canceled before the call, every
 // goroutine takes the <-ctx.Done() early-return branch and records via
 // newError WITHOUT ever calling CheckAccount. If the name stamp lived only at
 // the CheckAccount call site rather than at the single funnel every outcome
 // passes through, these Results would come back nameless.
-// ---------------------------------------------------------------------------
 
 func TestGravatarEnumerateTargetsWith_NamesSurviveCancelledContext(t *testing.T) {
 	t.Parallel()
@@ -332,7 +318,6 @@ func TestGravatarEnumerateTargetsWith_NamesSurviveCancelledContext(t *testing.T)
 	}
 }
 
-// ---------------------------------------------------------------------------
 // TestGravatarEnumerateTargetsWith_HashSurvivesFailingProbe
 //
 // This is the single most valuable test in this file (PLAN.md Part 3.3): every
@@ -348,7 +333,6 @@ func TestGravatarEnumerateTargetsWith_NamesSurviveCancelledContext(t *testing.T)
 //   - an already-canceled context -- this path never reaches CheckAccount at
 //     all, so newError alone is responsible for the Hash on this Result. If
 //     Hash is dropped, this is the case that proves it.
-// ---------------------------------------------------------------------------
 
 func TestGravatarEnumerateTargetsWith_HashSurvivesFailingProbe(t *testing.T) {
 	t.Parallel()

--- a/pkg/enum/gravatar/gravatar_test.go
+++ b/pkg/enum/gravatar/gravatar_test.go
@@ -38,10 +38,6 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
 
-// ---------------------------------------------------------------------------
-// TestHashEmail
-// ---------------------------------------------------------------------------
-
 func TestHashEmail(t *testing.T) {
 	t.Parallel()
 
@@ -52,10 +48,8 @@ func TestHashEmail(t *testing.T) {
 	assert.Equal(t, HashEmail("john.smith@mckesson.com"), HashEmail("  John.Smith@McKesson.com  "))
 }
 
-// ---------------------------------------------------------------------------
 // TestCheckAccount — mock server keyed by hash, mirroring microsoft365's
 // newMockServer pattern.
-// ---------------------------------------------------------------------------
 
 // registeredEmail is the email whose Gravatar hash the mock server treats as
 // "registered" (200); every other hash 404s.
@@ -149,12 +143,10 @@ func TestCheckAccount_ContextCancelled(t *testing.T) {
 	assert.False(t, result.Exists)
 }
 
-// ---------------------------------------------------------------------------
 // TestNewChecker — default baseURL is asserted indirectly by pointing the
 // checker at a test server and verifying it can be constructed with an empty
 // baseURL/proxyURL without error (baseURL is unexported, so behavior is
 // verified via CheckAccount against a real server rather than field access).
-// ---------------------------------------------------------------------------
 
 func TestNewChecker_DefaultBaseURLUsedWhenEmpty(t *testing.T) {
 	t.Parallel()
@@ -192,12 +184,10 @@ func TestNewChecker_WithProxyURL(t *testing.T) {
 	assert.NotNil(t, c)
 }
 
-// ---------------------------------------------------------------------------
 // enum.HTTPClientFromContext precedence: CheckAccount must prefer a shared
 // enum HTTP client carried on ctx (set via enum.WithHTTPClient) over the
 // Checker's own client, and fall back to its own client when ctx carries
 // none.
-// ---------------------------------------------------------------------------
 
 func TestCheckAccount_UsesHTTPClientFromContext(t *testing.T) {
 	t.Parallel()
@@ -247,7 +237,6 @@ func TestCheckAccount_FallsBackToOwnClientWithoutContextClient(t *testing.T) {
 	assert.True(t, result.Exists)
 }
 
-// ---------------------------------------------------------------------------
 // TestEnumerateWith_Callback
 // 4 emails, threads=4, onResult callback appends under a mutex.
 // After the run:
@@ -258,7 +247,6 @@ func TestCheckAccount_FallsBackToOwnClientWithoutContextClient(t *testing.T) {
 //
 // Run the package under -race (go test -race ./pkg/enum/gravatar/) to verify
 // the callback serialization guarantee.
-// ---------------------------------------------------------------------------
 
 func TestEnumerateWith_Callback(t *testing.T) {
 	t.Parallel()
@@ -328,11 +316,9 @@ func TestEnumerateWith_Callback(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // TestEnumerateWith_NilCallback
 // Passing nil as the callback must not panic and must return one result per
 // email.
-// ---------------------------------------------------------------------------
 
 func TestEnumerateWith_NilCallback(t *testing.T) {
 	t.Parallel()
@@ -349,13 +335,11 @@ func TestEnumerateWith_NilCallback(t *testing.T) {
 	require.Len(t, results, len(emails), "nil callback must not panic; must return one result per email")
 }
 
-// ---------------------------------------------------------------------------
 // TestEnumerateWith_CanceledContextRecordsAllSlots
 // Regression guard: with an already-canceled context, every worker hits the
 // <-ctx.Done() guard before the HTTP call. Each guard must still record
 // before returning, so every index is filled (Email set, input order
 // preserved) and the callback fires exactly once per email.
-// ---------------------------------------------------------------------------
 
 func TestEnumerateWith_CanceledContextRecordsAllSlots(t *testing.T) {
 	t.Parallel()
@@ -393,12 +377,10 @@ func TestEnumerateWith_CanceledContextRecordsAllSlots(t *testing.T) {
 	assert.Len(t, cbResults, len(emails), "onResult callback must fire exactly once per email, even on the canceled-context path")
 }
 
-// ---------------------------------------------------------------------------
 // TestEnumerateWith_ZeroOrNegativeThreadsDoesNotHang
 // Regression guard: threads<=0 must be normalized to 1 before g.SetLimit.
 // SetLimit(0) would permit zero concurrent goroutines, so no worker could
 // ever run and EnumerateWith would hang forever.
-// ---------------------------------------------------------------------------
 
 func TestEnumerateWith_ZeroOrNegativeThreadsDoesNotHang(t *testing.T) {
 	tests := []struct {

--- a/pkg/enum/httpclient.go
+++ b/pkg/enum/httpclient.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// pkg/enum/httpclient.go
 package enum
 
 import (

--- a/pkg/enum/httpclient_test.go
+++ b/pkg/enum/httpclient_test.go
@@ -28,10 +28,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ---------------------------------------------------------------------------
-// TestNewEnumHTTPClientWithProxy — Section D
-// ---------------------------------------------------------------------------
-
 func TestNewEnumHTTPClientWithProxy_EmptyProxy(t *testing.T) {
 	client, err := NewEnumHTTPClientWithProxy(5*time.Second, "")
 	require.NoError(t, err)

--- a/pkg/enum/hunter/hunter.go
+++ b/pkg/enum/hunter/hunter.go
@@ -50,10 +50,6 @@ const (
 	defaultPageSize = 100
 )
 
-// ---------------------------------------------------------------------------
-// Public types
-// ---------------------------------------------------------------------------
-
 // Person is one discovered contact for the domain.
 type Person struct {
 	Email      string
@@ -110,10 +106,6 @@ func (e *APIError) Unwrap() error {
 	}
 	return nil
 }
-
-// ---------------------------------------------------------------------------
-// Client
-// ---------------------------------------------------------------------------
 
 // Client holds state for querying the Hunter.io Domain Search API.
 type Client struct {
@@ -205,10 +197,6 @@ func (c *Client) Search(ctx context.Context, domain string, limit int) (*DomainR
 	return result, nil
 }
 
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
-
 // fetchPage performs a single paginated GET request to the Hunter.io API.
 // perPage is the requested page size for this request (sent as the "limit" query
 // param), letting the caller shrink the final page to only what's still needed.
@@ -282,10 +270,6 @@ func toPerson(e *apiEmail) Person {
 		Sources:    sources,
 	}
 }
-
-// ---------------------------------------------------------------------------
-// JSON-mapping structs (unexported — map exactly to Hunter API response shape)
-// ---------------------------------------------------------------------------
 
 type apiResponse struct {
 	Data   apiData    `json:"data"`

--- a/pkg/enum/hunter/hunter_test.go
+++ b/pkg/enum/hunter/hunter_test.go
@@ -30,10 +30,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ---------------------------------------------------------------------------
-// Task 1: toPerson + APIError/Unwrap
-// ---------------------------------------------------------------------------
-
 func TestToPerson(t *testing.T) {
 	src := apiEmail{
 		Value:      "alice@example.com",
@@ -93,10 +89,6 @@ func TestAPIError_Error(t *testing.T) {
 	assert.Contains(t, err.Error(), "401")
 	assert.Contains(t, err.Error(), "No valid API key")
 }
-
-// ---------------------------------------------------------------------------
-// Task 2: fetchPage - single-page success + error mapping
-// ---------------------------------------------------------------------------
 
 func makeResponse(domain, org string, emails []apiEmail, total, limit, offset int) []byte {
 	resp := apiResponse{
@@ -231,10 +223,6 @@ func TestFetchPage_QueryParams(t *testing.T) {
 	assert.Equal(t, "10", q.Get("limit"))
 	assert.Equal(t, "5", q.Get("offset"))
 }
-
-// ---------------------------------------------------------------------------
-// Task 3: Search pagination loop
-// ---------------------------------------------------------------------------
 
 func pagedServer(t *testing.T, allEmails []apiEmail, total, pageSize, midErrOffset int) (*httptest.Server, *atomic.Int32) {
 	t.Helper()
@@ -411,10 +399,6 @@ func TestSearch_LimitReducesFinalPageRequest(t *testing.T) {
 	assert.Equal(t, []int{100, 50}, reqLimits, "final page must request only the remaining 50, not a full 100")
 	assert.False(t, result.Truncated, "a user-requested --limit cap is not a plan-cap truncation")
 }
-
-// ---------------------------------------------------------------------------
-// Plan-cap pagination regression tests (fix/hunter-plan-cap-pagination)
-// ---------------------------------------------------------------------------
 
 // TestSearch_PlanLimited_ReturnsPartial verifies that when Hunter returns HTTP 400
 // with a plan-cap details message mid-pagination, Search stops cleanly and returns

--- a/pkg/enum/kerberos/kerberos.go
+++ b/pkg/enum/kerberos/kerberos.go
@@ -59,7 +59,6 @@ func EnumUser(ctx context.Context, kdcAddr, realm, username string, timeout time
 		Realm:    realm,
 	}
 
-	// Build AS-REQ
 	asReqBytes, err := buildASReq(username, realm)
 	if err != nil {
 		result.Error = fmt.Errorf("building AS-REQ: %w", err)
@@ -67,7 +66,6 @@ func EnumUser(ctx context.Context, kdcAddr, realm, username string, timeout time
 		return result
 	}
 
-	// Send to KDC
 	response, err := sendKerberosTCP(ctx, kdcAddr, asReqBytes, timeout)
 	if err != nil {
 		result.Error = fmt.Errorf("sending AS-REQ: %w", err)
@@ -75,19 +73,16 @@ func EnumUser(ctx context.Context, kdcAddr, realm, username string, timeout time
 		return result
 	}
 
-	// Parse response
-	// Try AS-REP first (success - user exists with no preauth)
+	// AS-REP means the user exists and does not require preauth.
 	var asRep messages.ASRep
 	err = asRep.Unmarshal(response)
 	if err == nil {
-		// AS-REP received - user exists AND has no preauth required
 		result.Exists = true
 		result.NoPreAuth = true
 		result.Duration = time.Since(start)
 		return result
 	}
 
-	// Not AS-REP, try KRB-ERROR
 	var krbErr messages.KRBError
 	err = krbErr.Unmarshal(response)
 	if err != nil {
@@ -96,17 +91,13 @@ func EnumUser(ctx context.Context, kdcAddr, realm, username string, timeout time
 		return result
 	}
 
-	// Interpret error code
 	switch krbErr.ErrorCode {
 	case errorcode.KDC_ERR_C_PRINCIPAL_UNKNOWN:
-		// User does not exist
 		result.Exists = false
 	case errorcode.KDC_ERR_PREAUTH_REQUIRED:
-		// User exists (preauth required)
 		result.Exists = true
 		result.NoPreAuth = false
 	default:
-		// Other error
 		result.Error = fmt.Errorf("KDC error: %s", errorcode.Lookup(krbErr.ErrorCode))
 	}
 
@@ -116,39 +107,32 @@ func EnumUser(ctx context.Context, kdcAddr, realm, username string, timeout time
 
 // buildASReq constructs a Kerberos AS-REQ message without pre-authentication data.
 func buildASReq(username, realm string) ([]byte, error) {
-	// Uppercase realm per Kerberos convention
 	realm = strings.ToUpper(realm)
 
-	// Generate random nonce
 	nonceInt, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt32))
 	if err != nil {
 		return nil, fmt.Errorf("generating nonce: %w", err)
 	}
 	nonce := int(nonceInt.Int64())
 
-	// Client principal name
 	cname := types.PrincipalName{
 		NameType:   nametype.KRB_NT_PRINCIPAL,
 		NameString: []string{username},
 	}
 
-	// Service principal name (krbtgt/REALM)
 	sname := types.PrincipalName{
 		NameType:   nametype.KRB_NT_SRV_INST,
 		NameString: []string{"krbtgt", realm},
 	}
 
-	// Till time: 24 hours from now
 	till := time.Now().UTC().Add(24 * time.Hour)
 
-	// Encryption types: AES256, AES128, RC4-HMAC (most common)
 	etypes := []int32{
 		etypeID.AES256_CTS_HMAC_SHA1_96,
 		etypeID.AES128_CTS_HMAC_SHA1_96,
 		etypeID.RC4_HMAC,
 	}
 
-	// Construct AS-REQ with empty PAData (no pre-authentication)
 	asReq := messages.ASReq{
 		KDCReqFields: messages.KDCReqFields{
 			PVNO:    iana.PVNO,
@@ -166,7 +150,6 @@ func buildASReq(username, realm string) ([]byte, error) {
 		},
 	}
 
-	// Marshal to bytes
 	return asReq.Marshal()
 }
 
@@ -179,7 +162,6 @@ func sendKerberosTCP(ctx context.Context, addr string, data []byte, timeout time
 		addr = net.JoinHostPort(addr, "88")
 	}
 
-	// Dial with context
 	var d net.Dialer
 	conn, err := d.DialContext(ctx, "tcp", addr)
 	if err != nil {
@@ -196,7 +178,6 @@ func sendKerberosTCP(ctx context.Context, addr string, data []byte, timeout time
 		return nil, fmt.Errorf("setting deadline: %w", err)
 	}
 
-	// Write 4-byte length prefix + data
 	length := make([]byte, 4)
 	binary.BigEndian.PutUint32(length, uint32(len(data)))
 
@@ -207,7 +188,6 @@ func sendKerberosTCP(ctx context.Context, addr string, data []byte, timeout time
 		return nil, fmt.Errorf("writing data: %w", err)
 	}
 
-	// Read 4-byte response length
 	respLength := make([]byte, 4)
 	if _, err := io.ReadFull(conn, respLength); err != nil {
 		return nil, fmt.Errorf("reading response length: %w", err)
@@ -218,7 +198,6 @@ func sendKerberosTCP(ctx context.Context, addr string, data []byte, timeout time
 		return nil, fmt.Errorf("response too large: %d bytes", respSize)
 	}
 
-	// Read response body
 	response := make([]byte, respSize)
 	if _, err := io.ReadFull(conn, response); err != nil {
 		return nil, fmt.Errorf("reading response: %w", err)

--- a/pkg/enum/lusha/lusha.go
+++ b/pkg/enum/lusha/lusha.go
@@ -61,10 +61,6 @@ const (
 	headerAPIKey = "api_key"
 )
 
-// ---------------------------------------------------------------------------
-// Public types
-// ---------------------------------------------------------------------------
-
 // ContactQuery carries exactly one identity group (validated at the CLI layer).
 type ContactQuery struct {
 	FirstName     string
@@ -167,10 +163,6 @@ func (e *APIError) Unwrap() error {
 	}
 	return nil
 }
-
-// ---------------------------------------------------------------------------
-// Client
-// ---------------------------------------------------------------------------
 
 // Client holds state for querying the Lusha v3 search-and-enrich API.
 type Client struct {
@@ -280,10 +272,6 @@ func (c *Client) SearchDomain(ctx context.Context, domain string, limit int) (*D
 
 	return result, nil
 }
-
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
 
 // do performs a single JSON request. It sets the api_key header inline (never
 // in the URL), reads the body via the bounded reader (P0-3), and maps non-2xx
@@ -525,12 +513,10 @@ func toProspectContact(d *prospectEnrichData) Contact {
 	return c
 }
 
-// ---------------------------------------------------------------------------
 // JSON-mapping structs (unexported) — verified against live API 2026-06-26.
 // Architecture §11: isolated here so a single edit corrects a live mismatch
 // without touching control flow. httptest tests use controlled payloads and
 // pass regardless of live-schema correctness.
-// ---------------------------------------------------------------------------
 
 // lushaEnrichRequest is the v3 search-and-enrich request body. The real v3
 // POST /v3/contacts/search-and-enrich uses a BATCH shape: a contacts array
@@ -628,10 +614,8 @@ type lushaErrorEnvelope struct {
 	Message string `json:"message"`
 }
 
-// ---------------------------------------------------------------------------
 // Prospecting (roster) JSON-mapping structs — field names DIFFER from the
 // single-identity search-and-enrich structs above. Verified live 2026-06-26.
-// ---------------------------------------------------------------------------
 
 // prospectSearchRequest filters prospecting search by company domain.
 type prospectSearchRequest struct {

--- a/pkg/enum/lusha/lusha_test.go
+++ b/pkg/enum/lusha/lusha_test.go
@@ -37,10 +37,6 @@ func newTestClient(baseURL string) *Client {
 	return c
 }
 
-// ---------------------------------------------------------------------------
-// T101: toContact + APIError/Unwrap
-// ---------------------------------------------------------------------------
-
 func TestToContact(t *testing.T) {
 	// v3 batch response: results array with top-level emails/phones on each result
 	// (no contactMethods wrapper). Verified against live API 2026-06-26.
@@ -173,10 +169,6 @@ func TestAPIError_Error(t *testing.T) {
 	assert.NotContains(t, err.Error(), "SECRETKEY-DO-NOT-LEAK",
 		"APIError.Error() must not include Details (P0-1 key-leak prevention)")
 }
-
-// ---------------------------------------------------------------------------
-// T102: Enrich success + auth header + request body
-// ---------------------------------------------------------------------------
 
 func TestEnrich_Success(t *testing.T) {
 	var capturedReqBody []byte
@@ -406,10 +398,6 @@ func TestEnrich_ContextCancellation(t *testing.T) {
 	_, err := c.Enrich(ctx, &ContactQuery{Email: "a@b.com"}, RevealOptions{Email: true})
 	require.Error(t, err, "context cancellation must produce an error")
 }
-
-// ---------------------------------------------------------------------------
-// T106: SearchDomain — prospecting search + enrich pagination
-// ---------------------------------------------------------------------------
 
 // prospectSearchBody mirrors the fields our handler needs to inspect.
 type prospectSearchBody struct {

--- a/pkg/enum/microsoft365/microsoft365.go
+++ b/pkg/enum/microsoft365/microsoft365.go
@@ -98,10 +98,6 @@ func NewChecker(baseURL, proxyURL string, timeout time.Duration) (*Checker, erro
 	}, nil
 }
 
-// ---------------------------------------------------------------------------
-// Enumeration
-// ---------------------------------------------------------------------------
-
 // Enumerate looks up each email using a bounded worker pool, applying rate
 // limiting and jitter when rateLimit > 0. Results preserve input order. It is a
 // thin wrapper around EnumerateWith with no per-result callback.

--- a/pkg/enum/microsoft365/microsoft365_hooks_test.go
+++ b/pkg/enum/microsoft365/microsoft365_hooks_test.go
@@ -39,7 +39,6 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/enum"
 )
 
-// ---------------------------------------------------------------------------
 // TestWorker_Label
 // microsoft365's pre-migration panic diagnostics were prefixed
 // "microsoft365 enum", yielding "microsoft365 enum: panic checking %s: %v"
@@ -48,7 +47,6 @@ import (
 // this exact string must never drift -- changing it is a log-format change
 // for anything that greps stderr or a Result's Error text, not a cosmetic
 // rename.
-// ---------------------------------------------------------------------------
 
 func TestWorker_Label(t *testing.T) {
 	t.Parallel()
@@ -59,7 +57,6 @@ func TestWorker_Label(t *testing.T) {
 	assert.Equal(t, "microsoft365 enum", c.worker().Label)
 }
 
-// ---------------------------------------------------------------------------
 // TestWorker_NewErrorShape
 // microsoft365's failure results carry no fields beyond Email and Error
 // (PLAN.md Part 0.4). Comparing the full struct -- not just Email/Error
@@ -67,7 +64,6 @@ func TestWorker_Label(t *testing.T) {
 // have caught gravatar's Hash regression had it been applied there, so it
 // must prove a negative (nothing else got set) as well as a positive
 // (Email/Error got set).
-// ---------------------------------------------------------------------------
 
 func TestWorker_NewErrorShape(t *testing.T) {
 	t.Parallel()
@@ -81,13 +77,11 @@ func TestWorker_NewErrorShape(t *testing.T) {
 	assert.Equal(t, Result{Email: "a@b.com", Error: sentinel}, got)
 }
 
-// ---------------------------------------------------------------------------
 // TestWorker_StampNameCopiesFirstLastOnly
 // StampName's documented contract (targetworker.go) is a one-line copy of
 // First/Last from the originating Target. This asserts both halves of that
 // contract: First/Last land correctly, and every other field on an
 // already-populated Result is left untouched.
-// ---------------------------------------------------------------------------
 
 func TestWorker_StampNameCopiesFirstLastOnly(t *testing.T) {
 	t.Parallel()
@@ -119,7 +113,6 @@ func TestWorker_StampNameCopiesFirstLastOnly(t *testing.T) {
 	assert.Equal(t, before.Duration, res.Duration, "StampName must not touch Duration")
 }
 
-// ---------------------------------------------------------------------------
 // TestWorker_NilResultGuardRoutesThroughNewError
 //
 // PLAN.md Part 3.3 requires that microsoft365's nil-result substitute route
@@ -142,7 +135,6 @@ func TestWorker_StampNameCopiesFirstLastOnly(t *testing.T) {
 // the package's real NewError. It is the strongest assertion reachable
 // without contorting the production code for testability; it does not prove
 // the guard itself is reached.
-// ---------------------------------------------------------------------------
 
 func TestWorker_NilResultGuardRoutesThroughNewError(t *testing.T) {
 	t.Parallel()

--- a/pkg/enum/microsoft365/microsoft365_targets_test.go
+++ b/pkg/enum/microsoft365/microsoft365_targets_test.go
@@ -66,13 +66,11 @@ func newTargetsMockServer(t *testing.T) *httptest.Server {
 	}))
 }
 
-// ---------------------------------------------------------------------------
 // TestEnumerateTargetsWith_NamesRideOnResult
 // Core test: 3 targets with distinct names against a stub that reports
 // existence for all of them. Each returned Result must carry the name of the
 // target that produced it, correlated by email. An implementation that
 // stamps every Result with the first target's name fails this test.
-// ---------------------------------------------------------------------------
 
 func TestEnumerateTargetsWith_NamesRideOnResult(t *testing.T) {
 	t.Parallel()
@@ -106,11 +104,9 @@ func TestEnumerateTargetsWith_NamesRideOnResult(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // TestEnumerateTargetsWith_NamelessTargetStaysNameless
 // A Target with no name (address supplied by the operator, not generated)
 // must yield First=="" && Last=="". The library must never invent a name.
-// ---------------------------------------------------------------------------
 
 func TestEnumerateTargetsWith_NamelessTargetStaysNameless(t *testing.T) {
 	t.Parallel()
@@ -128,12 +124,10 @@ func TestEnumerateTargetsWith_NamelessTargetStaysNameless(t *testing.T) {
 	assert.Empty(t, results[0].Last, "Last must stay empty for a nameless Target")
 }
 
-// ---------------------------------------------------------------------------
 // TestEnumerateWith_StillWorksAndYieldsEmptyNames
 // Pins that the existing EnumerateWith([]string) entry point is unaffected by
 // the refactor: it still returns correct results, and since bare addresses
 // carry no name, First/Last must be empty.
-// ---------------------------------------------------------------------------
 
 func TestEnumerateWith_StillWorksAndYieldsEmptyNames(t *testing.T) {
 	t.Parallel()
@@ -162,12 +156,10 @@ func TestEnumerateWith_StillWorksAndYieldsEmptyNames(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // TestEnumerateTargetsWith_NamesSurviveErrorPath
 // A name is a property of the address, not of the check outcome. Drive a
 // Result whose Error is non-nil (stub returns 500 -> "unexpected status") and
 // assert the name is still stamped.
-// ---------------------------------------------------------------------------
 
 func TestEnumerateTargetsWith_NamesSurviveErrorPath(t *testing.T) {
 	t.Parallel()
@@ -191,11 +183,9 @@ func TestEnumerateTargetsWith_NamesSurviveErrorPath(t *testing.T) {
 	assert.Equal(t, "fail", r.Last, "name must survive even when the probe errors")
 }
 
-// ---------------------------------------------------------------------------
 // TestEnumerateTargetsWith_MixedNamedAndUnnamed
 // A single batch containing both named and unnamed targets: each Result must
 // get exactly its own target's name, or empty for the unnamed ones.
-// ---------------------------------------------------------------------------
 
 func TestEnumerateTargetsWith_MixedNamedAndUnnamed(t *testing.T) {
 	t.Parallel()
@@ -228,12 +218,10 @@ func TestEnumerateTargetsWith_MixedNamedAndUnnamed(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // TestEnumerateTargetsWith_OrderingAndLength
 // len(results) == len(targets) and every index is filled even when some
 // probes fail. Completion order is not asserted (the worker pool is
 // concurrent); correlation is by email.
-// ---------------------------------------------------------------------------
 
 func TestEnumerateTargetsWith_OrderingAndLength(t *testing.T) {
 	t.Parallel()
@@ -273,7 +261,6 @@ func TestEnumerateTargetsWith_OrderingAndLength(t *testing.T) {
 	assert.NoError(t, byEmail["ok2@x.com"].Error)
 }
 
-// ---------------------------------------------------------------------------
 // TestEnumerateTargetsWith_NamesSurviveCancelledContext
 // Chokepoint test: with the context already canceled before the call, every
 // goroutine takes the <-ctx.Done() early-return branch and calls
@@ -282,7 +269,6 @@ func TestEnumerateTargetsWith_OrderingAndLength(t *testing.T) {
 // (record(i, *c.CheckAccount(...))) rather than inside record() itself, these
 // Results would come back nameless. This is what makes record() the enforced
 // chokepoint rather than an incidental detail.
-// ---------------------------------------------------------------------------
 
 func TestEnumerateTargetsWith_NamesSurviveCancelledContext(t *testing.T) {
 	t.Parallel()

--- a/pkg/enum/microsoft365/microsoft365_test.go
+++ b/pkg/enum/microsoft365/microsoft365_test.go
@@ -252,13 +252,11 @@ func TestNewChecker_WithProxyURL(t *testing.T) {
 	assert.NotNil(t, c)
 }
 
-// ---------------------------------------------------------------------------
 // enum.HTTPClientFromContext proxy support (dev): CheckAccount must prefer a
 // shared enum HTTP client carried on ctx (set for a run via
 // enum.WithHTTPClient to honor --proxy and connection pooling) over the
 // Checker's own client, and fall back to its own client when ctx carries
 // none.
-// ---------------------------------------------------------------------------
 
 func TestCheckAccount_UsesHTTPClientFromContext(t *testing.T) {
 	t.Parallel()
@@ -311,7 +309,6 @@ func TestCheckAccount_FallsBackToOwnClientWithoutContextClient(t *testing.T) {
 	assert.True(t, result.Exists)
 }
 
-// ---------------------------------------------------------------------------
 // TestEnumerateWith_Callback
 // 6 emails, threads=4, onResult callback appends under a mutex.
 // After the run:
@@ -322,7 +319,6 @@ func TestCheckAccount_FallsBackToOwnClientWithoutContextClient(t *testing.T) {
 //
 // Run the package under -race (go test -race ./pkg/enum/microsoft365/) to
 // verify the callback serialization guarantee.
-// ---------------------------------------------------------------------------
 
 func TestEnumerateWith_Callback(t *testing.T) {
 	t.Parallel()
@@ -401,11 +397,9 @@ func TestEnumerateWith_Callback(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // TestEnumerateWith_NilCallback
 // Passing nil as the callback must not panic and must return one result per
 // email.
-// ---------------------------------------------------------------------------
 
 func TestEnumerateWith_NilCallback(t *testing.T) {
 	t.Parallel()
@@ -422,7 +416,6 @@ func TestEnumerateWith_NilCallback(t *testing.T) {
 	require.Len(t, results, len(emails), "nil callback must not panic; must return one result per email")
 }
 
-// ---------------------------------------------------------------------------
 // TestEnumerateWith_CanceledContextRecordsAllSlots
 // Regression guard: with an already-canceled context, every worker hits the
 // <-ctx.Done() guard before the HTTP call. Each guard must still call
@@ -430,7 +423,6 @@ func TestEnumerateWith_NilCallback(t *testing.T) {
 // order preserved) and the callback fires exactly once per email. Reverting
 // that record() call leaves the dropped slots as zero-value Result{} (empty
 // Email, nil Error) and skips the callback for those emails.
-// ---------------------------------------------------------------------------
 
 func TestEnumerateWith_CanceledContextRecordsAllSlots(t *testing.T) {
 	t.Parallel()
@@ -468,13 +460,11 @@ func TestEnumerateWith_CanceledContextRecordsAllSlots(t *testing.T) {
 	assert.Len(t, cbResults, len(emails), "onResult callback must fire exactly once per email, even on the canceled-context path")
 }
 
-// ---------------------------------------------------------------------------
 // TestEnumerateWith_ZeroOrNegativeThreadsDoesNotHang
 // Regression guard: threads<=0 must be normalized to 1 before g.SetLimit.
 // SetLimit(0) would permit zero concurrent goroutines, so no worker could ever
 // run and EnumerateWith would hang forever. Guarded by a timeout rather than
 // relying solely on `go test -timeout`, so failure is immediate and specific.
-// ---------------------------------------------------------------------------
 
 func TestEnumerateWith_ZeroOrNegativeThreadsDoesNotHang(t *testing.T) {
 	tests := []struct {

--- a/pkg/enum/registry.go
+++ b/pkg/enum/registry.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// pkg/enum/registry.go
 package enum
 
 import (

--- a/pkg/enum/runner.go
+++ b/pkg/enum/runner.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// pkg/enum/runner.go
 package enum
 
 import (

--- a/pkg/enum/runner_test.go
+++ b/pkg/enum/runner_test.go
@@ -25,10 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ---------------------------------------------------------------------------
-// T10: EnumerateWithPlugin
-// ---------------------------------------------------------------------------
-
 // stubPlugin is an in-test implementation of Plugin that always returns a
 // configurable result. It is safe for concurrent use (stateless).
 type stubPlugin struct {
@@ -150,7 +146,6 @@ func TestEnumerateWithPlugin_SingleThread(t *testing.T) {
 	require.Len(t, results, 5, "single-threaded must still produce all results")
 }
 
-// ---------------------------------------------------------------------------
 // 10T-535 PR2: Config.Targets carries names through the framework, ADDITIVELY
 // alongside the legacy Config.Emails field. Nothing above this line changes:
 // the tests above still construct Config with only Emails, which is itself
@@ -160,7 +155,6 @@ func TestEnumerateWithPlugin_SingleThread(t *testing.T) {
 // promote each Emails entry to a nameless Target{Email: e}. validate() must
 // accept either field being populated and must keep rejecting the case
 // where both are empty.
-// ---------------------------------------------------------------------------
 
 // recordingPlugin is a stub Plugin that records every email it was asked to
 // Check, so tests can assert exactly what the framework passed into the

--- a/pkg/enum/targetworker.go
+++ b/pkg/enum/targetworker.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// pkg/enum/targetworker.go
 package enum
 
 import (

--- a/pkg/enum/targetworker_test.go
+++ b/pkg/enum/targetworker_test.go
@@ -66,10 +66,6 @@ func fakeWorker(check func(context.Context, string) fakeResult) TargetWorker[fak
 	}
 }
 
-// ---------------------------------------------------------------------------
-// W1 - TestRun_ReturnsInputOrder
-// ---------------------------------------------------------------------------
-
 func TestRun_ReturnsInputOrder(t *testing.T) {
 	t.Parallel()
 
@@ -97,10 +93,6 @@ func TestRun_ReturnsInputOrder(t *testing.T) {
 			"results[%d].Email must match targets[%d].Email regardless of completion order", i, i)
 	}
 }
-
-// ---------------------------------------------------------------------------
-// W2 - TestRun_EverySlotFilledAndCallbackOncePerTarget
-// ---------------------------------------------------------------------------
 
 func TestRun_EverySlotFilledAndCallbackOncePerTarget(t *testing.T) {
 	t.Parallel()
@@ -142,10 +134,6 @@ func TestRun_EverySlotFilledAndCallbackOncePerTarget(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// W3 - TestRun_StampsOriginatingTargetName
-// ---------------------------------------------------------------------------
-
 func TestRun_StampsOriginatingTargetName(t *testing.T) {
 	t.Parallel()
 
@@ -175,10 +163,6 @@ func TestRun_StampsOriginatingTargetName(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// W4 - TestRun_NamelessTargetStaysNameless
-// ---------------------------------------------------------------------------
-
 func TestRun_NamelessTargetStaysNameless(t *testing.T) {
 	t.Parallel()
 
@@ -193,10 +177,6 @@ func TestRun_NamelessTargetStaysNameless(t *testing.T) {
 	assert.Empty(t, results[0].First, "First must stay empty for a nameless Target")
 	assert.Empty(t, results[0].Last, "Last must stay empty for a nameless Target")
 }
-
-// ---------------------------------------------------------------------------
-// W5 - TestRun_MixedNamedAndUnnamed
-// ---------------------------------------------------------------------------
 
 func TestRun_MixedNamedAndUnnamed(t *testing.T) {
 	t.Parallel()
@@ -228,7 +208,6 @@ func TestRun_MixedNamedAndUnnamed(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // W6 - TestRun_NameSurvivesEveryAbortPath
 //
 // Table of the four paths that reach record() WITHOUT a normal Check return:
@@ -236,7 +215,6 @@ func TestRun_MixedNamedAndUnnamed(t *testing.T) {
 // jitter, and panic recovery. Every one must (a) carry the originating
 // target's name and (b) carry Sentinel == "from-newerror", proving the
 // result came from the NewError hook and not a generic zero value.
-// ---------------------------------------------------------------------------
 
 func TestRun_NameSurvivesEveryAbortPath(t *testing.T) {
 	t.Run("already-canceled context", func(t *testing.T) {
@@ -368,10 +346,6 @@ func TestRun_NameSurvivesEveryAbortPath(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
-// W7 - TestRun_CanceledContextRecordsEveryTarget
-// ---------------------------------------------------------------------------
-
 func TestRun_CanceledContextRecordsEveryTarget(t *testing.T) {
 	t.Parallel()
 
@@ -408,10 +382,6 @@ func TestRun_CanceledContextRecordsEveryTarget(t *testing.T) {
 	assert.Len(t, cbEmails, len(targets), "onResult must fire exactly once per target on the canceled-context path")
 }
 
-// ---------------------------------------------------------------------------
-// W8 - TestRun_ZeroOrNegativeThreadsDoesNotHang
-// ---------------------------------------------------------------------------
-
 func TestRun_ZeroOrNegativeThreadsDoesNotHang(t *testing.T) {
 	for _, threads := range []int{0, -1} {
 		t.Run(fmt.Sprintf("threads=%d", threads), func(t *testing.T) {
@@ -446,10 +416,6 @@ func TestRun_ZeroOrNegativeThreadsDoesNotHang(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// W9 - TestRun_BoundsConcurrency
-// ---------------------------------------------------------------------------
-
 func TestRun_BoundsConcurrency(t *testing.T) {
 	t.Parallel()
 
@@ -480,10 +446,6 @@ func TestRun_BoundsConcurrency(t *testing.T) {
 	assert.LessOrEqual(t, peak.Load(), int32(threads), "peak concurrent Check calls must not exceed threads")
 }
 
-// ---------------------------------------------------------------------------
-// W10 - TestRun_RateLimitPaces
-// ---------------------------------------------------------------------------
-
 func TestRun_RateLimitPaces(t *testing.T) {
 	t.Parallel()
 
@@ -508,10 +470,6 @@ func TestRun_RateLimitPaces(t *testing.T) {
 	assert.GreaterOrEqual(t, elapsed, 190*time.Millisecond, "rate limiting must pace requests to roughly the configured rate")
 }
 
-// ---------------------------------------------------------------------------
-// W11 - TestRun_JitterIgnoredWithoutRateLimit
-// ---------------------------------------------------------------------------
-
 func TestRun_JitterIgnoredWithoutRateLimit(t *testing.T) {
 	t.Parallel()
 
@@ -530,10 +488,6 @@ func TestRun_JitterIgnoredWithoutRateLimit(t *testing.T) {
 		"jitter must be ignored entirely when rateLimit is 0 -- jitter lives inside the rate-limiter branch, "+
 			"a 2s jitter here must not slow this run down")
 }
-
-// ---------------------------------------------------------------------------
-// W12 - TestRun_NilCallbackIsSafe
-// ---------------------------------------------------------------------------
 
 func TestRun_NilCallbackIsSafe(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
@@ -570,10 +524,6 @@ func TestRun_NilCallbackIsSafe(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
-// W13 - TestRun_CallbackIsSerialized
-// ---------------------------------------------------------------------------
-
 func TestRun_CallbackIsSerialized(t *testing.T) {
 	t.Parallel()
 
@@ -607,13 +557,11 @@ func TestRun_CallbackIsSerialized(t *testing.T) {
 	assert.False(t, raced.Load(), "onResult invoked concurrently: callback is not serialized under the results mutex")
 }
 
-// ---------------------------------------------------------------------------
 // W14 - TestRun_PanicInCheckIsIsolated
 //
 // Deliberately NOT t.Parallel(): swaps the package-level os.Stderr, same
 // hazard noted on the "panic in Check" subtest of TestRun_NameSurvivesEvery-
 // AbortPath above.
-// ---------------------------------------------------------------------------
 
 func TestRun_PanicInCheckIsIsolated(t *testing.T) {
 	targets := []Target{
@@ -660,10 +608,6 @@ func TestRun_PanicInCheckIsIsolated(t *testing.T) {
 		"Label must prefix the stderr diagnostic exactly as every real package's Label does")
 }
 
-// ---------------------------------------------------------------------------
-// W15 - TestRun_EmptyTargets
-// ---------------------------------------------------------------------------
-
 func TestRun_EmptyTargets(t *testing.T) {
 	t.Parallel()
 
@@ -683,10 +627,6 @@ func TestRun_EmptyTargets(t *testing.T) {
 	assert.Equal(t, int32(0), checkCalls.Load(), "Check must never be called when there are no targets")
 	assert.Equal(t, int32(0), callbackCalls.Load(), "onResult must never fire when there are no targets")
 }
-
-// ---------------------------------------------------------------------------
-// W16 - TestRun_PanicsOnMissingHooks
-// ---------------------------------------------------------------------------
 
 func TestRun_PanicsOnMissingHooks(t *testing.T) {
 	base := func() TargetWorker[fakeResult] {

--- a/pkg/enum/teams/audit.go
+++ b/pkg/enum/teams/audit.go
@@ -84,10 +84,6 @@ func Audit(domain, seedEmail string, result *EnumResult, posture *TenantPosture,
 	return findings
 }
 
-// ---------------------------------------------------------------------------
-// Rule builders (one per finding type)
-// ---------------------------------------------------------------------------
-
 // externalAccessFinding reports that external / cross-tenant Teams chat is
 // enabled: the externalsearchv3 endpoint resolved the seed user to this tenant
 // from an external context.
@@ -181,10 +177,6 @@ func metadataFinding(domain, seedEmail string, result *EnumResult) Finding {
 		Remediation: "This disclosure is inherent to Teams external resolution. Reduce external exposure by restricting federation/external access.",
 	}
 }
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
 
 // externalAccessSignals describes any federation/type signal observed on the
 // seed result, for inclusion in the external-access evidence string. It returns

--- a/pkg/enum/teams/audit_test.go
+++ b/pkg/enum/teams/audit_test.go
@@ -39,10 +39,6 @@ func hasFinding(findings []Finding, id string) bool {
 	return ok
 }
 
-// ---------------------------------------------------------------------------
-// Test 1: TestAudit_ExternalAccessOpen
-// ---------------------------------------------------------------------------
-
 func TestAudit_ExternalAccessOpen(t *testing.T) {
 	baseResult := EnumResult{
 		Email:  "alice@contoso.com",
@@ -73,10 +69,6 @@ func TestAudit_ExternalAccessOpen(t *testing.T) {
 			"teams-external-access must be absent when ExternalChatAllowed==\"unknown\"")
 	})
 }
-
-// ---------------------------------------------------------------------------
-// Test 2: TestAudit_UserEnumeration
-// ---------------------------------------------------------------------------
 
 func TestAudit_UserEnumeration(t *testing.T) {
 	posture := TenantPosture{ExternalChatAllowed: "open"}
@@ -115,10 +107,6 @@ func TestAudit_UserEnumeration(t *testing.T) {
 			"teams-user-enumeration must be absent when Exists==ExistenceUnknown")
 	})
 }
-
-// ---------------------------------------------------------------------------
-// Test 3: TestAudit_PresenceAndOOF_GatedByPresenceChecked
-// ---------------------------------------------------------------------------
 
 func TestAudit_PresenceAndOOF_GatedByPresenceChecked(t *testing.T) {
 	posture := TenantPosture{ExternalChatAllowed: "blocked"}
@@ -187,10 +175,6 @@ func TestAudit_PresenceAndOOF_GatedByPresenceChecked(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------------------
-// Test 4: TestAudit_MetadataDisclosure
-// ---------------------------------------------------------------------------
-
 func TestAudit_MetadataDisclosure(t *testing.T) {
 	posture := TenantPosture{ExternalChatAllowed: "open"}
 
@@ -252,10 +236,6 @@ func TestAudit_MetadataDisclosure(t *testing.T) {
 			"teams-metadata-disclosure must be absent when Exists!=ExistenceYes")
 	})
 }
-
-// ---------------------------------------------------------------------------
-// Test 5: TestAudit_Ordering
-// ---------------------------------------------------------------------------
 
 func TestAudit_Ordering(t *testing.T) {
 	// Craft a result+posture that triggers Medium + Low + Info findings.
@@ -365,10 +345,6 @@ func TestAudit_Ordering_WithinSeverityByID(t *testing.T) {
 		"teams-user-enumeration must appear among Info-severity findings (severity changed from Low to Info)")
 }
 
-// ---------------------------------------------------------------------------
-// Test 6: TestAudit_NoTokensInFindings
-// ---------------------------------------------------------------------------
-
 // TestAudit_NoTokensInFindings verifies that token-sentinel strings never
 // appear in any Finding field. The Audit function receives no tokens, so this
 // is primarily a structural guard: if caller code ever accidentally routes token
@@ -430,10 +406,6 @@ func TestAudit_NoTokensInFindings(t *testing.T) {
 			"Remediation must not contain the access-token sentinel")
 	}
 }
-
-// ---------------------------------------------------------------------------
-// Helpers used across multiple tests
-// ---------------------------------------------------------------------------
 
 // TestAudit_EmptyResult verifies that Audit never panics on a zero-value result
 // and returns an empty (non-nil) slice.

--- a/pkg/enum/teams/auth.go
+++ b/pkg/enum/teams/auth.go
@@ -77,10 +77,6 @@ var (
 	ErrAccessDenied         = errors.New("access denied by user or admin")
 )
 
-// ---------------------------------------------------------------------------
-// Public types
-// ---------------------------------------------------------------------------
-
 // DeviceCode holds the device authorization response. UserCode and
 // VerificationURI are shown to the user; deviceCode and interval are retained
 // internally for polling and are never exposed or logged.
@@ -116,10 +112,6 @@ type APIError struct {
 func (e *APIError) Error() string {
 	return fmt.Sprintf("entra device code error (HTTP %d): %q: %q", e.StatusCode, e.Code, e.Description)
 }
-
-// ---------------------------------------------------------------------------
-// Client
-// ---------------------------------------------------------------------------
 
 // Client performs the Microsoft Entra ID device code OAuth2 flow.
 type Client struct {
@@ -312,10 +304,6 @@ func (c *Client) RefreshAccessToken(ctx context.Context, refreshToken string) (*
 	}, nil
 }
 
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
-
 // poll performs a single token endpoint request for the given device code.
 // On HTTP 200 it returns a populated TokenSet. On an OAuth error it returns a
 // sentinel error (for the recoverable/terminal states) or an *APIError.
@@ -392,10 +380,6 @@ func decodeAuthError(statusCode int, body []byte) error {
 		Description: errResp.ErrorDescription,
 	}
 }
-
-// ---------------------------------------------------------------------------
-// JSON-mapping structs (unexported — map exactly to the Entra response shape)
-// ---------------------------------------------------------------------------
 
 type deviceCodeAPIResponse struct {
 	DeviceCode      string `json:"device_code"`

--- a/pkg/enum/teams/auth_refresh_test.go
+++ b/pkg/enum/teams/auth_refresh_test.go
@@ -27,10 +27,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ---------------------------------------------------------------------------
-// Test 16: DefaultScope constant is pinned to the Skype/Teams resource
-// ---------------------------------------------------------------------------
-
 func TestDefaultScope_PinnedToSkypeResource(t *testing.T) {
 	// Pin the corrected value: Teams uses the Skype resource, NOT Microsoft Graph.
 	// A regression to "https://graph.microsoft.com/.default" causes AADSTS65002.
@@ -42,10 +38,6 @@ func TestDefaultScope_PinnedToSkypeResource(t *testing.T) {
 		DefaultScope,
 		"DefaultScope must be the Skype/Teams resource .default scope, not the Graph scope")
 }
-
-// ---------------------------------------------------------------------------
-// Test 14: RefreshAccessToken happy path
-// ---------------------------------------------------------------------------
 
 func TestRefreshAccessToken_HappyPath(t *testing.T) {
 	const wantAccessToken = "fresh-access-token-value"
@@ -95,10 +87,6 @@ func TestRefreshAccessToken_HappyPath(t *testing.T) {
 	assert.Equal(t, DefaultScope, capturedForm.Get("scope"),
 		"scope must be DefaultScope (set by NewClient default)")
 }
-
-// ---------------------------------------------------------------------------
-// Test 15: RefreshAccessToken error — non-200 OAuth error terminates cleanly
-// ---------------------------------------------------------------------------
 
 func TestRefreshAccessToken_Error(t *testing.T) {
 	errBody, _ := json.Marshal(authErrorResponse{

--- a/pkg/enum/teams/auth_test.go
+++ b/pkg/enum/teams/auth_test.go
@@ -39,10 +39,6 @@ func newTestClient(t *testing.T, tenantID, clientID, scopes, deviceCodeURL, toke
 	return c
 }
 
-// ---------------------------------------------------------------------------
-// APIError
-// ---------------------------------------------------------------------------
-
 func TestAPIError_Error(t *testing.T) {
 	err := &APIError{StatusCode: 400, Code: "invalid_client", Description: "AADSTS70011"}
 	msg := err.Error()
@@ -51,10 +47,6 @@ func TestAPIError_Error(t *testing.T) {
 	assert.Contains(t, msg, "AADSTS70011")
 }
 
-// ---------------------------------------------------------------------------
-// NewClient defaults
-// ---------------------------------------------------------------------------
-
 func TestNewClient_Defaults(t *testing.T) {
 	c, err := NewClient("", "", "", "", 5*time.Second)
 	require.NoError(t, err)
@@ -62,10 +54,6 @@ func TestNewClient_Defaults(t *testing.T) {
 	assert.Equal(t, DefaultClientID, c.clientID)
 	assert.Equal(t, DefaultScope, c.scopes)
 }
-
-// ---------------------------------------------------------------------------
-// StartDeviceFlow
-// ---------------------------------------------------------------------------
 
 func TestStartDeviceFlow_Success(t *testing.T) {
 	resp := deviceCodeAPIResponse{
@@ -210,10 +198,6 @@ func TestStartDeviceFlow_MissingDeviceCode(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing")
 }
-
-// ---------------------------------------------------------------------------
-// WaitForToken
-// ---------------------------------------------------------------------------
 
 func makeTokenResponse() tokenAPIResponse {
 	return tokenAPIResponse{
@@ -475,10 +459,6 @@ func TestWaitForToken_MissingAccessToken(t *testing.T) {
 	assert.Contains(t, err.Error(), "missing")
 }
 
-// ---------------------------------------------------------------------------
-// NewClient — timeout flooring
-// ---------------------------------------------------------------------------
-
 func TestNewClient_TimeoutFloor(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -520,10 +500,6 @@ func TestNewClient_TimeoutFloor(t *testing.T) {
 		})
 	}
 }
-
-// ---------------------------------------------------------------------------
-// NewClient — proxy URL validation
-// ---------------------------------------------------------------------------
 
 func TestNewClient_Proxy(t *testing.T) {
 	tests := []struct {
@@ -571,10 +547,6 @@ func TestNewClient_Proxy(t *testing.T) {
 		})
 	}
 }
-
-// ---------------------------------------------------------------------------
-// decodeAuthError — table-driven for all 4 sentinel cases plus unknown
-// ---------------------------------------------------------------------------
 
 func TestDecodeAuthError_AllStates(t *testing.T) {
 	tests := []struct {

--- a/pkg/enum/teams/enum.go
+++ b/pkg/enum/teams/enum.go
@@ -127,10 +127,6 @@ const (
 	maxEnumBody   int64 = 64 << 10
 )
 
-// ---------------------------------------------------------------------------
-// Constructor
-// ---------------------------------------------------------------------------
-
 // NewEnumerator builds an Enumerator. The HTTP client is built via
 // brutus.NewHTTPClientWithProxy so the SOCKS5 --proxy flag works.
 //
@@ -165,10 +161,6 @@ func (e *Enumerator) SetRefreshFunc(fn func(ctx context.Context) (string, error)
 // accounts count as hits. Default false: only corporate (8:orgid:) matches
 // are treated as existing; a consumer-only match is reported as not found.
 func (e *Enumerator) SetIncludeConsumer(v bool) { e.includeConsumer = v }
-
-// ---------------------------------------------------------------------------
-// Enumeration
-// ---------------------------------------------------------------------------
 
 // Enumerate looks up each email using a bounded worker pool, applying rate
 // limiting and jitter when rateLimit > 0. Results preserve input order. It is a
@@ -407,10 +399,6 @@ func DerivePosture(domain string, results []EnumResult) TenantPosture {
 	return p
 }
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 // search issues the externalsearch lookup with the given bearer token. It
 // returns the decoded users, the HTTP status, and a non-nil error only on
 // transport/decode failure (never including the token).
@@ -532,10 +520,6 @@ func (e *Enumerator) token() string {
 	defer e.mu.Unlock()
 	return e.accessToken
 }
-
-// ---------------------------------------------------------------------------
-// JSON-mapping structs (unexported — map to the Teams response shapes)
-// ---------------------------------------------------------------------------
 
 type searchUser struct {
 	DisplayName       string `json:"displayName"`

--- a/pkg/enum/teams/enum_test.go
+++ b/pkg/enum/teams/enum_test.go
@@ -58,10 +58,6 @@ func searchServerReturning(statusCode int, body string) *httptest.Server {
 	}))
 }
 
-// ---------------------------------------------------------------------------
-// Test 1: Existence YES
-// ---------------------------------------------------------------------------
-
 func TestEnumerateOne_ExistenceYes(t *testing.T) {
 	srv := searchServerReturning(http.StatusOK,
 		`[{"displayName":"Alice","mri":"8:orgid:abc"}]`)
@@ -76,10 +72,6 @@ func TestEnumerateOne_ExistenceYes(t *testing.T) {
 	assert.Equal(t, "alice@contoso.com", res.Email)
 	assert.NoError(t, res.Error)
 }
-
-// ---------------------------------------------------------------------------
-// Test 2: Existence NO — empty array and non-array body
-// ---------------------------------------------------------------------------
 
 func TestEnumerateOne_ExistenceNo_EmptyArray(t *testing.T) {
 	srv := searchServerReturning(http.StatusOK, `[]`)
@@ -104,10 +96,6 @@ func TestEnumerateOne_ExistenceNo_NonArrayBody(t *testing.T) {
 		"a non-array 200 body must not produce ExistenceYes")
 }
 
-// ---------------------------------------------------------------------------
-// Test 3: Blocked (403) — error must not contain the access token
-// ---------------------------------------------------------------------------
-
 func TestEnumerateOne_Blocked(t *testing.T) {
 	srv := searchServerReturning(http.StatusForbidden, `{"error":"forbidden"}`)
 	defer srv.Close()
@@ -124,10 +112,6 @@ func TestEnumerateOne_Blocked(t *testing.T) {
 			"Error must not contain the access token")
 	}
 }
-
-// ---------------------------------------------------------------------------
-// Test 4: 401 + refresh success — refresh invoked exactly once
-// ---------------------------------------------------------------------------
 
 func TestEnumerateOne_UnauthorizedThenRefresh(t *testing.T) {
 	var callCount atomic.Int32
@@ -160,12 +144,10 @@ func TestEnumerateOne_UnauthorizedThenRefresh(t *testing.T) {
 	assert.Equal(t, int32(1), refreshCount.Load(), "refresh func must be invoked exactly once")
 }
 
-// ---------------------------------------------------------------------------
 // Test 5: 401 + no refresh -> ExistenceUnknown, error mentions "unauthorized",
 //
 //	error does NOT contain the token
 //
-// ---------------------------------------------------------------------------
 
 func TestEnumerateOne_UnauthorizedNoRefresh(t *testing.T) {
 	srv := searchServerReturning(http.StatusUnauthorized, "")
@@ -184,12 +166,10 @@ func TestEnumerateOne_UnauthorizedNoRefresh(t *testing.T) {
 		"error must not contain the access token")
 }
 
-// ---------------------------------------------------------------------------
 // Test 6: 401 loop guard — server always returns 401, refresh always succeeds,
 //
 //	result must be ExistenceUnknown and test must complete quickly
 //
-// ---------------------------------------------------------------------------
 
 func TestEnumerateOne_UnauthorizedLoopGuard(t *testing.T) {
 	var refreshCount atomic.Int32
@@ -216,10 +196,6 @@ func TestEnumerateOne_UnauthorizedLoopGuard(t *testing.T) {
 		"refresh must be invoked at most once regardless of repeated 401s")
 }
 
-// ---------------------------------------------------------------------------
-// Test 7: Other status (500) -> ExistenceUnknown, error mentions 500
-// ---------------------------------------------------------------------------
-
 func TestEnumerateOne_ServerError500(t *testing.T) {
 	srv := searchServerReturning(http.StatusInternalServerError, `{"error":"internal"}`)
 	defer srv.Close()
@@ -233,7 +209,6 @@ func TestEnumerateOne_ServerError500(t *testing.T) {
 		"error should mention the unexpected status code")
 }
 
-// ---------------------------------------------------------------------------
 // Test 8: Malformed JSON on 200 -> ExistenceUnknown — actually per production
 //
 //	code: json.Unmarshal errors return nil (silent decode failure means ExistenceNo).
@@ -242,7 +217,6 @@ func TestEnumerateOne_ServerError500(t *testing.T) {
 //	So malformed JSON produces ExistenceNo (not ExistenceUnknown) and no Error.
 //	This test pins that actual behavior and verifies no token leaks.
 //
-// ---------------------------------------------------------------------------
 
 func TestEnumerateOne_MalformedJSON(t *testing.T) {
 	srv := searchServerReturning(http.StatusOK, `not-valid-json{{`)
@@ -263,10 +237,6 @@ func TestEnumerateOne_MalformedJSON(t *testing.T) {
 			"error must not contain the access token")
 	}
 }
-
-// ---------------------------------------------------------------------------
-// Test 9: Presence success
-// ---------------------------------------------------------------------------
 
 func TestEnumerateOne_PresenceSuccess(t *testing.T) {
 	searchSrv := searchServerReturning(http.StatusOK,
@@ -290,10 +260,6 @@ func TestEnumerateOne_PresenceSuccess(t *testing.T) {
 	assert.Equal(t, "Desktop", res.DeviceType)
 	assert.NoError(t, res.Error)
 }
-
-// ---------------------------------------------------------------------------
-// Test 10: Presence failure is non-fatal
-// ---------------------------------------------------------------------------
 
 func TestEnumerateOne_PresenceFailureNonFatal(t *testing.T) {
 	searchSrv := searchServerReturning(http.StatusOK,
@@ -334,10 +300,6 @@ func TestEnumerateOne_PresenceEmptyArrayNonFatal(t *testing.T) {
 	assert.Empty(t, res.DeviceType)
 	assert.NoError(t, res.Error)
 }
-
-// ---------------------------------------------------------------------------
-// Test 11: Request assertions — headers, authorization, URL encoding
-// ---------------------------------------------------------------------------
 
 func TestEnumerateOne_RequestHeaders(t *testing.T) {
 	var captured *http.Request
@@ -453,11 +415,9 @@ func TestEnumerateOne_PresenceRequestAssertions(t *testing.T) {
 		"presence request body MRI must match the search result MRI")
 }
 
-// ---------------------------------------------------------------------------
 // Test: getPresence sends a browser User-Agent — regression for presence
 // requests going out as the default Go-http-client UA (which Teams silently
 // rejects), mirroring the browser UA already sent by search().
-// ---------------------------------------------------------------------------
 
 func TestGetPresence_SendsBrowserUserAgent(t *testing.T) {
 	searchSrv := searchServerReturning(http.StatusOK,
@@ -490,10 +450,6 @@ func TestGetPresence_SendsBrowserUserAgent(t *testing.T) {
 	assert.NotContains(t, ua, "Go-http-client",
 		"presence request must not go out with the default Go-http-client User-Agent")
 }
-
-// ---------------------------------------------------------------------------
-// Test 12: Concurrency — Enumerate over 6 emails with threads=2
-// ---------------------------------------------------------------------------
 
 func TestEnumerate_Concurrency(t *testing.T) {
 	var inFlight atomic.Int32
@@ -541,7 +497,6 @@ func TestEnumerate_Concurrency(t *testing.T) {
 		"in-flight requests must never exceed threads=2")
 }
 
-// ---------------------------------------------------------------------------
 // Test 13: Concurrent 401→refresh→retry — regression for the data race on
 // e.accessToken.
 //
@@ -556,7 +511,6 @@ func TestEnumerate_Concurrency(t *testing.T) {
 // exactly one refreshOnce() call while many goroutines are concurrently
 // reading e.token() — maximizing the read/write overlap the race detector
 // needs to observe.
-// ---------------------------------------------------------------------------
 
 func TestEnumerate_ConcurrentRefreshNoRace(t *testing.T) {
 	var reqCount atomic.Int32
@@ -618,14 +572,8 @@ func TestEnumerate_ConcurrentRefreshNoRace(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Test 13: P0-1 token-safety table — error paths must not leak tokens
-// ---------------------------------------------------------------------------
-
-// ---------------------------------------------------------------------------
 // Test: ParsesConfigFields — externalsearchv3 rich body: type, tenantId,
 // userPrincipalName, objectId, accountEnabled, featureSettings.coExistenceMode
-// ---------------------------------------------------------------------------
 
 func TestEnumerateOne_ParsesConfigFields(t *testing.T) {
 	srv := searchServerReturning(http.StatusOK,
@@ -645,10 +593,6 @@ func TestEnumerateOne_ParsesConfigFields(t *testing.T) {
 	assert.Equal(t, "TeamsOnly", res.CoExistenceMode)
 	assert.NoError(t, res.Error)
 }
-
-// ---------------------------------------------------------------------------
-// Test: Presence parses sourceNetwork and both OOO note locations
-// ---------------------------------------------------------------------------
 
 func TestEnumerateOne_PresenceParsesSourceNetworkAndOOO(t *testing.T) {
 	// Sub-test 1: OOO note under presence.outOfOfficeNote (direct path).
@@ -699,10 +643,6 @@ func TestEnumerateOne_PresenceParsesSourceNetworkAndOOO(t *testing.T) {
 		assert.NoError(t, res.Error)
 	})
 }
-
-// ---------------------------------------------------------------------------
-// Test: DerivePosture — table-driven coverage of all aggregation logic
-// ---------------------------------------------------------------------------
 
 func TestDerivePosture(t *testing.T) {
 	boolPtr := func(b bool) *bool { return &b }
@@ -817,10 +757,6 @@ func TestDerivePosture(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Test: DerivePosture_DomainAndCounts — Total, UsersFound, Blocked403, Domain
-// ---------------------------------------------------------------------------
-
 func TestDerivePosture_DomainAndCounts(t *testing.T) {
 	results := []EnumResult{
 		{Exists: ExistenceYes},
@@ -838,10 +774,6 @@ func TestDerivePosture_DomainAndCounts(t *testing.T) {
 	assert.Equal(t, 1, p.Blocked403, "Blocked403 must count ExistenceBlocked results only")
 	assert.Equal(t, "open", p.ExternalChatAllowed, "open because UsersFound > 0")
 }
-
-// ---------------------------------------------------------------------------
-// Test: TokenSafetyTable
-// ---------------------------------------------------------------------------
 
 func TestEnumerateOne_TokenSafetyTable(t *testing.T) {
 	const accessToken = "SUPER-SECRET-ACCESS-TOKEN"
@@ -891,10 +823,6 @@ func TestEnumerateOne_TokenSafetyTable(t *testing.T) {
 		})
 	}
 }
-
-// ---------------------------------------------------------------------------
-// Consumer-account filtering tests
-// ---------------------------------------------------------------------------
 
 // TestEnumerateOne_ConsumerOnly_IgnoredByDefault verifies that a search result
 // containing a single consumer (8:live:) user is treated as ExistenceNo when
@@ -1003,10 +931,6 @@ func TestEnumerateOne_CorporateOnly_AlwaysFound(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Test: AccountType — table-driven classification of MRI prefixes
-// ---------------------------------------------------------------------------
-
 func TestAccountType(t *testing.T) {
 	tests := []struct {
 		mri  string
@@ -1032,10 +956,6 @@ func TestAccountType(t *testing.T) {
 		})
 	}
 }
-
-// ---------------------------------------------------------------------------
-// Test: EnumerateWith — callback invoked exactly once per email
-// ---------------------------------------------------------------------------
 
 // searchServerPerEmail returns an httptest.Server that returns a user for
 // emails in the existSet (200 + user JSON) and an empty array for all others.
@@ -1116,10 +1036,6 @@ func TestEnumerateWith_CallbackPerResult(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Test: EnumerateWith — nil callback behaves like Enumerate
-// ---------------------------------------------------------------------------
-
 func TestEnumerateWith_NilCallback(t *testing.T) {
 	const n = 10
 	srv := searchServerReturning(http.StatusOK, `[]`)
@@ -1152,10 +1068,6 @@ func TestEnumerateWith_NilCallback(t *testing.T) {
 			"Enumerate and EnumerateWith(nil) must agree on result[%d].Exists", i)
 	}
 }
-
-// ---------------------------------------------------------------------------
-// Test: EnumerateWith — threads=0 must not deadlock (clamped to 1)
-// ---------------------------------------------------------------------------
 
 // TestEnumerateWith_ZeroThreadsDoesNotHang is a regression test for the bug
 // where passing threads=0 to EnumerateWith made errgroup.SetLimit(0) block
@@ -1191,9 +1103,6 @@ func TestEnumerateWith_ZeroThreadsDoesNotHang(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Test: EnumerateWith streaming race — non-nil callback under -race
-// ---------------------------------------------------------------------------
 //
 // This test extends TestEnumerate_ConcurrentRefreshNoRace to verify that the
 // streaming (onResult callback) surface is also race-clean when a concurrent

--- a/pkg/enum/teams/teams_hooks_test.go
+++ b/pkg/enum/teams/teams_hooks_test.go
@@ -41,7 +41,6 @@ import (
 	"github.com/praetorian-inc/brutus/pkg/enum"
 )
 
-// ---------------------------------------------------------------------------
 // TestWorker_Label
 // teams' pre-migration panic diagnostics were prefixed "teams enum"
 // (enum.go:227,231), yielding "teams enum: panic checking %s: %v" on stderr
@@ -49,7 +48,6 @@ import (
 // reproduces that prefix verbatim via Label, so this exact string must never
 // drift -- changing it is a log-format change for anything that greps stderr
 // or an EnumResult's Error text, not a cosmetic rename.
-// ---------------------------------------------------------------------------
 
 func TestWorker_Label(t *testing.T) {
 	t.Parallel()
@@ -60,7 +58,6 @@ func TestWorker_Label(t *testing.T) {
 	assert.Equal(t, "teams enum", e.worker().Label)
 }
 
-// ---------------------------------------------------------------------------
 // TestWorker_NewErrorShape
 //
 // teams' failure results carry Email, Exists AND Error -- Exists is the one
@@ -71,7 +68,6 @@ func TestWorker_Label(t *testing.T) {
 // individually -- is deliberate and load-bearing here: an assertion that
 // checked only Email and Error would pass even if Exists were left empty,
 // defeating the entire point of this test.
-// ---------------------------------------------------------------------------
 
 func TestWorker_NewErrorShape(t *testing.T) {
 	t.Parallel()
@@ -85,14 +81,12 @@ func TestWorker_NewErrorShape(t *testing.T) {
 	assert.Equal(t, EnumResult{Email: "a@b.com", Exists: ExistenceUnknown, Error: sentinel}, got)
 }
 
-// ---------------------------------------------------------------------------
 // TestWorker_StampNameCopiesFirstLastOnly
 // StampName's documented contract (targetworker.go) is a one-line copy of
 // First/Last from the originating Target. This asserts both halves of that
 // contract: First/Last land correctly, and every other field on an
 // already-populated EnumResult -- including Exists, teams' own tri-state
 // field -- is left untouched.
-// ---------------------------------------------------------------------------
 
 func TestWorker_StampNameCopiesFirstLastOnly(t *testing.T) {
 	t.Parallel()

--- a/pkg/enum/teams/teams_targets_test.go
+++ b/pkg/enum/teams/teams_targets_test.go
@@ -98,13 +98,11 @@ func newTargetsTestEnumerator(t *testing.T, srv *httptest.Server) *Enumerator {
 	return e
 }
 
-// ---------------------------------------------------------------------------
 // TestTeamsEnumerateTargetsWith_NamesRideOnResult
 // Core test: 3 targets with distinct names against a stub that reports
 // existence for all of them. Each returned EnumResult must carry the name of
 // the target that produced it, correlated by email. An implementation that
 // stamps every EnumResult with the first target's name fails this test.
-// ---------------------------------------------------------------------------
 
 func TestTeamsEnumerateTargetsWith_NamesRideOnResult(t *testing.T) {
 	t.Parallel()
@@ -137,11 +135,9 @@ func TestTeamsEnumerateTargetsWith_NamesRideOnResult(t *testing.T) {
 	assert.Equal(t, ExistenceYes, byEmail[registeredEmail].Exists, "registeredEmail must be reported as existing by the stub")
 }
 
-// ---------------------------------------------------------------------------
 // TestTeamsEnumerateTargetsWith_NamelessTargetStaysNameless
 // A Target with no name (address supplied by the operator, not generated)
 // must yield First=="" && Last=="". The library must never invent a name.
-// ---------------------------------------------------------------------------
 
 func TestTeamsEnumerateTargetsWith_NamelessTargetStaysNameless(t *testing.T) {
 	t.Parallel()
@@ -158,12 +154,10 @@ func TestTeamsEnumerateTargetsWith_NamelessTargetStaysNameless(t *testing.T) {
 	assert.Empty(t, results[0].Last, "Last must stay empty for a nameless Target")
 }
 
-// ---------------------------------------------------------------------------
 // TestTeamsEnumerateWith_StillWorksAndYieldsEmptyNames
 // Pins that the existing EnumerateWith([]string) entry point is unaffected by
 // the refactor: it still returns correct results, and since bare addresses
 // carry no name, First/Last must be empty.
-// ---------------------------------------------------------------------------
 
 func TestTeamsEnumerateWith_StillWorksAndYieldsEmptyNames(t *testing.T) {
 	t.Parallel()
@@ -191,12 +185,10 @@ func TestTeamsEnumerateWith_StillWorksAndYieldsEmptyNames(t *testing.T) {
 	assert.Equal(t, ExistenceYes, byEmail[registeredEmail].Exists, "registeredEmail must be reported as existing by the stub")
 }
 
-// ---------------------------------------------------------------------------
 // TestTeamsEnumerateTargetsWith_NamesSurviveErrorPath
 // A name is a property of the address, not of the check outcome. Drive an
 // EnumResult whose Error is non-nil (the mock server's 500 for failingEmail)
 // and assert the name is still stamped.
-// ---------------------------------------------------------------------------
 
 func TestTeamsEnumerateTargetsWith_NamesSurviveErrorPath(t *testing.T) {
 	t.Parallel()
@@ -220,11 +212,9 @@ func TestTeamsEnumerateTargetsWith_NamesSurviveErrorPath(t *testing.T) {
 	assert.Equal(t, "fail", r.Last, "name must survive even when the probe errors")
 }
 
-// ---------------------------------------------------------------------------
 // TestTeamsEnumerateTargetsWith_MixedNamedAndUnnamed
 // A single batch containing both named and unnamed targets: each EnumResult
 // must get exactly its own target's name, or empty for the unnamed ones.
-// ---------------------------------------------------------------------------
 
 func TestTeamsEnumerateTargetsWith_MixedNamedAndUnnamed(t *testing.T) {
 	t.Parallel()
@@ -256,12 +246,10 @@ func TestTeamsEnumerateTargetsWith_MixedNamedAndUnnamed(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // TestTeamsEnumerateTargetsWith_EveryTargetSlotFilled
 // len(results) == len(targets) and every target is present even when some
 // probes fail. Completion order is not asserted (the worker pool is
 // concurrent); correlation is by email only.
-// ---------------------------------------------------------------------------
 
 func TestTeamsEnumerateTargetsWith_EveryTargetSlotFilled(t *testing.T) {
 	t.Parallel()
@@ -298,7 +286,6 @@ func TestTeamsEnumerateTargetsWith_EveryTargetSlotFilled(t *testing.T) {
 	assert.NoError(t, byEmail["notfound@contoso.com"].Error)
 }
 
-// ---------------------------------------------------------------------------
 // TestTeamsEnumerateTargetsWith_NamesSurviveCancelledContext
 //
 // Chokepoint test: with the context already canceled before the call, every
@@ -317,7 +304,6 @@ func TestTeamsEnumerateTargetsWith_EveryTargetSlotFilled(t *testing.T) {
 // TestTeamsEnumerateWith_CanceledContextNowRecordsEverySlot below for the
 // same behavior change asserted through the unchanged EnumerateWith(
 // []string) entry point that cmd/brutus actually calls.
-// ---------------------------------------------------------------------------
 
 func TestTeamsEnumerateTargetsWith_NamesSurviveCancelledContext(t *testing.T) {
 	t.Parallel()
@@ -353,7 +339,6 @@ func TestTeamsEnumerateTargetsWith_NamesSurviveCancelledContext(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // TestTeamsEnumerateWith_CanceledContextNowRecordsEverySlot
 //
 // THE explicit before/after test for teams' abort-path behavior change
@@ -376,7 +361,6 @@ func TestTeamsEnumerateTargetsWith_NamesSurviveCancelledContext(t *testing.T) {
 // TestGithubEnumerateWith_CanceledContextNowRecordsEverySlot in
 // github_targets_test.go, where establishSession's own error handling
 // intercepts an already-canceled context before the pool ever runs).
-// ---------------------------------------------------------------------------
 
 func TestTeamsEnumerateWith_CanceledContextNowRecordsEverySlot(t *testing.T) {
 	t.Parallel()

--- a/pkg/enum/workers.go
+++ b/pkg/enum/workers.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// pkg/enum/workers.go
 package enum
 
 import (
@@ -44,13 +43,11 @@ type enumTask struct {
 // runWorkers executes enumeration checks using a bounded worker pool.
 // Iterates emails x services, applying rate limiting and jitter.
 func runWorkers(ctx context.Context, cfg *Config) ([]Result, error) {
-	// Resolve services to check
 	services := cfg.Services
 	if len(services) == 0 {
 		services = ListPlugins()
 	}
 
-	// Build task list: targets x services
 	var tasks []enumTask
 	for _, target := range cfg.resolveTargets() {
 		for _, svcName := range services {
@@ -76,7 +73,6 @@ func runWorkers(ctx context.Context, cfg *Config) ([]Result, error) {
 // recovery. It is the shared execution core for both the registry-keyed
 // runWorkers and the registry-bypassing EnumerateWithPlugin.
 func runTasks(ctx context.Context, cfg *Config, tasks []enumTask) ([]Result, error) {
-	// Setup errgroup with bounded concurrency
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -100,13 +96,11 @@ func runTasks(ctx context.Context, cfg *Config, tasks []enumTask) ([]Result, err
 	}
 	g.SetLimit(threads)
 
-	// Rate limiter
 	var limiter *rate.Limiter
 	if cfg.RateLimit > 0 {
 		limiter = rate.NewLimiter(rate.Limit(cfg.RateLimit), 1)
 	}
 
-	// Result collection
 	var (
 		results []Result
 		mu      sync.Mutex
@@ -136,7 +130,6 @@ func runTasks(ctx context.Context, cfg *Config, tasks []enumTask) ([]Result, err
 			default:
 			}
 
-			// Rate limiting
 			if limiter != nil {
 				if err := limiter.Wait(ctx); err != nil {
 					return nil

--- a/pkg/sdk/capability.go
+++ b/pkg/sdk/capability.go
@@ -87,12 +87,10 @@ func (c *Capability) Invoke(ctx capability.ExecutionContext, input capmodel.Port
 		return fmt.Errorf("no protocol specified and port has no service detected")
 	}
 
-	// Validate port number
 	if input.Port < 1 || input.Port > 65535 {
 		return fmt.Errorf("invalid port number: %d", input.Port)
 	}
 
-	// Validate hostname
 	if input.Parent.DNS == "" {
 		return fmt.Errorf("no hostname specified in port parent asset")
 	}


### PR DESCRIPTION
## Summary
- Remove decorative `// ---` / `// ===` section banners across tests and production code.
- Strip comments that only restated the next line of code (workers, plugins, kerberos, analyzers).
- Replace leftover `pkg/enum/foo.go` file-path package comments with a real `enum` package doc.
- Drop obsolete loop-variable copies (`cred := cred`) that Go 1.22+ makes unnecessary.

Godoc and comments that explain *why* are left in place.

## Test plan
- [x] `go test -short ./...`
- [x] `go vet ./...`