### PR TITLE
test(brutus): cover BuildTLSConfig and SchemeFromTLSMode

### DIFF
--- a/pkg/brutus/tls_test.go
+++ b/pkg/brutus/tls_test.go
@@ -1,0 +1,43 @@
+package brutus_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/brutus/pkg/brutus"
+)
+
+func TestBuildTLSConfig(t *testing.T) {
+	tests := []struct {
+		mode     string
+		wantNil  bool
+		wantSkip bool
+	}{
+		{mode: "verify", wantSkip: false},
+		{mode: "skip-verify", wantSkip: true},
+		{mode: "disable", wantNil: true},
+		{mode: "", wantNil: true},
+		{mode: "skip", wantNil: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.mode, func(t *testing.T) {
+			cfg := brutus.BuildTLSConfig(tt.mode)
+			if tt.wantNil {
+				assert.Nil(t, cfg)
+				return
+			}
+			require.NotNil(t, cfg)
+			assert.Equal(t, tt.wantSkip, cfg.InsecureSkipVerify)
+		})
+	}
+}
+
+func TestSchemeFromTLSMode(t *testing.T) {
+	assert.Equal(t, "https", brutus.SchemeFromTLSMode("verify"))
+	assert.Equal(t, "https", brutus.SchemeFromTLSMode("skip-verify"))
+	assert.Equal(t, "http", brutus.SchemeFromTLSMode("disable"))
+	assert.Equal(t, "http", brutus.SchemeFromTLSMode(""))
+	assert.Equal(t, "http", brutus.SchemeFromTLSMode("skip"))
+}


### PR DESCRIPTION
## Summary

`BuildTLSConfig` and `SchemeFromTLSMode` are used by every HTTP plugin and were untested. `"skip-verify"` vs `"verify"` vs default nil/http is the difference between scanning self-signed K8s and talking plaintext.

## Test plan

- [x] `go test -short ./pkg/brutus/ -run 'TestBuildTLSConfig|TestSchemeFromTLSMode'`