### PR TITLE
fix(brutus): synthesize a result when a plugin returns nil

### DIFF
--- a/pkg/brutus/workers.go
+++ b/pkg/brutus/workers.go
@@ -260,6 +260,12 @@ func executeWorkerPool(ctx context.Context, cfg *Config, plug Plugin, credential
 					result = plug.Test(ctx, cfg.Target, cred.username, cred.password, cfg.Timeout, pluginCfg)
 				}
 
+				if result == nil {
+					result = NewResult(cfg.Protocol, cfg.Target, cred.username, cred.password)
+					result.Error = fmt.Errorf("plugin returned nil result")
+					break
+				}
+
 				if result.Error == nil {
 					break
 				}

--- a/pkg/brutus/workers_test.go
+++ b/pkg/brutus/workers_test.go
@@ -78,6 +78,38 @@ func (p *panickingPlugin) Test(ctx context.Context, target, username, password s
 	panic("simulated plugin panic for regression test")
 }
 
+func TestExecuteWorkerPool_NilResult(t *testing.T) {
+	mock := &nilPlugin{}
+
+	cfg := &Config{
+		Target:    "test:22",
+		Protocol:  "nil-mock",
+		Usernames: []string{"user"},
+		Passwords: []string{"pass1", "pass2"},
+		Threads:   2,
+		Timeout:   1 * time.Second,
+		Plugin:    mock,
+	}
+
+	results, err := Brute(cfg)
+	assert.NoError(t, err)
+	assert.Len(t, results, 2)
+	for _, r := range results {
+		assert.False(t, r.Success)
+		assert.ErrorContains(t, r.Error, "plugin returned nil result")
+		assert.Equal(t, "nil-mock", r.Protocol)
+		assert.Equal(t, "user", r.Username)
+	}
+}
+
+type nilPlugin struct{}
+
+func (p *nilPlugin) Name() string { return "nil-mock" }
+
+func (p *nilPlugin) Test(ctx context.Context, target, username, password string, timeout time.Duration, pluginCfg PluginConfig) *Result {
+	return nil
+}
+
 func TestCaptureBanner_EmptyUsernames(t *testing.T) {
 	// Setup: Config with only Credentials (no Usernames), HTTP protocol, LLM enabled
 	cfg := &Config{


### PR DESCRIPTION
## Summary

Credential workers accessed `result.Error` and `*result` with no nil check. `pkg/enum/workers.go` already substitutes a synthetic result. A plugin that returns nil panics every attempt; recover records "plugin panic" and retries still panic.

If `Test`/`TestKey` returns nil, synthesize `NewResult` with `plugin returned nil result` and stop retrying.

## Test plan

- [x] `go test -short ./pkg/brutus/`
- [x] Two-password nil plugin produces two results, no panic