### PR TITLE
fix(mysql): build DSN with FormatDSN so special passwords work

### DIFF
--- a/internal/plugins/mysql/mysql.go
+++ b/internal/plugins/mysql/mysql.go
@@ -17,10 +17,10 @@ package mysql
 import (
 	"context"
 	"database/sql"
-	"fmt"
+	"net"
 	"time"
 
-	_ "github.com/go-sql-driver/mysql"
+	mysqldriver "github.com/go-sql-driver/mysql"
 
 	"github.com/praetorian-inc/brutus/pkg/brutus"
 )
@@ -52,19 +52,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	result := brutus.NewResult("mysql", target, username, password)
 	defer func() { result.Duration = time.Since(start) }()
 
-	tlsMode := pluginCfg.TLSMode
-
-	var tlsParam string
-	switch tlsMode {
-	case "verify":
-		tlsParam = "tls=true"
-	case "skip-verify":
-		tlsParam = "tls=skip-verify"
-	default: // "disable"
-		tlsParam = "tls=false"
-	}
-
-	dsn := fmt.Sprintf("%s:%s@tcp(%s)/?%s", username, password, target, tlsParam)
+	dsn := mysqlDSN(target, username, password, pluginCfg.TLSMode)
 
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {
@@ -90,7 +78,24 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	return result
 }
 
-// MySQL-specific auth failure indicators
+func mysqlDSN(target, username, password, tlsMode string) string {
+	host, port := brutus.ParseTarget(target, "3306")
+	tlsValue := "false"
+	switch tlsMode {
+	case "verify":
+		tlsValue = "true"
+	case "skip-verify":
+		tlsValue = "skip-verify"
+	}
+	cfg := mysqldriver.NewConfig()
+	cfg.User = username
+	cfg.Passwd = password
+	cfg.Net = "tcp"
+	cfg.Addr = net.JoinHostPort(host, port)
+	cfg.TLSConfig = tlsValue
+	return cfg.FormatDSN()
+}
+
 var mysqlAuthIndicators = []string{
 	"Access denied for user",
 	"authentication failed",

--- a/internal/plugins/mysql/mysql_test.go
+++ b/internal/plugins/mysql/mysql_test.go
@@ -20,7 +20,9 @@ import (
 	"testing"
 	"time"
 
+	mysqldriver "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/praetorian-inc/brutus/pkg/brutus"
 )
@@ -30,6 +32,55 @@ var (
 	mysqlTestUser = os.Getenv("MYSQL_TEST_USER")
 	mysqlTestPass = os.Getenv("MYSQL_TEST_PASS")
 )
+
+func TestMySQLDSN(t *testing.T) {
+	tests := []struct {
+		name     string
+		target   string
+		user     string
+		pass     string
+		tlsMode  string
+		wantAddr string
+		wantTLS  string
+	}{
+		{
+			name:     "special chars in password",
+			target:   "10.0.0.1:3306",
+			user:     "root",
+			pass:     "p@ss:word/x?",
+			wantAddr: "10.0.0.1:3306",
+			wantTLS:  "false",
+		},
+		{
+			name:     "IPv6",
+			target:   "::1",
+			user:     "root",
+			pass:     "x",
+			wantAddr: "[::1]:3306",
+			wantTLS:  "false",
+		},
+		{
+			name:     "skip-verify",
+			target:   "db.example.com",
+			user:     "app",
+			pass:     "secret",
+			tlsMode:  "skip-verify",
+			wantAddr: "db.example.com:3306",
+			wantTLS:  "skip-verify",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dsn := mysqlDSN(tt.target, tt.user, tt.pass, tt.tlsMode)
+			cfg, err := mysqldriver.ParseDSN(dsn)
+			require.NoError(t, err)
+			assert.Equal(t, tt.user, cfg.User)
+			assert.Equal(t, tt.pass, cfg.Passwd)
+			assert.Equal(t, tt.wantAddr, cfg.Addr)
+			assert.Equal(t, tt.wantTLS, cfg.TLSConfig)
+		})
+	}
+}
 
 func TestPlugin_Name(t *testing.T) {
 	p := &Plugin{}


### PR DESCRIPTION
## Summary

The MySQL DSN was `fmt.Sprintf("%s:%s@tcp(%s)/?%s", username, password, target, tls)`. A password containing `@`, `:`, `/`, or `?` is parsed as part of the user or host. MongoDB already URL-escapes credentials.

Use `mysql.Config.FormatDSN` and `net.JoinHostPort` after `ParseTarget` (IPv6 + default port 3306).

## Test plan

- [x] `go test -short ./internal/plugins/mysql/`
- [x] `ParseDSN` round-trips `p@ss:word/x?`, `[::1]:3306`, and `tls=skip-verify`