### PR TITLE
fix(cassandra): dial IPv6 via JoinHostPort

### DIFF
--- a/internal/plugins/cassandra/cassandra.go
+++ b/internal/plugins/cassandra/cassandra.go
@@ -16,6 +16,7 @@ package cassandra
 
 import (
 	"context"
+	"net"
 	"time"
 
 	"github.com/gocql/gocql"
@@ -56,7 +57,8 @@ func (p *Plugin) Test(ctx context.Context, target, username, password string,
 	result := brutus.NewResult("cassandra", target, username, password)
 	defer func() { result.Duration = time.Since(start) }()
 
-	cluster := gocql.NewCluster(target)
+	host, port := brutus.ParseTarget(target, "9042")
+	cluster := gocql.NewCluster(net.JoinHostPort(host, port))
 	cluster.Authenticator = gocql.PasswordAuthenticator{
 		Username: username,
 		Password: password,

--- a/internal/plugins/cassandra/cassandra_test.go
+++ b/internal/plugins/cassandra/cassandra_test.go
@@ -112,6 +112,16 @@ func TestPlugin_Test_ResultStructure(t *testing.T) {
 	assert.Greater(t, result.Duration, time.Duration(0))
 }
 
+func TestPlugin_Test_UnbracketedIPv6(t *testing.T) {
+	p := &Plugin{}
+	result := p.Test(context.Background(), "::1", "user", "pass", 200*time.Millisecond, brutus.PluginConfig{})
+
+	assert.NotNil(t, result)
+	assert.False(t, result.Success)
+	assert.NotNil(t, result.Error)
+	assert.NotContains(t, result.Error.Error(), "too many colons")
+}
+
 func TestPlugin_Test_ContextCancellation(t *testing.T) {
 	p := &Plugin{}
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Summary

`gocql.NewCluster(target)` received the raw target string. Unbracketed IPv6 (`::1`) is not a valid Cassandra host. ParseTarget + `net.JoinHostPort`, default port 9042.

## Test plan

- [x] `go test -short ./internal/plugins/cassandra/`
- [x] Unbracketed `::1` no longer errors with `too many colons`