### PR TITLE
ci: bump golangci-lint to v2.13.2 to unstick unparam on Go 1.27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     permissions:
       contents: read
     with:
-      golangci-lint-version: "v2.13.1"
+      golangci-lint-version: "v2.13.2"
       build-cmd-path: ./cmd/brutus
       build-binary-name: brutus
     secrets: inherit


### PR DESCRIPTION
## Summary

`ci / Lint` is red on main and every PR. golangci-lint v2.13.1's `unparam` panics while analyzing `pkg/enum`:

```
Panic: unparam: package "enum": go/types/gcsizes.go:157: assertion failed
golangci-lint exit with code 3
```

v2.13.2 bumps `mvdan.cc/unparam` to `2fa3d841b0c8` ([#6756](https://github.com/golangci/golangci-lint/pull/6756)), which is the Go 1.27 `Sizeof` assertion fix.

## Test plan

- [ ] CI Lint job on this PR (runs golangci-lint v2.13.2)