### PR TITLE
fix(snmp): parse unbracketed IPv6 via shared ParseTarget

### DIFF
--- a/internal/plugins/snmp/snmp.go
+++ b/internal/plugins/snmp/snmp.go
@@ -11,7 +11,6 @@ package snmp
 import (
 	"context"
 	"fmt"
-	"net"
 	"strconv"
 	"strings"
 	"time"
@@ -119,35 +118,12 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	return result
 }
 
-// parseTarget splits target into host and port.
-// Supports formats: "host", "host:port", "[ipv6]:port"
 func parseTarget(target string) (host string, port int, err error) {
-	// Check for IPv6 with port
-	if strings.HasPrefix(target, "[") {
-		// IPv6 format: [::1]:161
-		var portStr string
-		host, portStr, err = net.SplitHostPort(target)
-		if err != nil {
-			// IPv6 without port: [::1]
-			return strings.Trim(target, "[]"), DefaultPort, nil
-		}
-		port, err = strconv.Atoi(portStr)
-		if err != nil {
-			return "", 0, fmt.Errorf("invalid port: %s", portStr)
-		}
-		return host, port, nil
+	host, portStr := brutus.ParseTarget(target, strconv.Itoa(DefaultPort))
+	host = strings.Trim(host, "[]")
+	port, err = strconv.Atoi(portStr)
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid port: %s", portStr)
 	}
-
-	// Check for port separator
-	if strings.Contains(target, ":") {
-		parts := strings.SplitN(target, ":", 2)
-		port, err = strconv.Atoi(parts[1])
-		if err != nil {
-			return "", 0, fmt.Errorf("invalid port: %s", parts[1])
-		}
-		return parts[0], port, nil
-	}
-
-	// No port specified, use default
-	return target, DefaultPort, nil
+	return host, port, nil
 }

--- a/internal/plugins/snmp/snmp_test.go
+++ b/internal/plugins/snmp/snmp_test.go
@@ -68,6 +68,13 @@ func TestParseTarget_IPv6WithPort(t *testing.T) {
 	assert.Equal(t, 1161, port)
 }
 
+func TestParseTarget_UnbracketedIPv6(t *testing.T) {
+	host, port, err := parseTarget("2001:db8::1")
+	assert.NoError(t, err)
+	assert.Equal(t, "2001:db8::1", host)
+	assert.Equal(t, 161, port)
+}
+
 func TestParseTarget_InvalidPort(t *testing.T) {
 	_, _, err := parseTarget("192.168.1.1:abc")
 	assert.Error(t, err)


### PR DESCRIPTION
## Summary

SNMP reimplemented host:port parsing and split on the first `:`, so unbracketed IPv6 (`2001:db8::1`) failed with `invalid port`. Use `brutus.ParseTarget` (same as the other plugins) and trim leftover brackets for `[::1]` without a port.

## Test plan

- [x] `go test -short ./internal/plugins/snmp/`
- [x] `2001:db8::1` → host `2001:db8::1`, port 161
- [x] Existing `[::1]` / `[::1]:1161` / invalid-port cases still pass