### PR TITLE
feat(logon): retry a non-stabilized scan once, more patiently

### DIFF
--- a/internal/plugins/rdp/blackframe_test.go
+++ b/internal/plugins/rdp/blackframe_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -362,4 +363,92 @@ func TestRetryOnTerminationWiring(t *testing.T) {
 		assert.Zero(t, calls)
 		assert.Same(t, positive, got)
 	})
+}
+
+// TestRetryOnUnstableWiring covers the more-patient retry of a non-stabilized scan as it
+// is wired: whether the rerun fires, and which result reaches the caller. The patient
+// retry must fire ONLY on a performed, non-terminated, non-stabilized indeterminate, and
+// must never overwrite a settled observation (cardinal rule).
+func TestRetryOnUnstableWiring(t *testing.T) {
+	unstable := func() *StickyKeysResult {
+		return &StickyKeysResult{Performed: true, OverallVerdict: verdictIndeterminate, Stabilized: false}
+	}
+
+	t.Run("reruns a non-stabilized indeterminate more patiently", func(t *testing.T) {
+		calls := 0
+		second := &StickyKeysResult{Performed: true, OverallVerdict: "clean", Stabilized: true}
+		got := retryStickyKeysOnUnstable(false, unstable(), func() *StickyKeysResult {
+			calls++
+			return second
+		})
+		assert.Equal(t, 1, calls, "a render that did not settle must get a patient retry")
+		assert.Same(t, second, got)
+	})
+
+	t.Run("never overwrites a settled finding", func(t *testing.T) {
+		for _, verdict := range []string{"backdoor_confirmed", "backdoor_likely", "vulnerable", "clean"} {
+			first := &StickyKeysResult{Performed: true, OverallVerdict: verdict, Stabilized: true}
+			calls := 0
+			got := retryStickyKeysOnUnstable(false, first, func() *StickyKeysResult {
+				calls++
+				return unstable()
+			})
+			assert.Zero(t, calls, "%s: a stabilized verdict is a real observation and must not be re-run", verdict)
+			assert.Same(t, first, got)
+		}
+	})
+
+	t.Run("does not fire on a terminated session (termination retry owns that)", func(t *testing.T) {
+		first := &StickyKeysResult{Performed: true, OverallVerdict: verdictIndeterminate, Stabilized: false, SessionTerminated: true}
+		calls := 0
+		got := retryStickyKeysOnUnstable(false, first, func() *StickyKeysResult { calls++; return nil })
+		assert.Zero(t, calls, "a teardown is retried on the SHORT profile, not the patient one")
+		assert.Same(t, first, got)
+	})
+
+	t.Run("does not fire when the scan never performed", func(t *testing.T) {
+		first := &StickyKeysResult{Performed: false, OverallVerdict: verdictIndeterminate, Stabilized: false}
+		calls := 0
+		got := retryStickyKeysOnUnstable(false, first, func() *StickyKeysResult { calls++; return nil })
+		assert.Zero(t, calls, "a connect/wasm failure has no render to settle")
+		assert.Same(t, first, got)
+	})
+
+	t.Run("does not fire in fast mode", func(t *testing.T) {
+		calls := 0
+		got := retryStickyKeysOnUnstable(true, unstable(), func() *StickyKeysResult { calls++; return nil })
+		assert.Zero(t, calls, "--fast triage never spends extra settle time")
+		assert.Equal(t, verdictIndeterminate, got.OverallVerdict)
+	})
+
+	t.Run("tolerates a nil result", func(t *testing.T) {
+		calls := 0
+		got := retryStickyKeysOnUnstable(false, nil, func() *StickyKeysResult { calls++; return nil })
+		assert.Zero(t, calls)
+		assert.Nil(t, got)
+	})
+
+	t.Run("utilman is wired the same way", func(t *testing.T) {
+		calls := 0
+		first := &UtilmanResult{Performed: true, OverallVerdict: verdictIndeterminate, Stabilized: false}
+		second := &UtilmanResult{Performed: true, OverallVerdict: "clean", Stabilized: true}
+		got := retryUtilmanOnUnstable(false, first, func() *UtilmanResult { calls++; return second })
+		assert.Equal(t, 1, calls)
+		assert.Same(t, second, got)
+
+		calls = 0
+		settled := &UtilmanResult{Performed: true, OverallVerdict: "clean", Stabilized: true}
+		got = retryUtilmanOnUnstable(false, settled, func() *UtilmanResult { calls++; return second })
+		assert.Zero(t, calls, "a stabilized clean must not be re-run")
+		assert.Same(t, settled, got)
+	})
+}
+
+// TestPatientTimeout pins the patient-retry deadline: double the base, capped so an
+// already-generous --scan-timeout cannot balloon a stuck host without limit.
+func TestPatientTimeout(t *testing.T) {
+	assert.Equal(t, 20*time.Second, patientTimeout(10*time.Second))
+	assert.Equal(t, 30*time.Second, patientTimeout(15*time.Second))
+	assert.Equal(t, 45*time.Second, patientTimeout(40*time.Second), "cap holds")
+	assert.Equal(t, 45*time.Second, patientTimeout(60*time.Second), "cap holds above 2x")
 }

