### PR TITLE
test(brutus): cover ParseTarget empty and bracketed-IPv6-without-port

### DIFF
--- a/pkg/brutus/target_test.go
+++ b/pkg/brutus/target_test.go
@@ -91,6 +91,20 @@ func TestParseTarget_IPv6(t *testing.T) {
 			wantHost:    "2001:db8::1",
 			wantPort:    "22",
 		},
+		{
+			name:        "bracketed IPv6 without port",
+			target:      "[::1]",
+			defaultPort: "22",
+			wantHost:    "[::1]",
+			wantPort:    "22",
+		},
+		{
+			name:        "empty target uses default port",
+			target:      "",
+			defaultPort: "22",
+			wantHost:    "",
+			wantPort:    "22",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

`ParseTarget` tests covered IPv4 and `[::1]:port` / `::1`. Missing: empty target and `[::1]` without a port. Documents current behavior (SplitHostPort fails → keep brackets, apply default port).

## Test plan

- [x] `go test -short ./pkg/brutus/ -run TestParseTarget`