### PR TITLE
fix(neo4j): bracket IPv6 bolt URIs and close with Background

### DIFF
--- a/internal/plugins/neo4j/neo4j.go
+++ b/internal/plugins/neo4j/neo4j.go
@@ -16,7 +16,7 @@ package neo4j
 
 import (
 	"context"
-	"fmt"
+	"net"
 	"time"
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
@@ -58,7 +58,8 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	result := brutus.NewResult("neo4j", target, username, password)
 	defer func() { result.Duration = time.Since(start) }()
 
-	uri := fmt.Sprintf("bolt://%s", target)
+	host, port := brutus.ParseTarget(target, "7687")
+	uri := "bolt://" + net.JoinHostPort(host, port)
 	auth := neo4j.BasicAuth(username, password, "")
 	tlsMode := pluginCfg.TLSMode
 
@@ -69,7 +70,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 		result.Error = classifyError(err)
 		return result
 	}
-	defer func() { _ = driver.Close(ctx) }()
+	defer func() { _ = driver.Close(context.Background()) }()
 
 	verifyCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/internal/plugins/neo4j/neo4j_test.go
+++ b/internal/plugins/neo4j/neo4j_test.go
@@ -109,6 +109,16 @@ func TestPlugin_Test_ContextCancellation(t *testing.T) {
 	assert.NotNil(t, result.Error)
 }
 
+func TestPlugin_Test_UnbracketedIPv6(t *testing.T) {
+	p := &Plugin{}
+	result := p.Test(context.Background(), "::1", "neo4j", "password", 200*time.Millisecond, brutus.PluginConfig{})
+
+	assert.NotNil(t, result)
+	assert.False(t, result.Success)
+	assert.NotNil(t, result.Error)
+	assert.NotContains(t, result.Error.Error(), "too many colons")
+}
+
 func TestPlugin_Test_Timeout(t *testing.T) {
 	p := &Plugin{}
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Two Neo4j issues:

1. `bolt://%s` with unbracketed IPv6 (`::1`) is not a valid URI. ParseTarget + `net.JoinHostPort`, default port 7687.
2. `driver.Close(ctx)` on a cancelled context can skip teardown. MongoDB already uses `context.Background()` for `Disconnect`.

## Test plan

- [x] `go test -short ./internal/plugins/neo4j/`
- [x] Unbracketed `::1` no longer errors with `too many colons`