### PR TITLE
fix(phantombuster): honor --proxy like hunter/apollo/lusha

### DIFF
--- a/cmd/brutus/cmd_enum_linkedin.go
+++ b/cmd/brutus/cmd_enum_linkedin.go
@@ -101,7 +101,14 @@ func runEnumLinkedin(cmd *cobra.Command, args []string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	client := pb.NewClient(apiKey, flagTimeout)
+	proxyURL, err := resolveProxyURL()
+	if err != nil {
+		return err
+	}
+	client, err := pb.NewClient(apiKey, flagTimeout, proxyURL)
+	if err != nil {
+		return err
+	}
 
 	var resultData []byte
 

--- a/pkg/enum/phantombuster/client.go
+++ b/pkg/enum/phantombuster/client.go
@@ -70,15 +70,20 @@ type Client struct {
 }
 
 // NewClient builds a PhantomBuster client. timeout is the per-request HTTP budget.
-func NewClient(apiKey string, timeout time.Duration) *Client {
+// proxyURL is honored the same way as hunter/apollo/lusha (--proxy).
+func NewClient(apiKey string, timeout time.Duration, proxyURL string) (*Client, error) {
+	httpClient, err := enum.NewEnumHTTPClientWithProxy(timeout, proxyURL)
+	if err != nil {
+		return nil, err
+	}
 	return &Client{
 		apiKey:     apiKey,
-		httpClient: enum.NewEnumHTTPClient(timeout),
+		httpClient: httpClient,
 		baseURL:    defaultBaseURL,
 		pollInit:   defaultPollInit,
 		pollMax:    defaultPollMax,
 		pollMult:   defaultPollMult,
-	}
+	}, nil
 }
 
 // LaunchResult is returned by Launch.

--- a/pkg/enum/phantombuster/client_test.go
+++ b/pkg/enum/phantombuster/client_test.go
@@ -30,7 +30,10 @@ func newTestClient(t *testing.T, handler http.Handler) *Client {
 	t.Helper()
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
-	c := NewClient("test-key", 5*time.Second)
+	c, err := NewClient("test-key", 5*time.Second, "")
+	if err != nil {
+		t.Fatal(err)
+	}
 	c.baseURL = server.URL
 	c.pollInit = 10 * time.Millisecond
 	c.pollMax = 50 * time.Millisecond
@@ -218,7 +221,10 @@ func TestDownloadResult_Success(t *testing.T) {
 	server := httptest.NewServer(mux)
 	t.Cleanup(server.Close)
 
-	c := NewClient("test-key", 5*time.Second)
+	c, err := NewClient("test-key", 5*time.Second, "")
+	if err != nil {
+		t.Fatal(err)
+	}
 	c.baseURL = server.URL
 
 	// s3BaseURL is a const so we can't override it for tests. Instead, verify
@@ -232,6 +238,13 @@ func TestDownloadResult_Success(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != 200 {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestNewClient_InvalidProxy(t *testing.T) {
+	_, err := NewClient("test-key", time.Second, "ftp://127.0.0.1:9")
+	if err == nil {
+		t.Fatal("expected error for unsupported proxy scheme")
 	}
 }
 


### PR DESCRIPTION
## Summary

PhantomBuster `NewClient` called `NewEnumHTTPClient` with no proxy. Hunter/Apollo/Lusha all take `proxyURL`. LinkedIn enum therefore ignored `--proxy`.

`NewClient` now takes `proxyURL` and uses `NewEnumHTTPClientWithProxy`. The LinkedIn command threads `resolveProxyURL()`.

## Test plan

- [x] `go test -short ./pkg/enum/phantombuster/ ./cmd/brutus/`
- [x] Unsupported `ftp://` proxy is rejected