### PR TITLE
fix: bracket IPv6 hosts when building plugin URLs

### DIFF
--- a/internal/plugins/docker/docker.go
+++ b/internal/plugins/docker/docker.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"time"
 
@@ -52,7 +53,7 @@ func (c *Checker) CheckUnauth(ctx context.Context, target string, timeout time.D
 		scheme = "https"
 	}
 
-	url := fmt.Sprintf("%s://%s:%s/version", scheme, host, port)
+	url := fmt.Sprintf("%s://%s/version", scheme, net.JoinHostPort(host, port))
 
 	req, err := http.NewRequestWithContext(ctx, "GET", url, http.NoBody)
 	if err != nil {

--- a/internal/plugins/docker/docker_test.go
+++ b/internal/plugins/docker/docker_test.go
@@ -173,6 +173,16 @@ func TestCheckUnauth_Unreachable(t *testing.T) {
 	assert.Nil(t, result.Error)
 }
 
+func TestCheckUnauth_UnbracketedIPv6(t *testing.T) {
+	c := &Checker{}
+	result := c.CheckUnauth(context.Background(), "::1", 200*time.Millisecond, brutus.PluginConfig{})
+
+	require.NotNil(t, result)
+	assert.False(t, result.Success)
+	assert.Equal(t, "docker", result.Protocol)
+	assert.Equal(t, "::1", result.Target)
+}
+
 func TestCheckUnauth_TLS(t *testing.T) {
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/internal/plugins/kubernetes/kubernetes.go
+++ b/internal/plugins/kubernetes/kubernetes.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"time"
 
@@ -68,7 +69,7 @@ func (c *Checker) CheckUnauth(ctx context.Context, target string, timeout time.D
 
 	// For API server: /version is publicly accessible by default RBAC,
 	// so we must probe a protected resource to confirm anonymous access.
-	protectedURL := fmt.Sprintf("%s://%s:%s/api/v1/namespaces", scheme, host, port)
+	protectedURL := fmt.Sprintf("%s://%s/api/v1/namespaces", scheme, net.JoinHostPort(host, port))
 	req, err := http.NewRequestWithContext(ctx, "GET", protectedURL, http.NoBody)
 	if err != nil {
 		return result
@@ -86,7 +87,7 @@ func (c *Checker) CheckUnauth(ctx context.Context, target string, timeout time.D
 
 	// Anonymous access to protected resources confirmed — get version info
 	bannerText := "[CRITICAL] Kubernetes anonymous access enabled"
-	versionURL := fmt.Sprintf("%s://%s:%s/version", scheme, host, port)
+	versionURL := fmt.Sprintf("%s://%s/version", scheme, net.JoinHostPort(host, port))
 	vReq, err := http.NewRequestWithContext(ctx, "GET", versionURL, http.NoBody)
 	if err == nil {
 		vResp, err := client.Do(vReq)
@@ -106,7 +107,7 @@ func (c *Checker) CheckUnauth(ctx context.Context, target string, timeout time.D
 
 // checkKubelet probes the kubelet /pods endpoint for unauthenticated access.
 func (c *Checker) checkKubelet(ctx context.Context, client *http.Client, scheme, host, port string, result *brutus.Result) *brutus.Result {
-	podsURL := fmt.Sprintf("%s://%s:%s/pods", scheme, host, port)
+	podsURL := fmt.Sprintf("%s://%s/pods", scheme, net.JoinHostPort(host, port))
 	req, err := http.NewRequestWithContext(ctx, "GET", podsURL, http.NoBody)
 	if err != nil {
 		return result

--- a/internal/plugins/ldap/ldap.go
+++ b/internal/plugins/ldap/ldap.go
@@ -77,10 +77,11 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 
 	host, port := brutus.ParseTarget(target, "389")
 
-	ldapURL := fmt.Sprintf("ldap://%s:%s", host, port)
+	scheme := "ldap"
 	if port == "636" {
-		ldapURL = fmt.Sprintf("ldaps://%s:%s", host, port)
+		scheme = "ldaps"
 	}
+	ldapURL := fmt.Sprintf("%s://%s", scheme, net.JoinHostPort(host, port))
 
 	tlsMode := pluginCfg.TLSMode
 

--- a/internal/plugins/ldap/ldap_test.go
+++ b/internal/plugins/ldap/ldap_test.go
@@ -91,6 +91,17 @@ func TestPlugin_Test_ConnectionError(t *testing.T) {
 	assert.Contains(t, result.Error.Error(), "connection error")
 }
 
+func TestPlugin_Test_UnbracketedIPv6(t *testing.T) {
+	p := &Plugin{}
+	result := p.Test(context.Background(), "::1", "admin", "password", 200*time.Millisecond, brutus.PluginConfig{})
+
+	assert.NotNil(t, result)
+	assert.False(t, result.Success)
+	assert.NotNil(t, result.Error)
+	assert.NotContains(t, result.Error.Error(), "too many colons")
+	assert.NotContains(t, result.Error.Error(), "invalid port")
+}
+
 func TestPlugin_Test_ContextCancellation(t *testing.T) {
 	if ldapTestHost == "" {
 		t.Skip("Integration test - requires LDAP server (set LDAP_TEST_HOST)")

--- a/internal/plugins/oracle/oracle.go
+++ b/internal/plugins/oracle/oracle.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net"
 	"net/url"
 	"strings"
 	"time"
@@ -94,7 +95,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	userInfo := url.UserPassword(username, password).String()
 
 	for _, service := range defaultServiceNames {
-		connStr := fmt.Sprintf("oracle://%s@%s:%s/%s", userInfo, host, port, service)
+		connStr := fmt.Sprintf("oracle://%s@%s/%s", userInfo, net.JoinHostPort(host, port), service)
 
 		err := tryConnect(ctx, connStr, timeout)
 		if err == nil {

--- a/internal/plugins/oracle/oracle_test.go
+++ b/internal/plugins/oracle/oracle_test.go
@@ -204,6 +204,17 @@ func TestPlugin_Test_MissingPort(t *testing.T) {
 	assert.Greater(t, result.Duration, time.Duration(0))
 }
 
+func TestPlugin_Test_UnbracketedIPv6(t *testing.T) {
+	p := &Plugin{}
+	result := p.Test(context.Background(), "::1", "system", "oracle", 200*time.Millisecond, brutus.PluginConfig{})
+
+	assert.NotNil(t, result)
+	assert.False(t, result.Success)
+	assert.NotNil(t, result.Error)
+	assert.NotContains(t, result.Error.Error(), "too many colons")
+	assert.NotContains(t, result.Error.Error(), "missing port")
+}
+
 func TestPlugin_Test_ContextCancellation(t *testing.T) {
 	p := &Plugin{}
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/plugins/winrm/winrm.go
+++ b/internal/plugins/winrm/winrm.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 	"time"
 
@@ -104,7 +105,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	if p.UseHTTPS {
 		scheme = "https"
 	}
-	url := fmt.Sprintf("%s://%s:%d/wsman", scheme, host, port)
+	url := fmt.Sprintf("%s://%s/wsman", scheme, net.JoinHostPort(host, strconv.Itoa(port)))
 
 	// Send a lightweight WS-Management Enumerate request instead of CreateShell.
 	// CreateShell targets the "windows/shell/cmd" (WinRS) resource which requires
@@ -210,7 +211,7 @@ func parseTarget(target string, useHTTPS bool) (host string, port int) {
 	if useHTTPS {
 		defaultPort = 5986
 	}
-	return target, defaultPort
+	return strings.Trim(target, "[]"), defaultPort
 }
 
 // classifyError classifies WinRM errors into auth failures vs connection errors.

--- a/internal/plugins/winrm/winrm_test.go
+++ b/internal/plugins/winrm/winrm_test.go
@@ -165,6 +165,27 @@ func TestParseTarget(t *testing.T) {
 			wantHost: "::1",
 			wantPort: 5985,
 		},
+		{
+			name:     "unbracketed IPv6 without port",
+			target:   "::1",
+			useHTTPS: false,
+			wantHost: "::1",
+			wantPort: 5985,
+		},
+		{
+			name:     "bracketed IPv6 without port",
+			target:   "[::1]",
+			useHTTPS: false,
+			wantHost: "::1",
+			wantPort: 5985,
+		},
+		{
+			name:     "unbracketed IPv6 without port HTTPS",
+			target:   "2001:db8::1",
+			useHTTPS: true,
+			wantHost: "2001:db8::1",
+			wantPort: 5986,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

After `ParseTarget`, host is unbracketed (`::1`). These plugins rebuilt URLs with `sprintf("%s:%s", host, port)`:

- docker `/version`
- kubernetes `/api/v1/namespaces`, `/version`, `/pods`
- ldap `ldap(s)://`
- oracle `oracle://user@host:port/service`
- winrm SOAP `http(s)://host:port/wsman`

IPv6 became `http://::1:2375/...`, which `http.NewRequest` / go-ldap / go-ora reject. Use `net.JoinHostPort` like smb/rdp already do. WinRM `parseTarget` also strips leftover brackets for `[::1]` without a port.

## Test plan

- [x] `go test -short ./internal/plugins/docker/ ./internal/plugins/ldap/ ./internal/plugins/oracle/ ./internal/plugins/winrm/`
- [x] Unbracketed `::1` no longer errors with `too many colons` / `missing port`
- [x] WinRM parseTarget covers `::1`, `[::1]`, and `[::1]:5985`