### PR TITLE
fix(mongodb): bracket IPv6 hosts in the connection URI

### DIFF
--- a/internal/plugins/mongodb/mongodb.go
+++ b/internal/plugins/mongodb/mongodb.go
@@ -16,7 +16,7 @@ package mongodb
 
 import (
 	"context"
-	"fmt"
+	"net"
 	"net/url"
 	"time"
 
@@ -53,21 +53,7 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	result := brutus.NewResult("mongodb", target, username, password)
 	defer func() { result.Duration = time.Since(start) }()
 
-	tlsMode := pluginCfg.TLSMode
-
-	var tlsParam string
-	switch tlsMode {
-	case "verify":
-		tlsParam = "tls=true"
-	case "skip-verify":
-		tlsParam = "tls=true&tlsInsecure=true"
-	default: // "disable"
-		tlsParam = "tls=false"
-	}
-
-	// URL-encode username and password to handle special characters (@, :, /, %, #).
-	connStr := fmt.Sprintf("mongodb://%s:%s@%s/?%s",
-		url.QueryEscape(username), url.QueryEscape(password), target, tlsParam)
+	connStr := mongoURI(target, username, password, pluginCfg.TLSMode)
 
 	clientOpts := options.Client().
 		ApplyURI(connStr).
@@ -99,7 +85,19 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	return result
 }
 
-// mongodbAuthIndicators defines authentication failure indicators for MongoDB.
+func mongoURI(target, username, password, tlsMode string) string {
+	host, port := brutus.ParseTarget(target, "27017")
+	tlsParam := "tls=false"
+	switch tlsMode {
+	case "verify":
+		tlsParam = "tls=true"
+	case "skip-verify":
+		tlsParam = "tls=true&tlsInsecure=true"
+	}
+	return "mongodb://" + url.QueryEscape(username) + ":" + url.QueryEscape(password) + "@" +
+		net.JoinHostPort(host, port) + "/?" + tlsParam
+}
+
 var mongodbAuthIndicators = []string{
 	"Authentication failed",
 	"auth error",

--- a/internal/plugins/mongodb/mongodb_test.go
+++ b/internal/plugins/mongodb/mongodb_test.go
@@ -16,13 +16,40 @@ package mongodb
 
 import (
 	"context"
+	"net/url"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/praetorian-inc/brutus/pkg/brutus"
 )
+
+func TestMongoURI(t *testing.T) {
+	t.Run("special chars", func(t *testing.T) {
+		s := mongoURI("10.0.0.1:27017", "user", "p@ss:word", "")
+		u, err := url.Parse(s)
+		require.NoError(t, err)
+		pass, ok := u.User.Password()
+		require.True(t, ok)
+		assert.Equal(t, "p@ss:word", pass)
+		assert.Equal(t, "10.0.0.1:27017", u.Host)
+	})
+	t.Run("IPv6 default port", func(t *testing.T) {
+		s := mongoURI("::1", "user", "x", "")
+		u, err := url.Parse(s)
+		require.NoError(t, err)
+		assert.Equal(t, "[::1]:27017", u.Host)
+	})
+	t.Run("skip-verify", func(t *testing.T) {
+		s := mongoURI("db.example.com", "u", "p", "skip-verify")
+		u, err := url.Parse(s)
+		require.NoError(t, err)
+		assert.Equal(t, "true", u.Query().Get("tls"))
+		assert.Equal(t, "true", u.Query().Get("tlsInsecure"))
+	})
+}
 
 func TestPlugin_Name(t *testing.T) {
 	p := &Plugin{}


### PR DESCRIPTION
## Summary

MongoDB already URL-escapes userinfo, but interpolated `target` raw. Unbracketed IPv6 (`::1`) produced `mongodb://user:pass@::1/?tls=false`. Use `ParseTarget` + `net.JoinHostPort` (default 27017).

## Test plan

- [x] `go test -short ./internal/plugins/mongodb/`
- [x] `p@ss:word` round-trips; `::1` becomes `[::1]:27017`