### PR TITLE
fix(redis): dial IPv6 correctly and honor --proxy

### DIFF
--- a/internal/plugins/redis/redis.go
+++ b/internal/plugins/redis/redis.go
@@ -17,6 +17,7 @@ package redis
 import (
 	"context"
 	"fmt"
+	"net"
 	"strings"
 	"time"
 
@@ -62,16 +63,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	defer func() { result.Duration = time.Since(start) }()
 
 	host, port := brutus.ParseTarget(target, "6379")
-	addr := fmt.Sprintf("%s:%s", host, port)
-
-	client := redis.NewClient(&redis.Options{
-		Addr:         addr,
-		Password:     password,
-		DB:           0,
-		DialTimeout:  timeout,
-		ReadTimeout:  timeout,
-		WriteTimeout: timeout,
-	})
+	client := newRedisClient(net.JoinHostPort(host, port), password, timeout, pluginCfg.ProxyURL)
 	defer func() { _ = client.Close() }()
 
 	pingCtx, cancel := context.WithTimeout(ctx, timeout)
@@ -94,16 +86,7 @@ func (p *Plugin) CheckUnauth(ctx context.Context, target string, timeout time.Du
 	defer func() { result.Duration = time.Since(start) }()
 
 	host, port := brutus.ParseTarget(target, "6379")
-	addr := fmt.Sprintf("%s:%s", host, port)
-
-	client := redis.NewClient(&redis.Options{
-		Addr:         addr,
-		Password:     "",
-		DB:           0,
-		DialTimeout:  timeout,
-		ReadTimeout:  timeout,
-		WriteTimeout: timeout,
-	})
+	client := newRedisClient(net.JoinHostPort(host, port), "", timeout, pluginCfg.ProxyURL)
 	defer func() { _ = client.Close() }()
 
 	pingCtx, cancel := context.WithTimeout(ctx, timeout)
@@ -129,6 +112,20 @@ func (p *Plugin) CheckUnauth(ctx context.Context, target string, timeout time.Du
 	result.Success = true
 	result.Banner = bannerText
 	return result
+}
+
+func newRedisClient(addr, password string, timeout time.Duration, proxyURL string) *redis.Client {
+	return redis.NewClient(&redis.Options{
+		Addr:         addr,
+		Password:     password,
+		DB:           0,
+		DialTimeout:  timeout,
+		ReadTimeout:  timeout,
+		WriteTimeout: timeout,
+		Dialer: func(ctx context.Context, network, dialAddr string) (net.Conn, error) {
+			return brutus.DialWithProxy(ctx, network, dialAddr, timeout, proxyURL)
+		},
+	})
 }
 
 var classifyError = brutus.NewClassifier(redisAuthIndicators)

--- a/internal/plugins/redis/redis_test.go
+++ b/internal/plugins/redis/redis_test.go
@@ -269,6 +269,28 @@ func TestPlugin_Test_MissingPort(t *testing.T) {
 	assert.GreaterOrEqual(t, result.Duration, time.Duration(0))
 }
 
+func TestPlugin_Test_UnbracketedIPv6(t *testing.T) {
+	p := &Plugin{}
+	result := p.Test(context.Background(), "::1", "", "pass", 200*time.Millisecond, brutus.PluginConfig{})
+
+	assert.NotNil(t, result)
+	assert.False(t, result.Success)
+	assert.NotNil(t, result.Error)
+	assert.NotContains(t, result.Error.Error(), "too many colons")
+}
+
+func TestPlugin_Test_InvalidProxy(t *testing.T) {
+	p := &Plugin{}
+	result := p.Test(context.Background(), "127.0.0.1:6379", "", "pass", time.Second, brutus.PluginConfig{
+		ProxyURL: "http://127.0.0.1:1",
+	})
+
+	assert.NotNil(t, result)
+	assert.False(t, result.Success)
+	assert.NotNil(t, result.Error)
+	assert.Contains(t, result.Error.Error(), "connection error")
+}
+
 func TestInit(t *testing.T) {
 	// Just verify the plugin can be instantiated
 	p := &Plugin{}


### PR DESCRIPTION
## Summary

Redis built the dial address with `fmt.Sprintf("%s:%s", host, port)` after `ParseTarget`, so unbracketed IPv6 (`::1`) became `::1:6379`. `--proxy` was ignored; ssh/ftp/smb all go through `DialWithProxy`.

Both `Test` and `CheckUnauth` now use `net.JoinHostPort` and a go-redis `Dialer` wrapping `brutus.DialWithProxy`.

## Test plan

- [x] `go test -short ./internal/plugins/redis/`
- [x] Unbracketed `::1` no longer errors with `too many colons`
- [x] HTTP proxy URL is rejected (raw TCP) instead of silently dialing direct