### PR TITLE
ci: track go.mod for the Go toolchain instead of a hardcoded 1.26.0 pin

### DIFF
--- a/.github/workflows/browser-plugin-ci.yml
+++ b/.github/workflows/browser-plugin-ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.0'
+          go-version-file: go.mod
           cache: true
 
       - name: Run unit tests
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.0'
+          go-version-file: go.mod
           cache: true
 
       - name: Verify Chrome installation
@@ -120,7 +120,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.0'
+          go-version-file: go.mod
           cache: true
 
       - name: Build

--- a/.github/workflows/browser-plugin-integration.yml
+++ b/.github/workflows/browser-plugin-integration.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.0'
+          go-version-file: go.mod
           cache: true
 
       - name: Verify Chrome installation
@@ -62,7 +62,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.0'
+          go-version-file: go.mod
           cache: true
 
       - name: Verify Chrome installation

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -7,9 +7,6 @@ on:
 permissions:
   contents: read
 
-env:
-  GO_VERSION: '1.26.0'
-
 jobs:
   integration:
     name: Integration Tests
@@ -279,7 +276,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Wait for services
         run: |

--- a/.github/workflows/ci-unauth.yml
+++ b/.github/workflows/ci-unauth.yml
@@ -7,9 +7,6 @@ on:
 permissions:
   contents: read
 
-env:
-  GO_VERSION: '1.26.0'
-
 jobs:
   unauth:
     name: Unauthenticated Access Detection
@@ -79,7 +76,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Wait for services
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,6 @@ permissions:
   contents: write
   packages: write
 
-env:
-  GO_VERSION: '1.26.0'
-
 jobs:
   test:
     name: Test
@@ -31,7 +28,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Run tests
         run: CGO_ENABLED=0 go test -short -coverprofile=coverage.out ./...
@@ -55,7 +52,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0


### PR DESCRIPTION
## Problem

Integration Tests and Unauthenticated Access Tests have been failing on `main` — not from any test, but before tests even start:

```
go: go.mod requires go >= 1.27.0 (running go 1.26.0; GOTOOLCHAIN=local)
##[error]Process completed with exit code 1.
```

The module moved to `go 1.27.0` (#389), but several workflows still pinned Go **1.26.0** via `setup-go`. With `GOTOOLCHAIN=local` the job can't fetch a newer toolchain, so it errors out immediately.

## Fix

Point `setup-go` at **`go-version-file: go.mod`** in every affected workflow — the same pattern the already-green `ci-enum` and `cli-surface` workflows use. The CI Go version now tracks the module's declared version automatically, so this drift can't recur on the next `go.mod` bump. Unused `GO_VERSION` env blocks removed.

Workflows updated:
- `ci-integration.yml` (Integration Tests) — **actively failing**
- `ci-unauth.yml` (Unauthenticated Access Tests) — **actively failing**
- `release.yml` — same latent break on the next release build
- `browser-plugin-ci.yml`, `browser-plugin-integration.yml` — also build the 1.27 root module (`./cmd/brutus/`, `./internal/...`)

No hardcoded Go version remains in any workflow. YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)