### PR TITLE
fix(mssql): URL-escape userinfo and bracket IPv6

### DIFF
--- a/internal/plugins/mssql/mssql.go
+++ b/internal/plugins/mssql/mssql.go
@@ -17,7 +17,9 @@ package mssql
 import (
 	"context"
 	"database/sql"
-	"fmt"
+	"net"
+	"net/url"
+	"strconv"
 	"time"
 
 	_ "github.com/denisenkom/go-mssqldb"
@@ -57,9 +59,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	result := brutus.NewResult("mssql", target, username, password)
 	defer func() { result.Duration = time.Since(start) }()
 
-	// TrustServerCertificate=true and encrypt=disable allow connections without cert validation.
-	connStr := fmt.Sprintf("sqlserver://%s:%s@%s?database=master&connection+timeout=%d&encrypt=disable&TrustServerCertificate=true",
-		username, password, target, int(timeout.Seconds()))
+	connStr := mssqlURL(target, username, password, timeout)
 
 	db, err := sql.Open("sqlserver", connStr)
 	if err != nil {
@@ -83,4 +83,24 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 
 	result.Success = true
 	return result
+}
+
+func mssqlURL(target, username, password string, timeout time.Duration) string {
+	host, port := brutus.ParseTarget(target, "1433")
+	timeoutSec := int(timeout.Seconds())
+	if timeoutSec < 1 {
+		timeoutSec = 1
+	}
+	u := &url.URL{
+		Scheme: "sqlserver",
+		User:   url.UserPassword(username, password),
+		Host:   net.JoinHostPort(host, port),
+	}
+	q := url.Values{}
+	q.Set("database", "master")
+	q.Set("connection timeout", strconv.Itoa(timeoutSec))
+	q.Set("encrypt", "disable")
+	q.Set("TrustServerCertificate", "true")
+	u.RawQuery = q.Encode()
+	return u.String()
 }

--- a/internal/plugins/mssql/mssql_test.go
+++ b/internal/plugins/mssql/mssql_test.go
@@ -16,11 +16,13 @@ package mssql
 
 import (
 	"context"
+	"net/url"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/praetorian-inc/brutus/pkg/brutus"
 )
@@ -32,6 +34,34 @@ func getTestConfig() (host, user, pass string) {
 	user = os.Getenv("MSSQL_TEST_USER")
 	pass = os.Getenv("MSSQL_TEST_PASS")
 	return
+}
+
+func TestMssqlURL(t *testing.T) {
+	t.Run("special chars in password", func(t *testing.T) {
+		s := mssqlURL("10.0.0.1:1433", "sa", "p@ss:word", time.Second)
+		u, err := url.Parse(s)
+		require.NoError(t, err)
+		pass, ok := u.User.Password()
+		require.True(t, ok)
+		assert.Equal(t, "p@ss:word", pass)
+		assert.Equal(t, "sa", u.User.Username())
+		assert.Equal(t, "10.0.0.1:1433", u.Host)
+		assert.Equal(t, "master", u.Query().Get("database"))
+		assert.Equal(t, "disable", u.Query().Get("encrypt"))
+		assert.Equal(t, "true", u.Query().Get("TrustServerCertificate"))
+	})
+	t.Run("IPv6 default port", func(t *testing.T) {
+		s := mssqlURL("::1", "sa", "x", time.Second)
+		u, err := url.Parse(s)
+		require.NoError(t, err)
+		assert.Equal(t, "[::1]:1433", u.Host)
+	})
+	t.Run("subsecond timeout floors to 1s", func(t *testing.T) {
+		s := mssqlURL("h", "u", "p", 200*time.Millisecond)
+		u, err := url.Parse(s)
+		require.NoError(t, err)
+		assert.Equal(t, "1", u.Query().Get("connection timeout"))
+	})
 }
 
 func TestPlugin_Name(t *testing.T) {


### PR DESCRIPTION
## Summary

The MSSQL URL was `sqlserver://%s:%s@%s?...`. `@` or `:` in the password splits the URL, and `target` was interpolated raw so IPv6 was invalid. `int(timeout.Seconds())` can be 0.

Build the URL with `url.UserPassword`, `net.JoinHostPort` after `ParseTarget` (default 1433), and floor `connection timeout` at 1s. `encrypt=disable` and `TrustServerCertificate=true` are unchanged.

## Test plan

- [x] `go test -short ./internal/plugins/mssql/`
- [x] Password `p@ss:word` round-trips
- [x] `::1` becomes `[::1]:1433`
- [x] 200ms timeout becomes `connection timeout=1`