### PR TITLE
fix(imap): dial IPv6 correctly and bound Login to timeout

### DIFF
--- a/internal/plugins/imap/imap.go
+++ b/internal/plugins/imap/imap.go
@@ -16,7 +16,7 @@ package imap
 
 import (
 	"context"
-	"fmt"
+	"net"
 	"time"
 
 	"github.com/emersion/go-imap/v2/imapclient"
@@ -59,7 +59,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	defer func() { result.Duration = time.Since(start) }()
 
 	host, port := brutus.ParseTarget(target, "143")
-	addr := fmt.Sprintf("%s:%s", host, port)
+	addr := net.JoinHostPort(host, port)
 
 	dialCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -86,10 +86,19 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	loginCtx, loginCancel := context.WithTimeout(ctx, timeout)
 	defer loginCancel()
 
-	loginCmd := client.Login(username, password)
-	err := loginCmd.Wait()
+	// go-imap overwrites conn deadlines (30s greeting timer), so a silent
+	// server would hang Login().Wait() past the plugin timeout. Close the
+	// client when loginCtx fires to unblock Wait.
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- client.Login(username, password).Wait()
+	}()
 
-	if loginCtx.Err() != nil {
+	var err error
+	select {
+	case err = <-errCh:
+	case <-loginCtx.Done():
+		_ = client.Close()
 		result.Error = classifyError(loginCtx.Err())
 		return result
 	}

--- a/internal/plugins/imap/imap_test.go
+++ b/internal/plugins/imap/imap_test.go
@@ -21,6 +21,7 @@ package imap
 
 import (
 	"context"
+	"net"
 	"os"
 	"testing"
 	"time"
@@ -184,6 +185,40 @@ func TestPlugin_Test_MissingPort(t *testing.T) {
 	// Connection may fail or succeed depending on implementation
 	// Just verify we get a valid result structure
 	assert.Greater(t, result.Duration, time.Duration(0))
+}
+
+func TestPlugin_Test_UnbracketedIPv6(t *testing.T) {
+	p := &Plugin{}
+	result := p.Test(context.Background(), "::1", "user", "pass", 200*time.Millisecond, brutus.PluginConfig{})
+
+	require.NotNil(t, result)
+	assert.False(t, result.Success)
+	require.Error(t, result.Error)
+	assert.NotContains(t, result.Error.Error(), "too many colons")
+}
+
+func TestPlugin_Test_LoginDeadline(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { _ = ln.Close() }()
+
+	go func() {
+		conn, accErr := ln.Accept()
+		if accErr != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		time.Sleep(5 * time.Second)
+	}()
+
+	p := &Plugin{}
+	start := time.Now()
+	result := p.Test(context.Background(), ln.Addr().String(), "user", "pass", 300*time.Millisecond, brutus.PluginConfig{})
+	elapsed := time.Since(start)
+
+	require.NotNil(t, result)
+	assert.False(t, result.Success)
+	assert.Less(t, elapsed, 2*time.Second, "login must be bounded by the plugin timeout")
 }
 
 func TestInit(t *testing.T) {


### PR DESCRIPTION
## Summary

Two IMAP worker bugs:

1. `fmt.Sprintf("%s:%s", host, port)` after `ParseTarget` yields `::1:143` for IPv6. Use `net.JoinHostPort` like ssh/smb/rdp.
2. `Login().Wait()` ignored the plugin timeout. go-imap overwrites conn deadlines (30s greeting timer), and `loginCtx` was only checked *after* Wait returned, so a silent server hung the worker. Close the client when the timeout fires.

## Test plan

- [x] `go test -short ./internal/plugins/imap/`
- [x] Unbracketed `::1` no longer errors with `too many colons`
- [x] Silent TCP listener: Test returns in << 2s with a 300ms timeout