### PR TITLE
fix(sdk): bracket IPv6 hosts in capability target addresses

### DIFF
--- a/pkg/sdk/capability.go
+++ b/pkg/sdk/capability.go
@@ -22,6 +22,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
+	"strconv"
 	"strings"
 
 	"github.com/praetorian-inc/capability-sdk/pkg/capability"
@@ -95,7 +97,7 @@ func (c *Capability) Invoke(ctx capability.ExecutionContext, input capmodel.Port
 		return fmt.Errorf("no hostname specified in port parent asset")
 	}
 
-	target := fmt.Sprintf("%s:%d", input.Parent.DNS, input.Port)
+	target := net.JoinHostPort(input.Parent.DNS, strconv.Itoa(input.Port))
 
 	cfg := &brutus.Config{
 		Target:      target,

--- a/pkg/sdk/capability_test.go
+++ b/pkg/sdk/capability_test.go
@@ -364,6 +364,38 @@ func TestInvoke_RejectsNegativeRateLimit(t *testing.T) {
 	assert.False(t, called, "bruteFunc should not be called when ratelimit is negative")
 }
 
+func TestInvoke_IPv6Target(t *testing.T) {
+	orig := bruteFunc
+	defer func() { bruteFunc = orig }()
+
+	var capturedCfg *brutus.Config
+	bruteFunc = func(_ context.Context, cfg *brutus.Config) ([]brutus.Result, error) {
+		capturedCfg = cfg
+		return nil, nil
+	}
+
+	c := NewCapability()
+	ctx := capability.ExecutionContext{
+		Manual: true,
+		Parameters: capability.Parameters{
+			{Name: "usernames", Value: "admin", Type: "string"},
+			{Name: "passwords", Value: "pass", Type: "string"},
+			{Name: "protocol", Value: "ssh", Type: "string"},
+		},
+	}
+	input := capmodel.Port{
+		Port:    22,
+		Service: "ssh",
+		Parent:  capmodel.Asset{DNS: "2001:db8::1"},
+	}
+	emitter := capability.EmitterFunc(func(_ ...any) error { return nil })
+
+	err := c.Invoke(ctx, input, emitter)
+	require.NoError(t, err)
+	require.NotNil(t, capturedCfg)
+	assert.Equal(t, "[2001:db8::1]:22", capturedCfg.Target)
+}
+
 func TestInvoke_ZeroRateLimitMeansUnlimited(t *testing.T) {
 	orig := bruteFunc
 	defer func() { bruteFunc = orig }()


### PR DESCRIPTION
## Summary

The capability wrapper built `target` with `fmt.Sprintf("%s:%d", DNS, Port)`. An IPv6 parent asset became `2001:db8::1:22`. Use `net.JoinHostPort`.

## Test plan

- [x] `go test -short ./pkg/sdk/`
- [x] Stubbed Invoke captures `[2001:db8::1]:22`