### PR TITLE
fix(postgresql): URL-encode credentials and bracket IPv6

### DIFF
--- a/internal/plugins/postgresql/postgresql.go
+++ b/internal/plugins/postgresql/postgresql.go
@@ -18,7 +18,9 @@ import (
 	"context"
 	"crypto/tls"
 	"database/sql"
-	"fmt"
+	"net"
+	"net/url"
+	"strconv"
 	"sync"
 	"time"
 
@@ -89,13 +91,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 
 	host, port := brutus.ParseTarget(target, "5432")
 
-	// Default to dbname=postgres (the system database that always exists),
-	// consistent with how the MSSQL plugin defaults to database=master.
-	// Without this, lib/pq defaults to dbname=<username> which fails when
-	// no database matching the username has been created — PostgreSQL
-	// rejects the connection before authentication even occurs.
-	connStr := fmt.Sprintf("dbname=postgres user=%s password=%s host=%s port=%s sslmode=%s connect_timeout=%d",
-		username, password, host, port, sslMode(pluginCfg.TLSMode), int(timeout.Seconds()))
+	connStr := postgresURL(host, port, username, password, pluginCfg.TLSMode, timeout)
 
 	db, err := sql.Open("postgres", connStr)
 	if err != nil {
@@ -125,8 +121,7 @@ func (p *Plugin) CheckUnauth(ctx context.Context, target string, timeout time.Du
 
 	host, port := brutus.ParseTarget(target, "5432")
 
-	connStr := fmt.Sprintf("dbname=postgres user=postgres password='' host=%s port=%s sslmode=%s connect_timeout=%d",
-		host, port, sslMode(pluginCfg.TLSMode), int(timeout.Seconds()))
+	connStr := postgresURL(host, port, "postgres", "", pluginCfg.TLSMode, timeout)
 
 	db, err := sql.Open("postgres", connStr)
 	if err != nil {
@@ -144,6 +139,24 @@ func (p *Plugin) CheckUnauth(ctx context.Context, target string, timeout time.Du
 	result.Success = true
 	result.Banner = "[CRITICAL] PostgreSQL trust authentication enabled - unauthenticated access as 'postgres' superuser"
 	return result
+}
+
+func postgresURL(host, port, username, password, tlsMode string, timeout time.Duration) string {
+	timeoutSec := int(timeout.Seconds())
+	if timeoutSec < 1 {
+		timeoutSec = 1
+	}
+	u := &url.URL{
+		Scheme: "postgres",
+		User:   url.UserPassword(username, password),
+		Host:   net.JoinHostPort(host, port),
+		Path:   "/postgres",
+	}
+	q := url.Values{}
+	q.Set("sslmode", sslMode(tlsMode))
+	q.Set("connect_timeout", strconv.Itoa(timeoutSec))
+	u.RawQuery = q.Encode()
+	return u.String()
 }
 
 var classifyError = brutus.NewClassifier(postgresqlAuthIndicators)

--- a/internal/plugins/postgresql/postgresql_test.go
+++ b/internal/plugins/postgresql/postgresql_test.go
@@ -16,6 +16,7 @@ package postgresql
 
 import (
 	"context"
+	"net/url"
 	"os"
 	"testing"
 	"time"
@@ -41,6 +42,40 @@ func getTestConfig() (host, user, pass string) {
 		pass = "postgres"
 	}
 	return
+}
+
+func TestPostgresURL(t *testing.T) {
+	t.Run("special chars in password", func(t *testing.T) {
+		s := postgresURL("db.example.com", "5432", "user", `p@ss word'`, "disable", time.Second)
+		u, err := url.Parse(s)
+		require.NoError(t, err)
+		pass, ok := u.User.Password()
+		require.True(t, ok)
+		assert.Equal(t, `p@ss word'`, pass)
+		assert.Equal(t, "user", u.User.Username())
+		assert.Equal(t, "db.example.com:5432", u.Host)
+		assert.Equal(t, "/postgres", u.Path)
+		assert.Equal(t, "disable", u.Query().Get("sslmode"))
+		assert.Equal(t, "1", u.Query().Get("connect_timeout"))
+	})
+	t.Run("IPv6", func(t *testing.T) {
+		s := postgresURL("::1", "5432", "postgres", "x", "disable", time.Second)
+		u, err := url.Parse(s)
+		require.NoError(t, err)
+		assert.Equal(t, "[::1]:5432", u.Host)
+	})
+	t.Run("subsecond timeout floors to 1s", func(t *testing.T) {
+		s := postgresURL("h", "5432", "u", "p", "disable", 200*time.Millisecond)
+		u, err := url.Parse(s)
+		require.NoError(t, err)
+		assert.Equal(t, "1", u.Query().Get("connect_timeout"))
+	})
+	t.Run("skip-verify sslmode", func(t *testing.T) {
+		s := postgresURL("h", "5432", "u", "p", "skip-verify", time.Second)
+		u, err := url.Parse(s)
+		require.NoError(t, err)
+		assert.Equal(t, "pqgo-brutus-skip-verify", u.Query().Get("sslmode"))
+	})
 }
 
 func TestPlugin_Name(t *testing.T) {


### PR DESCRIPTION
## Summary

The lib/pq keyword/value connstr interpolated `user`/`password`/`host` raw:

- Passwords with space, `'`, `\`, or `=` broke parsing or injected extra keywords
- `host=::1` is not a valid lib/pq value
- `int(timeout.Seconds())` is 0 for sub-second timeouts; PostgreSQL treats `connect_timeout=0` as wait forever

Build a `postgres://` URL with `url.UserPassword`, `net.JoinHostPort`, and `connect_timeout` floored at 1s. Same helper for `CheckUnauth`. sslmode mapping (including `pqgo-brutus-skip-verify`) is unchanged.

## Test plan

- [x] `go test -short ./internal/plugins/postgresql/`
- [x] Password `p@ss word'` round-trips through `url.Parse`
- [x] IPv6 host is `[::1]:5432`
- [x] 200ms timeout becomes `connect_timeout=1`