### PR TITLE
fix(memcached): stop shadowing err in CheckUnauth

### DIFF
--- a/internal/plugins/memcached/memcached.go
+++ b/internal/plugins/memcached/memcached.go
@@ -111,7 +111,7 @@ func (p *Plugin) CheckUnauth(ctx context.Context, target string, timeout time.Du
 	}
 	defer func() { _ = conn.Close() }()
 
-	if _, err := fmt.Fprintf(conn, "version\r\n"); err != nil {
+	if _, err = fmt.Fprintf(conn, "version\r\n"); err != nil {
 		return result
 	}
 	line, err := brutus.ReadLine(bufio.NewReader(io.LimitReader(conn, 512)))


### PR DESCRIPTION
`ci / Lint` is failing on main (and on #393) because govet `shadow` flags `CheckUnauth`:

```
internal/plugins/memcached/memcached.go:114:8: shadow: declaration of "err" shadows declaration at line 108
```

Reuse the existing `err` from `dial` for the VERSION write instead of declaring a new one in the `if`.