### PR TITLE
test: add error-classification tables for mysql, mssql, and neo4j

### DIFF
--- a/internal/plugins/mssql/mssql_test.go
+++ b/internal/plugins/mssql/mssql_test.go
@@ -16,6 +16,7 @@ package mssql
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 	"time"
@@ -37,6 +38,29 @@ func getTestConfig() (host, user, pass string) {
 func TestPlugin_Name(t *testing.T) {
 	p := &Plugin{}
 	assert.Equal(t, "mssql", p.Name())
+}
+
+func TestPlugin_Test_ErrorClassification(t *testing.T) {
+	tests := []struct {
+		name     string
+		errStr   string
+		wantAuth bool
+	}{
+		{name: "login failed", errStr: "Login failed for user 'sa'", wantAuth: true},
+		{name: "timeout", errStr: "i/o timeout", wantAuth: false},
+		{name: "connection refused", errStr: "connection refused", wantAuth: false},
+		{name: "deadline exceeded", errStr: "context deadline exceeded", wantAuth: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := brutus.ClassifyAuthError(errors.New(tt.errStr), mssqlAuthIndicators)
+			if tt.wantAuth {
+				assert.Nil(t, result)
+			} else {
+				assert.ErrorContains(t, result, "connection error")
+			}
+		})
+	}
 }
 
 func TestPlugin_Test_ValidCredentials(t *testing.T) {

--- a/internal/plugins/mysql/mysql_test.go
+++ b/internal/plugins/mysql/mysql_test.go
@@ -16,6 +16,7 @@ package mysql
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 	"time"
@@ -34,6 +35,30 @@ var (
 func TestPlugin_Name(t *testing.T) {
 	p := &Plugin{}
 	assert.Equal(t, "mysql", p.Name())
+}
+
+func TestPlugin_Test_ErrorClassification(t *testing.T) {
+	tests := []struct {
+		name     string
+		errStr   string
+		wantAuth bool
+	}{
+		{name: "access denied", errStr: "Access denied for user 'root'", wantAuth: true},
+		{name: "authentication failed", errStr: "authentication failed", wantAuth: true},
+		{name: "timeout", errStr: "i/o timeout", wantAuth: false},
+		{name: "connection refused", errStr: "connection refused", wantAuth: false},
+		{name: "deadline exceeded", errStr: "context deadline exceeded", wantAuth: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := classifyError(errors.New(tt.errStr))
+			if tt.wantAuth {
+				assert.Nil(t, result)
+			} else {
+				assert.ErrorContains(t, result, "connection error")
+			}
+		})
+	}
 }
 
 func TestPlugin_Test_ValidCredentials(t *testing.T) {

--- a/internal/plugins/neo4j/neo4j_test.go
+++ b/internal/plugins/neo4j/neo4j_test.go
@@ -16,6 +16,7 @@ package neo4j
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 	"time"
@@ -34,6 +35,30 @@ var (
 func TestPlugin_Name(t *testing.T) {
 	p := &Plugin{}
 	assert.Equal(t, "neo4j", p.Name())
+}
+
+func TestPlugin_Test_ErrorClassification(t *testing.T) {
+	tests := []struct {
+		name     string
+		errStr   string
+		wantAuth bool
+	}{
+		{name: "authentication failure", errStr: "authentication failure", wantAuth: true},
+		{name: "invalid credentials", errStr: "invalid credentials", wantAuth: true},
+		{name: "authentication failed", errStr: "authentication failed", wantAuth: true},
+		{name: "timeout", errStr: "i/o timeout", wantAuth: false},
+		{name: "connection refused", errStr: "connection refused", wantAuth: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := classifyError(errors.New(tt.errStr))
+			if tt.wantAuth {
+				assert.Nil(t, result)
+			} else {
+				assert.ErrorContains(t, result, "connection error")
+			}
+		})
+	}
 }
 
 func TestPlugin_Test_ValidCredentials(t *testing.T) {


### PR DESCRIPTION
## Summary

MySQL, MSSQL, and Neo4j only had skip-gated live-server tests. Redis/postgres/oracle already table-drive auth vs connection classification. Wrong indicators treat timeouts as bad passwords (or lockouts as connection errors).

## Test plan

- [x] `go test -short ./internal/plugins/mysql/ ./internal/plugins/mssql/ ./internal/plugins/neo4j/`