--- a/internal/plugins/rdp/detect.go
+++ b/internal/plugins/rdp/detect.go
@@ -399,3 +399,42 @@ func retryAfterTermination(verdict string, performed bool) bool {
 		return true
 	}
 }
+
+// retryStickyKeysOnUnstable re-runs a non-stabilized (indeterminate) scan once on the
+// MORE patient settle profile. A render that did not settle within CarefulBudget is not
+// an observation -- the operator would otherwise have to rerun it by hand -- so one
+// automatic, more-patient retry spends the extra time ONLY on the hosts that need it.
+// It never touches a host that already settled (clean or a positive), so it cannot lose
+// a finding (cardinal rule). Terminated sessions are handled by the termination retry
+// (a SHORTER profile, to beat a re-teardown), so this deliberately skips them. rerun is
+// invoked at most once. fast mode never retries (never-clean triage owns that path).
+func retryStickyKeysOnUnstable(fast bool, first *StickyKeysResult, rerun func() *StickyKeysResult) *StickyKeysResult {
+	if fast || first == nil || first.SessionTerminated {
+		return first
+	}
+	if !retryWhenUnstable(first.OverallVerdict, first.Performed, first.Stabilized) {
+		return first
+	}
+	return rerun()
+}
+
+// retryUtilmanOnUnstable is retryStickyKeysOnUnstable for the utilman check. See it for
+// the rationale; the wiring is identical so both checks share one retry decision.
+func retryUtilmanOnUnstable(fast bool, first *UtilmanResult, rerun func() *UtilmanResult) *UtilmanResult {
+	if fast || first == nil || first.SessionTerminated {
+		return first
+	}
+	if !retryWhenUnstable(first.OverallVerdict, first.Performed, first.Stabilized) {
+		return first
+	}
+	return rerun()
+}
+
+// retryWhenUnstable reports whether a (non-terminated) result is worth a more-patient
+// rerun: only a scan that performed but did not stabilize AND landed on indeterminate.
+// A stabilized verdict -- clean or a positive -- is a real observation and is never
+// re-run (the retry could only lose it). A never-performed scan (connect/wasm failure)
+// has no render to settle, so a patient retry buys nothing.
+func retryWhenUnstable(verdict string, performed, stabilized bool) bool {
+	return performed && !stabilized && verdict == verdictIndeterminate
+}

--- a/internal/plugins/rdp/outcome.go
+++ b/internal/plugins/rdp/outcome.go
@@ -85,6 +85,9 @@ func DetectStickyKeysOutcome(ctx context.Context, target string, connectTimeout,
 	result = retryStickyKeysOnTermination(fast, result, func() *StickyKeysResult {
 		return plugin.RunStickyKeysCheck(ctx, target, "", connectTimeout, timeout, noVision, FastBudget, true)
 	})
+	result = retryStickyKeysOnUnstable(fast, result, func() *StickyKeysResult {
+		return plugin.RunStickyKeysCheck(ctx, target, "", connectTimeout, patientTimeout(timeout), noVision, PatientBudget, false)
+	})
 	return stickyOutcome(result)
 }
 
@@ -98,5 +101,21 @@ func DetectUtilmanOutcome(ctx context.Context, target string, connectTimeout, ti
 	result = retryUtilmanOnTermination(fast, result, func() *UtilmanResult {
 		return plugin.RunUtilmanCheck(ctx, target, "", connectTimeout, timeout, noVision, FastBudget, true)
 	})
+	result = retryUtilmanOnUnstable(fast, result, func() *UtilmanResult {
+		return plugin.RunUtilmanCheck(ctx, target, "", connectTimeout, patientTimeout(timeout), noVision, PatientBudget, false)
+	})
 	return utilmanOutcome(result)
+}
+
+// patientTimeout widens a per-phase settle deadline for the single more-patient retry of
+// a non-stabilized scan. Doubling gives a slow-painting logon screen room to reach the
+// wider PatientBudget quiet window; it is bounded so an already-generous --scan-timeout
+// cannot balloon a stuck host's cost without limit.
+func patientTimeout(d time.Duration) time.Duration {
+	const maxPatient = 45 * time.Second
+	patient := d * 2
+	if patient > maxPatient {
+		return maxPatient
+	}
+	return patient
 }

