### PR TITLE
style: strip remaining restating comments

### DIFF
--- a/cmd/brutus/cmd_enum_github_map_test.go
+++ b/cmd/brutus/cmd_enum_github_map_test.go
@@ -105,7 +105,6 @@ func TestCollectGithubEmails(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			// Build the sentinel error for this case (so we can use errors.Is).
 			sentinel := tc.noSourceErr

--- a/cmd/brutus/cmd_enum_github_test.go
+++ b/cmd/brutus/cmd_enum_github_test.go
@@ -377,7 +377,6 @@ func TestOutputGithubEnumJSONL(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
 			outputGithubEnumJSONL(&buf, []githubenum.Result{tc.result})

--- a/cmd/brutus/cmd_enum_google_test.go
+++ b/cmd/brutus/cmd_enum_google_test.go
@@ -141,7 +141,6 @@ func TestOutputGoogleEnumJSONL(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
 			outputGoogleEnumJSONL(&buf, []google.Result{tc.result})

--- a/cmd/brutus/cmd_enum_microsoft365_test.go
+++ b/cmd/brutus/cmd_enum_microsoft365_test.go
@@ -149,7 +149,6 @@ func TestEncodeMicrosoft365EnumResult(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
 			enc := json.NewEncoder(&buf)

--- a/cmd/brutus/cmd_enum_oracles.go
+++ b/cmd/brutus/cmd_enum_oracles.go
@@ -187,7 +187,6 @@ func runEnumOracles(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--domain, --emails/-e, or --email-file/-E is required (or pass a --known-valid address with a domain)")
 	}
 
-	// Setup output writer
 	jsonWriter, forceJSON, closeOutput, err := setupOutputWriter(flagOutputFile)
 	if err != nil {
 		return err
@@ -235,10 +234,8 @@ func runEnumOracles(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Phase 2: Build email list
 	var emails []string
 
-	// From --emails flag
 	if flagOraclesEmails != "" {
 		for _, e := range strings.Split(flagOraclesEmails, ",") {
 			e = strings.TrimSpace(e)
@@ -248,7 +245,6 @@ func runEnumOracles(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// From --email-file flag
 	if flagOraclesEmailFile != "" {
 		fileEmails, loadErr := loadLinesFromFile(flagOraclesEmailFile)
 		if loadErr != nil {
@@ -279,7 +275,6 @@ func runEnumOracles(cmd *cobra.Command, args []string) error {
 	// what was checked even when there are no emails to enumerate.
 	checkLabel := oracleCheckLabel(emails)
 
-	// Phase 3: Determine oracles to check
 	var services []string
 	if flagOraclesServices != "" {
 		for _, s := range strings.Split(flagOraclesServices, ",") {
@@ -309,7 +304,7 @@ func runEnumOracles(cmd *cobra.Command, args []string) error {
 	}
 	// If still empty, enum.Config.Services=nil means "all registered"
 
-	// Phase 3.5: Oracle check against the known-valid email — THE HEADLINE.
+	// Oracle check against the known-valid email — THE HEADLINE.
 	// --known-valid is a required flag, so this validation always runs before
 	// enumeration. It reports, per oracle, whether the oracle WORKED or NOT, and
 	// enumeration is restricted to the oracles that confirmed the known-valid
@@ -405,7 +400,6 @@ func runEnumOracles(cmd *cobra.Command, args []string) error {
 			dim(useColor, SymbolInfo), len(emails), len(svcNames), strings.Join(svcNames, ", "))
 	}
 
-	// Phase 4: Run enumeration against the working oracles
 	cfg := &enum.Config{
 		Emails:    emails,
 		Services:  services,
@@ -422,7 +416,6 @@ func runEnumOracles(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("enumeration failed: %w", err)
 	}
 
-	// Phase 5: Output results
 	if flagJSON {
 		if dnsResult != nil {
 			outputDNSReconJSONL(jsonWriter, dnsResult, teamsOracleAvailable(dnsResult))
@@ -456,7 +449,6 @@ func runEnumDiscover(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Phase 1: Determine oracles to test
 	var services []string
 	teamsRequested := false
 	if flagOraclesServices != "" {
@@ -511,7 +503,6 @@ func runEnumDiscover(cmd *cobra.Command, args []string) error {
 				dim(useColor, SymbolInfo), len(services), flagOraclesKnownValid)
 		}
 
-		// Phase 2: Test oracles
 		cfg := &enum.Config{
 			Emails:   []string{flagOraclesKnownValid},
 			Services: services,
@@ -527,7 +518,7 @@ func runEnumDiscover(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Phase 2.5: Opportunistically confirm the Teams oracle. Attempt only when
+	// Opportunistically confirm the Teams oracle. Attempt only when
 	// the org looks like M365 (microsoft365 discovered) or the user explicitly
 	// asked for teams via -s. Resolution and printing handle the no-token case
 	// gracefully (no error). teams is never run through the unauthenticated
@@ -537,7 +528,6 @@ func runEnumDiscover(cmd *cobra.Command, args []string) error {
 		teamsLine = confirmTeamsOracle(ctx, flagOraclesKnownValid, useColor)
 	}
 
-	// Phase 3: Output results
 	if flagJSON {
 		outputEnumJSONL(jsonWriter, results)
 		if teamsLine != "" {

--- a/cmd/brutus/cmd_enum_oracles.go
+++ b/cmd/brutus/cmd_enum_oracles.go
@@ -204,7 +204,7 @@ func runEnumOracles(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Phase 1: DNS TXT recon — supporting context, not the headline. Surfaces
+	// DNS TXT recon is supporting context, not the headline. Surfaces
 	// the candidate oracles so the oracle check below has something to validate.
 	// Full TXT detail stays under --verbose and in JSON; the human path leads
 	// with a single "Discovered candidate oracles" line.

--- a/cmd/brutus/cmd_enum_oracles_teams_test.go
+++ b/cmd/brutus/cmd_enum_oracles_teams_test.go
@@ -95,7 +95,6 @@ func TestTeamsOracleAvailable(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			got := teamsOracleAvailable(tc.result)
 			assert.Equal(t, tc.want, got,
@@ -335,7 +334,6 @@ func TestTeamsDiscoverLine_Mapping(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			line := teamsDiscoverLine(&tc.result)
 

--- a/cmd/brutus/cmd_enum_output_teams_test.go
+++ b/cmd/brutus/cmd_enum_output_teams_test.go
@@ -87,7 +87,6 @@ func TestOutputTeamsEnumResultLine_AccountType(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
 			outputTeamsEnumResultLine(&buf, &tc.result, false /* useColor */)
@@ -141,7 +140,6 @@ func TestOutputTeamsEnumResultLine_Sanitizes(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
 			outputTeamsEnumResultLine(&buf, &tc.result, false)
@@ -206,7 +204,6 @@ func TestOutputTeamsEnumJSONL_AccountType(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
 			outputTeamsEnumJSONL(&buf, []teams.EnumResult{tc.result})

--- a/cmd/brutus/cmd_enum_teams_audit_test.go
+++ b/cmd/brutus/cmd_enum_teams_audit_test.go
@@ -331,7 +331,6 @@ func TestOutputTeamsAuditHuman_SeverityLabels(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(string(tc.severity), func(t *testing.T) {
 			findings := []teams.Finding{
 				{

--- a/cmd/brutus/cmd_enum_teams_test.go
+++ b/cmd/brutus/cmd_enum_teams_test.go
@@ -317,7 +317,6 @@ func TestTeamsEnumDomain(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			got := teamsEnumDomain(tc.emails)
 			assert.Equal(t, tc.want, got)

--- a/cmd/brutus/cmd_logon.go
+++ b/cmd/brutus/cmd_logon.go
@@ -194,7 +194,6 @@ func runLogonChecks(cmd *cobra.Command, checks logon.Check) error {
 		return protocol == "rdp"
 	}
 
-	// Build logon-specific config
 	lc := &logonConfig{
 		execCmd:     flagExec,
 		webTerminal: flagWeb,
@@ -215,7 +214,6 @@ func runLogonChecks(cmd *cobra.Command, checks logon.Check) error {
 		flagJSON = true
 	}
 
-	// Show banner
 	if shouldShowBanner(flagJSON, useStdin, flagQuiet, base.useColor) {
 		printBanner(base.useColor)
 	}
@@ -224,7 +222,6 @@ func runLogonChecks(cmd *cobra.Command, checks logon.Check) error {
 	isDetectMode := lc.execCmd == "" && !lc.webTerminal
 
 	if isDetectMode {
-		// Scan/detection mode
 		var findings []logon.Finding
 
 		// A pump phase can only settle after rdp.MinViableTimeout of evidence; a

--- a/cmd/brutus/cmd_web.go
+++ b/cmd/brutus/cmd_web.go
@@ -82,7 +82,6 @@ func runWeb(cmd *cobra.Command, args []string) error {
 		}
 		base.llmConfig = llmCfg
 	}
-	// Build web-specific config
 	wc := &webConfig{
 		browserTimeout: flagBrowserTimeout,
 		browserTabs:    flagBrowserTabs,

--- a/cmd/brutus/fingerprint.go
+++ b/cmd/brutus/fingerprint.go
@@ -100,7 +100,6 @@ func fingerprintSingleTarget(target string, base *runConfig) (*fingerprintedServ
 func fingerprintTargets(targets []string, base *runConfig) (context.CancelFunc, []nervaplugins.Service, bool) {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 
-	// Phase 1: Parse host:port strings into Nerva targets.
 	var nervaTargets []nervaplugins.Target
 	for _, t := range targets {
 		nt, err := brutusinput.ParseNervaTarget(ctx, t)
@@ -116,7 +115,6 @@ func fingerprintTargets(targets []string, base *runConfig) (context.CancelFunc, 
 		return nil, nil, false
 	}
 
-	// Phase 2: Fingerprint with Nerva.
 	if !base.quiet {
 		fmt.Fprintf(os.Stderr, "%s Fingerprinting %d target(s) with Nerva...\n",
 			dim(base.useColor, SymbolInfo), len(nervaTargets))

--- a/cmd/brutus/logon_flags_wiring_test.go
+++ b/cmd/brutus/logon_flags_wiring_test.go
@@ -224,7 +224,6 @@ func TestScanTimeoutFlagWiring(t *testing.T) {
 // rejects it.
 func TestTimeoutRejectedOnLogonFamily(t *testing.T) {
 	for _, cmd := range []*cobra.Command{logonCmd, stickykeysCmd, utilmanCmd} {
-		cmd := cmd // capture range var
 		t.Run(cmd.Use+"_rejects_timeout_flag", func(t *testing.T) {
 			resetLogonFlags()
 			t.Cleanup(func() { resetTimeoutFlag(t) })

--- a/cmd/brutus/progress_test.go
+++ b/cmd/brutus/progress_test.go
@@ -119,7 +119,6 @@ func TestFormatDuration(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, tc.expected, formatDuration(tc.input))
@@ -177,7 +176,6 @@ func TestProgressRate(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, tc.expected, progressRate(tc.processed, tc.elapsed))

--- a/cmd/brutus/runner.go
+++ b/cmd/brutus/runner.go
@@ -151,7 +151,6 @@ func runFromStdin(base *runConfig, jsonOut bool) ([]brutus.Result, bool) {
 		errMsg(base.useColor, "reading stdin: %v", err)
 	}
 
-	// Phase 2: batch-fingerprint bare host:port targets via Nerva.
 	if len(bareTargets) > 0 {
 		fpResults, fpSuccess := runFromFingerprint(bareTargets, base, jsonOut)
 		allResults = append(allResults, fpResults...)
@@ -304,7 +303,6 @@ func runSingleTarget(target, protocol, tlsMode string, base *runConfig, aiCreds 
 		ProxyURL:        base.proxyURL,
 	}
 
-	// Handle HTTP with AI-researched credentials
 	if (protocol == "http" || protocol == "https") && len(aiCreds) > 0 {
 		config.Usernames = nil
 		config.Passwords = nil
@@ -313,7 +311,6 @@ func runSingleTarget(target, protocol, tlsMode string, base *runConfig, aiCreds 
 		logVerbose(base.verbose, "Using %d AI-researched credentials for HTTP (+ admin:admin fallback)", len(aiCreds))
 	}
 
-	// Handle browser-specific configuration
 	if protocol == "browser" && base.web != nil {
 		config.Threads = base.web.browserTabs
 		config.Timeout = base.web.browserTimeout
@@ -371,18 +368,15 @@ func runSingleTarget(target, protocol, tlsMode string, base *runConfig, aiCreds 
 		totalAttempts, config.Threads, config.Timeout)
 	logVerbose(base.verbose, "Starting brute force...")
 
-	// Create context that cancels on SIGINT/SIGTERM
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	// Run brute force with context
 	results, err := brutus.BruteWithContext(ctx, config)
 	if err != nil {
 		errMsg(base.useColor, "testing %s: %v", target, err)
 		return nil, false
 	}
 
-	// Check for success
 	hasSuccess := false
 	successCount := 0
 	for i := range results {

--- a/cmd/brutus/scan_tuning_flags_wiring_test.go
+++ b/cmd/brutus/scan_tuning_flags_wiring_test.go
@@ -31,7 +31,6 @@ var scanTuningFlagNames = []string{"connect-timeout", "mode", "retries"}
 // flags on rootCmd.
 func TestScanTuningFlags_NotOnRoot(t *testing.T) {
 	for _, name := range scanTuningFlagNames {
-		name := name
 		t.Run(name, func(t *testing.T) {
 			assert.Nil(t, rootCmd.PersistentFlags().Lookup(name),
 				"rootCmd must not have --%s as a persistent flag", name)
@@ -71,7 +70,6 @@ func TestScanTuningFlags_OnScanCommands(t *testing.T) {
 // scan-tuning flags, confirming the enum subtree is isolated from them.
 func TestScanTuningFlags_NotInheritedByEnumLeaf(t *testing.T) {
 	for _, name := range scanTuningFlagNames {
-		name := name
 		t.Run(name, func(t *testing.T) {
 			assert.Nil(t, enumGithubCmd.InheritedFlags().Lookup(name),
 				"enumGithubCmd must not inherit --%s", name)

--- a/internal/enumplugins/gravatar/gravatar_test.go
+++ b/internal/enumplugins/gravatar/gravatar_test.go
@@ -84,7 +84,6 @@ func TestCheck(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := contextWithStatus(tc.status)
 

--- a/internal/enumplugins/microsoft365/microsoft365_test.go
+++ b/internal/enumplugins/microsoft365/microsoft365_test.go
@@ -112,7 +112,6 @@ func TestCheck_MapsIfExistsResultToConfidence(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := contextWithCredTypeResponse(t, tc.ifExistsResult, 0)
 

--- a/internal/plugins/browser/browser.go
+++ b/internal/plugins/browser/browser.go
@@ -90,18 +90,15 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	// Set visible mode before getting browser (must be before first GetBrowser call)
 	SetBrowserVisible(p.Visible)
 
-	// Get browser instance
 	browser, err := GetBrowser(p.TabCount)
 	if err != nil {
 		result.Error = fmt.Errorf("browser error: %w", err)
 		return result
 	}
 
-	// Acquire a tab
 	tabCtx, release := browser.AcquireTab()
 	defer release()
 
-	// Build URL
 	url := buildURL(target, p.UseHTTPS)
 
 	if p.Verbose {
@@ -234,7 +231,6 @@ func (p *Plugin) AnalyzePage(ctx context.Context, target string) (*claude.PageAn
 	// Set visible mode before getting browser (must be before first GetBrowser call)
 	SetBrowserVisible(p.Visible)
 
-	// Get browser instance
 	browser, err := GetBrowser(p.TabCount)
 	if err != nil {
 		return nil, nil, fmt.Errorf("browser error: %w", err)
@@ -244,11 +240,9 @@ func (p *Plugin) AnalyzePage(ctx context.Context, target string) (*claude.PageAn
 		_, _ = fmt.Fprintf(logOutput, "[verbose] Browser started, acquiring tab...\n")
 	}
 
-	// Acquire a tab
 	tabCtx, release := browser.AcquireTab()
 	defer release()
 
-	// Build URL
 	url := buildURL(target, p.UseHTTPS)
 
 	if p.Verbose {

--- a/internal/plugins/browser/chrome.go
+++ b/internal/plugins/browser/chrome.go
@@ -46,7 +46,6 @@ func GetBrowser(tabCount int) (*Browser, error) {
 
 // startBrowser initializes Chrome and creates the tab pool
 func startBrowser(tabCount int, visible bool) (*Browser, error) {
-	// Create allocator context - headless unless visible mode is enabled
 	opts := append(chromedp.DefaultExecAllocatorOptions[:],
 		chromedp.Flag("headless", !visible),
 		chromedp.Flag("disable-gpu", !visible), // GPU can be enabled when visible
@@ -54,7 +53,6 @@ func startBrowser(tabCount int, visible bool) (*Browser, error) {
 		chromedp.Flag("disable-dev-shm-usage", true),
 	)
 
-	// Add window size for visible mode
 	if visible {
 		opts = append(opts,
 			chromedp.WindowSize(1280, 900),
@@ -63,7 +61,6 @@ func startBrowser(tabCount int, visible bool) (*Browser, error) {
 
 	allocCtx, cancel := chromedp.NewExecAllocator(context.Background(), opts...)
 
-	// Create browser context
 	browserCtx, _ := chromedp.NewContext(allocCtx)
 
 	// Start the browser by running an empty task
@@ -91,16 +88,12 @@ func startBrowser(tabCount int, visible bool) (*Browser, error) {
 // AcquireTab creates a fresh tab context (blocks if max tabs reached).
 // Each call creates a new tab to avoid state corruption issues with tab reuse.
 func (b *Browser) AcquireTab() (tabCtx context.Context, release func()) {
-	// Wait for semaphore slot
 	<-b.tabSem
 
-	// Create fresh tab context for this operation
 	tabCtx, tabCancel := chromedp.NewContext(b.browserCtx)
 
 	return tabCtx, func() {
-		// Close this tab when done
 		tabCancel()
-		// Return semaphore slot
 		b.tabSem <- struct{}{}
 	}
 }

--- a/internal/plugins/browser/e2e_test.go
+++ b/internal/plugins/browser/e2e_test.go
@@ -101,7 +101,6 @@ func TestE2E_ValidCredentials(t *testing.T) {
 	}
 
 	for _, tc := range deviceTestCases {
-		tc := tc // capture range variable
 		t.Run(tc.name+"_ValidLogin", func(t *testing.T) {
 			if !isServiceAvailable(tc.port) {
 				t.Skipf("Mock service not running on port %d - run: docker-compose -f testdata/docker-compose.yml up -d", tc.port)
@@ -143,7 +142,6 @@ func TestE2E_InvalidCredentials(t *testing.T) {
 	}
 
 	for _, tc := range deviceTestCases {
-		tc := tc
 		t.Run(tc.name+"_InvalidLogin", func(t *testing.T) {
 			if !isServiceAvailable(tc.port) {
 				t.Skipf("Mock service not running on port %d", tc.port)
@@ -180,7 +178,6 @@ func TestE2E_FormDetection(t *testing.T) {
 	}
 
 	for _, tc := range deviceTestCases {
-		tc := tc
 		t.Run(tc.name+"_FormDetection", func(t *testing.T) {
 			if !isServiceAvailable(tc.port) {
 				t.Skipf("Mock service not running on port %d", tc.port)
@@ -234,7 +231,6 @@ func TestE2E_ErrorMessageDetection(t *testing.T) {
 	}
 
 	for _, tc := range deviceTestCases {
-		tc := tc
 		t.Run(tc.name+"_ErrorDetection", func(t *testing.T) {
 			if !isServiceAvailable(tc.port) {
 				t.Skipf("Mock service not running on port %d", tc.port)
@@ -289,7 +285,6 @@ func TestE2E_SuccessfulLoginVerification(t *testing.T) {
 	}
 
 	for _, tc := range deviceTestCases {
-		tc := tc
 		t.Run(tc.name+"_SuccessVerification", func(t *testing.T) {
 			if !isServiceAvailable(tc.port) {
 				t.Skipf("Mock service not running on port %d", tc.port)

--- a/internal/plugins/cassandra/cassandra.go
+++ b/internal/plugins/cassandra/cassandra.go
@@ -56,7 +56,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	result := brutus.NewResult("cassandra", target, username, password)
 	defer func() { result.Duration = time.Since(start) }()
 
-	// Create cluster configuration
 	cluster := gocql.NewCluster(target)
 	cluster.Authenticator = gocql.PasswordAuthenticator{
 		Username: username,
@@ -69,7 +68,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	// don't enable TLS, and forcing TLS when the server doesn't support
 	// it causes "first record does not look like a TLS handshake" errors
 
-	// Create session with context
 	session, err := cluster.CreateSession()
 	if err != nil {
 		result.Error = classifyError(err)
@@ -77,18 +75,15 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	}
 	defer session.Close()
 
-	// Test connection with a simple query
 	queryCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	// Query system.local to verify authentication and connection
 	iter := session.Query("SELECT now() FROM system.local").WithContext(queryCtx).Iter()
 	if err := iter.Close(); err != nil {
 		result.Error = classifyError(err)
 		return result
 	}
 
-	// Success
 	result.Success = true
 	return result
 }

--- a/internal/plugins/ftp/ftp.go
+++ b/internal/plugins/ftp/ftp.go
@@ -57,7 +57,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	result := brutus.NewResult("ftp", target, username, password)
 	defer func() { result.Duration = time.Since(start) }()
 
-	// Connect with context-aware timeout
 	conn, err := brutus.DialWithProxy(ctx, "tcp", target, timeout, pluginCfg.ProxyURL)
 	if err != nil {
 		result.Error = brutus.WrapConnError(err)
@@ -65,7 +64,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	}
 	defer func() { _ = conn.Close() }()
 
-	// Set overall deadline for FTP operations
 	_ = conn.SetDeadline(time.Now().Add(timeout))
 
 	reader := bufio.NewReader(conn)
@@ -77,7 +75,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		return result
 	}
 
-	// Send USER command
 	_, err = fmt.Fprintf(conn, "USER %s\r\n", username)
 	if err != nil {
 		result.Error = classifyAuthError(err)
@@ -109,7 +106,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		return result
 	}
 
-	// Send PASS command
 	_, err = fmt.Fprintf(conn, "PASS %s\r\n", password)
 	if err != nil {
 		result.Error = classifyAuthError(err)
@@ -123,7 +119,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		return result
 	}
 
-	// Check authentication result
 	switch {
 	case strings.HasPrefix(response, "230"):
 		result.Success = true

--- a/internal/plugins/http/http.go
+++ b/internal/plugins/http/http.go
@@ -139,7 +139,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		req.SetBasicAuth(username, password)
 	}
 
-	// Execute request
 	resp, err := client.Do(req)
 	if err != nil {
 		result.Error = brutus.WrapConnError(err)
@@ -150,22 +149,16 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	// Read limited response body for banner
 	bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, MaxBodyRead))
 
-	// Build banner from HTTP response (for LLM analysis)
 	result.Banner = buildHTTPBanner(resp, bodyBytes)
 
-	// Classify response
 	switch {
 	case resp.StatusCode >= 200 && resp.StatusCode < 300:
-		// Success - valid credentials
 		result.Success = true
 
 	case resp.StatusCode == http.StatusUnauthorized,
 		resp.StatusCode == http.StatusForbidden:
-		// Auth failure - invalid credentials
-		// Return Success=false, Error=nil
 
 	default:
-		// Unexpected status - treat as error
 		result.Error = fmt.Errorf("connection error: HTTP %d", resp.StatusCode)
 	}
 

--- a/internal/plugins/http/http.go
+++ b/internal/plugins/http/http.go
@@ -87,13 +87,10 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	result := brutus.NewResult(p.Name(), target, username, password)
 	defer func() { result.Duration = time.Since(start) }()
 
-	// Build URL
 	url := p.buildURL(target)
 
-	// Read TLS mode from context
 	tlsMode := pluginCfg.TLSMode
 
-	// Helper to create HTTP clients with consistent config (proxy-aware)
 	tlsCfg := brutus.BuildTLSConfig(tlsMode)
 	newClient := func() (*http.Client, error) {
 		c, err := brutus.NewHTTPClientWithProxy(timeout, tlsCfg, pluginCfg.ProxyURL)
@@ -126,15 +123,13 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	}
 	defer client.CloseIdleConnections()
 
-	// Create request
 	req, err := http.NewRequestWithContext(ctx, "GET", url, http.NoBody)
 	if err != nil {
 		result.Error = brutus.WrapConnError(err)
 		return result
 	}
 
-	// Set Basic Auth header
-	// Empty username/password is used for banner capture
+	// Empty username/password is used for banner capture.
 	if username != "" || password != "" {
 		req.SetBasicAuth(username, password)
 	}
@@ -202,7 +197,6 @@ func (p *Plugin) buildURL(target string) string {
 		path = DefaultPath
 	}
 
-	// Handle target that may or may not have port
 	return fmt.Sprintf("%s://%s%s", scheme, target, path)
 }
 

--- a/internal/plugins/imap/imap.go
+++ b/internal/plugins/imap/imap.go
@@ -58,15 +58,12 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	result := brutus.NewResult("imap", target, username, password)
 	defer func() { result.Duration = time.Since(start) }()
 
-	// Parse target to extract host and port
 	host, port := brutus.ParseTarget(target, "143")
 	addr := fmt.Sprintf("%s:%s", host, port)
 
-	// Create context with timeout
 	dialCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	// Create options
 	options := &imapclient.Options{}
 
 	// Dial IMAP server. brutus.DialWithProxy honors the connect timeout and,
@@ -81,21 +78,17 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	client := imapclient.New(conn, options)
 	defer func() { _ = client.Close() }()
 
-	// Check if context was canceled during dial
 	if dialCtx.Err() != nil {
 		result.Error = classifyError(dialCtx.Err())
 		return result
 	}
 
-	// Create context with timeout for login
 	loginCtx, loginCancel := context.WithTimeout(ctx, timeout)
 	defer loginCancel()
 
-	// Attempt LOGIN authentication
 	loginCmd := client.Login(username, password)
 	err := loginCmd.Wait()
 
-	// Check if context was canceled during login
 	if loginCtx.Err() != nil {
 		result.Error = classifyError(loginCtx.Err())
 		return result
@@ -106,7 +99,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		return result
 	}
 
-	// Success
 	result.Success = true
 	return result
 }

--- a/internal/plugins/integration_test.go
+++ b/internal/plugins/integration_test.go
@@ -222,7 +222,6 @@ func TestAllProtocols(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc // capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/plugins/ldap/ldap.go
+++ b/internal/plugins/ldap/ldap.go
@@ -75,21 +75,16 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		return result
 	}
 
-	// Parse target to extract host and port
 	host, port := brutus.ParseTarget(target, "389")
 
-	// Build LDAP URL
 	ldapURL := fmt.Sprintf("ldap://%s:%s", host, port)
 	if port == "636" {
 		ldapURL = fmt.Sprintf("ldaps://%s:%s", host, port)
 	}
 
-	// Connect to LDAP server with timeout
-	// Read TLS mode from context
 	tlsMode := pluginCfg.TLSMode
 
-	// Configure TLS based on mode
-	// Note: For LDAP, even "disable" needs TLS config for LDAPS (port 636)
+	// For LDAP, even "disable" needs TLS config for LDAPS (port 636).
 	var tlsConfig *tls.Config
 	switch tlsMode {
 	case "verify":
@@ -128,7 +123,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 			}
 			conn = tlsConn
 		}
-		// Wrap the connection into an LDAP connection
 		ldapConn := ldap.NewConn(conn, isTLS)
 		ldapConn.Start()
 		defer func() { _ = ldapConn.Close() }()
@@ -154,13 +148,10 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	}
 	defer func() { _ = conn.Close() }()
 
-	// Set operation timeout
 	conn.SetTimeout(timeout)
 
-	// Try binding with simple username first
 	err = conn.Bind(username, password)
 	if err == nil {
-		// Success with simple username
 		result.Success = true
 		return result
 	}
@@ -169,7 +160,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	// The previous dc=example,dc=com DN patterns were dead code that never
 	// matched real LDAP directories.
 
-	// Classify the error
 	result.Error = classifyError(err)
 	return result
 }

--- a/internal/plugins/mssql/mssql.go
+++ b/internal/plugins/mssql/mssql.go
@@ -57,13 +57,10 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	result := brutus.NewResult("mssql", target, username, password)
 	defer func() { result.Duration = time.Since(start) }()
 
-	// Build MSSQL connection string
-	// Format: sqlserver://username:password@host:port?database=master
-	// TrustServerCertificate=true and encrypt=disable allow connections without cert validation
+	// TrustServerCertificate=true and encrypt=disable allow connections without cert validation.
 	connStr := fmt.Sprintf("sqlserver://%s:%s@%s?database=master&connection+timeout=%d&encrypt=disable&TrustServerCertificate=true",
 		username, password, target, int(timeout.Seconds()))
 
-	// Open database connection
 	db, err := sql.Open("sqlserver", connStr)
 	if err != nil {
 		result.Error = brutus.WrapConnError(err)
@@ -71,23 +68,19 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	}
 	defer func() { _ = db.Close() }()
 
-	// Set connection timeout
 	db.SetConnMaxLifetime(timeout)
 	db.SetMaxIdleConns(1)
 	db.SetMaxOpenConns(1)
 
-	// Create context with timeout
 	pingCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	// Test connection with ping
 	err = db.PingContext(pingCtx)
 	if err != nil {
 		result.Error = brutus.ClassifyAuthError(err, mssqlAuthIndicators)
 		return result
 	}
 
-	// Success
 	result.Success = true
 	return result
 }

--- a/internal/plugins/mysql/mysql.go
+++ b/internal/plugins/mysql/mysql.go
@@ -52,10 +52,8 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	result := brutus.NewResult("mysql", target, username, password)
 	defer func() { result.Duration = time.Since(start) }()
 
-	// Read TLS mode from context
 	tlsMode := pluginCfg.TLSMode
 
-	// Determine TLS parameter based on mode
 	var tlsParam string
 	switch tlsMode {
 	case "verify":
@@ -66,7 +64,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		tlsParam = "tls=false"
 	}
 
-	// Create DSN (Data Source Name)
 	dsn := fmt.Sprintf("%s:%s@tcp(%s)/?%s", username, password, target, tlsParam)
 
 	db, err := sql.Open("mysql", dsn)

--- a/internal/plugins/mysql/mysql.go
+++ b/internal/plugins/mysql/mysql.go
@@ -69,7 +69,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	// Create DSN (Data Source Name)
 	dsn := fmt.Sprintf("%s:%s@tcp(%s)/?%s", username, password, target, tlsParam)
 
-	// Open database connection
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {
 		result.Error = brutus.WrapConnError(err)
@@ -77,23 +76,19 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	}
 	defer func() { _ = db.Close() }()
 
-	// Set connection timeout
 	db.SetConnMaxLifetime(timeout)
 	db.SetMaxIdleConns(1)
 	db.SetMaxOpenConns(1)
 
-	// Create context with timeout
 	pingCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	// Test connection with ping
 	err = db.PingContext(pingCtx)
 	if err != nil {
 		result.Error = classifyError(err)
 		return result
 	}
 
-	// Success
 	result.Success = true
 	return result
 }

--- a/internal/plugins/neo4j/neo4j.go
+++ b/internal/plugins/neo4j/neo4j.go
@@ -58,16 +58,10 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	result := brutus.NewResult("neo4j", target, username, password)
 	defer func() { result.Duration = time.Since(start) }()
 
-	// Build Neo4j Bolt URI
 	uri := fmt.Sprintf("bolt://%s", target)
-
-	// Create authentication token
 	auth := neo4j.BasicAuth(username, password, "")
-
-	// Read TLS mode from context
 	tlsMode := pluginCfg.TLSMode
 
-	// Create driver with TLS config
 	driver, err := neo4j.NewDriverWithContext(uri, auth, func(c *config.Config) {
 		c.TlsConfig = brutus.BuildTLSConfig(tlsMode)
 	})
@@ -77,18 +71,15 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	}
 	defer func() { _ = driver.Close(ctx) }()
 
-	// Create context with timeout for verification
 	verifyCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	// Verify connectivity and authentication
 	err = driver.VerifyConnectivity(verifyCtx)
 	if err != nil {
 		result.Error = classifyError(err)
 		return result
 	}
 
-	// Success
 	result.Success = true
 	return result
 }

--- a/internal/plugins/pop3/pop3.go
+++ b/internal/plugins/pop3/pop3.go
@@ -53,7 +53,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	result := brutus.NewResult("pop3", target, username, password)
 	defer func() { result.Duration = time.Since(start) }()
 
-	// Connect with context-aware timeout
 	conn, err := brutus.DialWithProxy(ctx, "tcp", target, timeout, pluginCfg.ProxyURL)
 	if err != nil {
 		result.Error = brutus.WrapConnError(err)
@@ -61,7 +60,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	}
 	defer func() { _ = conn.Close() }()
 
-	// Set overall deadline for POP3 operations
 	_ = conn.SetDeadline(time.Now().Add(timeout))
 
 	reader := bufio.NewReader(conn)
@@ -73,7 +71,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		return result
 	}
 
-	// Send USER command
 	_, err = fmt.Fprintf(conn, "USER %s\r\n", username)
 	if err != nil {
 		result.Error = classifyAuthError(err)
@@ -100,7 +97,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		return result
 	}
 
-	// Send PASS command
 	_, err = fmt.Fprintf(conn, "PASS %s\r\n", password)
 	if err != nil {
 		result.Error = classifyAuthError(err)
@@ -114,7 +110,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		return result
 	}
 
-	// Check authentication result
 	switch {
 	case strings.HasPrefix(response, "+OK"):
 		result.Success = true

--- a/internal/plugins/postgresql/postgresql.go
+++ b/internal/plugins/postgresql/postgresql.go
@@ -87,10 +87,8 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	result := brutus.NewResult("postgresql", target, username, password)
 	defer func() { result.Duration = time.Since(start) }()
 
-	// Parse target to extract host and port
 	host, port := brutus.ParseTarget(target, "5432")
 
-	// Build PostgreSQL connection string.
 	// Default to dbname=postgres (the system database that always exists),
 	// consistent with how the MSSQL plugin defaults to database=master.
 	// Without this, lib/pq defaults to dbname=<username> which fails when
@@ -99,7 +97,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	connStr := fmt.Sprintf("dbname=postgres user=%s password=%s host=%s port=%s sslmode=%s connect_timeout=%d",
 		username, password, host, port, sslMode(pluginCfg.TLSMode), int(timeout.Seconds()))
 
-	// Open database connection
 	db, err := sql.Open("postgres", connStr)
 	if err != nil {
 		result.Error = classifyError(err)
@@ -107,18 +104,15 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	}
 	defer func() { _ = db.Close() }()
 
-	// Create context with timeout
 	pingCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	// Test connection with Ping
 	err = db.PingContext(pingCtx)
 	if err != nil {
 		result.Error = classifyError(err)
 		return result
 	}
 
-	// Success
 	result.Success = true
 	return result
 }

--- a/internal/plugins/rdp/rdp.go
+++ b/internal/plugins/rdp/rdp.go
@@ -87,11 +87,9 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	result := brutus.NewResult("rdp", target, username, password)
 	defer func() { result.Duration = time.Since(start) }()
 
-	// Parse target
 	host, port := brutus.ParseTarget(target, "3389")
 	addr := net.JoinHostPort(host, port)
 
-	// Parse domain\username (reuse SMB pattern)
 	domain, user := parseDomainUsername(username)
 
 	// Initialize WASM engine (singleton, first call compiles)
@@ -101,7 +99,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		return result
 	}
 
-	// Create TCP connection with timeout (proxy-aware)
 	conn, err := brutus.DialWithProxy(ctx, "tcp", addr, timeout, pluginCfg.ProxyURL)
 	if err != nil {
 		result.Error = brutus.WrapConnError(err)

--- a/internal/plugins/redis/redis.go
+++ b/internal/plugins/redis/redis.go
@@ -61,11 +61,9 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	result := brutus.NewResult("redis", target, username, password)
 	defer func() { result.Duration = time.Since(start) }()
 
-	// Parse target to extract host and port
 	host, port := brutus.ParseTarget(target, "6379")
 	addr := fmt.Sprintf("%s:%s", host, port)
 
-	// Create Redis client
 	client := redis.NewClient(&redis.Options{
 		Addr:         addr,
 		Password:     password,
@@ -76,18 +74,15 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	})
 	defer func() { _ = client.Close() }()
 
-	// Create context with timeout
 	pingCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	// Test connection with Ping
 	err := client.Ping(pingCtx).Err()
 	if err != nil {
 		result.Error = classifyError(err)
 		return result
 	}
 
-	// Success
 	result.Success = true
 	return result
 }

--- a/internal/plugins/smb/smb.go
+++ b/internal/plugins/smb/smb.go
@@ -61,10 +61,8 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	result := brutus.NewResult("smb", target, username, password)
 	defer func() { result.Duration = time.Since(start) }()
 
-	// Parse target to extract host and port
 	host, port := brutus.ParseTarget(target, "445")
 
-	// Connect with context timeout (proxy-aware)
 	conn, err := brutus.DialWithProxy(ctx, "tcp", net.JoinHostPort(host, port), timeout, pluginCfg.ProxyURL)
 	if err != nil {
 		result.Error = brutus.WrapConnError(err)
@@ -72,10 +70,8 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	}
 	defer func() { _ = conn.Close() }()
 
-	// Parse domain and username
 	domain, user := parseDomainUsername(username)
 
-	// Perform SMB handshake and authentication
 	d := &smb2.Dialer{
 		Initiator: &smb2.NTLMInitiator{
 			User:     user,
@@ -91,7 +87,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	}
 	defer func() { _ = session.Logoff() }()
 
-	// Test authentication by connecting to IPC$ share
 	share, err := session.Mount("IPC$")
 	if err != nil {
 		result.Error = classifyError(err)
@@ -99,14 +94,10 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	}
 	defer func() { _ = share.Umount() }()
 
-	// Success - authentication worked
 	result.Success = true
 	return result
 }
 
-// parseTarget splits target into host and port.
-// If no port is specified, defaults to 445 (SMB).
-// Supports IPv6 addresses with brackets: [::1]:445
 // parseDomainUsername splits username into domain and username.
 // Supports formats: DOMAIN\username or just username.
 // Returns empty string for domain if not specified.

--- a/internal/plugins/smtp/smtp.go
+++ b/internal/plugins/smtp/smtp.go
@@ -61,7 +61,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	result := brutus.NewResult("smtp", target, username, password)
 	defer func() { result.Duration = time.Since(start) }()
 
-	// Connect with timeout (proxy-aware)
 	conn, err := brutus.DialWithProxy(ctx, "tcp", target, timeout, pluginCfg.ProxyURL)
 	if err != nil {
 		result.Error = brutus.WrapConnError(err)
@@ -69,14 +68,12 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	}
 	defer func() { _ = conn.Close() }()
 
-	// Set deadline for the entire operation
 	deadline := time.Now().Add(timeout)
 	if deadlineErr := conn.SetDeadline(deadline); deadlineErr != nil {
 		result.Error = brutus.WrapConnError(deadlineErr)
 		return result
 	}
 
-	// Create SMTP client
 	host, _, err := net.SplitHostPort(target)
 	if err != nil {
 		result.Error = fmt.Errorf("connection error: invalid target format: %w", err)

--- a/internal/plugins/smtp/smtp.go
+++ b/internal/plugins/smtp/smtp.go
@@ -90,8 +90,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	}
 	defer func() { _ = client.Close() }()
 
-	// Try STARTTLS if available
-	// Read TLS mode from context
 	tlsMode := pluginCfg.TLSMode
 	if tlsMode != "disable" {
 		if ok, _ := client.Extension("STARTTLS"); ok {
@@ -110,17 +108,14 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		}
 	}
 
-	// Create auth mechanism (try PLAIN first, which is most common)
 	auth := smtp.PlainAuth("", username, password, host)
 
-	// Attempt authentication
 	err = client.Auth(auth)
 	if err != nil {
 		result.Error = classifyError(err)
 		return result
 	}
 
-	// Success
 	result.Success = true
 	return result
 }

--- a/internal/plugins/snmp/snmp.go
+++ b/internal/plugins/snmp/snmp.go
@@ -61,14 +61,12 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	result := brutus.NewResult("snmp", target, username, password)
 	defer func() { result.Duration = time.Since(start) }()
 
-	// Parse target into host and port
 	host, port, err := parseTarget(target)
 	if err != nil {
 		result.Error = fmt.Errorf("connection error: invalid target: %w", err)
 		return result
 	}
 
-	// Create SNMP client
 	snmp := &gosnmp.GoSNMP{
 		Target:    host,
 		Port:      uint16(port),
@@ -79,7 +77,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		Context:   ctx,
 	}
 
-	// Connect (establishes UDP socket)
 	if connectErr := snmp.Connect(); connectErr != nil {
 		result.Error = brutus.WrapConnError(connectErr)
 		return result
@@ -91,7 +88,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	response, err := snmp.Get(oids)
 
 	if err != nil {
-		// Check if context was canceled
 		if ctx.Err() != nil {
 			result.Error = brutus.WrapConnError(ctx.Err())
 			return result
@@ -103,7 +99,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		return result
 	}
 
-	// Check SNMP protocol error
 	if response.Error != gosnmp.NoError {
 		// SNMP error response - might indicate invalid community
 		// or OID not supported. Treat as auth failure.
@@ -111,7 +106,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		return result
 	}
 
-	// Success! Extract banner from sysDescr
 	result.Success = true
 	if len(response.Variables) > 0 {
 		switch v := response.Variables[0].Value.(type) {

--- a/internal/plugins/ssh/ssh.go
+++ b/internal/plugins/ssh/ssh.go
@@ -62,7 +62,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	result := brutus.NewResult("ssh", target, username, password)
 	defer func() { result.Duration = time.Since(start) }()
 
-	// Create SSH client config
 	config := &ssh.ClientConfig{
 		User: username,
 		Auth: []ssh.AuthMethod{
@@ -72,7 +71,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		Timeout:         timeout,
 	}
 
-	// Connect with context-aware timeout
 	conn, err := brutus.DialWithProxy(ctx, "tcp", target, timeout, pluginCfg.ProxyURL)
 	if err != nil {
 		result.Error = brutus.WrapConnError(err)
@@ -85,7 +83,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	// a server that stalls the handshake hangs the worker.
 	_ = conn.SetDeadline(time.Now().Add(timeout))
 
-	// Perform SSH handshake
 	sshConn, chans, reqs, err := ssh.NewClientConn(conn, target, config)
 	if err != nil {
 		result.Error = classifyAuthError(err)
@@ -103,7 +100,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		}
 	}()
 
-	// Success
 	result.Success = true
 	return result
 }
@@ -122,13 +118,11 @@ func (p *Plugin) TestKey(ctx context.Context, target, username string, key []byt
 	defer func() { result.Duration = time.Since(start) }()
 	result.Key = key
 
-	// Validate key is provided
 	if len(key) == 0 {
 		result.Error = fmt.Errorf("connection error: empty private key")
 		return result
 	}
 
-	// Parse private key
 	signer, err := ssh.ParsePrivateKey(key)
 	if err != nil {
 		// Check if key is passphrase-protected
@@ -140,7 +134,6 @@ func (p *Plugin) TestKey(ctx context.Context, target, username string, key []byt
 		return result
 	}
 
-	// Create SSH client config with public key auth
 	config := &ssh.ClientConfig{
 		User: username,
 		Auth: []ssh.AuthMethod{
@@ -150,7 +143,6 @@ func (p *Plugin) TestKey(ctx context.Context, target, username string, key []byt
 		Timeout:         timeout,
 	}
 
-	// Connect with context-aware timeout
 	conn, err := brutus.DialWithProxy(ctx, "tcp", target, timeout, pluginCfg.ProxyURL)
 	if err != nil {
 		result.Error = brutus.WrapConnError(err)
@@ -163,7 +155,6 @@ func (p *Plugin) TestKey(ctx context.Context, target, username string, key []byt
 	// a server that stalls the handshake hangs the worker.
 	_ = conn.SetDeadline(time.Now().Add(timeout))
 
-	// Perform SSH handshake
 	sshConn, chans, reqs, err := ssh.NewClientConn(conn, target, config)
 	if err != nil {
 		result.Error = classifyAuthError(err)
@@ -181,7 +172,6 @@ func (p *Plugin) TestKey(ctx context.Context, target, username string, key []byt
 		}
 	}()
 
-	// Success
 	result.Success = true
 	return result
 }

--- a/internal/plugins/vnc/vnc.go
+++ b/internal/plugins/vnc/vnc.go
@@ -60,7 +60,6 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	result := brutus.NewResult("vnc", target, username, password)
 	defer func() { result.Duration = time.Since(start) }()
 
-	// Connect to VNC server (proxy-aware)
 	conn, err := brutus.DialWithProxy(ctx, "tcp", target, timeout, pluginCfg.ProxyURL)
 	if err != nil {
 		result.Error = brutus.WrapConnError(err)
@@ -72,21 +71,18 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	// the worker (vnc.Client performs blocking reads with no timeout of its own).
 	_ = conn.SetDeadline(time.Now().Add(timeout))
 
-	// Create VNC client configuration
 	cfg := &vnc.ClientConfig{
 		Auth: []vnc.ClientAuth{
 			&vnc.PasswordAuth{Password: password},
 		},
 	}
 
-	// Attempt VNC handshake and authentication
 	_, err = vnc.Client(conn, cfg)
 	if err != nil {
 		result.Error = classifyError(err)
 		return result
 	}
 
-	// Success
 	result.Success = true
 	return result
 }

--- a/internal/plugins/winrm/winrm.go
+++ b/internal/plugins/winrm/winrm.go
@@ -198,7 +198,6 @@ func parseTarget(target string, useHTTPS bool) (host string, port int) {
 	if strings.Contains(target, ":") {
 		h, p, err := net.SplitHostPort(target)
 		if err == nil {
-			// Parse port string to int
 			var portNum int
 			_, err := fmt.Sscanf(p, "%d", &portNum)
 			if err == nil {
@@ -207,7 +206,6 @@ func parseTarget(target string, useHTTPS bool) (host string, port int) {
 		}
 	}
 
-	// No port specified or parsing failed - use default
 	defaultPort := 5985
 	if useHTTPS {
 		defaultPort = 5986

--- a/internal/plugins/winrm/winrm.go
+++ b/internal/plugins/winrm/winrm.go
@@ -70,10 +70,8 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	result := brutus.NewResult(p.Name(), target, username, password)
 	defer func() { result.Duration = time.Since(start) }()
 
-	// Parse target to extract host and port
 	host, port := parseTarget(target, p.UseHTTPS)
 
-	// Create WinRM endpoint
 	endpoint := winrm.NewEndpoint(host, port, p.UseHTTPS, true, nil, nil, nil, timeout)
 
 	// Use encrypted NTLM transport: default Windows WinRM has AllowUnencrypted=false,

--- a/pkg/brutus/http.go
+++ b/pkg/brutus/http.go
@@ -117,7 +117,6 @@ func DetectHTTPAuthType(target string, useHTTPS bool, timeout time.Duration, tls
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	// Build banner from response headers and body
 	var bannerBuilder strings.Builder
 	fmt.Fprintf(&bannerBuilder, "HTTP/%d.%d %s\n", resp.ProtoMajor, resp.ProtoMinor, resp.Status)
 

--- a/pkg/brutus/llm.go
+++ b/pkg/brutus/llm.go
@@ -56,7 +56,6 @@ func createAnalyzer(cfg *LLMConfig) BannerAnalyzer {
 		return nil
 	}
 
-	// Get analyzer from registry
 	factory := GetAnalyzerFactory(cfg.Provider)
 	if factory == nil {
 		return nil

--- a/pkg/enum/dehashed/dehashed_test.go
+++ b/pkg/enum/dehashed/dehashed_test.go
@@ -189,7 +189,7 @@ func TestRefine(t *testing.T) {
 		opts    RefineOptions
 		check   func(t *testing.T, got []Entry)
 	}{
-		// ----- CorporateOnly -----
+		// CorporateOnly
 		{
 			name: "CorporateOnly: keeps @domain email, drops @gmail.com email",
 			records: []Record{
@@ -224,7 +224,7 @@ func TestRefine(t *testing.T) {
 				assert.Equal(t, "bob@gmail.com", got[0].Email)
 			},
 		},
-		// ----- Dedup merge -----
+		// Dedup merge
 		{
 			name: "Dedup: two records with same email → one Entry, Count=2, databases merged",
 			records: []Record{
@@ -291,7 +291,7 @@ func TestRefine(t *testing.T) {
 				assert.ElementsMatch(t, []string{"+44-7000-000001", "+44-7000-000002"}, got[0].Phones)
 			},
 		},
-		// ----- ExcludeCombolists -----
+		// ExcludeCombolists
 		{
 			name: "ExcludeCombolists: Naz.API dropped",
 			records: []Record{
@@ -343,7 +343,7 @@ func TestRefine(t *testing.T) {
 				assert.Equal(t, "x@example.com", got[0].Email)
 			},
 		},
-		// ----- All opts false = passthrough -----
+		// All opts false = passthrough
 		{
 			name: "All opts false: @gmail kept, no dedup, combolists kept, Count=1",
 			records: []Record{
@@ -361,7 +361,7 @@ func TestRefine(t *testing.T) {
 				assert.Equal(t, "bob@gmail.com", got[1].Email)
 			},
 		},
-		// ----- Edge cases -----
+		// Edge cases
 		{
 			name:    "Empty input → empty output",
 			records: []Record{},

--- a/pkg/enum/generate_test.go
+++ b/pkg/enum/generate_test.go
@@ -76,7 +76,6 @@ func TestGenerateUsernames_DerivedFormats(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.format, func(t *testing.T) {
 			t.Parallel()
 
@@ -176,7 +175,6 @@ func TestGenerateUsernames_MultiPartSurnames(t *testing.T) {
 	}
 
 	for _, format := range noDotFormats {
-		format := format
 		t.Run(format+"_no_dots", func(t *testing.T) {
 			t.Parallel()
 
@@ -202,7 +200,6 @@ func TestGenerateUsernames_AllFormatsBoundedAndNonEmpty(t *testing.T) {
 	require.Len(t, formats, 9, "ListFormats must return exactly 9 formats")
 
 	for _, format := range formats {
-		format := format
 		t.Run(format, func(t *testing.T) {
 			t.Parallel()
 
@@ -386,7 +383,6 @@ func TestGenerateCandidates_UsernameParity(t *testing.T) {
 	formats := []string{FormatFirstDotLast, FormatFLast}
 
 	for _, format := range formats {
-		format := format
 		t.Run(format, func(t *testing.T) {
 			t.Parallel()
 
@@ -418,7 +414,6 @@ func TestGenerateCandidates_EmailParity(t *testing.T) {
 	formats := []string{FormatFirstDotLast, FormatFLast}
 
 	for _, format := range formats {
-		format := format
 		t.Run(format, func(t *testing.T) {
 			t.Parallel()
 
@@ -447,7 +442,6 @@ func TestGenerateCandidates_NamesPopulated(t *testing.T) {
 	t.Parallel()
 
 	for _, format := range []string{FormatFirstDotLast, FormatFLast} {
-		format := format
 		t.Run(format, func(t *testing.T) {
 			t.Parallel()
 
@@ -583,7 +577,6 @@ func TestCandidate_Email(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -621,7 +614,6 @@ func TestGenerateCandidates_AllFormatsPopulated(t *testing.T) {
 	t.Parallel()
 
 	for _, format := range ListFormats() {
-		format := format
 		t.Run(format, func(t *testing.T) {
 			t.Parallel()
 
@@ -682,7 +674,6 @@ func TestCandidate_Target(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/enum/google/google_test.go
+++ b/pkg/enum/google/google_test.go
@@ -344,7 +344,6 @@ func TestEnumerateWith_ZeroOrNegativeThreadsDoesNotHang(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -427,7 +426,6 @@ func Test_idpHost(t *testing.T) {
 		{"https://accounts.google.com/ServiceLogin", "accounts.google.com"},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.location, func(t *testing.T) {
 			t.Parallel()
 			got := idpHost(tc.location)

--- a/pkg/enum/gravatar/gravatar_test.go
+++ b/pkg/enum/gravatar/gravatar_test.go
@@ -392,7 +392,6 @@ func TestEnumerateWith_ZeroOrNegativeThreadsDoesNotHang(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/enum/kerberos/kerberos_test.go
+++ b/pkg/enum/kerberos/kerberos_test.go
@@ -175,7 +175,6 @@ func TestEnumUser_MultipleUsers(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			result := EnumUser(context.Background(), kdc.Addr(), "TEST.LOCAL", tt.username, 5*time.Second)

--- a/pkg/enum/microsoft365/microsoft365_test.go
+++ b/pkg/enum/microsoft365/microsoft365_test.go
@@ -476,7 +476,6 @@ func TestEnumerateWith_ZeroOrNegativeThreadsDoesNotHang(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/enum/teams/enum_test.go
+++ b/pkg/enum/teams/enum_test.go
@@ -749,7 +749,6 @@ func TestDerivePosture(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			p := DerivePosture("contoso.com", tc.results)
 			tc.check(t, p)
@@ -802,7 +801,6 @@ func TestEnumerateOne_TokenSafetyTable(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			srv := searchServerReturning(tc.statusCode, tc.body)
 			defer srv.Close()
@@ -879,7 +877,6 @@ func TestEnumerateOne_PrefersCorporateOverConsumer(t *testing.T) {
 	const mixedBody = `[{"displayName":"Personal","mri":"8:live:.cid.aaa"},{"displayName":"Corp User","mri":"8:orgid:bbb","userPrincipalName":"corp@x.com"}]`
 
 	for _, includeConsumer := range []bool{false, true} {
-		includeConsumer := includeConsumer
 		t.Run(fmt.Sprintf("includeConsumer=%v", includeConsumer), func(t *testing.T) {
 			srv := searchServerReturning(http.StatusOK, mixedBody)
 			defer srv.Close()
@@ -912,7 +909,6 @@ func TestEnumerateOne_CorporateOnly_AlwaysFound(t *testing.T) {
 	const corpBody = `[{"displayName":"Jane","mri":"8:orgid:xyz"}]`
 
 	for _, includeConsumer := range []bool{false, true} {
-		includeConsumer := includeConsumer
 		t.Run(fmt.Sprintf("includeConsumer=%v", includeConsumer), func(t *testing.T) {
 			srv := searchServerReturning(http.StatusOK, corpBody)
 			defer srv.Close()
@@ -949,7 +945,6 @@ func TestAccountType(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.mri, func(t *testing.T) {
 			got := AccountType(tc.mri)
 			assert.Equal(t, tc.want, got, "AccountType(%q) should be %q", tc.mri, tc.want)


### PR DESCRIPTION
## Summary
- #362 squash-merged only the banner cleanup. This lands the leftover plugin/cmd restating-comment pass plus a few more that were still in `http`, `mysql`, `smtp`, `browser`, and `winrm`.
- Also drops obsolete Go 1.22+ loop-variable copies (`tc := tc`) and a stale `parseTarget` godoc in the SMB plugin.

Godoc and comments that explain *why* are left in place.

## Test plan
- [x] `go test -short ./...`