### PR TITLE
perf(enum): resolve each service plugin once per run

### DIFF
--- a/pkg/enum/workers.go
+++ b/pkg/enum/workers.go
@@ -48,19 +48,24 @@ func runWorkers(ctx context.Context, cfg *Config) ([]Result, error) {
 		services = ListPlugins()
 	}
 
+	plugins := make(map[string]Plugin, len(services))
+	for _, svcName := range services {
+		plug, err := GetPlugin(svcName)
+		if err != nil {
+			return nil, fmt.Errorf("resolving service %q: %w", svcName, err)
+		}
+		plugins[svcName] = plug
+	}
+
 	var tasks []enumTask
 	for _, target := range cfg.resolveTargets() {
 		for _, svcName := range services {
-			plug, err := GetPlugin(svcName)
-			if err != nil {
-				return nil, fmt.Errorf("resolving service %q: %w", svcName, err)
-			}
 			tasks = append(tasks, enumTask{
 				email:   target.Email,
 				first:   target.First,
 				last:    target.Last,
 				service: svcName,
-				plugin:  plug,
+				plugin:  plugins[svcName],
 			})
 		}
 	}


### PR DESCRIPTION
## Summary

`runWorkers` called `GetPlugin` inside the email × service loop. 10k emails × 3 services meant 30k factory allocations and registry lock traffic. `EnumerateWithPlugin` already shares one instance; plugins must be concurrent-safe.

Resolve each service once into a map, then reuse that instance on every task. Unknown services still fail before any checks.

## Test plan

- [x] `go test -short ./pkg/enum/`