--- a/internal/plugins/rdp/session.go
+++ b/internal/plugins/rdp/session.go
@@ -150,6 +150,22 @@ var FastBudget = SettleBudget{
 	postKeystrokeWait: 700 * time.Millisecond,
 }
 
+// PatientBudget is the extra-patient settle profile used for a single retry of a
+// non-stabilized (indeterminate) careful scan. A host on a slow/high-latency link can
+// keep repainting past CarefulBudget's quiet window, or paint its logon screen in bursts
+// that never go quiet long enough inside the default deadline, so the first careful
+// attempt reads "render did not stabilize". Rather than surface that for a manual rerun,
+// one automatic retry widens the quiet window and per-frame read deadline so a slow paint
+// can settle. It is strictly more patient than CarefulBudget on every axis; the extra time
+// is spent ONLY on hosts that failed to settle, never on a host that already resolved.
+var PatientBudget = SettleBudget{
+	quietWindow:       2500 * time.Millisecond,
+	minPump:           2 * time.Second,
+	noisePixels:       2000,
+	readDeadline:      800 * time.Millisecond,
+	postKeystrokeWait: 2 * time.Second,
+}
+
 // MinViableTimeout is the smallest per-pump-phase timeout that can ever produce
 // a settled (non-indeterminate) verdict. A phase only settles after minPump has
 // elapsed AND the framebuffer has been quiet for quietWindow, so a --timeout


### PR DESCRIPTION
## Problem

Logon-screen checks report `indeterminate` / `needs_rerun` ("render did not stabilize") when the framebuffer never goes quiet for the careful settle window within the per-phase deadline. On **slow / high-latency hosts** this is common — the logon screen paints in bursts that don't settle in time — and today it's surfaced for a **manual rerun**, which the platform then repeats as a full reconnect. Observed live against internet hosts: several returned `indeterminate` with `stabilized:false` even though the response frame clearly showed a benign, static logon dialog.

## Approach — patience, but only where it's needed

The pump already **early-exits** the moment a frame settles, so a host that renders quickly never pays extra time regardless of the ceiling. The cost is only ever paid by hosts that *don't* settle. So instead of raising the settle ceiling for **every** host (throughput hit for internet-scale sweeps), this spends extra patience **adaptively**: one automatic, more-patient retry of exactly the scans that failed to settle.

When a careful (non-`--fast`) scan comes back **performed, non-terminated, non-stabilized, and `indeterminate`**, re-run it once on a new `PatientBudget` (wider quiet window + per-frame read deadline) with a **doubled, capped** per-phase deadline.

Cardinal-safe: a host that already resolved to `clean` or a positive is **never** re-run, so a finding can't be lost. `--fast` never retries (never-clean triage owns that path). Terminated sessions keep their existing **short**-profile retry (which races a re-teardown rather than waiting it out), so the two retries never overlap.

## Changes

- **`PatientBudget`** (`session.go`) — strictly more patient than `CarefulBudget` on every axis (quiet window 1.5s→2.5s, read deadline 500ms→800ms, post-keystroke 1.5s→2s).
- **`retryStickyKeysOnUnstable` / `retryUtilmanOnUnstable` + `retryWhenUnstable`** (`detect.go`) — pure, testable retry decision mirroring the existing termination-retry wiring.
- **`patientTimeout`** (`outcome.go`) — 2× the base per-phase deadline, capped at 45s.
- Wired after the termination retry in `DetectStickyKeysOutcome` / `DetectUtilmanOutcome`.

## Why this over raising the default `--scan-timeout`

A blanket ceiling bump slows every connected-but-slow host on internet-scale sweeps; this pays only on the minority that didn't settle, and at most once. It also *reduces* operator-facing reruns (each of which is otherwise a fresh reconnect), so on slow hosts it's net-cheaper than the manual-rerun status quo.

## Tests

- `TestRetryOnUnstableWiring` — fires only on performed / non-terminated / non-stabilized / `indeterminate`; never overwrites a settled verdict (`clean` or any positive); skips `--fast`, terminated, never-performed, and nil.
- `TestPatientTimeout` — double-and-cap.

`gofmt`, `go vet`, full `./internal/plugins/rdp/`, `./cmd/brutus/...`, and `./pkg/brutus/...` suites, plus repo-wide `go build ./...`, all pass. No flag/CLI changes, so CLI docs are unaffected.

## Follow-up (separate)

Guard-side companion to consume the corrected/retried verdicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)